### PR TITLE
Try to fix Hex-STRING prefix issue of snmp.php

### DIFF
--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -834,11 +834,11 @@ function format_snmp_string($string, $snmp_oid_included) {
 		}
 
 		$string = $output;
-	}elseif (preg_match('/(hex-string:)/i', $string)) {
+	}elseif (preg_match('/hex-/i', $string)) {
 		$output = '';
 
 		/* strip off the 'Hex-STRING:' */
-		$string = preg_replace('/hex-string: ?/i', '', $string);
+		$string = preg_replace('/hex- ?/i', '', $string);
 
 		/* normalize some forms */
 		$string = str_replace(' ', ':', $string);
@@ -860,7 +860,7 @@ function format_snmp_string($string, $snmp_oid_included) {
 
 				$output .= chr(hexdec($part));
 			} else {
-				$output .= ($output != '' ? ':':'') . $output;
+				$output .= ($output != '' ? ':' : '') . $part;
 			}
 		}
 


### PR DESCRIPTION
After replacing manipulation in line 770, the original string prefix "Hex-STRING: " should be "Hex-".

It may need to remove the remain part "Hex-" from string, because there is no more Hex-"STRING:" in the string.

Another problem is line 863. The last variable in this line should be "$part".