### PR TITLE
Fix for graphs not showing in some cases

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1945,7 +1945,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 				}
 
 				break;
-			case GRAPH_ITEM_TYPE_TICK:
+			case GRAPH_ITEM_TYPE_TIC:
 				$_fraction = (empty($graph_item['graph_type_id']) ? '' : (':' . $graph_item['value']));
 				$_legend   = (empty($graph_variables['text_format'][$graph_item_id]) ? '' : (':' . "'" . $graph_variables['text_format'][$graph_item_id] . $hardreturn[$graph_item_id] . "'"));
 				$txt_graph_items .= $graph_item_types{$graph_item['graph_type_id']} . ':' . $data_source_name . $graph_item_color_code . $_fraction . $_legend;
@@ -1955,7 +1955,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 				$graph_variables['value'][$graph_item_id] = str_replace(':', '\:', $graph_variables['value'][$graph_item_id]); /* escape colons */
 
 				/* perform variable substitution; if this does not return a number, rrdtool will FAIL! */
-				$substitute = rrd_substitute_device_query_data($graph_variables['value'][$graph_item_id], $graph, $graph_item);
+				$substitute = rrd_substitute_host_query_data($graph_variables['value'][$graph_item_id], $graph, $graph_item);
 
 				if (is_numeric($substitute)) {
 					$graph_variables['value'][$graph_item_id] = $substitute;


### PR DESCRIPTION
[Wed Mar 02 16:29:49.681303 2016] [:error] [pid 48688] [client ] PHP Fatal error:  Call to undefined function rrd_substitute_device_query_data() in lib/rrd.php on line 1958, referer: http:///cacti/graph_view.php?action=tree&filter=&host_id=undefined&columns=2&graphs=10&graph_template_id=undefined&thumbnails=false

And fix for:

[Wed Mar 02 16:44:07.238563 2016] [:error] [pid 49193] [client ] PHP Notice:  Use of undefined constant GRAPH_ITEM_TYPE_TICK - assumed 'GRAPH_ITEM_TYPE_TICK' in /lib/rrd.php on line 1273, referer: http:///cacti/graph_view.php?action=tree&tree_id=1&leaf_id=2&host_group_data=&nodeid=2