### PR TITLE
Fixe the first pull request #352

### DIFF
--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -555,32 +555,54 @@ function query_snmp_host($host_id, $snmp_query_id) {
 
 			query_debug_timer_offset('data_query', "Executing SNMP walk for data @ '" . $field_array['oid'] . "'");
 
-			if ($field_array['source'] == 'value') {
-				foreach($snmp_data as $oid => $value) {
-					$snmp_index = preg_replace((isset($field_array['oid_index_parse']) ? '/' . $field_array['oid_index_parse'] . '/' : $index_parse_regexp), "\\1", $oid);
+			if (preg_match('/^VALUE\/TABLE:(.*)/',$field_array["source"],$matches)) {
+				preg_match_all('/([^:]+):([^:]+)/',$matches[1],$match_temp);
+				$const_table = array_combine($match_temp[1],$match_temp[2]);
+			}
 
-					$oid = $field_array['oid'] . ".$snmp_index";
-
-					if ($field_name == 'ifOperStatus') {
-						if ((substr_count(strtolower($value), 'down')) ||
-							($value == '2')) {
-							$value = 'Down';
-						} elseif ((substr_count(strtolower($value), 'up')) ||
-							($value == '1')) {
-							$value = 'Up';
-						} elseif ((substr_count(strtolower($value), 'notpresent')) ||
-							($value == '6')) {
-							$value = 'notPresent';
-						}else{
-							$value = 'Testing';
+			if (preg_match('/^value/i',$field_array["source"])) {
+				foreach ($snmp_data as $oid => $value) {
+					$index_regex = (isset($field_array["oid_index_parse"]) ? $field_array["oid_index_parse"] : $index_parse_regexp) . (isset($field_array["oid_suffix"]) ? ("." . $field_array["oid_suffix"]) : "");
+					if (!preg_match("$index_regex", $oid)) { continue; }
+					$snmp_index = preg_replace("$index_regex","\\1", $oid);
+					$oid = $field_array["oid"] . ".$snmp_index" . (isset($field_array["oid_suffix"]) ? ("." . $field_array["oid_suffix"]) : "");
+					if ($field_name == "ifOperStatus") {
+						switch(true) {
+							case preg_match('/^(down|2)/i',$value):
+								$value = "Down";
+								break;
+							case preg_match('/^(up|1)/i',$value):
+								$value = "Up";
+								break;
+							case preg_match('/^(notpresent|6)/i',$value):
+								$value = "notPresent";
+								break;
+							default:
+								$value = "Testing";
 						}
+						$mode = "value";
+					} elseif (preg_match('/VALUE\/REGEXP:(.*)/',$field_array["source"],$matches)) {
+						$modified_value = preg_replace('/' . $matches[1] . '/', "\\1", $value);
+						$mode = "regexp value parse";
+					} elseif (preg_match('/^VALUE\/TEST:(.*):(.*):(.*)/',$field_array["source"],$matches)) {
+						$modified_value = (strcmp($matches[1],$value) !== 0)?$matches[3]:$matches[2];
+						$mode = "test value parse";
+					} elseif (preg_match('/^VALUE\/TABLE:(.*)/',$field_array["source"])) {
+						$modified_value = (array_key_exists($value,$const_table))?$const_table[$value]:'N/A';
+						$mode = "table value parse";
+					} elseif (preg_match('/^VALUE\/HEX2IP:(\d+):(\d+)/',$field_array["source"],$matches)) {
+						#$modified_value = substr(str_replace(':','',$value),$matches[1],$matches[2]);
+						$modified_value = substr(preg_replace('/(:|HEX-)/','',$value),$matches[1],$matches[2]);
+						$modified_value = implode('.',unpack ("C*",pack("H*", $modified_value)));
+						$mode = "hex2ip value parse";
+					} else {
+						$mode = "value";
 					}
-
-					debug_log_insert('data_query', "Found item [$field_name='$value'] index: $snmp_index [from value]");
-
-					$output_array[] = data_query_format_record($host_id, $snmp_query_id, $field_name, $rewrite_value, $value , $snmp_index, $oid);
+					$output_array[] = data_query_format_record($host_id, $snmp_query_id, $field_name, $rewrite_value, isset($modified_value)?$modified_value:$value , $snmp_index, $oid);
+					debug_log_insert("data_query",sprintf("Found item [%s='%s'] index: %s [from %s]",$field_name,isset($modified_value)?"$modified_value ($value)":$value,$snmp_index,$mode));
+					unset($modified_value);
 				}
-			}elseif (substr($field_array['source'], 0, 11) == 'OID/REGEXP:') {
+			} elseif (substr($field_array['source'], 0, 11) == 'OID/REGEXP:') {
 				foreach($snmp_data as $oid => $value) {
 					$parse_value = preg_replace('/' . str_replace('OID/REGEXP:', '', $field_array['source']) . '/', "\\1", $oid);
 
@@ -624,16 +646,6 @@ function query_snmp_host($host_id, $snmp_query_id) {
 					debug_log_insert('data_query', "Found item [$field_name='$parse_value'] index: $snmp_index [from regexp oid parse]");
 
 					$output_array[] = data_query_format_record($host_id, $snmp_query_id, $field_name, $rewrite_value, $parse_value, $snmp_index, $oid);
-				}
-			}elseif (substr($field_array['source'], 0, 13) == 'VALUE/REGEXP:') {
-				foreach($snmp_data as $oid => $value) {
-					$value = preg_replace('/' . str_replace('VALUE/REGEXP:', '', $field_array['source']) . '/', "\\1", $value);
-					$snmp_index = preg_replace((isset($field_array['oid_index_parse']) ? '/' . $field_array['oid_index_parse'] . '/' : $index_parse_regexp), "\\1", $oid);
-					$oid = $field_array['oid'] . '.' . $snmp_index;
-
-					debug_log_insert('data_query', "Found item [$field_name='$value'] index: $snmp_index [from regexp value parse]");
-
-					$output_array[] = data_query_format_record($host_id, $snmp_query_id, $field_name, $rewrite_value, $value, $snmp_index, $oid);
 				}
 			}
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3113,8 +3113,9 @@ function debug_log_return($type) {
 	}else{
 		if (isset($_SESSION['debug_log'][$type])) {
 			$log_text .= "<table style='width:100%;'>";
-			for ($i=0; $i<count($_SESSION['debug_log'][$type]); $i++) {
-				$log_text .= '<tr><td>' . $_SESSION['debug_log'][$type][$i] . '</td></tr>';
+			foreach($_SESSION['debug_log'][$type] as $key => $val) {
+				$log_text .= "<tr><td>$val</td></tr>\n";
+				unset($_SESSION['debug_log'][$type][$key]);
 			}
 			$log_text .= '</table>';
 		}

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -269,9 +269,9 @@ function update_reindex_cache($host_id, $data_query_id) {
 					$assert_value = $index['field_value'];
 
 					if ($data_query_type == DATA_INPUT_TYPE_SNMP_QUERY) {
-						$recache_stack[] = sprintf("(%d, %d, %s, '=', '%s', '%s.%s','1')",$host_id,$data_query_id,POLLER_ACTION_SNMP,$assert_value,($data_query_xml['fields']{$data_query['sort_field']}['source'] == 'index')?$data_query_xml['oid_index']:$data_query_xml['fields']{$data_query['sort_field']}['oid'],$index['snmp_index']);
+						$recache_stack[] = "(".db_qstr($host_id).", ".db_qstr($data_query_id).", ".POLLER_ACTION_SNMP.", '=', ".db_qstr($assert_value).", ".db_qstr(($data_query_xml['fields']{$data_query['sort_field']}['source'] == 'index')?$data_query_xml['oid_index']:$data_query_xml['fields']{$data_query['sort_field']}['oid'].".".$index['snmp_index']).", '1')";
 					}else if ($data_query_type == DATA_INPUT_TYPE_SCRIPT_QUERY) {
-						$recache_stack[] = "('$host_id', '$data_query_id'," . POLLER_ACTION_SCRIPT . ", '=', '$assert_value', '" . get_script_query_path((isset($data_query_xml['arg_prepend']) ? $data_query_xml['arg_prepend'] . ' ': '') . $data_query_xml['arg_get'] . ' ' . $data_query_xml['fields']{$data_query['sort_field']}['query_name'] . ' ' . $index['snmp_index'], $data_query_xml['script_path'], $host_id) . "', '1')";
+						$recache_stack[] = "(".db_qstr($host_id).", ".db_qstr($data_query_id).", ".POLLER_ACTION_SCRIPT.", '=', ".db_qstr($assert_value).", ".db_qstr(get_script_query_path((isset($data_query_xml['arg_prepend']) ? $data_query_xml['arg_prepend'] . ' ': '') . $data_query_xml['arg_get'] . ' ' . $data_query_xml['fields']{$data_query['sort_field']}['query_name'] . ' ' . $index['snmp_index'], $data_query_xml['script_path'], $host_id)).", '1')";
 					}
 				}
 			}

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -269,7 +269,7 @@ function update_reindex_cache($host_id, $data_query_id) {
 					$assert_value = $index['field_value'];
 
 					if ($data_query_type == DATA_INPUT_TYPE_SNMP_QUERY) {
-						$recache_stack[] = "($host_id, $data_query_id," .  POLLER_ACTION_SNMP . ", '=', '$assert_value', '" . $data_query_xml['fields']{$data_query['sort_field']}['oid'] . '.' . $index['snmp_index'] . "', '1')";
+						$recache_stack[] = sprintf("(%d, %d, %s, '=', '%s', '%s.%s','1')",$host_id,$data_query_id,POLLER_ACTION_SNMP,$assert_value,($data_query_xml['fields']{$data_query['sort_field']}['source'] == 'index')?$data_query_xml['oid_index']:$data_query_xml['fields']{$data_query['sort_field']}['oid'],$index['snmp_index']);
 					}else if ($data_query_type == DATA_INPUT_TYPE_SCRIPT_QUERY) {
 						$recache_stack[] = "('$host_id', '$data_query_id'," . POLLER_ACTION_SCRIPT . ", '=', '$assert_value', '" . get_script_query_path((isset($data_query_xml['arg_prepend']) ? $data_query_xml['arg_prepend'] . ' ': '') . $data_query_xml['arg_get'] . ' ' . $data_query_xml['fields']{$data_query['sort_field']}['query_name'] . ' ' . $index['snmp_index'], $data_query_xml['script_path'], $host_id) . "', '1')";
 					}


### PR DESCRIPTION
New version of the pul request #352.
As indicated in the commit log, I have found the issue:

* in data_query, the $index_revalue has directly the / charatcter, so I don't need to add them in the preg_match function
* in the poller function, if you have a fake index in your XML file, the reindex method return a warning (there is no oid field in a fake index field)