### PR TITLE
Quotes problem using RRDtool 1.4.5 and Windows environment

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1857,9 +1857,9 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					$graph_variables['text_format'][$graph_item_id] = str_replace(':', '\:', $graph_variables['text_format'][$graph_item_id]);
 
 					if ($graph_item['vdef_id'] == '0') {
-						$txt_graph_items .= 'GPRINT:' . $data_source_name . ":AVERAGE:'" . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . "' ";
+						$txt_graph_items .= 'GPRINT:' . $data_source_name . ':AVERAGE:"' . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . '" ';
 					}else{
-						$txt_graph_items .= 'GPRINT:' . $data_source_name . ":'" . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . "' ";
+						$txt_graph_items .= 'GPRINT:' . $data_source_name . ':"' . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . '" ';
 					}
 				}
 
@@ -1869,9 +1869,9 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					$graph_variables['text_format'][$graph_item_id] = str_replace(':', '\:', $graph_variables['text_format'][$graph_item_id]);
 
 					if ($graph_item['vdef_id'] == '0') {
-						$txt_graph_items .= 'GPRINT:' . $data_source_name . ":LAST:'" . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . "' ";
+						$txt_graph_items .= 'GPRINT:' . $data_source_name . ':LAST:"' . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . '" ';
 					}else{
-						$txt_graph_items .= 'GPRINT:' . $data_source_name . ":'" . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . "' ";
+						$txt_graph_items .= 'GPRINT:' . $data_source_name . ':"' . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . '" ';
 					}
 				}
 
@@ -1881,9 +1881,9 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					$graph_variables['text_format'][$graph_item_id] = str_replace(':', '\:', $graph_variables['text_format'][$graph_item_id]);
 
 					if ($graph_item['vdef_id'] == '0') {
-						$txt_graph_items .= 'GPRINT:' . $data_source_name . ":MAX:'" . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . "' ";
+						$txt_graph_items .= 'GPRINT:' . $data_source_name . ':MAX:"' . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . '" ';
 					}else{
-						$txt_graph_items .= 'GPRINT:' . $data_source_name . ":'" . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . "' ";
+						$txt_graph_items .= 'GPRINT:' . $data_source_name . ':"' . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . '" ';
 					}
 				}
 
@@ -1893,9 +1893,9 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					$graph_variables['text_format'][$graph_item_id] = str_replace(':', '\:', $graph_variables['text_format'][$graph_item_id]);
 
 					if ($graph_item['vdef_id'] == '0') {
-						$txt_graph_items .= 'GPRINT:' . $data_source_name . ":MIN:'" . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . "' ";
+						$txt_graph_items .= 'GPRINT:' . $data_source_name . ':MIN:"' . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . '" ';
 					}else{
-						$txt_graph_items .= 'GPRINT:' . $data_source_name . ":'" . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . "' ";
+						$txt_graph_items .= 'GPRINT:' . $data_source_name . ':"' . $graph_variables['text_format'][$graph_item_id] . $graph_item['gprint_text'] . $hardreturn[$graph_item_id] . '" ';
 					}
 				}
 
@@ -1933,7 +1933,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 
 				break;
 			case GRAPH_ITEM_TYPE_LINESTACK:
-				$txt_graph_items .= 'LINE' . $graph_item['line_width'] . ':' . $data_source_name . $graph_item_color_code . ':' . "'" . $graph_variables['text_format'][$graph_item_id] . $hardreturn[$graph_item_id] . "':STACK" . $dash;
+				$txt_graph_items .= 'LINE' . $graph_item['line_width'] . ':' . $data_source_name . $graph_item_color_code . ':"' . $graph_variables['text_format'][$graph_item_id] . $hardreturn[$graph_item_id] . '":STACK' . $dash;
 
 				if ($graph_item['shift'] == CHECKED && $graph_item['value'] > 0) {      # create a SHIFT statement
 					$txt_graph_items .= RRD_NL . 'SHIFT:' . $data_source_name . ':' . $graph_item['value'];
@@ -1942,7 +1942,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 				break;
 			case GRAPH_ITEM_TYPE_TIC:
 				$_fraction = (empty($graph_item['graph_type_id']) ? '' : (':' . $graph_item['value']));
-				$_legend   = (empty($graph_variables['text_format'][$graph_item_id]) ? '' : (':' . "'" . $graph_variables['text_format'][$graph_item_id] . $hardreturn[$graph_item_id] . "'"));
+				$_legend   = (empty($graph_variables['text_format'][$graph_item_id]) ? '' : (':"' . $graph_variables['text_format'][$graph_item_id] . $hardreturn[$graph_item_id] . '"'));
 				$txt_graph_items .= $graph_item_types{$graph_item['graph_type_id']} . ':' . $data_source_name . $graph_item_color_code . $_fraction . $_legend;
 
 				break;
@@ -1956,7 +1956,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					$graph_variables['value'][$graph_item_id] = $substitute;
 				}
 
-				$txt_graph_items .= $graph_item_types{$graph_item['graph_type_id']} . ':' . $graph_variables['value'][$graph_item_id] . $graph_item_color_code . ":'" . $graph_variables['text_format'][$graph_item_id] . $hardreturn[$graph_item_id] . "'" . $dash;
+				$txt_graph_items .= $graph_item_types{$graph_item['graph_type_id']} . ':' . $graph_variables['value'][$graph_item_id] . $graph_item_color_code . ':"' . $graph_variables['text_format'][$graph_item_id] . $hardreturn[$graph_item_id] . '"' . $dash;
 
 				break;
 			case GRAPH_ITEM_TYPE_VRULE:
