### PR TITLE
Fix undefined variable check for hostInfoHeight

### DIFF
--- a/host.php
+++ b/host.php
@@ -1150,7 +1150,7 @@ function device_javascript() {
 	}
 
 	$(function() {
-		if (hostInfoHeight > 0) {
+		if (typeof hostInfoHeight != "undefined") {
 			if ($(window).scrollTop() == 0) {
 				$('.hostInfoHeader').css('height', '');
 			}else{


### PR DESCRIPTION
Was throwing "Uncaught ReferenceError: hostInfoHeight is not defined" in chrome browser.