### PR TITLE
use the decoded value if found

### DIFF
--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -614,7 +614,7 @@ function query_snmp_host($host_id, $snmp_query_id) {
 							}
 							if ($isascii) {
 								query_debug_timer_offset('data_query', "Found OCTET STRING '$parse_value' decoded value: '$decoded'");
-								$value = $decoded;
+								$parse_value = $decoded;
 							}
 						}
 					}


### PR DESCRIPTION
Hi,

Cacti decodes the octet string if an octet string is found in a OID/REGEXP value but it does not use the decoded value. This patch fixes this. 