### PR TITLE
Host optimisations

### DIFF
--- a/cacti.sql
+++ b/cacti.sql
@@ -233,7 +233,7 @@ CREATE TABLE `automation_graph_rules` (
   `graph_type_id` smallint(3) unsigned NOT NULL DEFAULT '0',
   `enabled` char(2) DEFAULT '',
   PRIMARY KEY (`id`),
-  KEY `name` (`name`)
+  KEY `name` (`name`(171))
 ) ENGINE=InnoDB AUTO_INCREMENT=5 COMMENT='Automation Graph Rules';
 
 --
@@ -445,7 +445,7 @@ CREATE TABLE `automation_tree_rules` (
   `host_grouping_type` smallint(3) unsigned NOT NULL DEFAULT '0',
   `enabled` char(2) DEFAULT '',
   PRIMARY KEY (`id`),
-  KEY `name` (`name`)
+  KEY `name` (`name`(171))
 ) ENGINE=InnoDB AUTO_INCREMENT=4 COMMENT='Automation Tree Rules';
 
 --
@@ -465,7 +465,7 @@ CREATE TABLE cdef (
   name varchar(255) NOT NULL default '',
   PRIMARY KEY (id),
   KEY `hash` (`hash`),
-  KEY `name` (`name`)
+  KEY `name` (`name`(171))
 ) ENGINE=InnoDB;
 
 --
@@ -1057,7 +1057,7 @@ CREATE TABLE data_input (
   input_string varchar(512) default NULL,
   type_id tinyint(2) NOT NULL default '0',
   PRIMARY KEY (id),
-  KEY `name_type_id` (`name`, `type_id`)
+  KEY `name_type_id` (`name`(171), `type_id`)
 ) ENGINE=InnoDB;
 
 --
@@ -1251,7 +1251,7 @@ CREATE TABLE `data_source_profiles` (
   `x_files_factor` double DEFAULT '0.5',
   `default` char(2) DEFAULT '',
   PRIMARY KEY (`id`),
-  KEY `name` (`name`)
+  KEY `name` (`name`(171))
 ) ENGINE=InnoDB COMMENT='Stores Data Source Profiles';
 
 --
@@ -1584,8 +1584,8 @@ CREATE TABLE graph_templates (
   `name` char(255) NOT NULL default '',
   `multiple` char(2) NOT NULL default '',
   PRIMARY KEY (`id`),
-  KEY `multiple_name` (`multiple`, `name`),
-  KEY `name` (`name`)
+  KEY `multiple_name` (`multiple`, `name`(171)),
+  KEY `name` (`name`(171))
 ) ENGINE=InnoDB COMMENT='Contains each graph template name.';
 
 --
@@ -1750,7 +1750,7 @@ CREATE TABLE graph_tree (
   modified_by int(10) unsigned DEFAULT '1',
   PRIMARY KEY (id),
   KEY `sequence` (`sequence`),
-  KEY `name` (`name`)
+  KEY `name` (`name`(171))
 ) ENGINE=InnoDB;
 
 --
@@ -2870,7 +2870,7 @@ CREATE TABLE vdef (
   name varchar(255) NOT NULL default '',
   PRIMARY KEY (id),
   KEY `hash` (`hash`),
-  KEY `name` (`name`)
+  KEY `name` (`name`(171))
 ) ENGINE=InnoDB COMMENT='vdef';
 
 --

