### PR TITLE
Attempt at fixing automation trees regexp duplication.

### DIFF
--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -1462,8 +1462,8 @@ function duplicate_automation_tree_rules($_id, $_title) {
 		foreach ($rule_items as $rule_item) {
 			$save = $rule_item;
 			/* make sure, that regexp is correctly masked */
-			$save['search_pattern'] = mysql_real_escape_string($rule_item['search_pattern']);
-			$save['replace_pattern'] = mysql_real_escape_string($rule_item['replace_pattern']);
+			$save['search_pattern'] = form_input_validate($rule_item['search_pattern'], 'search_pattern', '', false, 3);
+			$save['replace_pattern'] = form_input_validate($rule_item['replace_pattern'], 'replace_pattern', '', true, 3);
 			$save['id'] = 0;
 			$save['rule_id'] = $rule_id;
 			$rule_item_id = sql_save($save, 'automation_tree_rule_items');


### PR DESCRIPTION
when duplicating a tree rule, the regexp [search pattern, replace_pattern}] strings throws:

 PHP Warning:  mysql_real_escape_string(): Access denied for user 'apache'@'localhost' (u                  sing password: NO) in /var/www/html/commitcommit4868/lib/api_automation.php on line 1465, referer: http://192.168.206.136/cacti/automation_tree_rules.php

Changed to use the same validation as we use when we save them in the first place.