### PR TITLE
RRD optimisations

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1149,23 +1149,26 @@ function get_full_script_path($local_data_id) {
    @arg $data_template_rrd_id - (int) the ID of the data source item
    @returns - the name of the data source item or an empty string for an error */
 function get_data_source_item_name($data_template_rrd_id) {
-	if (empty($data_template_rrd_id)) { return ''; }
+	if (empty($data_template_rrd_id)) {
+		return '';
+	}
 
 	$data_source = db_fetch_row_prepared('SELECT ' . SQL_NO_CACHE . '
 		data_template_rrd.data_source_name,
 		data_template_data.name
-		FROM (data_template_rrd, data_template_data)
-		WHERE data_template_rrd.local_data_id = data_template_data.local_data_id
-		AND data_template_rrd.id = ?', array($data_template_rrd_id));
+		FROM data_template_rrd
+		INNER JOIN data_template_data ON data_template_rrd.local_data_id = data_template_data.local_data_id
+		WHERE data_template_rrd.id = ?', array($data_template_rrd_id)
+	);
 
 	/* use the cacti ds name by default or the user defined one, if entered */
 	if (empty($data_source['data_source_name'])) {
 		/* limit input to 19 characters */
 		$data_source_name = clean_up_name($data_source['name']);
-		$data_source_name = substr(strtolower($data_source_name),0,(19-strlen($data_template_rrd_id))) . $data_template_rrd_id;
+		$data_source_name = substr(strtolower($data_source_name), 0, (19-strlen($data_template_rrd_id))) . $data_template_rrd_id;
 
 		return $data_source_name;
-	}else{
+	} else {
 		return $data_source['data_source_name'];
 	}
 }

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -644,10 +644,14 @@ function rrdtool_function_update($update_cache_array, $rrdtool_pipe = '') {
 					$rrd_update_values = $update_time . ':';
 				}
 
-				$i = 0;
 				$rrd_update_template = '';
 
 				foreach ($field_array as $field_name => $value) {
+					if ($rrd_update_template != '') {
+						$rrd_update_template .= ':';
+						$rrd_update_values .= ':';
+					}
+
 					$rrd_update_template .= $field_name;
 
 					/* if we have "invalid data", give rrdtool an Unknown (U) */
@@ -656,13 +660,6 @@ function rrdtool_function_update($update_cache_array, $rrdtool_pipe = '') {
 					}
 
 					$rrd_update_values .= $value;
-
-					if ($i+1 < count($field_array)) {
-						$rrd_update_template .= ':';
-						$rrd_update_values .= ':';
-					}
-
-					$i++;
 				}
 
 				rrdtool_execute("update $rrd_path --template $rrd_update_template $rrd_update_values", true, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'POLLER');

--- a/lib/variables.php
+++ b/lib/variables.php
@@ -119,8 +119,6 @@ function update_graph_title_cache($local_graph_id) {
    @arg $string - the string to clean out unsubstituted variables for
    @returns - the cleaned up string */
 function null_out_substitutions($string) {
-	global $regexps;
-
 	return preg_replace("/\|host_" . VALID_HOST_FIELDS . "\|( - )?/i", '', $string);
 }
 


### PR DESCRIPTION
- Added missing globals
- Removed unused globals
- Optimised rrdtool_function_create() by moving queries and a function call out of the foreach()
- Optimised rrdtool_cacti_compare() by moving queries and a function call out of the foreach()
- Fixed small bug (== instead of =) in rrdtool_cacti_compare()
- Fixed parameters in html_header() calls. Function accepts only 2 parameters (4 given).
- Optimised rrdtool_function_update()

Also, the following functions are not doing anything and are not used in the Cacti code (maybe reports or plugins?). I'm unsure if they can be removed.
- rrd_check()
- rrd_repair()