### PR TITLE
BUGFIX - Date don't start in realtime

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -785,6 +785,11 @@ function update_host_status($status, $host_id, &$hosts, &$ping, $ping_availabili
 	}
 
 	if ($status == HOST_DOWN) {
+		/* Set initial date down. BUGFIX */
+		if (empty($hosts[$host_id]["status_fail_date"]){
+                    $hosts[$host_id]["status_fail_date"] = date("Y-m-d H:i:s");
+		}
+		    
 		/* update total polls, failed polls and availability */
 		$hosts[$host_id]['failed_polls']++;
 		$hosts[$host_id]['total_polls']++;


### PR DESCRIPTION
PT-BR: Quando um device sai do ar o sistema está carregando a data inicial do sistema. Corrigi o bug para que, quando a data está vazia, ele pega a data do sistema.