### PR TITLE
minor fix for automation tree

### DIFF
--- a/include/global_form.php
+++ b/include/global_form.php
@@ -2181,7 +2181,6 @@ $fields_automation_tree_rules_edit1 = array(
 		'friendly_name' => __('Tree'),
 		'description' => __('Choose a Tree for the new Tree Items.'),
 		'value' => '|arg1:tree_id|',
-		'on_change' => 'applyTreeChange()',
 		'sql' => 'SELECT id, name FROM graph_tree ORDER BY name'
 	),
 	'leaf_type' => array(


### PR DESCRIPTION
When trying to change a tree automation rule to use a different tree than default it instantly saves, but not the changed value.

onchange=applyTreeChange() causes this.

Works fine now.