### PR TITLE
Fix CSS definition of .deviceUnmonitored: rgba requires 4 arguments

### DIFF
--- a/include/themes/classic/main.css
+++ b/include/themes/classic/main.css
@@ -317,7 +317,7 @@ label {
 }
 
 .deviceUnmonitored {
-	color: rgba(250, 253, 158) !important;
+	color: rgba(250, 253, 158, 0.8) !important;
 }
 
 .deviceWarning {

--- a/include/themes/dark/main.css
+++ b/include/themes/dark/main.css
@@ -319,7 +319,7 @@ label {
 }
 
 .deviceUnmonitored {
-	color: rgba(250, 253, 158) !important;
+	color: rgba(250, 253, 158, 0.8) !important;
 }
 
 .deviceWarning {

--- a/include/themes/modern/main.css
+++ b/include/themes/modern/main.css
@@ -287,7 +287,7 @@ fieldset {
 }
 
 .deviceUnmonitored {
-	color: rgba(250, 253, 158) !important;
+	color: rgba(250, 253, 158, 0.8) !important;
 }
 
 .deviceWarning {

--- a/include/themes/paper-plane/main.css
+++ b/include/themes/paper-plane/main.css
@@ -287,7 +287,7 @@ fieldset {
 }
 
 .deviceUnmonitored {
-	color: rgba(250, 253, 158) !important;
+	color: rgba(250, 253, 158, 0.8) !important;
 }
 
 .deviceWarning {

--- a/include/themes/paw/main.css
+++ b/include/themes/paw/main.css
@@ -270,7 +270,7 @@ fieldset {
 }
 
 .deviceUnmonitored {
-	color: rgba(250, 253, 158) !important;
+	color: rgba(250, 253, 158, 0.8) !important;
 }
 
 .deviceWarning {


### PR DESCRIPTION
Will working on the Debian package, I noticed CSS issues. This one is trivial to fix (albeit I more or less guessed the value of 0.8; please check): when using rgba to specify a color, it requires 4 input arguments.