### PR TITLE
Attempt at fixing rebuild poller cache sql error

### DIFF
--- a/lib/api_data_source.php
+++ b/lib/api_data_source.php
@@ -28,7 +28,7 @@
 function api_data_source_cache_crc_update($poller_id) {
 	$hash = hash('ripemd160', date('Y-m-d H:i:s') . rand() . $poller_id);
 
-	db_execute_prepared("REPLACE INTO settings SET value = ? WHERE name='data_source_cache_crc_$poller_id'", array($hash));
+	db_execute_prepared("REPLACE INTO settings SET value = ?,name='data_source_cache_crc_$poller_id'", array($hash));
 }
 
 function api_data_source_remove($local_data_id) {

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -28,7 +28,7 @@
 function api_device_cache_crc_update($poller_id) {
 	$hash = hash('ripemd160', date('Y-m-d H:i:s') . rand() . $poller_id);
 
-	db_execute_prepared("REPLACE INTO settings SET value = ? WHERE name='device_cache_crc_$poller_id'", array($hash));
+	db_execute_prepared("REPLACE INTO settings SET value = ?, name='device_cache_crc_$poller_id'", array($hash));
 }
 
 /* api_device_remove - removes a device


### PR DESCRIPTION
Throws an sql error. Replace into cannot take a where statement.

05/13/2016 10:18:41 PM - CMDPHP SQL Backtrace: (/utilities.php: 38 repopulate_poller_cache)(/lib/utility.php: 53 api_data_source_cache_crc_update)(/lib/api_data_source.php: 31 db_execute_prepared)(/lib/database.php: 158 cacti_debug_backtrace)
05/13/2016 10:18:41 PM - CMDPHP ERROR: A DB Exec Failed!, Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'WHERE name='data_source_cache_crc_0'' at line 1
05/13/2016 10:18:41 PM - CMDPHP ERROR: A DB Exec Failed!, Error:1064, SQL:"REPLACE INTO settings SET value = ? WHERE name='data_source_cache_crc_0''