### PR TITLE
fix small jquery typo preventing Safari from displaying cacti pages

### DIFF
--- a/include/layout.js
+++ b/include/layout.js
@@ -403,7 +403,7 @@ function applySkin() {
 		applySelectorVisibilityAndActions();
 	}else{
 		// Allows selection of a non disabled row
-		$('tr.selectable:not([id^="gt_line"]').find('td').not('.checkbox').each(function(data) {
+		$('tr.selectable:not([id^="gt_line"])').find('td').not('.checkbox').each(function(data) {
 			$(this).unbind().click(function(data) {
 				$(this).parent().toggleClass('selected');
 				var $checkbox = $(this).parent().find(':checkbox');


### PR DESCRIPTION
A missing parenthesis was throwing a jquery error and preventing Safari from displaying cacti webpages.