### PR TITLE
Attempt at fixing graph template duplication.

### DIFF
--- a/lib/utility.php
+++ b/lib/utility.php
@@ -549,6 +549,11 @@ function duplicate_graph($_local_graph_id, $_graph_template_id, $graph_title) {
 	}
 
 	unset($save);
+	unset($struct_graph['general_header']);
+	unset($struct_graph['scaling_header']);
+	unset($struct_graph['grid_header']);
+	unset($struct_graph['axis_header']);
+	unset($struct_graph['legend_header']);
 	reset($struct_graph);
 
 	/* create new entry: graph_templates_graph */


### PR DESCRIPTION
Graphs duplication throws error:

PHP Notice:  Undefined index: t_general_header in /lib/utility.php on line 564, referer: http://192.168.206.136/cacti/graph_templates.php
PHP Notice:  Undefined index: scaling_header in /lib/utility.php on line 563, referer: http://192.168.206.136/cacti/graph_templates.php
PHP Notice:  Undefined index: t_scaling_header in /lib/utility.php on line 564, referer: http://192.168.206.136/cacti/graph_templates.php
PHP Notice:  Undefined index: grid_header in /lib/utility.php on line 563, referer: http://192.168.206.136/cacti/graph_templates.php
PHP Notice:  Undefined index: t_grid_header in/lib/utility.php on line 564, referer: http://192.168.206.136/cacti/graph_templates.php
PHP Notice:  Undefined index: axis_header in /lib/utility.php on line 563, referer: http://192.168.206.136/cacti/graph_templates.php
PHP Notice:  Undefined index: t_axis_header in /lib/utility.php on line 564, referer: http://192.168.206.136/cacti/graph_templates.php
PHP Notice:  Undefined index: legend_header in /lib/utility.php on line 563, referer: http://192.168.206.136/cacti/graph_templates.php
PHP Notice:  Undefined index: t_legend_header in /lib/utility.php on line 564, referer: http://192.168.206.136/cacti/graph_templates.php
PHP Notice:  Undefined index: t_general_header in/lib/utility.php on line 564, referer: http://192.168.206.136/cacti/graph_templates.php

Fixing by unsetting all headers before we duplicate. We probably shouldn't be reading them in, in the first place?