### PR TITLE
Proposal to change data sources Data display from B to KB

### DIFF
--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -602,7 +602,7 @@ function get_size($id, $type, $cfs = '') {
 		$cfs  = db_fetch_cell_prepared('SELECT COUNT(*) FROM data_source_profiles_cf WHERE data_source_profile_id = ?', array($id));
 		$rows = get_filter_request_var('rows');
 
-		return number_format($rows * $row * $cfs) . " Bytes per Data Source.";
+		return number_format(($rows * $row * $cfs) / 1000) . " KBytes per Data Source.";
 	}
 }
 

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -597,7 +597,7 @@ function get_size($id, $type, $cfs = '') {
 
 		$rows = db_fetch_cell_prepared('SELECT SUM(rows) FROM data_source_profiles_rra WHERE data_source_profile_id = ?', array($id));
 
-		return number_format($rows * $row * $cfs + $dsheader) . " Bytes per Data Source, and $header Bytes for the Header.";
+		return number_format(($rows * $row * $cfs + $dsheader) / 1000) . " KBytes per Data Source, and $header Bytes for the Header.";
 	}else{
 		$cfs  = db_fetch_cell_prepared('SELECT COUNT(*) FROM data_source_profiles_cf WHERE data_source_profile_id = ?', array($id));
 		$rows = get_filter_request_var('rows');


### PR DESCRIPTION
makes it a bit easier(for me at least) to estimate sizes.

![proposal_kb](https://cloud.githubusercontent.com/assets/16924668/14588322/e51e1e1a-04d7-11e6-95d2-1c53da735948.png)

EDIT:

Also seeing some other bugs, unable to find what causes them:

1. When saving a datasource template with a new datasource profile it only saves the value for one of the DS_RRAs.

Example:

Making "interface traffic" use a new 1 minute poller only saves traffic_in and not traffic_out. To save it you have to go into both of them individually and save. This might be intended but there is no way to see which data profile they use individually.

2. Unable to get one minute poller to work without lots of:

 Poller[0] WARNING: Poller Output Table not Empty. Issues Found: 1, Data Sources: traffic_in(DS[170] Graphs['Localhost - Traffic - lo'])

The really weird thing is that if i add several interfaces at the same time only the first interface will get this error.

Adding:
Ethernet1/1
Ethernet1/2
Ethernet1/3

Only Ethernet1/1 will have this issue. I cant see any differences in the mysqldb.

I'm investigating further, but glad for any input on this.

