### PR TITLE
Replace table rows with count

### DIFF
--- a/lib/boost.php
+++ b/lib/boost.php
@@ -557,7 +557,7 @@ function boost_get_arch_table_name() {
 	$tables = db_fetch_assoc("SELECT table_name AS name
 			FROM information_schema.tables
 			WHERE table_schema='$database_default'
-			AND table_name LIKE 'poller_output_boost_arch_%");
+			AND table_name LIKE 'poller_output_boost_arch_%'");
 
 	if (count($tables)) {
 		foreach($tables as $table) {
@@ -630,7 +630,7 @@ function boost_process_poller_output($local_data_id = '', $rrdtool_pipe = '') {
 		$arch_tables = db_fetch_assoc("SELECT table_name AS name
 			FROM information_schema.tables
 			WHERE table_schema='$database_default'
-			AND table_name LIKE 'poller_output_boost_arch_%';");
+			AND table_name LIKE 'poller_output_boost_arch_%'");
 
 		if(count($arch_tables)) {
 			foreach($arch_tables as $table) {
@@ -885,7 +885,7 @@ function boost_process_poller_output($local_data_id = '', $rrdtool_pipe = '') {
 			$tables = db_fetch_assoc("SELECT table_name AS name
 				FROM information_schema.tables
 				WHERE table_schema='$database_default'
-				AND (table_name LIKE 'poller_output_boost_arch_%' OR table_name LIKE 'poller_output_boost';");
+				AND (table_name LIKE 'poller_output_boost_arch_%' OR table_name LIKE 'poller_output_boost'");
 
 			if (count($tables)) {
 				foreach($tables as $table) {

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -885,7 +885,7 @@ function boost_process_poller_output($local_data_id = '', $rrdtool_pipe = '') {
 			$tables = db_fetch_assoc("SELECT table_name AS name
 				FROM information_schema.tables
 				WHERE table_schema='$database_default'
-				AND (table_name LIKE 'poller_output_boost_arch_%' OR table_name LIKE 'poller_output_boost'");
+				AND (table_name LIKE 'poller_output_boost_arch_%' OR table_name LIKE 'poller_output_boost')");
 
 			if (count($tables)) {
 				foreach($tables as $table) {

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -559,12 +559,10 @@ function boost_get_arch_table_name() {
 			WHERE table_schema='$database_default'
 			AND table_name LIKE 'poller_output_boost_arch_%'");
 
-	if (count($tables)) {
-		foreach($tables as $table) {
-			$rows = db_fetch_cell('SELECT count(*) FROM '.$table['name']);
-			if (is_integer($rows) && intval($rows) > 0) {
-				return $table['name'];
-			}
+	foreach($tables as $table) {
+		$rows = db_fetch_cell('SELECT count(*) FROM '.$table['name']);
+		if (is_numeric($rows) && intval($rows) > 0) {
+			return $table['name'];
 		}
 	}
 	return false;
@@ -635,7 +633,7 @@ function boost_process_poller_output($local_data_id = '', $rrdtool_pipe = '') {
 		if(count($arch_tables)) {
 			foreach($arch_tables as $table) {
 				$rows = db_fetch_cell('SELECT count(*) FROM '.$table['name']);
-				if (db_table_exists($table['name']) && is_integer($rows) && intval($rows) > 0) {
+				if (db_table_exists($table['name']) && is_numeric($rows) && intval($rows) > 0) {
 					if (strlen($query_string)) {
 						$query_string .= ' UNION ';
 					}

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -555,9 +555,9 @@ function boost_timer_get_overhead() {
 function boost_get_arch_table_name() {
 	global $database_default;
 	$tables = db_fetch_assoc("SELECT table_name AS name
-			FROM information_schema.tables
-			WHERE table_schema='$database_default'
-			AND table_name LIKE 'poller_output_boost_arch_%'");
+		FROM information_schema.tables
+		WHERE table_schema='$database_default'
+		AND table_name LIKE 'poller_output_boost_arch_%'");
 
 	foreach($tables as $table) {
 		$rows = db_fetch_cell('SELECT count(*) FROM '.$table['name']);

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -182,7 +182,7 @@ function output_rrd_data($start_time, $force = FALSE) {
 	$tables = db_fetch_assoc("SELECT table_name AS name
 		FROM information_schema.tables
 		WHERE table_schema=SCHEMA()
-		AND table_name LIKE 'poller_output_boost_arch_%';");
+		AND table_name LIKE 'poller_output_boost_arch_%'");
 
 	if (count($tables)) {
 	foreach($tables as $table) {

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -132,7 +132,7 @@ function output_rrd_data($start_time, $force = FALSE) {
 		foreach($more_arch_tables as $table) {
 			$table_name = $table['name'];
 			$rows = db_fetch_cell("SELECT count(*) FROM $table_name");
-			if (is_integer($rows) && intval($rows) > 0) {
+			if (is_numeric($rows) && intval($rows) > 0) {
 				db_execute("INSERT INTO $archive_table SELECT * FROM $table_name");
 				db_execute("TRUNCATE TABLE $table_name");
 			}
@@ -187,7 +187,7 @@ function output_rrd_data($start_time, $force = FALSE) {
 	if (count($tables)) {
 	foreach($tables as $table) {
 		$rows = db_fetch_cell('SELECT count(*) FROM '.$table['name']);
-		if (is_integer($rows) && intval($rows) == 0) {
+		if (is_numeric($rows) && intval($rows) == 0) {
 			db_execute('DROP TABLE ' . $table['name']);
 		}
 	}

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -126,14 +126,16 @@ function output_rrd_data($start_time, $force = FALSE) {
 		FROM information_schema.tables
 		WHERE table_schema = ?
 		AND table_name LIKE 'poller_output_boost_arch_%'
-		AND table_name != ?
-		AND table_rows > 0", array($database_default, $archive_table));
+		AND table_name != ?", array($database_default, $archive_table));
 
 	if(count($more_arch_tables)) {
 		foreach($more_arch_tables as $table) {
 			$table_name = $table['name'];
-			db_execute("INSERT INTO $archive_table SELECT * FROM $table_name");
-			db_execute("TRUNCATE TABLE $table_name");
+			$rows = db_fetch_cell("SELECT count(*) FROM $table_name");
+			if (is_integer($rows) && intval($rows) > 0) {
+				db_execute("INSERT INTO $archive_table SELECT * FROM $table_name");
+				db_execute("TRUNCATE TABLE $table_name");
+			}
 		}
 	}
 
@@ -180,12 +182,14 @@ function output_rrd_data($start_time, $force = FALSE) {
 	$tables = db_fetch_assoc("SELECT table_name AS name
 		FROM information_schema.tables
 		WHERE table_schema=SCHEMA()
-		AND table_name LIKE 'poller_output_boost_arch_%'
-		AND table_rows=0;");
+		AND table_name LIKE 'poller_output_boost_arch_%';");
 
 	if (count($tables)) {
 	foreach($tables as $table) {
-		db_execute('DROP TABLE ' . $table['name']);
+		$rows = db_fetch_cell('SELECT count(*) FROM '.$table['name']);
+		if (is_integer($rows) && intval($rows) == 0) {
+			db_execute('DROP TABLE ' . $table['name']);
+		}
 	}
 	}
 	db_execute("SELECT RELEASE_LOCK('poller_boost');");


### PR DESCRIPTION
We were having issues with boost hanging after some time without any apparent reason.

After investigation @rprofijt found that the boost code determines the number of rows in a boost archive table using the table_rows column from the information_schema.tables table. This value was 0 while there were a couple of rows found when doing an actual count(*) on the table.

This is also discussed in the MySQL documentation: https://dev.mysql.com/doc/refman/5.7/en/show-table-status.html

> Rows
> 
> The number of rows. Some storage engines, such as MyISAM, store the exact count. For other storage engines, such as InnoDB, this value is an approximation, and may vary from the actual value by as much as 40 to 50%. In such cases, use SELECT COUNT(*) to obtain an accurate count.
> 

This patch replaces all the usages of table_rows with count(*) on the table.