@@ -1972,7 +1972,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					$value = $graph_item['value'];
 				}
 
-				$txt_graph_items .= $graph_item_types{$graph_item['graph_type_id']} . ':' . $value . $graph_item_color_code . ":'" . $graph_variables['text_format'][$graph_item_id] . $hardreturn[$graph_item_id] . "'" . $dash;
+				$txt_graph_items .= $graph_item_types{$graph_item['graph_type_id']} . ':' . $value . $graph_item_color_code . ':"' . $graph_variables['text_format'][$graph_item_id] . $hardreturn[$graph_item_id] . '"' . $dash;
 
 				break;
 			default:

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1115,8 +1115,6 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 		return 'GRAPH ACCESS DENIED';
 	}
 
-	$version = read_config_option('rrdtool_version');
-	
 	/* check the boost image cache and if we find a live file there return it instead */
 	if (!isset($graph_data_array['export_csv']) && !isset($graph_data_array['export_realtime']) && !isset($graph_data_array['disable_cache'])) {
 		$graph_data = boost_graph_cache_check($local_graph_id, $rra_id, $rrdtool_pipe, $graph_data_array, false);
@@ -2015,6 +2013,11 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 		if (isset($graph_data_array['print_source'])) {
 			print '<PRE>' . htmlspecialchars(read_config_option('path_rrdtool') . ' graph ' . $graph_opts . $graph_defs . $txt_graph_items) . '</PRE>';
 		}else{
+			if (isset($graph_data_array['graphv'])) {
+				$graph = 'graphv';
+			}else{
+				$graph = 'graph';
+			}
 
 			if (isset($graph_data_array['export'])) {
 				rrdtool_execute("graph $graph_opts$graph_defs$txt_graph_items", false, RRDTOOL_OUTPUT_NULL, $rrdtool_pipe);
@@ -2040,19 +2043,8 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 				}else{
 					$output_flag = $graph_data_array['output_flag'];
 				}
-				
-				if (isset($graph_data_array['graphv']) && $version != RRD_VERSION_1_2) {
-					$output = rrdtool_execute("graphv $graph_opts$graph_defs$txt_graph_items", false, $output_flag, $rrdtool_pipe);
-				}elseif (isset($graph_data_array['graphv']) && $version == RRD_VERSION_1_2){
-					// RRD Tool 1.2.x does not support 'graphv' option, do workaround
-					$output2 = rrdtool_execute("graph $graph_opts$graph_defs$txt_graph_items", false, $output_flag, $rrdtool_pipe);
-					
-					$output =         'graph_width = '.$graph_data_array['graph_width']."\r\n".'graph_height = '.$graph_data_array['graph_height']."\r\n";
-					$output = $output.'graph_start = '.$graph_data_array['graph_start']."\r\n".'graph_end = '.$graph_data_array['graph_end']."\r\n";
-					$output = $output.'image = BLOB_SIZE:'.strlen($output2)."\r\n".$output2;
-				}else{
-					$output = rrdtool_execute("graph $graph_opts$graph_defs$txt_graph_items", false, $output_flag, $rrdtool_pipe);
-				}
+
+				$output = rrdtool_execute("$graph $graph_opts$graph_defs$txt_graph_items", false, $output_flag, $rrdtool_pipe);
 
 				boost_graph_set_file($output, $local_graph_id, $rra_id);
 

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -2043,13 +2043,15 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 				
 				if (isset($graph_data_array['graphv']) && $version != RRD_VERSION_1_2) {
 					$output = rrdtool_execute("graphv $graph_opts$graph_defs$txt_graph_items", false, $output_flag, $rrdtool_pipe);
-				}else{
+				}elseif (isset($graph_data_array['graphv']) && $version == RRD_VERSION_1_2){
 					// RRD Tool 1.2.x does not support 'graphv' option, do workaround
 					$output2 = rrdtool_execute("graph $graph_opts$graph_defs$txt_graph_items", false, $output_flag, $rrdtool_pipe);
 					
-					$output =        'graph_width = '.$graph_data_array['graph_width']."\r\n".'graph_height = '.$graph_data_array['graph_height']."\r\n";
+					$output =         'graph_width = '.$graph_data_array['graph_width']."\r\n".'graph_height = '.$graph_data_array['graph_height']."\r\n";
 					$output = $output.'graph_start = '.$graph_data_array['graph_start']."\r\n".'graph_end = '.$graph_data_array['graph_end']."\r\n";
 					$output = $output.'image = BLOB_SIZE:'.strlen($output2)."\r\n".$output2;
+				}else{
+					$output = rrdtool_execute("graph $graph_opts$graph_defs$txt_graph_items", false, $output_flag, $rrdtool_pipe);
 				}
 
 				boost_graph_set_file($output, $local_graph_id, $rra_id);


### PR DESCRIPTION
Quotes " ' " do not work in Windows environment.
Some tags use " ' ", some tags use ' " '.

Windows environment: Windows Server 2008 R2 English

Samples with the problem:

![rrd145_2](https://cloud.githubusercontent.com/assets/10796236/14688456/51e38da8-074b-11e6-992d-4115963f3e8b.png)

![rrd145](https://cloud.githubusercontent.com/assets/10796236/14688329/b95af206-074a-11e6-8033-65eab8577e16.png)
