### PR TITLE
Allow pinging to IPv6-only hosts

### DIFF
--- a/lib/ping.php
+++ b/lib/ping.php
@@ -164,7 +164,10 @@ class Net_Ping
 				 * ping: cap_set_proc: Permission denied
 				 * as it now tries to open an ICMP socket and fails 
 				 * $result will be empty, then. */
-				$result = shell_exec("ping -W " . ceil($this->timeout/1000) . " -c " . $this->retries . " -p " . $pattern . " " . $this->host["hostname"]);
+				$result = shell_exec("ping -W " . ceil($this->timeout/1000) . " -c " . $this->retries . " -p " . $pattern . " " . $this->host["hostname"] . " 2>&1");
+				if (substr_count($result, "unknown host")) {
+					$result = shell_exec("ping6 -W " . ceil($this->timeout/1000) . " -c " . $this->retries . " -p " . $pattern . " " . $this->host["hostname"]);
+				}
 			}
 
 			if (strtolower(PHP_OS) != "winnt") {

--- a/scripts/ping.pl
+++ b/scripts/ping.pl
@@ -7,9 +7,17 @@ $host =~ s/:[0-9]{1,5}/$1/gis;
 
 # old linux version use "icmp_seq"
 # newer use "icmp_req" instead
-open(PROCESS, "ping -c 1 $host | grep 'icmp_[s|r]eq' | grep time |");
+open(PROCESS, "ping -c 1 $host 2>&1 | grep -E '(icmp_[s|r]eq.*time|unknown host)' |");
 $ping = <PROCESS>;
 close(PROCESS);
+
+if ($ping =~ "unknown host") {
+	open(PROCESS, "ping6 -c 1 $host | grep 'icmp_[s|r]eq.*time' |");
+	$ping = <PROCESS>;
+	close(PROCESS);
+}
+
+$ping = join("\n", grep { /icmp_[s|r]eq.*time/ } split(/\n/, $ping) );
 $ping =~ m/(.*time=)(.*) (ms|usec)/;
 
 if ($2 == "") {


### PR DESCRIPTION
This is a "quick and dirty" patch to allow measuring the latency
to hosts which do not have an IPv4 address, but an IPv6 one only.

If an IPv4 ping fails with an "unknown host" then, with this patch,
cacti will simply retry with the ping6 command.

Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>