### PR TITLE
Attempt to remove ucd-snmp

### DIFF
--- a/lib/snmpagent.php
+++ b/lib/snmpagent.php
@@ -477,9 +477,8 @@ function snmpagent_read($object){
 			$value = db_fetch_cell("SELECT `cacti` FROM `version`");
 			break;
 		case "cactiApplSnmpVersion":
-			$versions = array("net-snmp" => 1, "ucd-snmp" => 2);
 			$snmp_version = read_config_option("snmp_version", true);
-			$value = $versions[$snmp_version];
+			$value = $snmp_version;
 			if(function_exists("snmpget")) {
 				$value = 3;
 			}


### PR DESCRIPTION
Throws error during install:

[Wed Mar 02 17:34:19.867348 2016] [:error] [pid 51152] [client :25624] PHP Notice:  Undefined index:  in /lib/snmpagent.php on line 482, referer: http://cacti/install/index.php