### PR TITLE
CLOG Bugfix for hosts that are deleted

### DIFF
--- a/lib/clog_webapi.php
+++ b/lib/clog_webapi.php
@@ -218,7 +218,7 @@ function clog_view_logfile() {
 				$host_end    = strpos($item, ']', $host_start);
 				$host_id     = substr($item, $host_start + 7, $host_end - ($host_start + 7));
 				$new_item   .= cacti_htmlspecialchars(substr($item, 0, $host_start + 7)) . "<a href='" . cacti_htmlspecialchars($config['url_path'] . 'host.php?action=edit&id=' . $host_id) . "'>$host_id</a>";
-				$new_item   .= '] Description[' . $hostDescriptions[$host_id];
+				$new_item   .= '] Description[' . (isset($hostDescriptions[$host_id]) ? $hostDescriptions[$host_id] : '');
 				$item        = substr($item, $host_end);
 				$host_start  = strpos($item, 'Device[');
 			}


### PR DESCRIPTION
Noticed some notices of deleted hosts that could not be found in the array of hostDescriptions