### PR TITLE
db_fetch_cell() returns a single integer, hence $tree is not an array…

### DIFF
--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -311,7 +311,7 @@ function draw_dhtml_tree_level_graphing($tree_id, $parent = 0) {
 
 							if (sizeof($graph_templates) > 0) {
 								foreach ($graph_templates as $graph_template) {
-									$dhtml_tree[] = "\t\t\t\t\t\t<li data-jstree='{ \"icon\" : \"" . $config['url_path'] . "images/server_chart.png\" }'><a href=\"" . htmlspecialchars('graph_view.php?action=tree&tree_id=' . $tree['id'] . '&leaf_id=' . $leaf['id'] . '&host_group_data=graph_template:' . $graph_template['id']) . '">' . htmlspecialchars($graph_template['name']) . "</a></li>\n";
+									$dhtml_tree[] = "\t\t\t\t\t\t<li data-jstree='{ \"icon\" : \"" . $config['url_path'] . "images/server_chart.png\" }'><a href=\"" . htmlspecialchars('graph_view.php?action=tree&tree_id=' . $tree_id . '&leaf_id=' . $leaf['id'] . '&host_group_data=graph_template:' . $graph_template['id']) . '">' . htmlspecialchars($graph_template['name']) . "</a></li>\n";
 								}
 							}
 						}else if ($leaf['host_grouping_type'] == HOST_GROUPING_DATA_QUERY_INDEX) {


### PR DESCRIPTION
…. This generates warnings.

Fix for:
PHP Warning:  Illegal string offset 'id' in /var/www/html/cacti/lib/html_tree.php on line 314, referer: http://cacti/graph_view.php