### PR TITLE
sql typo

### DIFF
--- a/lib/poller.php
+++ b/lib/poller.php
@@ -385,7 +385,7 @@ function process_poller_output(&$rrdtool_pipe, $remainder = FALSE) {
 	if (!sizeof($rrd_field_names)) {
 		$rrd_field_names = array_rekey(
 			db_fetch_assoc_prepared('SELECT ' . SQL_NO_CACHE . '
-				CONCAT(data_template_id, "_", data_name) AS keyname, data_source_names AS data_source_name
+				CONCAT(data_template_id, "_", data_name) AS keyname, data_source_name
 				FROM poller_data_template_field_mappings'), 
 			'keyname', Array('data_source_name'));
 	}


### PR DESCRIPTION
Fix following error:
```
2016-12-29 01:43:20 - DBCALL ERROR: SQL Assoc Failed!, Error:1054,
SQL:"SELECT SQL_NO_CACHE    CONCAT(data_template_id, "_", data_name) AS
keyname, data_source_names    FROM poller_data_template_field_mappings"
2016-12-29 01:43:20 - DBCALL ERROR: SQL Assoc Failed!, Error: Unknown
column 'data_source_names' in 'field list'
2016-12-29 01:43:20 - CMDPHP SQL Backtrace: (/poller.php: 507
process_poller_output)(/lib/poller.php: 384
db_fetch_assoc_prepared)(/lib/database.php: 348 cacti_debug_backtrace)
```