### PR TITLE
fix for automatic device add

### DIFF
--- a/automation_networks.php
+++ b/automation_networks.php
@@ -122,6 +122,7 @@ function api_networks_save($post) {
 
 		$save['enabled']            = (isset($post['enabled']) ? 'on':'');
 		$save['enable_netbios']     = (isset($post['enable_netbios']) ? 'on':'');
+		$save['add_to_cacti']     = (isset($post['add_to_cacti']) ? 'on':'');
 		$save['rerun_data_queries'] = (isset($post['rerun_data_queries']) ? 'on':'');
 
 		/* discovery connectivity settings */

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -2638,9 +2638,9 @@ function automation_add_device ($device, $web = false) {
 	global $plugins, $config;
 
 	$template_id          = $device['host_template'];
-	$snmp_sysName         = preg_split('/[\s.]+/', $device['sysName'], -1, PREG_SPLIT_NO_EMPTY);
+	$snmp_sysName         = preg_split('/[\s.]+/', $device['snmp_sysName'], -1, PREG_SPLIT_NO_EMPTY);
 	$description          = $snmp_sysName[0] != '' ? $snmp_sysName[0] : $device['hostname'];
-	$ip                   = $device['ip'];
+	$ip                   = $device['ip_address'];
 	$community            = $device['community'];
 	$snmp_ver             = $device['snmp_version'];
 	$snmp_username	      = $device['snmp_username'];

--- a/poller_automation.php
+++ b/poller_automation.php
@@ -487,8 +487,8 @@ function discoverDevices($network_id, $thread) {
 							automation_debug(" Responded");
 
 							$fos = automation_find_os($device['snmp_sysDescr'], $device['snmp_sysObjectID'], $device['snmp_sysName']);
-
-							if ($fos != false && read_config_option('add_to_cacti') == 'on') {
+							
+							if ($fos != false && $network['add_to_cacti'] == 'on') {
 								automation_debug(", Template: " . $fos['name']);
 								$device['os']                   = $fos['name'];
 								$device['host_template']        = $fos['host_template'];


### PR DESCRIPTION
automation_networks,  Added add_to_cacti so you can save it in the database

api_automation, fixed some names being wrong

PHP Notice:  Undefined index: sysName in /var/www/html/commit4812/lib/api_automation.php on line 2641
PHP Notice:  Undefined offset: 0 in /var/www/html/commit4812/lib/api_automation.php on line 2642
PHP Notice:  Undefined index: ip in /var/www/html/commit4812/lib/api_automation.php on line 2643

poller_automation.php, changed it read from $network instead of read_config_option. Add_to_cacti is not a global value.

Automatic device addition should now work fine.

