### PR TITLE
Small optimisations for treeview

### DIFF
--- a/graph_view.php
+++ b/graph_view.php
@@ -49,8 +49,7 @@ function get_matching_nodes() {
 	$filter = '%' . get_nfilter_request_var('str') . '%';
 
 	if (get_nfilter_request_var('str') != '') {
-		$matching = db_fetch_assoc_prepared("SELECT gti.id, gti.parent, 
-			gti.graph_tree_id, IF(gti.title != '', '1', '0') AS node
+		$matching = db_fetch_assoc_prepared("SELECT gti.parent, gti.graph_tree_id
 			FROM graph_tree_items AS gti 
 			LEFT JOIN host AS h
 			ON h.id=gti.host_id
@@ -61,22 +60,18 @@ function get_matching_nodes() {
 			OR h.hostname LIKE ?
 			OR gti.title LIKE ?",
 			array($filter, $filter, $filter, $filter));
-	}else{
-		$matching = db_fetch_assoc("SELECT gti.id, gti.parent, 
-			gti.graph_tree_id, IF(gti.title != '', '1', '0') AS node
-			FROM graph_tree_items AS gti 
-			LEFT JOIN host AS h
-			ON h.id=gti.host_id
-			LEFT JOIN graph_templates_graph AS gtg
-			ON gtg.local_graph_id=gti.local_graph_id AND gtg.local_graph_id>0");
+	} else {
+		$matching = db_fetch_assoc("SELECT parent, graph_tree_id FROM graph_tree_items");
 	}
 
 	if (sizeof($matching)) {
 		foreach($matching as $row) {
 			while ($row['parent'] != '0') {
 				$match[] = 'tbranch-' . $row['parent'];
-				$row = db_fetch_row_prepared('SELECT id, parent, graph_tree_id FROM graph_tree_items WHERE id = ?', array($row['parent']));
-				if (!sizeof($row)) break;
+				$row = db_fetch_row_prepared('SELECT parent, graph_tree_id FROM graph_tree_items WHERE id = ?', array($row['parent']));
+				if (!sizeof($row)) {
+				    break;
+				}
 			}
 
 			if (sizeof($row)) {
@@ -95,7 +90,7 @@ function get_matching_nodes() {
 				if (isset($match[$level])) {
 					if ($level == 0) {
 						$final_array[$match[$level]][$match[$level]] = 1;
-					}else{
+					} else {
 						$final_array[$match[0]][$match[$level]] = 1;
 					}
 					$found++;
@@ -103,10 +98,14 @@ function get_matching_nodes() {
 			}
 			$level++;
 
-			if ($found == 0) break;
+			if ($found == 0) {
+			    break;
+			}
 		}
 
 		if (sizeof($final_array)) {
+			$fa = array();
+
 			foreach($final_array as $key => $matches) {
 				foreach($matches as $branch => $dnc) {
 					$fa[] = $branch;
@@ -131,7 +130,7 @@ case 'ajax_search':
 	exit;
 
 	break;
-case 'update_timepsan':
+case 'update_timespan':
 	// we really don't need to do anything.  The session variables have already been updated
 
 	break;
@@ -561,9 +560,9 @@ case 'list':
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (sizeof($item_rows) > 0) {
-							foreach ($item_rows as $key => $value) {
-								print "<option value='" . $key . "'"; if (get_request_var('rows') == $key) { print ' selected'; } print '>' . $value . "</option>\n";
-							}
+								foreach ($item_rows as $key => $value) {
+									print "<option value='" . $key . "'"; if (get_request_var('rows') == $key) { print ' selected'; } print '>' . $value . "</option>\n";
+								}
 							}
 							?>
 						</select>

--- a/lib/api_tree.php
+++ b/lib/api_tree.php
@@ -314,16 +314,16 @@ function api_tree_delete_node_content($tree_id, $leaf_id) {
 		WHERE graph_tree_id = ? AND parent = ?', array($tree_id, $leaf_id));
 
 	if (sizeof($children)) {
-	foreach($children as $child) {
-		if ($child['host_id'] == 0 && $child['graph_id'] == 0) {
-			api_tree_delete_node_content($tree_id, $child['id']);
-		}
+		foreach($children as $child) {
+			if ($child['host_id'] == 0 && $child['graph_id'] == 0) {
+				api_tree_delete_node_content($tree_id, $child['id']);
+			}
 
-		db_execute_prepared('DELETE 
-			FROM graph_tree_items 
-			WHERE graph_tree_id = ?
-			AND id = ?', array($tree_id, $child['id']));
-	}
+			db_execute_prepared('DELETE 
+				FROM graph_tree_items 
+				WHERE graph_tree_id = ?
+				AND id = ?', array($tree_id, $child['id']));
+		}
 	}
 }
 
@@ -373,10 +373,10 @@ function api_tree_move_node($tree_id, $node_id, $new_parent, $new_position) {
 
 		$position = $new_position + 1;
 		if (sizeof($others)) {
-		foreach($others as $other) {
-			db_execute_prepared('UPDATE graph_tree_items SET position = ? WHERE id = ?', array($position, $other['id']));
-			$position++;
-		}
+			foreach($others as $other) {
+				db_execute_prepared('UPDATE graph_tree_items SET position = ? WHERE id = ?', array($position, $other['id']));
+				$position++;
+			}
 		}
 
 		api_tree_sort_branch($data['leaf_id'], $tree_id);
@@ -395,10 +395,10 @@ function api_tree_move_node($tree_id, $node_id, $new_parent, $new_position) {
 
 		$position = $new_position + 1;
 		if (sizeof($others)) {
-		foreach($others as $other) {
-			db_execute_prepared('UPDATE graph_tree_items SET position = ? WHERE id = ?', array($position, $other['id']));
-			$position++;
-		}
+			foreach($others as $other) {
+				db_execute_prepared('UPDATE graph_tree_items SET position = ? WHERE id = ?', array($position, $other['id']));
+				$position++;
+			}
 		}
 
 		api_tree_sort_branch($data['leaf_id'], $tree_id);
@@ -422,24 +422,24 @@ function api_tree_parse_node_data($variable) {
 		// Process the 'id' variable
 		$ndata   = explode('_', $variable);
 		if (sizeof($ndata)) {
-		foreach($ndata as $data) {
-			list($type, $tid) = explode(':', $data);
+			foreach($ndata as $data) {
+				list($type, $tid) = explode(':', $data);
 
-			/* watch out for monkey business */
-			input_validate_input_number($tid);
+				/* watch out for monkey business */
+				input_validate_input_number($tid);
 
-			switch ($type) {
-				case 'tbranch':
-					$leaf_id  = $tid;
-					break;
-				case 'tgraph':
-					$graph_id = $tid;
-					break;
-				case 'thost':
-					$host_id  = $tid;
-					break;
+				switch ($type) {
+					case 'tbranch':
+						$leaf_id  = $tid;
+						break;
+					case 'tgraph':
+						$graph_id = $tid;
+						break;
+					case 'thost':
+						$host_id  = $tid;
+						break;
+				}
 			}
-		}
 		}
 	}
 
@@ -483,44 +483,38 @@ function api_tree_rename_node($tree_id, $node_id = '', $text = '') {
 		return;
 	}
 
-	$data  = api_tree_parse_node_data($node_id);
-
-	$oname = api_tree_get_branch_name($tree_id, $data['leaf_id']);
-
-	$exists_id = api_tree_branch_exists($tree_id, $data['parent'], $text);
-
 	// Initialize some variables
 	$leaf_id  = 0;
 	$graph_id = 0;
 	$host_id  = 0;
 
 	// Process the 'id' variable
-	$ndata   = explode('_', $node_id);
+	$ndata = explode('_', $node_id);
 	if (sizeof($ndata)) {
-	foreach($ndata as $data) {
-		list($type, $tid) = explode(':', $data);
+		foreach($ndata as $data) {
+			list($type, $tid) = explode(':', $data);
 
-		/* watch out for monkey business */
-		input_validate_input_number($tid);
+			/* watch out for monkey business */
+			input_validate_input_number($tid);
 
-		switch ($type) {
-			case 'tbranch':
-				$leaf_id  = $tid;
-				break;
-			case 'tgraph':
-				$graph_id = $tid;
-				break;
-			case 'thost':
-				$host_id  = $tid;
-				break;
+			switch ($type) {
+				case 'tbranch':
+					$leaf_id  = $tid;
+					break;
+				case 'tgraph':
+					$graph_id = $tid;
+					break;
+				case 'thost':
+					$host_id  = $tid;
+					break;
+			}
 		}
-	}
 	}
 
 	if (isset($leaf_id) && $leaf_id > 0) {
 		if ($host_id > 0 || $graph_id > 0) {
 			// Ignore.  Need to customize context
-		}else{
+		} else {
 			db_execute_prepared('UPDATE graph_tree_items 
 				SET title = ? 
 				WHERE graph_tree_id = ? 
@@ -551,26 +545,26 @@ function api_tree_get_main($tree_id, $parent = 0) {
 			$heirarchy = draw_dhtml_tree_level_graphing($tree_id, $parent);
 
 			if (sizeof($heirarchy)) {
-			foreach($heirarchy as $h) {
-				print $h;
-			}
+				foreach($heirarchy as $h) {
+					print $h;
+				}
 			}
 		}else{
 			$heirarchy = draw_dhtml_tree_level_graphing($tree_id, $parent);
 
 			if (sizeof($heirarchy)) {
-			foreach($heirarchy as $h) {
-				print $h;
-			}
+				foreach($heirarchy as $h) {
+					print $h;
+				}
 			}
 		}
 	}else{
 		$heirarchy = draw_dhtml_tree_level_graphing($tree_id, $parent);
 
 		if (sizeof($heirarchy)) {
-		foreach($heirarchy as $h) {
-			print $h;
-		}
+			foreach($heirarchy as $h) {
+				print $h;
+			}
 		}
 	}
 
@@ -595,9 +589,9 @@ function api_tree_get_node($tree_id, $node_id) {
 	}
 
 	if (sizeof($heirarchy)) {
-	foreach($heirarchy as $h) {
-		print $h;
-	}
+		foreach($heirarchy as $h) {
+			print $h;
+		}
 	}
 }
 
@@ -621,8 +615,6 @@ function api_tree_item_save($id, $tree_id, $type, $parent_tree_item_id, $title, 
 	input_validate_input_number($parent_tree_item_id);
 
 	//api_tree_get_lock('tree-lock', 10);
-
-	$position = db_fetch_cell_prepared('SELECT MAX(position)+1 FROM graph_tree_items WHERE parent = ? AND graph_tree_id = ?', array($parent_tree_item_id, $tree_id));
 
 	if ($local_graph_id > 0) {
 		$exists = db_fetch_cell_prepared('SELECT id FROM graph_tree_items WHERE local_graph_id = ? AND parent = ? AND graph_tree_id = ?', array($local_graph_id, $parent_tree_item_id, $tree_id));
@@ -698,7 +690,7 @@ function naturally_sort_graphs($a, $b) {
  * @arg $leaf_id - the leaf_id of the element
  * @returns - the ordering of the parent leaf/branch */
 function api_tree_get_branch_ordering($leaf_id) {
-	$leaf = db_fetch_row_prepared('SELECT * FROM graph_tree_items WHERE id = ?', array($leaf_id));
+	$leaf = db_fetch_row_prepared('SELECT sort_children_type, parent, graph_tree_id FROM graph_tree_items WHERE id = ?', array($leaf_id));
 
 	if (sizeof($leaf)) {
 		if ($leaf['sort_children_type'] == 0) {

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -774,17 +774,21 @@ function get_allowed_tree_header_graphs($tree_id, $leaf_id = 0, $sql_where = '',
 
 		/* get policies for all groups and user */
 		$policies   = db_fetch_assoc_prepared("SELECT uag.id, 'group' AS type, 
-			policy_graphs, policy_hosts, policy_graph_templates 
+			uag.policy_graphs, uag.policy_hosts, uag.policy_graph_templates 
 			FROM user_auth_group AS uag
 			INNER JOIN user_auth_group_members AS uagm
 			ON uag.id = uagm.group_id
-			WHERE uag.enabled = 'on' AND uagm.user_id = ?", 
-			array($user));
+			WHERE uag.enabled = 'on' 
+			AND uagm.user_id = ?",
+			array($user)
+		);
 
 		$policies[] = db_fetch_row_prepared("SELECT id, 'user' AS type, 
 			policy_graphs, policy_hosts, policy_graph_templates 
-			FROM user_auth WHERE id = ?", 
-			array($user));
+			FROM user_auth 
+			WHERE id = ?",
+			array($user)
+		);
 		
 		foreach($policies as $policy) {
 			if ($policy['policy_graphs'] == 1) {
@@ -940,11 +944,14 @@ function get_allowed_graphs($sql_where = '', $order_by = 'gtg.title_cache', $lim
 
 		/* get policies for all groups and user */
 		$policies   = db_fetch_assoc_prepared("SELECT uag.id, 
-			'group' AS type, policy_graphs, policy_hosts, policy_graph_templates 
+			'group' AS type, uag.policy_graphs, uag.policy_hosts, uag.policy_graph_templates 
 			FROM user_auth_group AS uag
 			INNER JOIN user_auth_group_members AS uagm
 			ON uag.id = uagm.group_id
-			WHERE uag.enabled = 'on' AND uagm.user_id = ?", array($user));
+			WHERE uag.enabled = 'on'
+			AND uagm.user_id = ?",
+			array($user)
+		);
 
 		$policies[] = db_fetch_row_prepared("SELECT id, 'user' AS type, policy_graphs, policy_hosts, policy_graph_templates FROM user_auth WHERE id = ?", array($user));
 		
@@ -1340,7 +1347,7 @@ function get_allowed_devices($sql_where = '', $order_by = 'description', $limit 
 
 		/* get policies for all groups and user */
 		$policies   = db_fetch_assoc_prepared("SELECT uag.id, 'group' AS type, 
-			policy_graphs, policy_hosts, policy_graph_templates 
+			uag.policy_graphs, uag.policy_hosts, uag.policy_graph_templates 
 			FROM user_auth_group AS uag
 			INNER JOIN user_auth_group_members AS uagm
 			ON uag.id = uagm.group_id

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -629,25 +629,26 @@ function get_allowed_tree_level($tree_id, $parent_id, $user = 0) {
 		ON gt.id = gti.graph_tree_id
 		LEFT JOIN host AS h
 		ON h.id = gti.host_id
-		WHERE graph_tree_id = ?
-		AND parent = ?
-		ORDER BY position ASC', array($tree_id, $parent_id));
+		WHERE gti.graph_tree_id = ?
+		AND gti.parent = ?
+		ORDER BY gti.position ASC', array($tree_id, $parent_id)
+	);
 
-	$i     = 0;
+	$i = 0;
 	if (sizeof($items)) {
-	foreach($items as $item) {
-		if ($item['host_id'] > 0) {
-			if (!is_device_allowed($item['host_id'], $user)) {
-				unset($items[$i]);
+		foreach($items as $item) {
+			if ($item['host_id'] > 0) {
+				if (!is_device_allowed($item['host_id'], $user)) {
+					unset($items[$i]);
+				}
+			} elseif($item['local_graph_id'] > 0) {
+				if (!is_graph_allowed($item['local_graph_id'], $user)) {
+					unset($items[$i]);
+				}
 			}
-		}elseif($item['local_graph_id'] > 0) {
-			if (!is_graph_allowed($item['local_graph_id'], $user)) {
-				unset($items[$i]);
-			}
-		}
 
-		$i++;
-	}
+			$i++;
+		}
 	}
 
 	return $items;
@@ -1091,11 +1092,14 @@ function get_allowed_graph_templates($sql_where = '', $order_by = 'name', $limit
 
 		/* get policies for all groups and user */
 		$policies   = db_fetch_assoc_prepared("SELECT uag.id, 
-			'group' AS type, policy_graphs, policy_hosts, policy_graph_templates 
+			'group' AS type, uag.policy_graphs, uag.policy_hosts, uag.policy_graph_templates 
 			FROM user_auth_group AS uag
 			INNER JOIN user_auth_group_members AS uagm
 			ON uag.id = uagm.group_id
-			WHERE uag.enabled = 'on' AND uagm.user_id = ?", array($user));
+			WHERE uag.enabled = 'on'
+			AND uagm.user_id = ?",
+			array($user)
+		);
 
 		$policies[] = db_fetch_row_prepared("SELECT id, 'user' AS type, policy_graphs, policy_hosts, policy_graph_templates FROM user_auth WHERE id = ?", array($user));
 		
@@ -1524,9 +1528,9 @@ function get_allowed_ajax_hosts($include_any = true, $include_none = true, $sql_
 	}
 
 	if (sizeof($hosts)) {
-	foreach($hosts as $host) {
-		$return[] = array('label' => $host['description'], 'value' => $host['description'], 'id' => $host['id']);
-	}
+		foreach($hosts as $host) {
+			$return[] = array('label' => $host['description'], 'value' => $host['description'], 'id' => $host['id']);
+		}
 	}
 
 	print json_encode($return);

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -408,12 +408,14 @@ function draw_dhtml_tree_level_graphing($tree_id, $parent = 0) {
 								foreach ($data_queries as $data_query) {
 									if ($data_query['id'] == 0) {
 										$non_template_graphs = $ntg;
+										$sort_field_data     = array();
 									} else {
 										$non_template_graphs = array();
+
+										/* fetch a list of field names that are sorted by the preferred sort field */
+										$sort_field_data     = get_formatted_data_query_indexes($leaf['host_id'], $data_query['id']);
 									}
 
-									/* fetch a list of field names that are sorted by the preferred sort field */
-									$sort_field_data = get_formatted_data_query_indexes($leaf['host_id'], $data_query['id']);
 									if (($data_query['id'] == 0 && sizeof($non_template_graphs)) ||
 										($data_query['id'] > 0 && sizeof($sort_field_data) > 0)
 									) {

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -285,7 +285,7 @@ function get_tree_path() {
 
 			$linknode = db_fetch_row_prepared('SELECT * 
 				FROM graph_tree_items 
-				WHERE id = ?', 
+				WHERE id = ?',
 				array($node));
 
 			if (sizeof($linknode)) {
@@ -362,7 +362,7 @@ function draw_dhtml_tree_level($tree_id, $parent = 0, $graphing = false) {
 	return $dhtml_tree;
 }
 
-function draw_dhtml_tree_level_graphing($tree_id, $parent = 0, $export = false) {
+function draw_dhtml_tree_level_graphing($tree_id, $parent = 0) {
 	global $config;
 
 	include_once($config['base_path'] . '/lib/data_query.php');
@@ -388,7 +388,7 @@ function draw_dhtml_tree_level_graphing($tree_id, $parent = 0, $export = false) 
 									$dhtml_tree[] = "\t\t\t\t\t\t<li id='tbranch-" . $leaf['id'] . "-gt-" . $graph_template['id'] . "' data-jstree='{ \"type\" : \"graph_template\" }'><a href='" . htmlspecialchars('graph_view.php?action=tree&node=tbranch-' . $leaf['id'] . '&hgd=gt:' . $graph_template['id']) . "'>" . htmlspecialchars($graph_template['name']) . "</a></li>\n";
 								}
 							}
-						}else if ($leaf['host_grouping_type'] == HOST_GROUPING_DATA_QUERY_INDEX) {
+						} elseif ($leaf['host_grouping_type'] == HOST_GROUPING_DATA_QUERY_INDEX) {
 							$data_queries = db_fetch_assoc_prepared('SELECT sq.id, sq.name
 								FROM graph_local AS gl
 								INNER JOIN snmp_query AS sq
@@ -403,20 +403,23 @@ function draw_dhtml_tree_level_graphing($tree_id, $parent = 0, $export = false) 
 							));
 
 							if (sizeof($data_queries)) {
+								$ntg = get_allowed_graphs('gl.host_id=' . $leaf['host_id'] . ' AND gl.snmp_query_id=0');
+
 								foreach ($data_queries as $data_query) {
+									if ($data_query['id'] == 0) {
+										$non_template_graphs = $ntg;
+									} else {
+										$non_template_graphs = array();
+									}
+
 									/* fetch a list of field names that are sorted by the preferred sort field */
 									$sort_field_data = get_formatted_data_query_indexes($leaf['host_id'], $data_query['id']);
-									if ($data_query['id'] == 0) {
-										$non_template_graphs = get_allowed_graphs('gl.host_id=' . $leaf['host_id'] . ' AND gl.snmp_query_id=0');
-									}else{
-										$non_template_graphs = 0;
-									}
-	
-									if ((($data_query['id'] == 0) && (sizeof($non_template_graphs))) ||
-										(($data_query['id'] > 0) && (sizeof($sort_field_data) > 0))) {
+									if (($data_query['id'] == 0 && sizeof($non_template_graphs)) ||
+										($data_query['id'] > 0 && sizeof($sort_field_data) > 0)
+									) {
 										if ($data_query['name'] != 'Non Query Based') {
 											$dhtml_tree[] = "\t\t\t\t\t\t<li id='tbranch-" . $leaf['id'] . "-dq-" . $data_query['id'] . "' data-jstree='{ \"type\" : \"data_query\" }'><a class='treepick' href=\"" . htmlspecialchars('graph_view.php?action=tree&node=tbranch-' . $leaf['id'] . "&hgd=dq:" . $data_query['id']) . '">' . htmlspecialchars($data_query['name']) . "</a>\n";
-										}else{
+										} else {
 											$dhtml_tree[] = "\t\t\t\t\t\t<li id='tbranch-" . $leaf['id'] . '-dq-' . $data_query['id'] . "' data-jstree='{ \"type\" : \"data_query\" }'><a class='treepick' href=\"" . htmlspecialchars('graph_view.php?action=tree&node=tbranch-' . $leaf['id'] . "&hgd=dq:" . $data_query['id']) . '">' . htmlspecialchars($data_query['name']) . "</a>\n";
 										}
 
@@ -440,7 +443,7 @@ function draw_dhtml_tree_level_graphing($tree_id, $parent = 0, $export = false) 
 					}
 	
 					$dhtml_tree[] = "\t\t\t\t</li>\n";
-				}else{ //It's not a host
+				} else { //It's not a host
 					$children = db_fetch_cell_prepared('SELECT COUNT(*) FROM graph_tree_items WHERE parent = ? AND local_graph_id=0', array($leaf['id']));
 
 					$dhtml_tree[] = "\t\t\t\t<li id='tbranch-" . $leaf['id'] . "' " . ($children > 0 ? "class='jstree-closed'":"") . "><a href=\"" . htmlspecialchars('graph_view.php?action=tree&node=tbranch-' . $leaf['id'] . '&hgd=') . '">' . htmlspecialchars($leaf['title']) . "</a></li>\n";
@@ -448,7 +451,7 @@ function draw_dhtml_tree_level_graphing($tree_id, $parent = 0, $export = false) 
 			}
 	
 			$dhtml_tree[] = "\t\t\t</ul>\n";
-		}else{
+		} else {
 			$dhtml_tree[] = "<ul>\n";
 			foreach($heirarchy as $h) {
 				$dhtml_tree[] = "<li id='tree_anchor-" . $h['tree_id'] . "' data-jstree='{ \"type\" : \"tree\" }' class='jstree-closed'><a href='" . htmlspecialchars('graph_view.php?action=tree&node=tree_anchor-' . $h['tree_id'] . '&hgd=') . "'>" . htmlspecialchars($h['title']) . "</a></li>\n";
@@ -660,9 +663,9 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 						<select id='graphs' onChange='applyGraphFilter()'>
 							<?php
 							if (sizeof($graphs_per_page) > 0) {
-							foreach ($graphs_per_page as $key => $value) {
-								print "<option value='" . $key . "'"; if (get_request_var('graphs') == $key) { print ' selected'; } print '>' . $value . "</option>\n";
-							}
+								foreach ($graphs_per_page as $key => $value) {
+									print "<option value='" . $key . "'"; if (get_request_var('graphs') == $key) { print ' selected'; } print '>' . $value . "</option>\n";
+								}
 							}
 							?>
 						</select>


### PR DESCRIPTION
All files:
- fixed several alignment issues

api_tree.php
- api_tree_rename_node() Removed 3 unused methodcalls
- api_tree_item_save() removed unused query
- api_tree_get_branch_ordering() defined fields in query

auth.php:
- defined tablenames for fields

html_tree.php
- draw_dhtml_tree_level_graphing()
  - removed unused parameter
  - moved get_allowed_graphs() call out of the foreach()
  - get_formatted_data_query_indexes() only needs to be called if $data_query['id'] > 0

graph_view.php
- simplified the $matched queries
- typo in "update_timepsan" => "update_timespan"