### PR TITLE
Fix typo causing syntax error in classic/main.css

### DIFF
--- a/include/themes/classic/main.css
+++ b/include/themes/classic/main.css
@@ -899,7 +899,7 @@ legend {
 	color: white;
 	font-weight: normal;
 	text-decoration: none;
-	cursor;pointer;
+	cursor: pointer;
 }
 
 .linkOverDark:hover {


### PR DESCRIPTION
The main.css in the classic theme has  a syntax error due to a typo ; i.s.o. :.