### PR TITLE
Fixed tr.realtime height for dark and classic

### DIFF
--- a/include/themes/classic/main.css
+++ b/include/themes/classic/main.css
@@ -1205,5 +1205,5 @@ ul.pagination li a:hover:not(.active) {
 }
 
 tr#realtime td:first-child {
-	height:68px;
+	height:54px;
 }

--- a/include/themes/dark/main.css
+++ b/include/themes/dark/main.css
@@ -1477,5 +1477,5 @@ ul.pagination li a:hover:not(.active) {
 }
 
 tr#realtime td:first-child {
-	height:68px;
+	height:64px;
 }


### PR DESCRIPTION
They had different fontsizes so they need individual heights.

Note:
In latest IE Edge it moves a minimal bit no matter what value you give. Chrome is perfect.