### PR TITLE
Fix page jumping when using Realtime

### DIFF
--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -675,7 +675,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 						</td>
 					</tr>
 					<tr id='realtime' style='display:none;'>
-						<td>
+						<td height="68">
 							Window
 						</td>
 						<td>


### PR DESCRIPTION
When activating Realtime on a graph, the page jumps up due only having one <tr> as opposed to the graph filters which has two.

Increased the height to be the same as two <tr>.

Now when pressing Realtime nothing on the page moves, creates a smoother user experience.