--- a/cacti.sql
+++ b/cacti.sql
@@ -232,7 +232,8 @@ CREATE TABLE `automation_graph_rules` (
   `snmp_query_id` smallint(3) unsigned NOT NULL DEFAULT '0',
   `graph_type_id` smallint(3) unsigned NOT NULL DEFAULT '0',
   `enabled` char(2) DEFAULT '',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=5 COMMENT='Automation Graph Rules';
 
 --
@@ -443,7 +444,8 @@ CREATE TABLE `automation_tree_rules` (
   `leaf_type` smallint(3) unsigned NOT NULL DEFAULT '0',
   `host_grouping_type` smallint(3) unsigned NOT NULL DEFAULT '0',
   `enabled` char(2) DEFAULT '',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 COMMENT='Automation Tree Rules';
 
 --
@@ -462,7 +464,8 @@ CREATE TABLE cdef (
   system mediumint(8) unsigned NOT NULL DEFAULT '0',
   name varchar(255) NOT NULL default '',
   PRIMARY KEY (id),
-  KEY `hash` (`hash`)
+  KEY `hash` (`hash`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB;
 
 --
@@ -1053,7 +1056,8 @@ CREATE TABLE data_input (
   name varchar(200) NOT NULL default '',
   input_string varchar(512) default NULL,
   type_id tinyint(2) NOT NULL default '0',
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  KEY `name_type_id` (`name`, `type_id`)
 ) ENGINE=InnoDB;
 
 --
@@ -1246,7 +1250,8 @@ CREATE TABLE `data_source_profiles` (
   `heartbeat` int(10) unsigned NOT NULL DEFAULT '600',
   `x_files_factor` double DEFAULT '0.5',
   `default` char(2) DEFAULT '',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB COMMENT='Stores Data Source Profiles';
 
 --
@@ -1431,7 +1436,8 @@ CREATE TABLE data_template (
   id mediumint(8) unsigned NOT NULL auto_increment,
   hash varchar(32) NOT NULL default '',
   name varchar(150) NOT NULL default '',
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB;
 
 --
@@ -1578,7 +1584,8 @@ CREATE TABLE graph_templates (
   `name` char(255) NOT NULL default '',
   `multiple` char(2) NOT NULL default '',
   PRIMARY KEY (`id`),
-  KEY `multiple_name` (`multiple`, `name`)
+  KEY `multiple_name` (`multiple`, `name`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB COMMENT='Contains each graph template name.';
 
 --
@@ -1594,7 +1601,8 @@ CREATE TABLE graph_templates_gprint (
   hash varchar(32) NOT NULL default '',
   name varchar(100) NOT NULL default '',
   gprint_text varchar(255) default NULL,
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB;
 
 --
@@ -1741,7 +1749,8 @@ CREATE TABLE graph_tree (
   last_modified timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   modified_by int(10) unsigned DEFAULT '1',
   PRIMARY KEY (id),
-  KEY sequence(sequence)
+  KEY `sequence` (`sequence`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB;
 
 --
@@ -1908,7 +1917,8 @@ CREATE TABLE host_template (
   id mediumint(8) unsigned NOT NULL auto_increment,
   hash varchar(32) NOT NULL default '',
   name varchar(100) NOT NULL default '',
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB;
 
 --
@@ -2033,7 +2043,8 @@ CREATE TABLE `poller` (
   `server` mediumint(8) unsigned DEFAULT '0',
   `last_update` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   `last_status` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`)
 ) ENGINE=InnoDB COMMENT='Pollers for Cacti';
 
 INSERT INTO poller (id,name,hostname) VALUES (1,'Main Poller', 'localhost');
@@ -2344,7 +2355,8 @@ CREATE TABLE snmp_query_graph (
   name varchar(100) NOT NULL default '',
   graph_template_id mediumint(8) unsigned NOT NULL default '0',
   PRIMARY KEY (id),
-  KEY `graph_template_id_name` (`graph_template_id`, `name`)
+  KEY `graph_template_id_name` (`graph_template_id`, `name`),
+  KEY `snmp_query_id_name` (`snmp_query_id`, `name`)
 ) ENGINE=InnoDB;
 
 --
@@ -2857,7 +2869,8 @@ CREATE TABLE vdef (
   hash varchar(32) NOT NULL default '',
   name varchar(255) NOT NULL default '',
   PRIMARY KEY (id),
-  KEY `hash` (`hash`)
+  KEY `hash` (`hash`),
+  ADD INDEX `name` (`name`)
 ) ENGINE=InnoDB COMMENT='vdef';
 
 --

--- a/cacti.sql
+++ b/cacti.sql
@@ -2870,7 +2870,7 @@ CREATE TABLE vdef (
   name varchar(255) NOT NULL default '',
   PRIMARY KEY (id),
   KEY `hash` (`hash`),
-  ADD INDEX `name` (`name`)
+  KEY `name` (`name`)
 ) ENGINE=InnoDB COMMENT='vdef';
 
 --

--- a/include/global_form.php
+++ b/include/global_form.php
@@ -384,7 +384,7 @@ $struct_data_source = array(
 	'data_input_id' => array(
 		'friendly_name' => __('Data Input Method'),
 		'method' => 'drop_sql',
-		'sql' => 'SELECT id,name FROM data_input ORDER BY name',
+		'sql' => 'SELECT id, name FROM data_input ORDER BY name',
 		'default' => '',
 		'none_value' => __('None'),
 		'description' => __('The script/source used to gather data for this data source.'),
@@ -707,7 +707,7 @@ $struct_graph = array(
 	'right_axis_format' => array(
 		'friendly_name' => __('Right Axis Format (--right-axis-format &lt;format&gt;)'),
 		'method' => 'drop_sql',
-		'sql' => 'select id,name from graph_templates_gprint order by name',
+		'sql' => 'SELECT id, name FROM graph_templates_gprint ORDER BY name',
 		'default' => '',
 		'none_value' => __('None'),
 		'description' => __('By default, the format of the axis labels gets determined automatically. 
@@ -832,7 +832,7 @@ $struct_graph_item = array(
 	'cdef_id' => array(
 		'friendly_name' => __('CDEF Function'),
 		'method' => 'drop_sql',
-		'sql' => 'SELECT id,name FROM cdef ORDER BY name',
+		'sql' => 'SELECT id, name FROM cdef ORDER BY name',
 		'default' => '0',
 		'none_value' => __('None'),
 		'description' => __('A CDEF (math) function to apply to this item on the graph or legend.')
@@ -864,7 +864,7 @@ $struct_graph_item = array(
 	'gprint_id' => array(
 		'friendly_name' => __('GPRINT Type'),
 		'method' => 'drop_sql',
-		'sql' => 'SELECT id,name FROM graph_templates_gprint ORDER BY name',
+		'sql' => 'SELECT id, name FROM graph_templates_gprint ORDER BY name',
 		'default' => '2',
 		'description' => __('If this graph item is a GPRINT, you can optionally choose another format
 			here. You can define additional types under "GPRINT Presets".')
@@ -1031,7 +1031,7 @@ $fields_host_edit = array(
 		'value' => '|arg1:site_id|',
 		'none_value' => __('None'),
 		'default' => read_config_option('default_site'),
-		'sql' => 'SELECT id,name FROM sites ORDER BY name',
+		'sql' => 'SELECT id, name FROM sites ORDER BY name',
 		),
 	'host_template_id' => array(
 		'method' => 'drop_sql',
@@ -1039,7 +1039,7 @@ $fields_host_edit = array(
 		'description' => __('Choose the Device Template to use to define the default Graph Templates and Data Queries associated with this Device.'),
 		'value' => '|arg1:host_template_id|',
 		'none_value' => __('None'),
-		'sql' => 'SELECT id,name FROM host_template ORDER BY name',
+		'sql' => 'SELECT id, name FROM host_template ORDER BY name',
 		),
 	'device_threads' => array(
 		'method' => 'drop_array',
@@ -1304,7 +1304,7 @@ $fields_data_query_edit = array(
 		'friendly_name' => __('Data Input Method'),
 		'description' => __('Choose the input method for this Data Query.  This input method defines how data is collected for each Device associated with the Data Query.'),
 		'value' => '|arg1:data_input_id|',
-		'sql' => 'SELECT id,name FROM data_input WHERE type_id IN(3,4,6) ORDER BY name',
+		'sql' => 'SELECT id, name FROM data_input WHERE type_id IN(3,4,6) ORDER BY name',
 		),
 	'id' => array(
 		'method' => 'hidden_zero',
@@ -1323,23 +1323,26 @@ $fields_data_query_item_edit = array(
 		'friendly_name' => __('Graph Template'),
 		'description' => __('Choose the Graph Template to use for this Data Query Graph Template item.'),
 		'value' => '|arg1:graph_template_id|',
-		'sql' => 'SELECT DISTINCT gt.id, gt.name
+		'sql' => 'SELECT gt.id, gt.name
 			FROM graph_templates AS gt
-			INNER JOIN graph_templates_graph AS gtg
-			ON gt.id=gtg.graph_template_id
-			AND gtg.local_graph_id=0
-			INNER JOIN graph_templates_item AS gti
-			ON gtg.graph_template_id=gti.graph_template_id
-			AND gti.local_graph_id=0
-			INNER JOIN data_template_rrd AS dtr
-			ON gti.task_item_id=dtr.id
-			AND dtr.local_data_id=0
-			INNER JOIN data_template_data AS dtd
-			ON dtd.data_template_id=dtr.data_template_id
-			AND dtd.local_data_id=0
-			INNER JOIN data_input AS di
-			ON di.id=dtd.data_input_id
-			WHERE di.id in (2,11,12) ORDER BY gt.name',
+			WHERE gt.id IN(
+				SELECT gtg.graph_template_id 
+				FROM graph_templates_graph AS gtg 
+				INNER JOIN graph_templates_item AS gti
+				ON gtg.graph_template_id=gti.graph_template_id 
+				AND gti.local_graph_id = 0
+				INNER JOIN data_template_rrd AS dtr
+				ON gti.task_item_id=dtr.id
+				AND dtr.local_data_id = 0
+				INNER JOIN data_template_data AS dtd
+				ON dtd.data_template_id=dtr.data_template_id 
+				AND dtd.local_data_id = 0
+				INNER JOIN data_input AS di
+				ON di.id = dtd.data_input_id
+				WHERE di.id in (2, 11, 12) 
+				ORDER BY gt.name 
+			)
+			ORDER BY gt.name',
 		),
 	'name' => array(
 		'method' => 'textbox',
@@ -1542,22 +1545,22 @@ $export_types = array(
 	'host_template' => array(
 		'name' => __('Device Template'),
 		'title_sql' => 'SELECT name FROM host_template WHERE id=|id|',
-		'dropdown_sql' => 'SELECT id,name FROM host_template ORDER BY name'
+		'dropdown_sql' => 'SELECT id, name FROM host_template ORDER BY name'
 		),
 	'graph_template' => array(
 		'name' => __('Graph Template'),
 		'title_sql' => 'SELECT name FROM graph_templates WHERE id=|id|',
-		'dropdown_sql' => 'SELECT id,name FROM graph_templates ORDER BY name'
+		'dropdown_sql' => 'SELECT id, name FROM graph_templates ORDER BY name'
 		),
 	'data_template' => array(
 		'name' => __('Data Template'),
 		'title_sql' => 'SELECT name FROM data_template WHERE id=|id|',
-		'dropdown_sql' => 'SELECT id,name FROM data_template ORDER BY name'
+		'dropdown_sql' => 'SELECT id, name FROM data_template ORDER BY name'
 		),
 	'data_query' => array(
 		'name' => __('Data Query'),
 		'title_sql' => 'SELECT name FROM snmp_query WHERE id=|id|',
-		'dropdown_sql' => 'SELECT id,name FROM snmp_query ORDER BY name'
+		'dropdown_sql' => 'SELECT id, name FROM snmp_query ORDER BY name'
 		),
 	'automation_devices' => array(
 		'name' => __('Discovery Rules'),
@@ -1610,7 +1613,7 @@ $fields_template_import = array(
 		'friendly_name' => __('Data Source Profile'),
 		'method' => 'drop_sql',
 		'description' => __('Select the Data Source Profile.  The Data Source Profile controls polling interval, the data aggregation, and retention policy for the resulting Data Sources.'),
-		'sql' => "SELECT * FROM (SELECT '0' AS id, 'Create New From Template' AS name UNION SELECT id, name FROM data_source_profiles ORDER BY name) AS rs",
+		'sql' => "SELECT '0' AS id, 'Create New From Template' AS name UNION SELECT id, name FROM data_source_profiles ORDER BY name",
 		'value' => '',
 		'default' => '1'
 		),
@@ -2189,8 +2192,6 @@ $fields_automation_graph_rules_edit2 = array(
 			'snmp_query_graph.id, ' .
 			'snmp_query_graph.name ' .
 			'FROM snmp_query_graph ' .
-			'LEFT JOIN graph_templates ' .
-			'ON (snmp_query_graph.graph_template_id=graph_templates.id) ' .
 			'WHERE snmp_query_graph.snmp_query_id=|arg1:snmp_query_id| ' .
 			'ORDER BY snmp_query_graph.name'
 	)

--- a/install/upgrades/1_1_6.php
+++ b/install/upgrades/1_1_6.php
@@ -27,9 +27,15 @@ function upgrade_to_1_1_6() {
 		MODIFY COLUMN `input_string` varchar(512) default NULL'
 	);
 
+	if (!db_index_exists('data_input', 'name_type_id')) {
+		db_install_execute('ALTER TABLE `data_input` 
+			ADD KEY `name_type_id` (`name`, `type_id`)'
+		);
+	}
+
 	if (!db_index_exists('snmp_query_graph', 'graph_template_id_name')) {
 		db_install_execute("ALTER TABLE `snmp_query_graph` 
-			ADD INDEX `graph_template_id_name` (`graph_template_id`, `name`)"
+			ADD KEY `graph_template_id_name` (`graph_template_id`, `name`)"
 		);
 	}
 
@@ -50,4 +56,76 @@ function upgrade_to_1_1_6() {
 		MODIFY COLUMN output VARCHAR(512) NOT NULL default '',
 		ENGINE=MEMORY"
 	);
+
+	if (!db_index_exists('graph_templates_gprint', 'name')) {
+		db_install_execute("ALTER TABLE `graph_templates_gprint` 
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('data_source_profiles', 'name')) {
+		db_install_execute("ALTER TABLE `data_source_profiles` 
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('cdef', 'name')) {
+		db_install_execute("ALTER TABLE `cdef`
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('vdef', 'name')) {
+		db_install_execute("ALTER TABLE `vdef`
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('poller', 'name')) {
+		db_install_execute("ALTER TABLE `poller`
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('host_template', 'name')) {
+		db_install_execute("ALTER TABLE `host_template`
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('data_template', 'name')) {
+		db_install_execute("ALTER TABLE `data_template`
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('automation_tree_rules', 'name')) {
+		db_install_execute("ALTER TABLE `automation_tree_rules`
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('automation_graph_rules', 'name')) {
+		db_install_execute("ALTER TABLE `automation_graph_rules`
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('graph_templates', 'name')) {
+		db_install_execute("ALTER TABLE `graph_templates`
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('graph_tree', 'name')) {
+		db_install_execute("ALTER TABLE `graph_tree`
+			ADD KEY `name` (`name`)"
+		);
+	}
+
+	if (!db_index_exists('snmp_query_graph', 'snmp_query_id_name')) {
+		db_install_execute("ALTER TABLE `snmp_query_graph`
+			ADD KEY `snmp_query_id_name` (`snmp_query_id`, `name`)"
+		);
+	}
 }

--- a/install/upgrades/1_1_6.php
+++ b/install/upgrades/1_1_6.php
@@ -29,7 +29,7 @@ function upgrade_to_1_1_6() {
 
 	if (!db_index_exists('data_input', 'name_type_id')) {
 		db_install_execute('ALTER TABLE `data_input` 
-			ADD KEY `name_type_id` (`name`, `type_id`)'
+			ADD KEY `name_type_id` (`name`(171), `type_id`)'
 		);
 	}
 
@@ -43,7 +43,7 @@ function upgrade_to_1_1_6() {
 		db_install_execute(
 			"ALTER TABLE `graph_templates` 
 				ADD `multiple` CHAR(2) NOT NULL DEFAULT '' AFTER `name`,
-				ADD KEY `multiple_name` (`multiple`, `name`)"
+				ADD KEY `multiple_name` (`multiple`, `name`(171))"
 		);
 	}
 
@@ -65,19 +65,19 @@ function upgrade_to_1_1_6() {
 
 	if (!db_index_exists('data_source_profiles', 'name')) {
 		db_install_execute("ALTER TABLE `data_source_profiles` 
-			ADD KEY `name` (`name`)"
+			ADD KEY `name` (`name`(171))"
 		);
 	}
 
 	if (!db_index_exists('cdef', 'name')) {
 		db_install_execute("ALTER TABLE `cdef`
-			ADD KEY `name` (`name`)"
+			ADD KEY `name` (`name`(171))"
 		);
 	}
 
 	if (!db_index_exists('vdef', 'name')) {
 		db_install_execute("ALTER TABLE `vdef`
-			ADD KEY `name` (`name`)"
+			ADD KEY `name` (`name`(171))"
 		);
 	}
 
@@ -101,25 +101,25 @@ function upgrade_to_1_1_6() {
 
 	if (!db_index_exists('automation_tree_rules', 'name')) {
 		db_install_execute("ALTER TABLE `automation_tree_rules`
-			ADD KEY `name` (`name`)"
+			ADD KEY `name` (`name`(171))"
 		);
 	}
 
 	if (!db_index_exists('automation_graph_rules', 'name')) {
 		db_install_execute("ALTER TABLE `automation_graph_rules`
-			ADD KEY `name` (`name`)"
+			ADD KEY `name` (`name`(171))"
 		);
 	}
 
 	if (!db_index_exists('graph_templates', 'name')) {
 		db_install_execute("ALTER TABLE `graph_templates`
-			ADD KEY `name` (`name`)"
+			ADD KEY `name` (`name`(171))"
 		);
 	}
 
 	if (!db_index_exists('graph_tree', 'name')) {
 		db_install_execute("ALTER TABLE `graph_tree`
-			ADD KEY `name` (`name`)"
+			ADD KEY `name` (`name`(171))"
 		);
 	}
 


### PR DESCRIPTION
1_1_6.php and cacti.sql
- Suggested schema changes to take away several file-sorts for every query (mostly used in GUI) using the table sorting by name

host.php:
- optimised the 2 Associated Data Queries loops by removing the queries out of the loops and adding them into their main query.

global_form.php
- some spacing and capitalization usage
- refactored 3 queries (removed unnecessary joined tables, removed unnecessary SELECT in UNION query and optimised query so no file-sort and temporary-table was needed anymore)
- row #1616(my version) needs translation in SQL (don't know how to do that here)