### PR TITLE
Proposal to change default snmp version to 2

### DIFF
--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -345,7 +345,7 @@ $settings = array(
 			'friendly_name' => 'Version',
 			'description' => 'Default SNMP version for all new hosts.',
 			'method' => 'drop_array',
-			'default' => '1',
+			'default' => '2',
 			'array' => $snmp_versions,
 			),
 		'snmp_community' => array(


### PR DESCRIPTION
I think most people will use 2 because of 64 bit counter support.

Can we make it default?