### PR TITLE
Corrected grammar on device defaults SNMP retries text.

### DIFF
--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -532,7 +532,7 @@ $settings = array(
 			),
 		'snmp_retries' => array(
 			'friendly_name' => __('Retries'),
-			'description' => __('The number times the SNMP poller will attempt to reach the host before failing.'),
+			'description' => __('The number of times the SNMP poller will attempt to reach the host before failing.'),
 			'method' => 'textbox',
 			'default' => '3',
 			'max_length' => '10',

--- a/locales/po/cacti.pot
+++ b/locales/po/cacti.pot
@@ -8,16 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-04-26 20:04-0400\n"
+"POT-Creation-Date: 2017-05-10 17:14+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../about.php:29 ../lib/functions.php:2396
+#: ../about.php:29 ../lib/functions.php:2407
 msgid "About Cacti"
 msgstr ""
 
@@ -93,23 +94,23 @@ msgstr ""
 
 #: ../aggregate_graphs.php:40 ../aggregate_templates.php:29
 #: ../automation_graph_rules.php:32 ../automation_networks.php:31
-#: ../automation_snmp.php:29 ../automation_snmp.php:725
+#: ../automation_snmp.php:29 ../automation_snmp.php:727
 #: ../automation_templates.php:29 ../automation_tree_rules.php:32
 #: ../cdef.php:29 ../cdef.php:619 ../color.php:28 ../color_templates.php:28
-#: ../color_templates.php:121 ../data_input.php:29 ../data_input.php:490
+#: ../color_templates.php:122 ../data_input.php:29 ../data_input.php:490
 #: ../data_input.php:528 ../data_queries.php:30 ../data_queries.php:637
-#: ../data_queries.php:732 ../data_queries.php:940
+#: ../data_queries.php:735 ../data_queries.php:949
 #: ../data_source_profiles.php:29 ../data_source_profiles.php:513
-#: ../data_sources.php:35 ../data_sources.php:893 ../data_templates.php:33
-#: ../data_templates.php:573 ../gprint_presets.php:28
-#: ../graph_templates.php:33 ../graph_templates.php:439 ../graphs.php:44
-#: ../host.php:38 ../host_templates.php:30 ../host_templates.php:485
-#: ../host_templates.php:542 ../lib/api_automation.php:1246
-#: ../lib/api_automation.php:1309 ../lib/api_automation.php:1373
-#: ../lib/html.php:991 ../lib/html_form.php:1052 ../lib/html_reports.php:1298
-#: ../links.php:28 ../managers.php:28 ../pollers.php:29 ../sites.php:28
-#: ../tree.php:1051 ../tree.php:1204 ../tree.php:1264 ../user_admin.php:28
-#: ../user_domains.php:29 ../user_group_admin.php:30 ../vdef.php:29
+#: ../data_sources.php:35 ../data_sources.php:942 ../data_templates.php:33
+#: ../data_templates.php:571 ../gprint_presets.php:28 ../graph_templates.php:33
+#: ../graph_templates.php:440 ../graphs.php:44 ../host.php:38
+#: ../host_templates.php:30 ../host_templates.php:485 ../host_templates.php:542
+#: ../lib/api_automation.php:1246 ../lib/api_automation.php:1309
+#: ../lib/api_automation.php:1373 ../lib/html.php:970 ../lib/html_form.php:1096
+#: ../lib/html_reports.php:1303 ../links.php:28 ../managers.php:28
+#: ../pollers.php:29 ../sites.php:28 ../tree.php:1051 ../tree.php:1204
+#: ../tree.php:1264 ../user_admin.php:28 ../user_domains.php:29
+#: ../user_group_admin.php:30 ../vdef.php:29
 msgid "Delete"
 msgstr ""
 
@@ -146,27 +147,27 @@ msgstr ""
 #: ../automation_snmp.php:253 ../automation_snmp.php:356
 #: ../automation_templates.php:195 ../automation_tree_rules.php:286
 #: ../cdef.php:282 ../cdef.php:292 ../cdef.php:344 ../color.php:192
-#: ../color_templates.php:231 ../color_templates.php:241
-#: ../color_templates_items.php:280 ../data_input.php:218
-#: ../data_input.php:266 ../data_queries.php:322 ../data_queries.php:425
+#: ../color_templates.php:232 ../color_templates.php:242
+#: ../color_templates_items.php:280 ../data_input.php:218 ../data_input.php:266
+#: ../data_queries.php:322 ../data_queries.php:425
 #: ../data_source_profiles.php:266 ../data_source_profiles.php:276
-#: ../data_source_profiles.php:324 ../data_sources.php:460
-#: ../data_sources.php:470 ../data_sources.php:479 ../data_sources.php:488
-#: ../data_sources.php:497 ../data_sources.php:503 ../data_templates.php:358
+#: ../data_source_profiles.php:324 ../data_sources.php:468
+#: ../data_sources.php:478 ../data_sources.php:487 ../data_sources.php:496
+#: ../data_sources.php:505 ../data_sources.php:511 ../data_templates.php:358
 #: ../data_templates.php:368 ../data_templates.php:384
-#: ../gprint_presets.php:153 ../graph_templates.php:316
-#: ../graph_templates.php:326 ../graph_templates.php:346
-#: ../graph_templates.php:355 ../graphs.php:818 ../graphs.php:842
+#: ../gprint_presets.php:153 ../graph_templates.php:317
+#: ../graph_templates.php:327 ../graph_templates.php:347
+#: ../graph_templates.php:356 ../graphs.php:818 ../graphs.php:842
 #: ../graphs.php:853 ../graphs.php:864 ../graphs.php:879 ../graphs.php:902
-#: ../graphs.php:1022 ../graphs.php:1065 ../graphs.php:1087 ../graphs.php:1095
-#: ../graphs.php:1491 ../host.php:381 ../host.php:390 ../host.php:432
+#: ../graphs.php:1026 ../graphs.php:1069 ../graphs.php:1091 ../graphs.php:1099
+#: ../graphs.php:1532 ../host.php:381 ../host.php:390 ../host.php:432
 #: ../host.php:441 ../host.php:450 ../host.php:464 ../host.php:478
 #: ../host.php:487 ../host.php:495 ../host_templates.php:261
 #: ../host_templates.php:275 ../host_templates.php:286
 #: ../host_templates.php:334 ../host_templates.php:394
-#: ../lib/clog_webapi.php:128 ../lib/html_form.php:1051
-#: ../lib/html_form.php:1063 ../lib/html_form.php:1074
-#: ../lib/html_utility.php:200 ../links.php:196 ../links.php:205
+#: ../lib/clog_webapi.php:129 ../lib/html_form.php:1095
+#: ../lib/html_form.php:1107 ../lib/html_form.php:1118
+#: ../lib/html_utility.php:198 ../links.php:196 ../links.php:205
 #: ../links.php:214 ../managers.php:1002 ../managers.php:1059
 #: ../pollers.php:288 ../pollers.php:297 ../pollers.php:306 ../pollers.php:315
 #: ../sites.php:280 ../tree.php:490 ../tree.php:499 ../tree.php:508
@@ -187,25 +188,25 @@ msgstr ""
 #: ../automation_snmp.php:228 ../automation_snmp.php:357
 #: ../automation_templates.php:195 ../automation_tree_rules.php:286
 #: ../cdef.php:282 ../cdef.php:292 ../cdef.php:345 ../color.php:192
-#: ../color_templates.php:231 ../color_templates.php:241
-#: ../color_templates_items.php:281 ../data_input.php:218
-#: ../data_input.php:267 ../data_queries.php:322 ../data_queries.php:426
+#: ../color_templates.php:232 ../color_templates.php:242
+#: ../color_templates_items.php:281 ../data_input.php:218 ../data_input.php:267
+#: ../data_queries.php:322 ../data_queries.php:426
 #: ../data_source_profiles.php:266 ../data_source_profiles.php:276
-#: ../data_source_profiles.php:325 ../data_sources.php:460
-#: ../data_sources.php:470 ../data_sources.php:479 ../data_sources.php:488
-#: ../data_sources.php:497 ../data_sources.php:503 ../data_templates.php:358
+#: ../data_source_profiles.php:325 ../data_sources.php:468
+#: ../data_sources.php:478 ../data_sources.php:487 ../data_sources.php:496
+#: ../data_sources.php:505 ../data_sources.php:511 ../data_templates.php:358
 #: ../data_templates.php:368 ../data_templates.php:384
-#: ../gprint_presets.php:153 ../graph_templates.php:316
-#: ../graph_templates.php:326 ../graph_templates.php:346
-#: ../graph_templates.php:355 ../graphs.php:818 ../graphs.php:842
+#: ../gprint_presets.php:153 ../graph_templates.php:317
+#: ../graph_templates.php:327 ../graph_templates.php:347
+#: ../graph_templates.php:356 ../graphs.php:818 ../graphs.php:842
 #: ../graphs.php:853 ../graphs.php:864 ../graphs.php:879 ../graphs.php:902
-#: ../graphs.php:1022 ../graphs.php:1065 ../graphs.php:1087 ../graphs.php:1095
+#: ../graphs.php:1026 ../graphs.php:1069 ../graphs.php:1091 ../graphs.php:1099
 #: ../host.php:381 ../host.php:390 ../host.php:432 ../host.php:441
 #: ../host.php:450 ../host.php:464 ../host.php:478 ../host.php:487
 #: ../host.php:495 ../host_templates.php:261 ../host_templates.php:275
 #: ../host_templates.php:286 ../host_templates.php:335
-#: ../host_templates.php:395 ../lib/clog_webapi.php:129
-#: ../lib/html_reports.php:669 ../lib/html_utility.php:200 ../links.php:196
+#: ../host_templates.php:395 ../lib/clog_webapi.php:130
+#: ../lib/html_reports.php:671 ../lib/html_utility.php:198 ../links.php:196
 #: ../links.php:205 ../links.php:214 ../managers.php:1002 ../managers.php:1059
 #: ../pollers.php:288 ../pollers.php:297 ../pollers.php:306 ../pollers.php:315
 #: ../sites.php:280 ../tree.php:490 ../tree.php:499 ../tree.php:508
@@ -243,13 +244,13 @@ msgstr ""
 #: ../automation_graph_rules.php:282 ../automation_networks.php:359
 #: ../automation_snmp.php:253 ../automation_templates.php:199
 #: ../automation_tree_rules.php:284 ../cdef.php:296 ../color.php:196
-#: ../color_templates.php:245 ../data_input.php:221 ../data_queries.php:325
-#: ../data_source_profiles.php:280 ../data_sources.php:507
+#: ../color_templates.php:246 ../data_input.php:221 ../data_queries.php:325
+#: ../data_source_profiles.php:280 ../data_sources.php:515
 #: ../data_templates.php:388 ../gprint_presets.php:157
-#: ../graph_templates.php:359 ../graphs.php:1024 ../graphs.php:1074
-#: ../graphs.php:1077 ../graphs.php:1100 ../host.php:499
-#: ../host_templates.php:290 ../include/auth.php:115 ../lib/html_form.php:1072
-#: ../lib/html_utility.php:198 ../links.php:218 ../managers.php:1062
+#: ../graph_templates.php:360 ../graphs.php:1028 ../graphs.php:1078
+#: ../graphs.php:1081 ../graphs.php:1104 ../host.php:499
+#: ../host_templates.php:290 ../include/auth.php:115 ../lib/html_form.php:1116
+#: ../lib/html_utility.php:196 ../links.php:218 ../managers.php:1062
 #: ../permission_denied.php:30 ../permission_denied.php:32 ../pollers.php:319
 #: ../sites.php:284 ../tree.php:512 ../user_admin.php:439
 #: ../user_domains.php:258 ../user_group_admin.php:491 ../vdef.php:284
@@ -334,28 +335,28 @@ msgstr ""
 msgid "You must select at least one graph."
 msgstr ""
 
-#: ../aggregate_graphs.php:476 ../graphs.php:1133
+#: ../aggregate_graphs.php:476 ../graphs.php:1137
 msgid "Graph Items [new]"
 msgstr ""
 
-#: ../aggregate_graphs.php:492 ../graphs.php:1153
+#: ../aggregate_graphs.php:492 ../graphs.php:1157
 #, php-format
 msgid "Graph Items [edit: %s]"
 msgstr ""
 
 #: ../aggregate_graphs.php:560 ../aggregate_graphs.php:563
-#: ../lib/html_reports.php:1085 ../lib/html_reports.php:1090
-#: ../utilities.php:1692
+#: ../lib/html_reports.php:1088 ../lib/html_reports.php:1093
+#: ../lib/html_reports.php:1132 ../utilities.php:1699
 msgid "Details"
 msgstr ""
 
-#: ../aggregate_graphs.php:560 ../lib/html_reports.php:1085
-#: ../utilities.php:306
+#: ../aggregate_graphs.php:560 ../lib/html_reports.php:1088
+#: ../lib/html_reports.php:1179 ../utilities.php:306
 msgid "Items"
 msgstr ""
 
-#: ../aggregate_graphs.php:560 ../aggregate_graphs.php:563
-#: ../lib/html.php:1580 ../lib/html_reports.php:1085
+#: ../aggregate_graphs.php:560 ../aggregate_graphs.php:563 ../lib/html.php:1559
+#: ../lib/html_reports.php:1088
 msgid "Preview"
 msgstr ""
 
@@ -376,11 +377,11 @@ msgstr ""
 msgid "Aggregate Preview [%s]"
 msgstr ""
 
-#: ../aggregate_graphs.php:633 ../graph.php:431 ../graphs.php:1390
+#: ../aggregate_graphs.php:633 ../graph.php:431 ../graphs.php:1395
 msgid "RRDTool Command:"
 msgstr ""
 
-#: ../aggregate_graphs.php:635 ../graph.php:434 ../graphs.php:1392
+#: ../aggregate_graphs.php:635 ../graph.php:434 ../graphs.php:1397
 msgid "RRDTool Says:"
 msgstr ""
 
@@ -397,8 +398,7 @@ msgstr ""
 msgid "All Items"
 msgstr ""
 
-#: ../aggregate_graphs.php:825 ../graphs.php:1406
-#: ../lib/api_aggregate.php:1368
+#: ../aggregate_graphs.php:825 ../graphs.php:1411 ../lib/api_aggregate.php:1367
 msgid "Graph Configuration"
 msgstr ""
 
@@ -418,44 +418,45 @@ msgstr ""
 
 #: ../aggregate_graphs.php:1007 ../aggregate_graphs.php:1326
 #: ../aggregate_templates.php:538 ../automation_devices.php:448
-#: ../automation_graph_rules.php:700 ../automation_networks.php:1061
-#: ../automation_networks.php:1082 ../automation_snmp.php:826
+#: ../automation_graph_rules.php:701 ../automation_networks.php:1061
+#: ../automation_networks.php:1082 ../automation_snmp.php:828
 #: ../automation_templates.php:412 ../automation_tree_rules.php:715
-#: ../cdef.php:722 ../color.php:529 ../color_templates.php:437
-#: ../data_input.php:619 ../data_queries.php:1038
-#: ../data_source_profiles.php:719 ../data_sources.php:1196
-#: ../data_templates.php:747 ../gprint_presets.php:262
-#: ../graph_templates.php:626 ../graph_view.php:518 ../graph_view.php:819
-#: ../graphs.php:1643 ../graphs_new.php:568 ../host.php:1367
+#: ../cdef.php:722 ../color.php:529 ../color_templates.php:439
+#: ../data_input.php:619 ../data_queries.php:1047
+#: ../data_source_profiles.php:719 ../data_sources.php:1251
+#: ../data_templates.php:754 ../gprint_presets.php:262
+#: ../graph_templates.php:628 ../graph_view.php:517 ../graph_view.php:818
+#: ../graphs.php:1684 ../graphs_new.php:548 ../host.php:1375
 #: ../host_templates.php:700 ../lib/api_automation.php:133
 #: ../lib/api_automation.php:460 ../lib/api_automation.php:683
-#: ../lib/api_automation.php:988 ../lib/clog_webapi.php:366
-#: ../lib/html_graph.php:206 ../lib/html_graph.php:432
-#: ../lib/html_reports.php:1383 ../lib/html_tree.php:604
-#: ../lib/html_tree.php:878 ../links.php:309 ../managers.php:150
-#: ../managers.php:533 ../managers.php:722 ../plugins.php:276
-#: ../pollers.php:507 ../rrdcleaner.php:475 ../settings.php:200
-#: ../settings.php:217 ../settings.php:263 ../sites.php:387 ../tree.php:633
-#: ../tree.php:668 ../tree.php:1485 ../user_admin.php:2176
+#: ../lib/api_automation.php:988 ../lib/clog_webapi.php:380
+#: ../lib/html_filter.php:63 ../lib/html_graph.php:206
+#: ../lib/html_graph.php:432 ../lib/html_reports.php:1388
+#: ../lib/html_tree.php:605 ../lib/html_tree.php:879 ../links.php:309
+#: ../managers.php:150 ../managers.php:533 ../managers.php:722
+#: ../plugins.php:276 ../pollers.php:517 ../rrdcleaner.php:475
+#: ../settings.php:204 ../settings.php:221 ../settings.php:267 ../sites.php:387
+#: ../tree.php:633 ../tree.php:668 ../tree.php:1485 ../user_admin.php:2176
 #: ../user_admin.php:2514 ../user_admin.php:2623 ../user_admin.php:2711
 #: ../user_admin.php:2816 ../user_admin.php:2903 ../user_admin.php:2990
 #: ../user_domains.php:621 ../user_group_admin.php:1806
 #: ../user_group_admin.php:2133 ../user_group_admin.php:2243
 #: ../user_group_admin.php:2348 ../user_group_admin.php:2435
 #: ../user_group_admin.php:2522 ../utilities.php:689 ../utilities.php:1045
-#: ../utilities.php:1275 ../utilities.php:1587 ../utilities.php:2250
-#: ../utilities.php:2503 ../vdef.php:659
+#: ../utilities.php:1282 ../utilities.php:1594 ../utilities.php:2257
+#: ../utilities.php:2510 ../vdef.php:659
 msgid "Search"
 msgstr ""
 
 #: ../aggregate_graphs.php:1013 ../aggregate_graphs.php:1111
-#: ../aggregate_graphs.php:1354 ../color_templates.php:547
-#: ../graph_view.php:396 ../graph_view.php:557 ../graphs.php:1649
-#: ../host.php:1493 ../include/global_arrays.php:634
-#: ../include/global_arrays.php:813 ../lib/api_automation.php:274
-#: ../lib/functions.php:1828 ../lib/html.php:1404 ../lib/html_graph.php:212
-#: ../lib/html_tree.php:657 ../lib/html_tree.php:1075 ../tree.php:1568
-#: ../user_admin.php:1229 ../user_admin.php:2542 ../user_group_admin.php:813
+#: ../aggregate_graphs.php:1354 ../color_templates.php:549
+#: ../graph_view.php:395 ../graph_view.php:556 ../graphs.php:1690
+#: ../host.php:1501 ../include/global_arrays.php:685
+#: ../include/global_arrays.php:864 ../lib/api_automation.php:274
+#: ../lib/functions.php:1839 ../lib/html.php:1308 ../lib/html.php:1310
+#: ../lib/html.php:1383 ../lib/html_graph.php:212 ../lib/html_tree.php:658
+#: ../lib/html_tree.php:1076 ../tree.php:1568 ../user_admin.php:1229
+#: ../user_admin.php:2542 ../user_group_admin.php:813
 #: ../user_group_admin.php:966 ../user_group_admin.php:2161
 #: ../utilities.php:268
 msgid "Graphs"
@@ -463,28 +464,27 @@ msgstr ""
 
 #: ../aggregate_graphs.php:1017 ../aggregate_graphs.php:1358
 #: ../aggregate_templates.php:554 ../automation_devices.php:533
-#: ../automation_graph_rules.php:742 ../automation_networks.php:1071
-#: ../automation_snmp.php:836 ../automation_templates.php:422
+#: ../automation_graph_rules.php:743 ../automation_networks.php:1071
+#: ../automation_snmp.php:838 ../automation_templates.php:422
 #: ../automation_tree_rules.php:735 ../cdef.php:732 ../color.php:539
-#: ../color_templates.php:451 ../data_input.php:629 ../data_queries.php:1048
+#: ../color_templates.php:453 ../data_input.php:629 ../data_queries.php:1057
 #: ../data_source_profiles.php:729 ../data_source_profiles.php:848
-#: ../data_sources.php:1232 ../data_templates.php:773
-#: ../gprint_presets.php:272 ../graph_templates.php:636 ../graph_view.php:561
-#: ../graphs.php:1653 ../graphs_new.php:550 ../host.php:1392
-#: ../host_templates.php:710 ../include/global_form.php:79
-#: ../lib/api_automation.php:176 ../lib/api_automation.php:470
-#: ../lib/api_automation.php:693 ../lib/api_automation.php:1031
-#: ../lib/html_reports.php:1403 ../links.php:319 ../managers.php:160
-#: ../managers.php:543 ../plugins.php:299 ../pollers.php:517
-#: ../rrdcleaner.php:501 ../sites.php:397 ../tree.php:1495
+#: ../data_sources.php:1287 ../data_templates.php:780 ../gprint_presets.php:272
+#: ../graph_templates.php:638 ../graph_view.php:560 ../graphs.php:1694
+#: ../graphs_new.php:530 ../host.php:1400 ../host_templates.php:710
+#: ../include/global_form.php:79 ../lib/api_automation.php:176
+#: ../lib/api_automation.php:470 ../lib/api_automation.php:693
+#: ../lib/api_automation.php:1031 ../lib/html_reports.php:1408 ../links.php:319
+#: ../managers.php:160 ../managers.php:543 ../plugins.php:299
+#: ../pollers.php:527 ../rrdcleaner.php:501 ../sites.php:397 ../tree.php:1495
 #: ../user_admin.php:2186 ../user_admin.php:2546 ../user_admin.php:2633
 #: ../user_admin.php:2739 ../user_admin.php:2826 ../user_admin.php:2913
 #: ../user_admin.php:3000 ../user_domains.php:32 ../user_domains.php:631
 #: ../user_domains.php:716 ../user_group_admin.php:1816
 #: ../user_group_admin.php:2165 ../user_group_admin.php:2271
 #: ../user_group_admin.php:2358 ../user_group_admin.php:2445
-#: ../user_group_admin.php:2532 ../utilities.php:665 ../utilities.php:1319
-#: ../utilities.php:1608 ../utilities.php:2275 ../utilities.php:2539
+#: ../user_group_admin.php:2532 ../utilities.php:665 ../utilities.php:1326
+#: ../utilities.php:1615 ../utilities.php:2282 ../utilities.php:2546
 #: ../vdef.php:669
 msgid "Default"
 msgstr ""
@@ -495,102 +495,103 @@ msgstr ""
 
 #: ../aggregate_graphs.php:1034 ../aggregate_graphs.php:1369
 #: ../aggregate_templates.php:574 ../automation_devices.php:468
-#: ../automation_graph_rules.php:753 ../automation_networks.php:1082
-#: ../automation_snmp.php:847 ../automation_templates.php:433
+#: ../automation_graph_rules.php:754 ../automation_networks.php:1082
+#: ../automation_snmp.php:849 ../automation_templates.php:433
 #: ../automation_tree_rules.php:746 ../cdef.php:749 ../color.php:562
-#: ../color_templates.php:470 ../data_input.php:640 ../data_queries.php:1059
-#: ../data_source_profiles.php:746 ../data_sources.php:1186
-#: ../data_templates.php:790 ../gprint_presets.php:289
-#: ../graph_templates.php:653 ../graph_view.php:572 ../graphs.php:1633
-#: ../graphs_new.php:574 ../host.php:1357 ../host_templates.php:727
+#: ../color_templates.php:472 ../data_input.php:640 ../data_queries.php:1068
+#: ../data_source_profiles.php:746 ../data_sources.php:1241
+#: ../data_templates.php:797 ../gprint_presets.php:289
+#: ../graph_templates.php:655 ../graph_view.php:571 ../graphs.php:1674
+#: ../graphs_new.php:554 ../host.php:1365 ../host_templates.php:727
 #: ../lib/api_automation.php:187 ../lib/api_automation.php:452
 #: ../lib/api_automation.php:704 ../lib/api_automation.php:1042
-#: ../lib/clog_webapi.php:330 ../lib/html.php:1175 ../lib/html_graph.php:190
-#: ../lib/html_reports.php:1413 ../lib/html_tree.php:641 ../links.php:328
-#: ../managers.php:171 ../managers.php:554 ../managers.php:741
-#: ../plugins.php:310 ../pollers.php:528 ../sites.php:408 ../tree.php:1506
-#: ../user_admin.php:2197 ../user_admin.php:2563 ../user_admin.php:2650
-#: ../user_admin.php:2756 ../user_admin.php:2843 ../user_admin.php:2930
-#: ../user_admin.php:3017
+#: ../lib/clog_webapi.php:340 ../lib/html.php:1154 ../lib/html_filter.php:81
+#: ../lib/html_graph.php:190 ../lib/html_reports.php:1418
+#: ../lib/html_tree.php:642 ../links.php:328 ../managers.php:171
+#: ../managers.php:554 ../managers.php:741 ../plugins.php:310
+#: ../pollers.php:538 ../sites.php:408 ../tree.php:1506 ../user_admin.php:2197
+#: ../user_admin.php:2563 ../user_admin.php:2650 ../user_admin.php:2756
+#: ../user_admin.php:2843 ../user_admin.php:2930 ../user_admin.php:3017
 msgid "Go"
 msgstr ""
 
 #: ../aggregate_graphs.php:1034 ../aggregate_graphs.php:1369
-#: ../automation_devices.php:468 ../automation_snmp.php:847
+#: ../automation_devices.php:468 ../automation_snmp.php:849
 #: ../automation_templates.php:433 ../cdef.php:749 ../color.php:562
-#: ../data_input.php:640 ../data_queries.php:1059
-#: ../data_source_profiles.php:746 ../data_sources.php:1186
-#: ../data_templates.php:790 ../gprint_presets.php:289
-#: ../graph_templates.php:653 ../graph_view.php:572 ../graphs.php:1633
-#: ../graphs_new.php:574 ../host.php:1357 ../host_templates.php:727
+#: ../data_input.php:640 ../data_queries.php:1068
+#: ../data_source_profiles.php:746 ../data_sources.php:1241
+#: ../data_templates.php:797 ../gprint_presets.php:289
+#: ../graph_templates.php:655 ../graph_view.php:571 ../graphs.php:1674
+#: ../graphs_new.php:554 ../host.php:1365 ../host_templates.php:727
 #: ../lib/html_graph.php:190 ../managers.php:171 ../managers.php:554
-#: ../managers.php:741 ../plugins.php:310 ../pollers.php:528 ../sites.php:408
+#: ../managers.php:741 ../plugins.php:310 ../pollers.php:538 ../sites.php:408
 #: ../tree.php:1506 ../user_admin.php:2197 ../user_admin.php:2563
 #: ../user_admin.php:2650 ../user_admin.php:2756 ../user_admin.php:2843
 #: ../user_admin.php:2930 ../user_admin.php:3017 ../user_domains.php:642
 #: ../user_group_admin.php:1827 ../user_group_admin.php:2182
 #: ../user_group_admin.php:2288 ../user_group_admin.php:2375
 #: ../user_group_admin.php:2462 ../user_group_admin.php:2549
-#: ../utilities.php:676 ../utilities.php:1009 ../utilities.php:1330
-#: ../utilities.php:1577 ../utilities.php:2286 ../utilities.php:2550
+#: ../utilities.php:676 ../utilities.php:1009 ../utilities.php:1337
+#: ../utilities.php:1584 ../utilities.php:2293 ../utilities.php:2557
 msgid "Set/Refresh Filters"
 msgstr ""
 
 #: ../aggregate_graphs.php:1037 ../aggregate_graphs.php:1372
 #: ../aggregate_templates.php:577 ../automation_devices.php:471
-#: ../automation_graph_rules.php:756 ../automation_networks.php:1085
-#: ../automation_snmp.php:850 ../automation_templates.php:436
+#: ../automation_graph_rules.php:757 ../automation_networks.php:1085
+#: ../automation_snmp.php:852 ../automation_templates.php:436
 #: ../automation_tree_rules.php:749 ../cdef.php:752 ../color.php:565
-#: ../color_templates.php:473 ../data_input.php:643 ../data_queries.php:1062
-#: ../data_source_profiles.php:749 ../data_sources.php:1189
-#: ../data_templates.php:793 ../gprint_presets.php:292
-#: ../graph_templates.php:656 ../graph_view.php:575 ../graphs.php:1636
-#: ../graphs_new.php:575 ../host.php:1360 ../host_templates.php:730
+#: ../color_templates.php:475 ../data_input.php:643 ../data_queries.php:1071
+#: ../data_source_profiles.php:749 ../data_sources.php:1244
+#: ../data_templates.php:800 ../gprint_presets.php:292
+#: ../graph_templates.php:658 ../graph_view.php:574 ../graphs.php:1677
+#: ../graphs_new.php:555 ../host.php:1368 ../host_templates.php:730
 #: ../lib/api_automation.php:190 ../lib/api_automation.php:455
 #: ../lib/api_automation.php:707 ../lib/api_automation.php:1045
-#: ../lib/clog_webapi.php:333 ../lib/html_graph.php:193
-#: ../lib/html_graph.php:322 ../lib/html_reports.php:1416
-#: ../lib/html_tree.php:644 ../lib/html_tree.php:767 ../links.php:331
-#: ../managers.php:174 ../managers.php:557 ../managers.php:744
-#: ../plugins.php:313 ../pollers.php:531 ../sites.php:411 ../tree.php:1509
-#: ../user_admin.php:2200 ../user_admin.php:2566 ../user_admin.php:2653
-#: ../user_admin.php:2759 ../user_admin.php:2846 ../user_admin.php:2933
-#: ../user_admin.php:3020 ../user_domains.php:645
+#: ../lib/clog_webapi.php:343 ../lib/html_filter.php:86
+#: ../lib/html_graph.php:193 ../lib/html_graph.php:322
+#: ../lib/html_reports.php:1421 ../lib/html_tree.php:645
+#: ../lib/html_tree.php:768 ../links.php:331 ../managers.php:174
+#: ../managers.php:557 ../managers.php:744 ../plugins.php:313
+#: ../pollers.php:541 ../sites.php:411 ../tree.php:1509 ../user_admin.php:2200
+#: ../user_admin.php:2566 ../user_admin.php:2653 ../user_admin.php:2759
+#: ../user_admin.php:2846 ../user_admin.php:2933 ../user_admin.php:3020
+#: ../user_domains.php:645
 msgid "Clear"
 msgstr ""
 
 #: ../aggregate_graphs.php:1037 ../aggregate_graphs.php:1372
-#: ../automation_snmp.php:850 ../automation_templates.php:436 ../cdef.php:752
-#: ../color.php:565 ../data_input.php:643 ../data_queries.php:1062
-#: ../data_source_profiles.php:749 ../data_sources.php:1189
-#: ../data_templates.php:793 ../gprint_presets.php:292
-#: ../graph_templates.php:656 ../graph_view.php:575 ../graphs.php:1636
-#: ../graphs_new.php:575 ../host.php:1360 ../host_templates.php:730
-#: ../lib/html_graph.php:193 ../lib/html_tree.php:644 ../managers.php:174
+#: ../automation_snmp.php:852 ../automation_templates.php:436 ../cdef.php:752
+#: ../color.php:565 ../data_input.php:643 ../data_queries.php:1071
+#: ../data_source_profiles.php:749 ../data_sources.php:1244
+#: ../data_templates.php:800 ../gprint_presets.php:292
+#: ../graph_templates.php:658 ../graph_view.php:574 ../graphs.php:1677
+#: ../graphs_new.php:555 ../host.php:1368 ../host_templates.php:730
+#: ../lib/html_graph.php:193 ../lib/html_tree.php:645 ../managers.php:174
 #: ../managers.php:557 ../managers.php:744 ../plugins.php:313
-#: ../pollers.php:531 ../sites.php:411 ../tree.php:1509 ../user_admin.php:2200
+#: ../pollers.php:541 ../sites.php:411 ../tree.php:1509 ../user_admin.php:2200
 #: ../user_admin.php:2566 ../user_admin.php:2653 ../user_admin.php:2759
 #: ../user_admin.php:2846 ../user_admin.php:2933 ../user_admin.php:3020
 #: ../user_domains.php:645 ../user_group_admin.php:1830
 #: ../user_group_admin.php:2185 ../user_group_admin.php:2291
 #: ../user_group_admin.php:2378 ../user_group_admin.php:2465
 #: ../user_group_admin.php:2552 ../utilities.php:679 ../utilities.php:1012
-#: ../utilities.php:1333 ../utilities.php:1580 ../utilities.php:2289
-#: ../utilities.php:2551
+#: ../utilities.php:1340 ../utilities.php:1587 ../utilities.php:2296
+#: ../utilities.php:2558
 msgid "Clear Filters"
 msgstr ""
 
 #: ../aggregate_graphs.php:1116 ../aggregate_graphs.php:1435
-#: ../graph_view.php:620 ../graphs.php:1051 ../lib/api_automation.php:561
+#: ../graph_view.php:619 ../graphs.php:1055 ../lib/api_automation.php:561
 #: ../user_admin.php:1006 ../user_group_admin.php:821
 msgid "Graph Title"
 msgstr ""
 
 #: ../aggregate_graphs.php:1117 ../aggregate_graphs.php:1436
-#: ../automation_graph_rules.php:857 ../automation_tree_rules.php:845
-#: ../data_queries.php:1143 ../data_sources.php:1351 ../data_templates.php:903
-#: ../graph_templates.php:760 ../graphs.php:1744 ../host.php:1492
-#: ../host_templates.php:815 ../lib/api_automation.php:273 ../pollers.php:602
+#: ../automation_graph_rules.php:856 ../automation_tree_rules.php:843
+#: ../data_queries.php:1152 ../data_sources.php:1406 ../data_templates.php:910
+#: ../graph_templates.php:762 ../graphs.php:1785 ../host.php:1500
+#: ../host_templates.php:815 ../lib/api_automation.php:273 ../pollers.php:612
 #: ../sites.php:482 ../tree.php:1559 ../user_admin.php:1006
 #: ../user_admin.php:1101 ../user_admin.php:1229 ../user_admin.php:1371
 #: ../user_admin.php:1504 ../user_group_admin.php:675
@@ -604,101 +605,102 @@ msgid "Included in Aggregate"
 msgstr ""
 
 #: ../aggregate_graphs.php:1119 ../aggregate_graphs.php:1438
-#: ../graph_templates.php:763 ../graphs.php:1746
+#: ../graph_templates.php:765 ../graphs.php:1787
 msgid "Size"
 msgstr ""
 
 #: ../aggregate_graphs.php:1129 ../cdef.php:869 ../color.php:722
-#: ../color.php:724 ../color_templates.php:564 ../data_input.php:741
-#: ../data_queries.php:1163 ../data_source_profiles.php:876
-#: ../data_source_profiles.php:877 ../data_sources.php:1395
-#: ../data_sources.php:1396 ../data_templates.php:923
-#: ../gprint_presets.php:411 ../graph_templates.php:781
-#: ../host_templates.php:834 ../include/global_settings.php:398
-#: ../install/index.php:653 ../install/index.php:674 ../tree.php:1593
-#: ../tree.php:1594 ../user_admin.php:2268 ../user_domains.php:731
-#: ../user_group_admin.php:1897 ../vdef.php:864
+#: ../color.php:724 ../color_templates.php:566 ../data_input.php:741
+#: ../data_queries.php:1172 ../data_source_profiles.php:876
+#: ../data_source_profiles.php:877 ../data_sources.php:1450
+#: ../data_sources.php:1451 ../data_templates.php:930 ../gprint_presets.php:411
+#: ../graph_templates.php:783 ../host_templates.php:834
+#: ../include/global_settings.php:398 ../install/index.php:527
+#: ../install/index.php:548 ../tree.php:1593 ../tree.php:1594
+#: ../user_admin.php:2268 ../user_domains.php:731 ../user_group_admin.php:1897
+#: ../vdef.php:864
 msgid "No"
 msgstr ""
 
 #: ../aggregate_graphs.php:1129 ../cdef.php:869 ../color.php:722
-#: ../color.php:724 ../color_templates.php:564 ../data_input.php:741
-#: ../data_queries.php:1163 ../data_source_profiles.php:876
-#: ../data_source_profiles.php:877 ../data_sources.php:1395
-#: ../data_sources.php:1396 ../data_templates.php:923
-#: ../gprint_presets.php:411 ../graph_templates.php:781
-#: ../host_templates.php:834 ../include/global_settings.php:398
-#: ../install/index.php:652 ../install/index.php:653 ../install/index.php:673
-#: ../install/index.php:674 ../tree.php:1593 ../tree.php:1594
-#: ../user_admin.php:2266 ../user_domains.php:729 ../user_domains.php:731
-#: ../user_group_admin.php:1895 ../vdef.php:864
+#: ../color.php:724 ../color_templates.php:566 ../data_input.php:741
+#: ../data_queries.php:1172 ../data_source_profiles.php:876
+#: ../data_source_profiles.php:877 ../data_sources.php:1450
+#: ../data_sources.php:1451 ../data_templates.php:930 ../gprint_presets.php:411
+#: ../graph_templates.php:783 ../host_templates.php:834
+#: ../include/global_settings.php:398 ../install/index.php:526
+#: ../install/index.php:527 ../install/index.php:547 ../install/index.php:548
+#: ../tree.php:1593 ../tree.php:1594 ../user_admin.php:2266
+#: ../user_domains.php:729 ../user_domains.php:731 ../user_group_admin.php:1895
+#: ../vdef.php:864
 msgid "Yes"
 msgstr ""
 
-#: ../aggregate_graphs.php:1135 ../graphs.php:1766
+#: ../aggregate_graphs.php:1135 ../graphs.php:1807
 #: ../lib/api_automation.php:588
 msgid "No Graphs Found"
 msgstr ""
 
 #: ../aggregate_graphs.php:1317 ../aggregate_graphs.php:1426
-#: ../lib/functions.php:2522
+#: ../lib/functions.php:2533
 msgid "Aggregate Graphs"
 msgstr ""
 
-#: ../aggregate_graphs.php:1332 ../data_sources.php:1151 ../graph_view.php:525
-#: ../graphs.php:1609 ../host.php:1339 ../lib/api_automation.php:434
-#: ../lib/html_graph.php:159 ../lib/html_tree.php:610 ../rrdcleaner.php:351
+#: ../aggregate_graphs.php:1332 ../data_sources.php:1206 ../graph_view.php:524
+#: ../graphs.php:1650 ../host.php:1347 ../lib/api_automation.php:434
+#: ../lib/html_graph.php:159 ../lib/html_tree.php:611 ../rrdcleaner.php:351
 #: ../user_admin.php:2520 ../user_admin.php:2717 ../user_group_admin.php:2139
-#: ../user_group_admin.php:2249 ../utilities.php:1548
+#: ../user_group_admin.php:2249 ../utilities.php:1555
 msgid "Template"
 msgstr ""
 
 #: ../aggregate_graphs.php:1336 ../automation_devices.php:458
 #: ../automation_devices.php:488 ../automation_devices.php:503
-#: ../automation_devices.php:518 ../automation_graph_rules.php:710
-#: ../automation_graph_rules.php:732 ../data_sources.php:1155
-#: ../graphs.php:1613 ../graphs_items.php:308 ../graphs_items.php:329
-#: ../host.php:1308 ../host.php:1326 ../host.php:1343 ../host.php:1377
+#: ../automation_devices.php:518 ../automation_graph_rules.php:711
+#: ../automation_graph_rules.php:733 ../data_sources.php:1210
+#: ../graphs.php:1654 ../graphs_items.php:308 ../graphs_items.php:329
+#: ../host.php:1316 ../host.php:1334 ../host.php:1351 ../host.php:1385
 #: ../lib/api_automation.php:143 ../lib/api_automation.php:161
 #: ../lib/api_automation.php:421 ../lib/api_automation.php:438
 #: ../lib/api_automation.php:998 ../lib/api_automation.php:1016
-#: ../lib/html.php:1654 ../lib/html_reports.php:1393 ../managers.php:522
+#: ../lib/html.php:1633 ../lib/html_reports.php:1398 ../managers.php:522
 #: ../managers.php:732 ../user_admin.php:2524 ../user_admin.php:2721
 #: ../user_group_admin.php:2143 ../user_group_admin.php:2253
-#: ../utilities.php:654 ../utilities.php:1286 ../utilities.php:1552
-#: ../utilities.php:1597 ../utilities.php:2260 ../utilities.php:2513
-#: ../utilities.php:2526
+#: ../utilities.php:654 ../utilities.php:1293 ../utilities.php:1559
+#: ../utilities.php:1604 ../utilities.php:2267 ../utilities.php:2520
+#: ../utilities.php:2533
 msgid "Any"
 msgstr ""
 
 #: ../aggregate_graphs.php:1337 ../aggregate_graphs.php:1450
-#: ../automation_graph_rules.php:867 ../automation_graph_rules.php:868
+#: ../automation_graph_rules.php:866 ../automation_graph_rules.php:867
 #: ../automation_networks.php:421 ../automation_networks.php:633
-#: ../automation_tree_rules.php:857 ../data_sources.php:1156
-#: ../data_sources.php:1381 ../data_templates.php:925 ../graph_view.php:783
-#: ../graphs.php:1319 ../graphs.php:1614 ../graphs_items.php:309
-#: ../graphs_items.php:330 ../host.php:1005 ../host.php:1309 ../host.php:1344
-#: ../include/global_arrays.php:278 ../include/global_arrays.php:331
-#: ../include/global_arrays.php:407 ../include/global_arrays.php:519
-#: ../include/global_arrays.php:542 ../include/global_arrays.php:1316
-#: ../include/global_form.php:389 ../include/global_form.php:712
-#: ../include/global_form.php:721 ../include/global_form.php:732
-#: ../include/global_form.php:775 ../include/global_form.php:782
-#: ../include/global_form.php:808 ../include/global_form.php:837
-#: ../include/global_form.php:845 ../include/global_form.php:1024
-#: ../include/global_form.php:1033 ../include/global_form.php:2086
-#: ../include/global_form.php:2128 ../include/global_settings.php:445
-#: ../include/global_settings.php:453 ../include/global_settings.php:892
-#: ../include/global_settings.php:1309 ../lib/api_automation.php:144
-#: ../lib/api_automation.php:422 ../lib/api_automation.php:439
-#: ../lib/api_automation.php:576 ../lib/api_automation.php:999
-#: ../lib/html.php:1655 ../lib/html_graph.php:396 ../lib/html_reports.php:320
+#: ../automation_tree_rules.php:855 ../data_sources.php:824
+#: ../data_sources.php:1211 ../data_sources.php:1436 ../data_templates.php:932
+#: ../graph_view.php:782 ../graphs.php:1323 ../graphs.php:1655
+#: ../graphs_items.php:309 ../graphs_items.php:330 ../host.php:1013
+#: ../host.php:1317 ../host.php:1352 ../include/global_arrays.php:329
+#: ../include/global_arrays.php:382 ../include/global_arrays.php:458
+#: ../include/global_arrays.php:570 ../include/global_arrays.php:593
+#: ../include/global_arrays.php:1318 ../include/global_form.php:389
+#: ../include/global_form.php:712 ../include/global_form.php:721
+#: ../include/global_form.php:732 ../include/global_form.php:775
+#: ../include/global_form.php:782 ../include/global_form.php:808
+#: ../include/global_form.php:837 ../include/global_form.php:845
+#: ../include/global_form.php:1032 ../include/global_form.php:1041
+#: ../include/global_form.php:2097 ../include/global_form.php:2139
+#: ../include/global_settings.php:445 ../include/global_settings.php:453
+#: ../include/global_settings.php:900 ../include/global_settings.php:1317
+#: ../lib/api_automation.php:144 ../lib/api_automation.php:422
+#: ../lib/api_automation.php:439 ../lib/api_automation.php:576
+#: ../lib/api_automation.php:999 ../lib/html.php:1634 ../lib/html_form.php:315
+#: ../lib/html_graph.php:396 ../lib/html_reports.php:320
 #: ../lib/html_reports.php:362 ../lib/html_reports.php:373
 #: ../lib/html_reports.php:381 ../lib/html_reports.php:390
-#: ../lib/html_tree.php:842 ../settings.php:193 ../settings.php:210
-#: ../settings.php:233 ../user_admin.php:2525 ../user_admin.php:2722
+#: ../lib/html_tree.php:843 ../settings.php:197 ../settings.php:214
+#: ../settings.php:237 ../user_admin.php:2525 ../user_admin.php:2722
 #: ../user_group_admin.php:2144 ../user_group_admin.php:2254
-#: ../utilities.php:1553
+#: ../utilities.php:1560
 msgid "None"
 msgstr ""
 
@@ -710,7 +712,7 @@ msgstr ""
 msgid "The internal database identifier for this object"
 msgstr ""
 
-#: ../aggregate_graphs.php:1437 ../graphs.php:1055
+#: ../aggregate_graphs.php:1437 ../graphs.php:1059
 msgid "Aggregate Template"
 msgstr ""
 
@@ -726,7 +728,7 @@ msgstr ""
 msgid "Override Values for Graph Item"
 msgstr ""
 
-#: ../aggregate_items.php:357 ../lib/api_aggregate.php:1393
+#: ../aggregate_items.php:357 ../lib/api_aggregate.php:1392
 msgid "Override this Value"
 msgstr ""
 
@@ -752,25 +754,24 @@ msgid "Aggregate Template [new]"
 msgstr ""
 
 #: ../aggregate_templates.php:531 ../aggregate_templates.php:631
-#: ../lib/functions.php:2504
+#: ../lib/functions.php:2515
 msgid "Aggregate Templates"
 msgstr ""
 
 #: ../aggregate_templates.php:544 ../automation_templates.php:418
-#: ../automation_templates.php:503 ../color_templates.php:548
-#: ../include/global_arrays.php:643 ../include/global_arrays.php:701
-#: ../install/index.php:1031 ../user_admin.php:2822
-#: ../user_group_admin.php:2354
+#: ../automation_templates.php:503 ../color_templates.php:550
+#: ../include/global_arrays.php:694 ../include/global_arrays.php:752
+#: ../install/index.php:905 ../user_admin.php:2822 ../user_group_admin.php:2354
 msgid "Templates"
 msgstr ""
 
 #: ../aggregate_templates.php:571 ../cdef.php:746 ../color.php:559
-#: ../color_templates.php:467 ../data_sources.php:1223
-#: ../gprint_presets.php:286 ../graph_templates.php:650 ../vdef.php:683
+#: ../color_templates.php:469 ../data_sources.php:1278
+#: ../gprint_presets.php:286 ../graph_templates.php:652 ../vdef.php:683
 msgid "Has Graphs"
 msgstr ""
 
-#: ../aggregate_templates.php:640 ../color_templates.php:545
+#: ../aggregate_templates.php:640 ../color_templates.php:547
 msgid "Template Title"
 msgstr ""
 
@@ -781,22 +782,22 @@ msgid ""
 msgstr ""
 
 #: ../aggregate_templates.php:641 ../cdef.php:852 ../color.php:699
-#: ../color_templates.php:546 ../data_input.php:723 ../data_queries.php:1144
-#: ../data_source_profiles.php:849 ../data_sources.php:1353
-#: ../data_templates.php:904 ../gprint_presets.php:392
-#: ../graph_templates.php:761 ../host_templates.php:816 ../vdef.php:846
+#: ../color_templates.php:548 ../data_input.php:723 ../data_queries.php:1153
+#: ../data_source_profiles.php:849 ../data_sources.php:1408
+#: ../data_templates.php:911 ../gprint_presets.php:392
+#: ../graph_templates.php:763 ../host_templates.php:816 ../vdef.php:846
 msgid "Deletable"
 msgstr ""
 
 #: ../aggregate_templates.php:642 ../cdef.php:853 ../color.php:700
-#: ../data_queries.php:902 ../data_queries.php:1145 ../gprint_presets.php:393
-#: ../graph_templates.php:762 ../vdef.php:847
+#: ../data_queries.php:911 ../data_queries.php:1154 ../gprint_presets.php:393
+#: ../graph_templates.php:764 ../vdef.php:847
 msgid "Graphs Using"
 msgstr ""
 
-#: ../aggregate_templates.php:643 ../graph_view.php:620
-#: ../include/global_arrays.php:603 ../include/global_arrays.php:986
-#: ../include/global_form.php:1315 ../include/global_form.php:1540
+#: ../aggregate_templates.php:643 ../graph_view.php:619
+#: ../include/global_arrays.php:654 ../include/global_arrays.php:988
+#: ../include/global_form.php:1323 ../include/global_form.php:1551
 #: ../lib/html_reports.php:377 ../tree.php:1286
 msgid "Graph Template"
 msgstr ""
@@ -853,7 +854,7 @@ msgid "Cannot be reused for %d password changes"
 msgstr ""
 
 #: ../auth_changepassword.php:258 ../auth_changepassword.php:284
-#: ../include/global_form.php:1457 ../lib/functions.php:1798
+#: ../include/global_form.php:1468 ../lib/functions.php:1809
 msgid "Change Password"
 msgstr ""
 
@@ -873,9 +874,8 @@ msgstr ""
 msgid "Confirm new password"
 msgstr ""
 
-#: ../auth_changepassword.php:307 ../lib/html_form.php:1069
-#: ../lib/html_form.php:1078 ../lib/html_graph.php:197
-#: ../lib/html_tree.php:648
+#: ../auth_changepassword.php:307 ../lib/html_form.php:1113
+#: ../lib/html_form.php:1122 ../lib/html_graph.php:197 ../lib/html_tree.php:649
 msgid "Save"
 msgstr ""
 
@@ -938,21 +938,21 @@ msgid "Enter your Username and Password below"
 msgstr ""
 
 #: ../auth_login.php:570 ../auth_login.php:573
-#: ../include/global_settings.php:1179 ../lib/functions.php:3768
+#: ../include/global_settings.php:1187 ../lib/functions.php:3780
 msgid "Username"
 msgstr ""
 
-#: ../auth_login.php:578 ../include/global_form.php:1424
-#: ../lib/functions.php:3769
+#: ../auth_login.php:578 ../include/global_form.php:1435
+#: ../lib/functions.php:3781
 msgid "Password"
 msgstr ""
 
-#: ../auth_login.php:590 ../include/global_settings.php:1559
+#: ../auth_login.php:590 ../include/global_settings.php:1567
 #: ../lib/auth.php:285 ../lib/auth.php:297 ../lib/auth.php:308
 msgid "Local"
 msgstr ""
 
-#: ../auth_login.php:594 ../include/global_arrays.php:530 ../lib/auth.php:309
+#: ../auth_login.php:594 ../include/global_arrays.php:581 ../lib/auth.php:309
 msgid "LDAP"
 msgstr ""
 
@@ -980,43 +980,43 @@ msgstr ""
 msgid "User Account Details"
 msgstr ""
 
-#: ../auth_profile.php:161 ../include/global_arrays.php:513
-#: ../include/global_settings.php:1895 ../lib/html.php:1540
-#: ../lib/html.php:1562
+#: ../auth_profile.php:161 ../include/global_arrays.php:564
+#: ../include/global_settings.php:1903 ../lib/html.php:1519
+#: ../lib/html.php:1541
 msgid "Tree View"
 msgstr ""
 
-#: ../auth_profile.php:165 ../include/global_arrays.php:514
-#: ../lib/html.php:1547 ../lib/html.php:1571
+#: ../auth_profile.php:165 ../include/global_arrays.php:565
+#: ../lib/html.php:1526 ../lib/html.php:1550
 msgid "List View"
 msgstr ""
 
-#: ../auth_profile.php:169 ../include/global_arrays.php:515
-#: ../lib/html.php:1554
+#: ../auth_profile.php:169 ../include/global_arrays.php:566
+#: ../lib/html.php:1533
 msgid "Preview View"
 msgstr ""
 
-#: ../auth_profile.php:182 ../include/global_form.php:1400
+#: ../auth_profile.php:182 ../include/global_form.php:1411
 #: ../user_admin.php:2246
 msgid "User Name"
 msgstr ""
 
-#: ../auth_profile.php:183 ../include/global_form.php:1401
+#: ../auth_profile.php:183 ../include/global_form.php:1412
 msgid "The login name for this user."
 msgstr ""
 
-#: ../auth_profile.php:190 ../include/global_form.php:1408
+#: ../auth_profile.php:190 ../include/global_form.php:1419
 #: ../user_admin.php:2247 ../user_group_admin.php:675 ../utilities.php:764
 msgid "Full Name"
 msgstr ""
 
-#: ../auth_profile.php:191 ../include/global_form.php:1409
+#: ../auth_profile.php:191 ../include/global_form.php:1420
 msgid ""
 "A more descriptive name for this user, that can include spaces or special "
 "characters."
 msgstr ""
 
-#: ../auth_profile.php:198 ../include/global_form.php:1416
+#: ../auth_profile.php:198 ../include/global_form.php:1427
 msgid "Email Address"
 msgstr ""
 
@@ -1044,19 +1044,19 @@ msgstr ""
 msgid "User Settings"
 msgstr ""
 
-#: ../auth_profile.php:292
+#: ../auth_profile.php:296
 msgid "Private Data Cleared"
 msgstr ""
 
-#: ../auth_profile.php:292
+#: ../auth_profile.php:296
 msgid "Your Private Data has been cleared."
 msgstr ""
 
-#: ../auth_profile.php:312
+#: ../auth_profile.php:316
 msgid "All your login sessions have been cleared."
 msgstr ""
 
-#: ../auth_profile.php:312
+#: ../auth_profile.php:316
 msgid "User Sessions Cleared"
 msgstr ""
 
@@ -1066,17 +1066,17 @@ msgstr ""
 
 #: ../automation_devices.php:39 ../automation_devices.php:271
 #: ../automation_devices.php:389 ../automation_devices.php:399
-#: ../automation_devices.php:622 ../automation_devices.php:623
-#: ../host.php:1382 ../lib/api_automation.php:166
-#: ../lib/api_automation.php:1021 ../lib/html_utility.php:806
+#: ../automation_devices.php:622 ../automation_devices.php:623 ../host.php:1390
+#: ../lib/api_automation.php:166 ../lib/api_automation.php:1021
+#: ../lib/html_utility.php:811
 msgid "Down"
 msgstr ""
 
 #: ../automation_devices.php:40 ../automation_devices.php:271
 #: ../automation_devices.php:391 ../automation_devices.php:401
-#: ../automation_devices.php:622 ../automation_devices.php:623
-#: ../host.php:1381 ../lib/api_automation.php:165
-#: ../lib/api_automation.php:1020 ../lib/html_utility.php:812
+#: ../automation_devices.php:622 ../automation_devices.php:623 ../host.php:1389
+#: ../lib/api_automation.php:165 ../lib/api_automation.php:1020
+#: ../lib/html_utility.php:817
 msgid "Up"
 msgstr ""
 
@@ -1089,12 +1089,11 @@ msgid "Added to Cacti"
 msgstr ""
 
 #: ../automation_devices.php:106 ../automation_devices.php:108
-#: ../data_sources.php:773 ../graph_view.php:620 ../graphs.php:1324
-#: ../graphs_items.php:304 ../include/global_arrays.php:599
-#: ../include/global_arrays.php:644 ../include/global_arrays.php:1432
-#: ../lib/api_automation.php:417 ../lib/functions.php:3763
-#: ../lib/html.php:1650 ../lib/html.php:1680 ../lib/html_reports.php:368
-#: ../utilities.php:1402
+#: ../data_sources.php:822 ../graph_view.php:619 ../graphs.php:1328
+#: ../graphs_items.php:304 ../include/global_arrays.php:650
+#: ../include/global_arrays.php:695 ../include/global_arrays.php:1434
+#: ../lib/api_automation.php:417 ../lib/functions.php:3775 ../lib/html.php:1629
+#: ../lib/html.php:1659 ../lib/html_reports.php:368 ../utilities.php:1409
 msgid "Device"
 msgstr ""
 
@@ -1106,7 +1105,7 @@ msgstr ""
 msgid "Click 'Continue' to add the following Discovered device(s)."
 msgstr ""
 
-#: ../automation_devices.php:183 ../pollers.php:592
+#: ../automation_devices.php:183 ../pollers.php:602
 msgid "Pollers"
 msgstr ""
 
@@ -1127,13 +1126,13 @@ msgstr ""
 msgid "You must select at least one Device."
 msgstr ""
 
-#: ../automation_devices.php:239 ../automation_devices.php:529
-#: ../host.php:1295 ../host.php:1388 ../host.php:1481
-#: ../include/global_arrays.php:631 ../include/global_arrays.php:683
-#: ../lib/api_automation.php:172 ../lib/api_automation.php:466
-#: ../lib/functions.php:2108 ../pollers.php:606 ../sites.php:483
-#: ../tree.php:1567 ../user_admin.php:2735 ../user_group_admin.php:958
-#: ../user_group_admin.php:2267 ../utilities.php:263
+#: ../automation_devices.php:239 ../automation_devices.php:529 ../host.php:1303
+#: ../host.php:1396 ../host.php:1489 ../include/global_arrays.php:682
+#: ../include/global_arrays.php:734 ../lib/api_automation.php:172
+#: ../lib/api_automation.php:466 ../lib/functions.php:2119 ../pollers.php:616
+#: ../sites.php:483 ../tree.php:1567 ../user_admin.php:2735
+#: ../user_group_admin.php:958 ../user_group_admin.php:2267
+#: ../utilities.php:263
 msgid "Devices"
 msgstr ""
 
@@ -1149,7 +1148,7 @@ msgstr ""
 msgid "SNMP Name"
 msgstr ""
 
-#: ../automation_devices.php:251 ../include/global_settings.php:1555
+#: ../automation_devices.php:251 ../include/global_settings.php:1563
 msgid "Location"
 msgstr ""
 
@@ -1157,9 +1156,9 @@ msgstr ""
 msgid "Contact"
 msgstr ""
 
-#: ../automation_devices.php:253 ../include/global_form.php:962
-#: ../include/global_form.php:998 ../include/global_form.php:1279
-#: ../include/global_form.php:1619 ../install/index.php:1032
+#: ../automation_devices.php:253 ../include/global_form.php:970
+#: ../include/global_form.php:1006 ../include/global_form.php:1287
+#: ../include/global_form.php:1630 ../install/index.php:906
 #: ../lib/api_automation.php:269 ../lib/api_automation.php:1137
 #: ../managers.php:222 ../tree.php:647 ../user_admin.php:1101
 #: ../user_admin.php:1229 ../user_group_admin.php:966
@@ -1171,26 +1170,25 @@ msgstr ""
 msgid "OS"
 msgstr ""
 
-#: ../automation_devices.php:255 ../host.php:1497
-#: ../include/global_arrays.php:279
+#: ../automation_devices.php:255 ../host.php:1505
+#: ../include/global_arrays.php:330
 msgid "Uptime"
 msgstr ""
 
 #: ../automation_devices.php:256 ../automation_devices.php:514
-#: ../utilities.php:1598
+#: ../utilities.php:1605
 msgid "SNMP"
 msgstr ""
 
 #: ../automation_devices.php:257 ../automation_devices.php:484
-#: ../automation_graph_rules.php:728 ../automation_networks.php:964
-#: ../automation_tree_rules.php:721 ../data_sources.php:1176
-#: ../data_templates.php:908 ../host.php:681 ../host.php:772 ../host.php:1373
-#: ../host.php:1495 ../lib/api_automation.php:157
-#: ../lib/api_automation.php:271 ../lib/api_automation.php:560
-#: ../lib/api_automation.php:1012 ../lib/api_automation.php:1140
-#: ../lib/html_reports.php:1389 ../managers.php:224 ../plugins.php:282
-#: ../plugins.php:377 ../pollers.php:604 ../user_admin.php:1229
-#: ../user_group_admin.php:966
+#: ../automation_graph_rules.php:729 ../automation_networks.php:964
+#: ../automation_tree_rules.php:721 ../data_sources.php:1231
+#: ../data_templates.php:915 ../host.php:686 ../host.php:778 ../host.php:1381
+#: ../host.php:1503 ../lib/api_automation.php:157 ../lib/api_automation.php:271
+#: ../lib/api_automation.php:560 ../lib/api_automation.php:1012
+#: ../lib/api_automation.php:1140 ../lib/html_reports.php:1394
+#: ../managers.php:224 ../plugins.php:282 ../plugins.php:377 ../pollers.php:614
+#: ../user_admin.php:1229 ../user_group_admin.php:966
 msgid "Status"
 msgstr ""
 
@@ -1202,7 +1200,7 @@ msgstr ""
 msgid "Not Detected"
 msgstr ""
 
-#: ../automation_devices.php:303 ../host.php:1539
+#: ../automation_devices.php:303 ../host.php:1547
 msgid "No Devices Found"
 msgstr ""
 
@@ -1218,7 +1216,7 @@ msgstr ""
 msgid "Reset fields to defaults"
 msgstr ""
 
-#: ../automation_devices.php:474 ../color.php:571 ../lib/html_form.php:1084
+#: ../automation_devices.php:474 ../color.php:571 ../lib/html_form.php:1128
 msgid "Export"
 msgstr ""
 
@@ -1226,8 +1224,8 @@ msgstr ""
 msgid "Export to a file"
 msgstr ""
 
-#: ../automation_devices.php:477 ../lib/clog_webapi.php:119
-#: ../lib/clog_webapi.php:336 ../managers.php:747
+#: ../automation_devices.php:477 ../lib/clog_webapi.php:120
+#: ../lib/clog_webapi.php:346 ../managers.php:747
 msgid "Purge"
 msgstr ""
 
@@ -1244,7 +1242,7 @@ msgstr ""
 
 #: ../automation_graph_rules.php:30 ../automation_networks.php:33
 #: ../automation_tree_rules.php:30 ../data_sources.php:38 ../host.php:39
-#: ../include/global_settings.php:1137 ../links.php:29 ../managers.php:29
+#: ../include/global_settings.php:1145 ../links.php:29 ../managers.php:29
 #: ../managers.php:35 ../plugins.php:29 ../pollers.php:31 ../user_admin.php:30
 #: ../user_domains.php:31 ../user_domains.php:402 ../user_group_admin.php:32
 msgid "Enable"
@@ -1333,79 +1331,79 @@ msgstr ""
 msgid "Matching Objects."
 msgstr ""
 
-#: ../automation_graph_rules.php:579
+#: ../automation_graph_rules.php:580
 msgid "Device Selection Criteria"
 msgstr ""
 
-#: ../automation_graph_rules.php:585
+#: ../automation_graph_rules.php:586
 msgid "Graph Creation Criteria"
 msgstr ""
 
-#: ../automation_graph_rules.php:691 ../automation_graph_rules.php:738
-#: ../automation_graph_rules.php:847 ../include/global_arrays.php:654
-#: ../include/global_form.php:1560 ../lib/functions.php:2558
+#: ../automation_graph_rules.php:692 ../automation_graph_rules.php:739
+#: ../automation_graph_rules.php:846 ../include/global_arrays.php:705
+#: ../include/global_form.php:1571 ../lib/functions.php:2569
 msgid "Graph Rules"
 msgstr ""
 
-#: ../automation_graph_rules.php:706 ../automation_graph_rules.php:858
-#: ../include/global_arrays.php:989 ../include/global_form.php:1550
-#: ../include/global_form.php:2165
+#: ../automation_graph_rules.php:707 ../automation_graph_rules.php:857
+#: ../include/global_arrays.php:991 ../include/global_form.php:1561
+#: ../include/global_form.php:2176
 msgid "Data Query"
 msgstr ""
 
-#: ../automation_graph_rules.php:733 ../automation_graph_rules.php:860
-#: ../automation_networks.php:496 ../automation_tree_rules.php:850
-#: ../automation_tree_rules.php:868 ../data_sources.php:1181 ../host.php:1378
-#: ../include/global_arrays.php:562 ../include/global_form.php:1432
+#: ../automation_graph_rules.php:734 ../automation_graph_rules.php:859
+#: ../automation_networks.php:496 ../automation_tree_rules.php:848
+#: ../automation_tree_rules.php:866 ../data_sources.php:1236 ../host.php:1386
+#: ../include/global_arrays.php:613 ../include/global_form.php:1443
 #: ../include/global_settings.php:339 ../lib/api_automation.php:162
-#: ../lib/api_automation.php:1017 ../lib/html_reports.php:1394
-#: ../lib/html_reports.php:1487 ../lib/html_reports.php:1498
-#: ../lib/html_reports.php:1521 ../links.php:381 ../managers.php:249
+#: ../lib/api_automation.php:1017 ../lib/html_reports.php:1399
+#: ../lib/html_reports.php:1492 ../lib/html_reports.php:1503
+#: ../lib/html_reports.php:1526 ../links.php:381 ../managers.php:249
 #: ../managers.php:626 ../user_admin.php:1101 ../user_admin.php:1113
 #: ../user_admin.php:2248 ../user_domains.php:341 ../user_domains.php:718
 #: ../user_group_admin.php:87 ../user_group_admin.php:675
 #: ../user_group_admin.php:690 ../user_group_admin.php:1887
-#: ../utilities.php:2135
+#: ../utilities.php:2142
 msgid "Enabled"
 msgstr ""
 
-#: ../automation_graph_rules.php:734 ../automation_networks.php:979
-#: ../automation_tree_rules.php:868 ../data_sources.php:1182
-#: ../data_templates.php:927 ../host.php:1379 ../include/global_arrays.php:561
-#: ../include/global_arrays.php:1156 ../include/global_arrays.php:1440
-#: ../include/global_settings.php:339 ../include/global_settings.php:1013
-#: ../include/global_settings.php:1027 ../include/global_settings.php:1039
-#: ../include/global_settings.php:1064 ../include/global_settings.php:1078
-#: ../include/global_settings.php:1137 ../include/global_settings.php:1749
+#: ../automation_graph_rules.php:735 ../automation_networks.php:979
+#: ../automation_tree_rules.php:866 ../data_sources.php:1237
+#: ../data_templates.php:934 ../host.php:1387 ../include/global_arrays.php:612
+#: ../include/global_arrays.php:1158 ../include/global_arrays.php:1442
+#: ../include/global_settings.php:339 ../include/global_settings.php:1021
+#: ../include/global_settings.php:1035 ../include/global_settings.php:1047
+#: ../include/global_settings.php:1072 ../include/global_settings.php:1086
+#: ../include/global_settings.php:1145 ../include/global_settings.php:1757
 #: ../lib/api_automation.php:163 ../lib/api_automation.php:1018
-#: ../lib/html_reports.php:1395 ../lib/html_reports.php:1521
-#: ../lib/html_utility.php:802 ../managers.php:249 ../managers.php:626
+#: ../lib/html_reports.php:1400 ../lib/html_reports.php:1526
+#: ../lib/html_utility.php:807 ../managers.php:249 ../managers.php:626
 #: ../pollers.php:40 ../user_admin.php:1113 ../user_domains.php:402
-#: ../user_group_admin.php:690 ../utilities.php:2135
+#: ../user_group_admin.php:690 ../utilities.php:2142
 msgid "Disabled"
 msgstr ""
 
-#: ../automation_graph_rules.php:856 ../automation_tree_rules.php:844
+#: ../automation_graph_rules.php:855 ../automation_tree_rules.php:842
 msgid "Rule Name"
 msgstr ""
 
-#: ../automation_graph_rules.php:856
+#: ../automation_graph_rules.php:855
 msgid "The name of this rule."
 msgstr ""
 
-#: ../automation_graph_rules.php:857
+#: ../automation_graph_rules.php:856
 msgid ""
 "The internal database ID for this rule.  Useful in performing debugging and "
 "automation."
 msgstr ""
 
-#: ../automation_graph_rules.php:859 ../include/global_form.php:1792
-#: ../include/global_form.php:1875 ../include/global_form.php:1977
-#: ../include/global_form.php:2176
+#: ../automation_graph_rules.php:858 ../include/global_form.php:1803
+#: ../include/global_form.php:1886 ../include/global_form.php:1988
+#: ../include/global_form.php:2187
 msgid "Graph Type"
 msgstr ""
 
-#: ../automation_graph_rules.php:882
+#: ../automation_graph_rules.php:881
 msgid "No Graph Rules Found"
 msgstr ""
 
@@ -1471,7 +1469,7 @@ msgid "Manual"
 msgstr ""
 
 #: ../automation_networks.php:379 ../automation_networks.php:953
-#: ../include/global_arrays.php:448
+#: ../include/global_arrays.php:499
 msgid "Daily"
 msgstr ""
 
@@ -1496,29 +1494,28 @@ msgstr ""
 msgid "Network Discovery Range [new]"
 msgstr ""
 
-#: ../automation_networks.php:395 ../include/global_form.php:1844
-#: ../include/global_form.php:1944 ../include/global_settings.php:51
+#: ../automation_networks.php:395 ../include/global_form.php:1855
+#: ../include/global_form.php:1955 ../include/global_settings.php:51
 #: ../lib/html_reports.php:30
 msgid "General Settings"
 msgstr ""
 
-#: ../automation_networks.php:400 ../automation_snmp.php:644
+#: ../automation_networks.php:400 ../automation_snmp.php:645
 #: ../data_input.php:468 ../data_input.php:502 ../data_queries.php:593
-#: ../data_queries.php:686 ../data_queries.php:900
-#: ../data_source_profiles.php:486 ../graph_templates.php:422
+#: ../data_queries.php:689 ../data_queries.php:909
+#: ../data_source_profiles.php:486 ../graph_templates.php:423
 #: ../include/global_form.php:35 ../include/global_form.php:104
 #: ../include/global_form.php:154 ../include/global_form.php:174
 #: ../include/global_form.php:215 ../include/global_form.php:339
 #: ../include/global_form.php:366 ../include/global_form.php:473
-#: ../include/global_form.php:930 ../include/global_form.php:954
-#: ../include/global_form.php:1251 ../include/global_form.php:1271
-#: ../include/global_form.php:1338 ../include/global_form.php:1366
-#: ../include/global_form.php:2059 ../include/global_form.php:2157
-#: ../include/global_form.php:2206 ../install/index.php:592
-#: ../install/index.php:669 ../install/index.php:1032 ../lib/vdef.php:74
-#: ../managers.php:607 ../pollers.php:52 ../sites.php:40
-#: ../user_admin.php:1101 ../user_domains.php:317 ../utilities.php:466
-#: ../utilities.php:2331
+#: ../include/global_form.php:930 ../include/global_form.php:962
+#: ../include/global_form.php:1259 ../include/global_form.php:1279
+#: ../include/global_form.php:1349 ../include/global_form.php:1377
+#: ../include/global_form.php:2070 ../include/global_form.php:2168
+#: ../include/global_form.php:2215 ../install/index.php:466
+#: ../install/index.php:543 ../install/index.php:906 ../lib/vdef.php:74
+#: ../managers.php:607 ../pollers.php:52 ../sites.php:40 ../user_admin.php:1101
+#: ../user_domains.php:317 ../utilities.php:466 ../utilities.php:2338
 msgid "Name"
 msgstr ""
 
@@ -1531,11 +1528,11 @@ msgid "New Network Discovery Range"
 msgstr ""
 
 #: ../automation_networks.php:408 ../automation_networks.php:961
-#: ../host.php:1322
+#: ../host.php:1330
 msgid "Data Collector"
 msgstr ""
 
-#: ../automation_networks.php:409 ../include/global_form.php:1014
+#: ../automation_networks.php:409 ../include/global_form.php:1022
 msgid ""
 "Choose the Cacti Data Collector/Poller to be used to gather data from this "
 "Device."
@@ -1609,9 +1606,9 @@ msgstr ""
 #: ../automation_networks.php:466 ../automation_networks.php:467
 #: ../automation_networks.php:468 ../automation_networks.php:469
 #: ../automation_networks.php:470 ../automation_networks.php:471
-#: ../automation_networks.php:472 ../include/global_arrays.php:496
-#: ../include/global_arrays.php:497 ../include/global_arrays.php:498
-#: ../include/global_arrays.php:499 ../include/global_arrays.php:500
+#: ../automation_networks.php:472 ../include/global_arrays.php:547
+#: ../include/global_arrays.php:548 ../include/global_arrays.php:549
+#: ../include/global_arrays.php:550 ../include/global_arrays.php:551
 #, php-format
 msgid "%d Threads"
 msgstr ""
@@ -1631,46 +1628,46 @@ msgstr ""
 
 #: ../automation_networks.php:483 ../automation_networks.php:484
 #: ../automation_networks.php:485 ../automation_networks.php:486
-#: ../data_sources.php:1022 ../include/global_arrays.php:438
-#: ../include/global_arrays.php:439 ../include/global_arrays.php:440
-#: ../include/global_arrays.php:441 ../include/global_arrays.php:471
-#: ../include/global_arrays.php:472 ../include/global_arrays.php:473
-#: ../include/global_arrays.php:474 ../include/global_arrays.php:475
-#: ../include/global_arrays.php:476 ../include/global_arrays.php:794
-#: ../include/global_arrays.php:795 ../include/global_arrays.php:1163
-#: ../include/global_arrays.php:1167 ../include/global_arrays.php:1175
-#: ../include/global_arrays.php:1176 ../include/global_arrays.php:1198
-#: ../include/global_arrays.php:1199 ../include/global_arrays.php:1200
+#: ../data_sources.php:1071 ../include/global_arrays.php:489
+#: ../include/global_arrays.php:490 ../include/global_arrays.php:491
+#: ../include/global_arrays.php:492 ../include/global_arrays.php:522
+#: ../include/global_arrays.php:523 ../include/global_arrays.php:524
+#: ../include/global_arrays.php:525 ../include/global_arrays.php:526
+#: ../include/global_arrays.php:527 ../include/global_arrays.php:845
+#: ../include/global_arrays.php:846 ../include/global_arrays.php:1165
+#: ../include/global_arrays.php:1169 ../include/global_arrays.php:1177
+#: ../include/global_arrays.php:1178 ../include/global_arrays.php:1200
 #: ../include/global_arrays.php:1201 ../include/global_arrays.php:1202
-#: ../include/global_arrays.php:1213 ../include/global_settings.php:1080
-#: ../include/global_settings.php:1081 ../include/global_settings.php:1082
-#: ../include/global_settings.php:1083 ../include/global_settings.php:1084
-#: ../include/global_settings.php:1822
+#: ../include/global_arrays.php:1203 ../include/global_arrays.php:1204
+#: ../include/global_arrays.php:1215 ../include/global_settings.php:1088
+#: ../include/global_settings.php:1089 ../include/global_settings.php:1090
+#: ../include/global_settings.php:1091 ../include/global_settings.php:1092
+#: ../include/global_settings.php:1830
 #, php-format
 msgid "%d Minutes"
 msgstr ""
 
-#: ../automation_networks.php:487 ../include/global_arrays.php:1068
+#: ../automation_networks.php:487 ../include/global_arrays.php:1070
 #, php-format
 msgid "%d Hour"
 msgstr ""
 
 #: ../automation_networks.php:488 ../automation_networks.php:489
 #: ../automation_networks.php:490 ../data_source_profiles.php:656
-#: ../include/global_arrays.php:443 ../include/global_arrays.php:444
-#: ../include/global_arrays.php:445 ../include/global_arrays.php:446
-#: ../include/global_arrays.php:447 ../include/global_arrays.php:478
-#: ../include/global_arrays.php:479 ../include/global_arrays.php:480
-#: ../include/global_arrays.php:481 ../include/global_arrays.php:1069
-#: ../include/global_arrays.php:1070 ../include/global_arrays.php:1071
-#: ../include/global_arrays.php:1072 ../include/global_arrays.php:1115
-#: ../include/global_arrays.php:1116 ../include/global_arrays.php:1117
+#: ../include/global_arrays.php:494 ../include/global_arrays.php:495
+#: ../include/global_arrays.php:496 ../include/global_arrays.php:497
+#: ../include/global_arrays.php:498 ../include/global_arrays.php:529
+#: ../include/global_arrays.php:530 ../include/global_arrays.php:531
+#: ../include/global_arrays.php:532 ../include/global_arrays.php:1071
+#: ../include/global_arrays.php:1072 ../include/global_arrays.php:1073
+#: ../include/global_arrays.php:1074 ../include/global_arrays.php:1117
 #: ../include/global_arrays.php:1118 ../include/global_arrays.php:1119
-#: ../include/global_arrays.php:1136 ../include/global_arrays.php:1137
+#: ../include/global_arrays.php:1120 ../include/global_arrays.php:1121
 #: ../include/global_arrays.php:1138 ../include/global_arrays.php:1139
-#: ../include/global_arrays.php:1140 ../include/global_settings.php:1086
-#: ../include/global_settings.php:1087 ../include/global_settings.php:1088
-#: ../include/global_settings.php:1089
+#: ../include/global_arrays.php:1140 ../include/global_arrays.php:1141
+#: ../include/global_arrays.php:1142 ../include/global_settings.php:1094
+#: ../include/global_settings.php:1095 ../include/global_settings.php:1096
+#: ../include/global_settings.php:1097
 #, php-format
 msgid "%d Hours"
 msgstr ""
@@ -1735,37 +1732,37 @@ msgid "What Day(s) of the week will this Network Range be discovered."
 msgstr ""
 
 #: ../automation_networks.php:554 ../automation_networks.php:612
-#: ../include/global_arrays.php:1490
+#: ../include/global_arrays.php:1492
 msgid "Sunday"
 msgstr ""
 
 #: ../automation_networks.php:555 ../automation_networks.php:613
-#: ../include/global_arrays.php:1491
+#: ../include/global_arrays.php:1493
 msgid "Monday"
 msgstr ""
 
 #: ../automation_networks.php:556 ../automation_networks.php:614
-#: ../include/global_arrays.php:1492
+#: ../include/global_arrays.php:1494
 msgid "Tuesday"
 msgstr ""
 
 #: ../automation_networks.php:557 ../automation_networks.php:615
-#: ../include/global_arrays.php:1493
+#: ../include/global_arrays.php:1495
 msgid "Wednesday"
 msgstr ""
 
 #: ../automation_networks.php:558 ../automation_networks.php:616
-#: ../include/global_arrays.php:1494
+#: ../include/global_arrays.php:1496
 msgid "Thursday"
 msgstr ""
 
 #: ../automation_networks.php:559 ../automation_networks.php:617
-#: ../include/global_arrays.php:1495
+#: ../include/global_arrays.php:1497
 msgid "Friday"
 msgstr ""
 
 #: ../automation_networks.php:560 ../automation_networks.php:618
-#: ../include/global_arrays.php:1496
+#: ../include/global_arrays.php:1498
 msgid "Saturday"
 msgstr ""
 
@@ -1777,51 +1774,51 @@ msgstr ""
 msgid "What Months(s) of the Year will this Network Range be discovered."
 msgstr ""
 
-#: ../automation_networks.php:570 ../include/global_arrays.php:1460
+#: ../automation_networks.php:570 ../include/global_arrays.php:1462
 msgid "January"
 msgstr ""
 
-#: ../automation_networks.php:571 ../include/global_arrays.php:1461
+#: ../automation_networks.php:571 ../include/global_arrays.php:1463
 msgid "February"
 msgstr ""
 
-#: ../automation_networks.php:572 ../include/global_arrays.php:1462
+#: ../automation_networks.php:572 ../include/global_arrays.php:1464
 msgid "March"
 msgstr ""
 
-#: ../automation_networks.php:573 ../include/global_arrays.php:1463
+#: ../automation_networks.php:573 ../include/global_arrays.php:1465
 msgid "April"
 msgstr ""
 
-#: ../automation_networks.php:574 ../include/global_arrays.php:1464
+#: ../automation_networks.php:574 ../include/global_arrays.php:1466
 msgid "May"
 msgstr ""
 
-#: ../automation_networks.php:575 ../include/global_arrays.php:1465
+#: ../automation_networks.php:575 ../include/global_arrays.php:1467
 msgid "June"
 msgstr ""
 
-#: ../automation_networks.php:576 ../include/global_arrays.php:1466
+#: ../automation_networks.php:576 ../include/global_arrays.php:1468
 msgid "July"
 msgstr ""
 
-#: ../automation_networks.php:577 ../include/global_arrays.php:1467
+#: ../automation_networks.php:577 ../include/global_arrays.php:1469
 msgid "August"
 msgstr ""
 
-#: ../automation_networks.php:578 ../include/global_arrays.php:1468
+#: ../automation_networks.php:578 ../include/global_arrays.php:1470
 msgid "September"
 msgstr ""
 
-#: ../automation_networks.php:579 ../include/global_arrays.php:1469
+#: ../automation_networks.php:579 ../include/global_arrays.php:1471
 msgid "October"
 msgstr ""
 
-#: ../automation_networks.php:580 ../include/global_arrays.php:1470
+#: ../automation_networks.php:580 ../include/global_arrays.php:1472
 msgid "November"
 msgstr ""
 
-#: ../automation_networks.php:581 ../include/global_arrays.php:1471
+#: ../automation_networks.php:581 ../include/global_arrays.php:1473
 msgid "December"
 msgstr ""
 
@@ -1865,8 +1862,8 @@ msgstr ""
 msgid "Reachability Settings"
 msgstr ""
 
-#: ../automation_networks.php:630 ../include/global_arrays.php:656
-#: ../include/global_form.php:1054 ../include/global_form.php:1651
+#: ../automation_networks.php:630 ../include/global_arrays.php:707
+#: ../include/global_form.php:1062 ../include/global_form.php:1662
 msgid "SNMP Options"
 msgstr ""
 
@@ -1874,7 +1871,7 @@ msgstr ""
 msgid "Select the SNMP Options to use for discovery of this Network Range."
 msgstr ""
 
-#: ../automation_networks.php:637 ../include/global_form.php:1179
+#: ../automation_networks.php:637 ../include/global_form.php:1187
 msgid "Ping Method"
 msgstr ""
 
@@ -1882,33 +1879,33 @@ msgstr ""
 msgid "The type of ping packet to send."
 msgstr ""
 
-#: ../automation_networks.php:646 ../include/global_form.php:1189
+#: ../automation_networks.php:646 ../include/global_form.php:1197
 #: ../include/global_settings.php:561
 msgid "Ping Port"
 msgstr ""
 
-#: ../automation_networks.php:648 ../include/global_form.php:1191
+#: ../automation_networks.php:648 ../include/global_form.php:1199
 msgid "TCP or UDP port to attempt connection."
 msgstr ""
 
-#: ../automation_networks.php:654 ../include/global_form.php:1197
+#: ../automation_networks.php:654 ../include/global_form.php:1205
 #: ../include/global_settings.php:569
 msgid "Ping Timeout Value"
 msgstr ""
 
-#: ../automation_networks.php:655 ../include/global_form.php:1198
+#: ../automation_networks.php:655 ../include/global_form.php:1206
 #: ../include/global_settings.php:570
 msgid ""
 "The timeout value to use for host ICMP and UDP pinging.  This host SNMP "
 "timeout value applies for SNMP pings."
 msgstr ""
 
-#: ../automation_networks.php:663 ../include/global_form.php:1206
+#: ../automation_networks.php:663 ../include/global_form.php:1214
 #: ../include/global_settings.php:577
 msgid "Ping Retry Count"
 msgstr ""
 
-#: ../automation_networks.php:664 ../include/global_form.php:1207
+#: ../automation_networks.php:664 ../include/global_form.php:1215
 msgid ""
 "After an initial failure, the number of ping retries Cacti will attempt "
 "before failing."
@@ -1959,7 +1956,7 @@ msgid "Network Filters"
 msgstr ""
 
 #: ../automation_networks.php:943 ../automation_networks.php:1067
-#: ../include/global_arrays.php:651
+#: ../include/global_arrays.php:702
 msgid "Networks"
 msgstr ""
 
@@ -2007,21 +2004,21 @@ msgstr ""
 msgid "Last Started"
 msgstr ""
 
-#: ../automation_networks.php:995 ../pollers.php:37 ../utilities.php:1945
+#: ../automation_networks.php:995 ../pollers.php:37 ../utilities.php:1952
 msgid "Running"
 msgstr ""
 
-#: ../automation_networks.php:1015 ../pollers.php:38 ../utilities.php:1944
+#: ../automation_networks.php:1015 ../pollers.php:38 ../utilities.php:1951
 msgid "Idle"
 msgstr ""
 
-#: ../automation_networks.php:1030 ../automation_snmp.php:703
-#: ../automation_snmp.php:704 ../automation_snmp.php:705
+#: ../automation_networks.php:1030 ../automation_snmp.php:705
 #: ../automation_snmp.php:706 ../automation_snmp.php:707
-#: ../automation_snmp.php:708 ../lib/html.php:958 ../user_admin.php:2261
-#: ../utilities.php:406 ../utilities.php:792 ../utilities.php:2008
-#: ../utilities.php:2108 ../utilities.php:2111 ../utilities.php:2114
-#: ../utilities.php:2120 ../utilities.php:2351
+#: ../automation_snmp.php:708 ../automation_snmp.php:709
+#: ../automation_snmp.php:710 ../lib/html.php:937 ../user_admin.php:2261
+#: ../utilities.php:406 ../utilities.php:792 ../utilities.php:2015
+#: ../utilities.php:2115 ../utilities.php:2118 ../utilities.php:2121
+#: ../utilities.php:2127 ../utilities.php:2358
 msgid "N/A"
 msgstr ""
 
@@ -2086,8 +2083,8 @@ msgstr ""
 msgid "SNMP Options [new]"
 msgstr ""
 
-#: ../automation_snmp.php:434 ../include/global_form.php:1059
-#: ../include/global_form.php:1656
+#: ../automation_snmp.php:434 ../include/global_form.php:1067
+#: ../include/global_form.php:1667
 msgid "SNMP Version"
 msgstr ""
 
@@ -2103,8 +2100,8 @@ msgstr ""
 msgid "Fill in the SNMP read community for this device."
 msgstr ""
 
-#: ../automation_snmp.php:452 ../include/global_form.php:1139
-#: ../include/global_form.php:1726
+#: ../automation_snmp.php:452 ../include/global_form.php:1147
+#: ../include/global_form.php:1737
 msgid "SNMP Port"
 msgstr ""
 
@@ -2112,13 +2109,13 @@ msgstr ""
 msgid "The UDP/TCP Port to poll the SNMP agent on."
 msgstr ""
 
-#: ../automation_snmp.php:461 ../include/global_form.php:1148
-#: ../include/global_form.php:1735
+#: ../automation_snmp.php:461 ../include/global_form.php:1156
+#: ../include/global_form.php:1746
 msgid "SNMP Timeout"
 msgstr ""
 
-#: ../automation_snmp.php:462 ../include/global_form.php:1149
-#: ../include/global_form.php:1736
+#: ../automation_snmp.php:462 ../include/global_form.php:1157
+#: ../include/global_form.php:1747
 msgid ""
 "The maximum number of milliseconds Cacti will wait for an SNMP response "
 "(does not work with php-snmp support)."
@@ -2138,23 +2135,23 @@ msgstr ""
 msgid "Maximum OID's Per Get Request"
 msgstr ""
 
-#: ../automation_snmp.php:480 ../include/global_form.php:1158
+#: ../automation_snmp.php:480 ../include/global_form.php:1166
 msgid ""
 "Specified the number of OIDs that can be obtained in a single SNMP Get "
 "request."
 msgstr ""
 
-#: ../automation_snmp.php:488 ../include/global_form.php:1078
-#: ../include/global_form.php:1675
+#: ../automation_snmp.php:488 ../include/global_form.php:1086
+#: ../include/global_form.php:1686
 msgid "SNMP Username (v3)"
 msgstr ""
 
-#: ../automation_snmp.php:489 ../include/global_form.php:1079
-#: ../include/global_form.php:1676
+#: ../automation_snmp.php:489 ../include/global_form.php:1087
+#: ../include/global_form.php:1687
 msgid "SNMP v3 username for this device."
 msgstr ""
 
-#: ../automation_snmp.php:497 ../include/global_form.php:1087
+#: ../automation_snmp.php:497 ../include/global_form.php:1095
 msgid "SNMP Password (v3)"
 msgstr ""
 
@@ -2162,8 +2159,8 @@ msgstr ""
 msgid "SNMP v3 password for this device."
 msgstr ""
 
-#: ../automation_snmp.php:506 ../include/global_form.php:1096
-#: ../include/global_form.php:1693
+#: ../automation_snmp.php:506 ../include/global_form.php:1104
+#: ../include/global_form.php:1704
 msgid "SNMP Auth Protocol (v3)"
 msgstr ""
 
@@ -2171,17 +2168,17 @@ msgstr ""
 msgid "Choose the SNMPv3 Authorization Protocol."
 msgstr ""
 
-#: ../automation_snmp.php:514 ../include/global_form.php:1104
+#: ../automation_snmp.php:514 ../include/global_form.php:1112
 msgid "SNMP Privacy Passphrase (v3)"
 msgstr ""
 
-#: ../automation_snmp.php:515 ../include/global_form.php:1702
+#: ../automation_snmp.php:515 ../include/global_form.php:1713
 #: ../include/global_settings.php:506
 msgid "Choose the SNMPv3 Privacy Passphrase."
 msgstr ""
 
-#: ../automation_snmp.php:523 ../include/global_form.php:1113
-#: ../include/global_form.php:1710
+#: ../automation_snmp.php:523 ../include/global_form.php:1121
+#: ../include/global_form.php:1721
 msgid "SNMP Privacy Protocol (v3)"
 msgstr ""
 
@@ -2198,10 +2195,10 @@ msgid "Enter the SNMP Context to use for this device."
 msgstr ""
 
 #: ../automation_snmp.php:544 ../include/global_form.php:921
-#: ../include/global_form.php:2106 ../include/global_form.php:2148
-#: ../include/global_form.php:2304 ../lib/api_automation.php:1207
+#: ../include/global_form.php:2117 ../include/global_form.php:2159
+#: ../include/global_form.php:2313 ../lib/api_automation.php:1207
 #: ../lib/api_automation.php:1269 ../lib/api_automation.php:1332
-#: ../lib/html_reports.php:428 ../lib/html_reports.php:1230
+#: ../lib/html_reports.php:428 ../lib/html_reports.php:1235
 msgid "Sequence"
 msgstr ""
 
@@ -2209,144 +2206,145 @@ msgstr ""
 msgid "Sequence of Item."
 msgstr ""
 
-#: ../automation_snmp.php:631
-msgid "edit"
+#: ../automation_snmp.php:632
+#, php-format
+msgid "SNMP Option Set [edit: %s]"
 msgstr ""
 
-#: ../automation_snmp.php:633
-msgid "new"
+#: ../automation_snmp.php:634
+msgid "SNMP Option Set [new]"
 msgstr ""
 
-#: ../automation_snmp.php:638 ../automation_snmp.php:930
-msgid "SNMP Option Set"
-msgstr ""
-
-#: ../automation_snmp.php:645
+#: ../automation_snmp.php:646
 msgid "Fill in the name of this SNMP Option Set."
 msgstr ""
 
-#: ../automation_snmp.php:669 ../automation_snmp.php:818
+#: ../automation_snmp.php:671 ../automation_snmp.php:820
 msgid "Automation SNMP Options"
 msgstr ""
 
-#: ../automation_snmp.php:672 ../cdef.php:584 ../lib/api_automation.php:1206
+#: ../automation_snmp.php:674 ../cdef.php:584 ../lib/api_automation.php:1206
 #: ../lib/api_automation.php:1268 ../lib/api_automation.php:1331
-#: ../lib/html_reports.php:1230 ../vdef.php:564
+#: ../lib/html_reports.php:1235 ../vdef.php:564
 msgid "Item"
 msgstr ""
 
-#: ../automation_snmp.php:673 ../include/auth.php:154
+#: ../automation_snmp.php:675 ../include/auth.php:154
 #: ../include/global_settings.php:469 ../permission_denied.php:67
 #: ../plugins.php:379
 msgid "Version"
 msgstr ""
 
-#: ../automation_snmp.php:674 ../include/global_settings.php:476
+#: ../automation_snmp.php:676 ../include/global_settings.php:476
 msgid "Community"
 msgstr ""
 
-#: ../automation_snmp.php:675 ../lib/functions.php:3764
+#: ../automation_snmp.php:677 ../lib/functions.php:3776
 msgid "Port"
 msgstr ""
 
-#: ../automation_snmp.php:676 ../include/global_settings.php:518
+#: ../automation_snmp.php:678 ../include/global_settings.php:518
 msgid "Timeout"
 msgstr ""
 
-#: ../automation_snmp.php:677 ../include/global_settings.php:534
+#: ../automation_snmp.php:679 ../include/global_settings.php:534
 msgid "Retries"
 msgstr ""
 
-#: ../automation_snmp.php:678
+#: ../automation_snmp.php:680
 msgid "Max OIDS"
 msgstr ""
 
-#: ../automation_snmp.php:679
+#: ../automation_snmp.php:681
 msgid "Auth Username"
 msgstr ""
 
-#: ../automation_snmp.php:680
+#: ../automation_snmp.php:682
 msgid "Auth Password"
 msgstr ""
 
-#: ../automation_snmp.php:681
+#: ../automation_snmp.php:683
 msgid "Auth Protocol"
 msgstr ""
 
-#: ../automation_snmp.php:682
+#: ../automation_snmp.php:684
 msgid "Priv Passphrase"
 msgstr ""
 
-#: ../automation_snmp.php:683
+#: ../automation_snmp.php:685
 msgid "Priv Protocol"
 msgstr ""
 
-#: ../automation_snmp.php:684
+#: ../automation_snmp.php:686
 msgid "Context"
 msgstr ""
 
-#: ../automation_snmp.php:685 ../data_queries.php:904 ../utilities.php:1593
+#: ../automation_snmp.php:687 ../data_queries.php:913 ../utilities.php:1600
 msgid "Action"
 msgstr ""
 
-#: ../automation_snmp.php:698
+#: ../automation_snmp.php:700
 msgid "none"
 msgstr ""
 
-#: ../automation_snmp.php:713 ../automation_templates.php:545 ../cdef.php:607
-#: ../color_templates.php:109 ../data_queries.php:623 ../data_queries.php:718
+#: ../automation_snmp.php:715 ../automation_templates.php:545 ../cdef.php:607
+#: ../color_templates.php:110 ../data_queries.php:623 ../data_queries.php:721
 #: ../lib/api_automation.php:1233 ../lib/api_automation.php:1296
-#: ../lib/api_automation.php:1360 ../lib/html.php:980
-#: ../lib/html_reports.php:1296 ../tree.php:1578 ../tree.php:1582
+#: ../lib/api_automation.php:1360 ../lib/html.php:959
+#: ../lib/html_reports.php:1301 ../tree.php:1578 ../tree.php:1582
 #: ../tree.php:1585 ../tree.php:1586 ../vdef.php:588
 msgid "Move Down"
 msgstr ""
 
-#: ../automation_snmp.php:719 ../automation_templates.php:551 ../cdef.php:613
-#: ../color_templates.php:115 ../data_queries.php:628 ../data_queries.php:723
+#: ../automation_snmp.php:721 ../automation_templates.php:551 ../cdef.php:613
+#: ../color_templates.php:116 ../data_queries.php:628 ../data_queries.php:726
 #: ../lib/api_automation.php:1239 ../lib/api_automation.php:1302
-#: ../lib/api_automation.php:1366 ../lib/html.php:985
-#: ../lib/html_reports.php:1296 ../vdef.php:594
+#: ../lib/api_automation.php:1366 ../lib/html.php:964
+#: ../lib/html_reports.php:1301 ../vdef.php:594
 msgid "Move Up"
 msgstr ""
 
-#: ../automation_snmp.php:733
+#: ../automation_snmp.php:735
 msgid "No SNMP Items"
 msgstr ""
 
-#: ../automation_snmp.php:768
+#: ../automation_snmp.php:770
 msgid "Delete SNMP Option Item"
 msgstr ""
 
-#: ../automation_snmp.php:832
+#: ../automation_snmp.php:834
 msgid "SNMP Rules"
 msgstr ""
 
-#: ../automation_snmp.php:921
+#: ../automation_snmp.php:923
 msgid "SNMP Option Sets"
 msgstr ""
 
-#: ../automation_snmp.php:931
-msgid "Networks Using"
-msgstr ""
-
 #: ../automation_snmp.php:932
-msgid "SNMP Entries"
+msgid "SNMP Option Set"
 msgstr ""
 
 #: ../automation_snmp.php:933
-msgid "V1 Entries"
+msgid "Networks Using"
 msgstr ""
 
 #: ../automation_snmp.php:934
-msgid "V2 Entries"
+msgid "SNMP Entries"
 msgstr ""
 
 #: ../automation_snmp.php:935
+msgid "V1 Entries"
+msgstr ""
+
+#: ../automation_snmp.php:936
+msgid "V2 Entries"
+msgstr ""
+
+#: ../automation_snmp.php:937
 msgid "V3 Entries"
 msgstr ""
 
-#: ../automation_snmp.php:955
+#: ../automation_snmp.php:957
 msgid "No SNMP Option Sets Found"
 msgstr ""
 
@@ -2362,8 +2360,8 @@ msgstr ""
 msgid "You must select at least one Automation Template."
 msgstr ""
 
-#: ../automation_templates.php:300 ../include/global_arrays.php:990
-#: ../include/global_form.php:1030 ../include/global_form.php:1535
+#: ../automation_templates.php:300 ../include/global_arrays.php:992
+#: ../include/global_form.php:1038 ../include/global_form.php:1546
 #: ../lib/html_reports.php:359
 msgid "Device Template"
 msgstr ""
@@ -2422,7 +2420,7 @@ msgstr ""
 msgid "Device Automation Templates"
 msgstr ""
 
-#: ../automation_templates.php:512 ../data_sources.php:1355 ../graphs.php:1745
+#: ../automation_templates.php:512 ../data_sources.php:1410 ../graphs.php:1786
 #: ../user_admin.php:1371 ../user_group_admin.php:1109
 msgid "Template Name"
 msgstr ""
@@ -2432,7 +2430,7 @@ msgid "System ObjectId Match"
 msgstr ""
 
 #: ../automation_templates.php:520 ../data_queries.php:594
-#: ../data_queries.php:687 ../links.php:382 ../tree.php:1563
+#: ../data_queries.php:690 ../links.php:382 ../tree.php:1563
 msgid "Order"
 msgstr ""
 
@@ -2477,32 +2475,32 @@ msgid "Tree Rules Selection [new]"
 msgstr ""
 
 #: ../automation_tree_rules.php:706 ../automation_tree_rules.php:731
-#: ../automation_tree_rules.php:835 ../include/global_arrays.php:655
-#: ../include/global_form.php:1565 ../lib/functions.php:2582
+#: ../automation_tree_rules.php:833 ../include/global_arrays.php:706
+#: ../include/global_form.php:1576 ../lib/functions.php:2593
 msgid "Tree Rules"
 msgstr ""
 
-#: ../automation_tree_rules.php:846
+#: ../automation_tree_rules.php:844
 msgid "Hook into Tree"
 msgstr ""
 
-#: ../automation_tree_rules.php:847
+#: ../automation_tree_rules.php:845
 msgid "At Subtree"
 msgstr ""
 
-#: ../automation_tree_rules.php:848
+#: ../automation_tree_rules.php:846
 msgid "This Type"
 msgstr ""
 
-#: ../automation_tree_rules.php:849
+#: ../automation_tree_rules.php:847
 msgid "Using Grouping"
 msgstr ""
 
-#: ../automation_tree_rules.php:858
+#: ../automation_tree_rules.php:856
 msgid "ROOT"
 msgstr ""
 
-#: ../automation_tree_rules.php:874
+#: ../automation_tree_rules.php:872
 msgid "No Tree Rules Found"
 msgstr ""
 
@@ -2551,6 +2549,10 @@ msgstr ""
 msgid "Remove CDEF Item"
 msgstr ""
 
+#: ../cdef.php:424
+msgid "CDEF Preview"
+msgstr ""
+
 #: ../cdef.php:430
 #, php-format
 msgid "CDEF Items [edit: %s]"
@@ -2581,7 +2583,7 @@ msgstr ""
 msgid "CDEF [new]"
 msgstr ""
 
-#: ../cdef.php:581 ../lib/functions.php:1958
+#: ../cdef.php:581 ../lib/functions.php:1969
 msgid "CDEF Items"
 msgstr ""
 
@@ -2599,7 +2601,7 @@ msgid "Delete CDEF Item"
 msgstr ""
 
 #: ../cdef.php:713 ../cdef.php:728 ../cdef.php:842
-#: ../include/global_arrays.php:660 ../lib/functions.php:1940
+#: ../include/global_arrays.php:711 ../lib/functions.php:1951
 msgid "CDEFs"
 msgstr ""
 
@@ -2622,7 +2624,7 @@ msgid "The number of Graphs using this CDEF."
 msgstr ""
 
 #: ../cdef.php:854 ../color.php:701 ../data_input.php:725
-#: ../data_queries.php:1146 ../data_source_profiles.php:854
+#: ../data_queries.php:1155 ../data_source_profiles.php:854
 #: ../gprint_presets.php:394 ../vdef.php:848
 msgid "Templates Using"
 msgstr ""
@@ -2677,7 +2679,7 @@ msgid ""
 "information."
 msgstr ""
 
-#: ../color.php:373 ../lib/html_form.php:417
+#: ../color.php:373 ../lib/html_form.php:463
 msgid "Select a File"
 msgstr ""
 
@@ -2720,8 +2722,8 @@ msgstr ""
 msgid "Colors [new]"
 msgstr ""
 
-#: ../color.php:520 ../color.php:535 ../include/global_arrays.php:662
-#: ../lib/functions.php:2006
+#: ../color.php:520 ../color.php:535 ../include/global_arrays.php:713
+#: ../lib/functions.php:2017
 msgid "Colors"
 msgstr ""
 
@@ -2729,7 +2731,7 @@ msgstr ""
 msgid "Named Colors"
 msgstr ""
 
-#: ../color.php:568 ../lib/html_form.php:1082
+#: ../color.php:568 ../lib/html_form.php:1126
 msgid "Import"
 msgstr ""
 
@@ -2737,7 +2739,7 @@ msgstr ""
 msgid "Export Colors"
 msgstr ""
 
-#: ../color.php:695
+#: ../color.php:695 ../color_templates.php:74
 msgid "Hex"
 msgstr ""
 
@@ -2761,8 +2763,8 @@ msgstr ""
 msgid "Named Color"
 msgstr ""
 
-#: ../color.php:698 ../include/global_arrays.php:648
-#: ../include/global_form.php:812 ../include/global_form.php:2047
+#: ../color.php:698 ../color_templates.php:73 ../include/global_arrays.php:699
+#: ../include/global_form.php:812 ../include/global_form.php:2058
 msgid "Color"
 msgstr ""
 
@@ -2792,35 +2794,31 @@ msgstr ""
 msgid "Color Item"
 msgstr ""
 
-#: ../color_templates.php:73 ../lib/api_aggregate.php:1218 ../lib/html.php:881
-msgid "Item Color"
-msgstr ""
-
-#: ../color_templates.php:92 ../lib/api_aggregate.php:1290
+#: ../color_templates.php:93 ../lib/api_aggregate.php:1290
 #: ../lib/api_aggregate.php:1293 ../lib/api_aggregate.php:1297
-#: ../lib/html.php:917
+#: ../lib/html.php:896
 #, php-format
 msgid "Item # %d"
 msgstr ""
 
-#: ../color_templates.php:131 ../graph_templates_inputs.php:222
-#: ../lib/api_aggregate.php:1350 ../lib/html.php:999
+#: ../color_templates.php:132 ../graph_templates_inputs.php:222
+#: ../lib/api_aggregate.php:1349 ../lib/html.php:978
 msgid "No Items"
 msgstr ""
 
-#: ../color_templates.php:226
+#: ../color_templates.php:227
 msgid "Click 'Continue' to delete the following Color Template"
 msgid_plural "Click 'Continue' to delete following Color Templates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../color_templates.php:231
+#: ../color_templates.php:232
 msgid "Delete Color Template"
 msgid_plural "Delete Color Templates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../color_templates.php:235
+#: ../color_templates.php:236
 msgid ""
 "Click 'Continue' to duplicate the following Color Template. You can "
 "optionally change the title format for the new color template."
@@ -2830,56 +2828,56 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../color_templates.php:237 ../data_source_profiles.php:272
-#: ../data_templates.php:364 ../graph_templates.php:322
+#: ../color_templates.php:238 ../data_source_profiles.php:272
+#: ../data_templates.php:364 ../graph_templates.php:323
 #: ../host_templates.php:267 ../vdef.php:276
 msgid "Title Format:"
 msgstr ""
 
-#: ../color_templates.php:241
+#: ../color_templates.php:242
 msgid "Duplicate Color Template"
 msgid_plural "Duplicate Color Templates"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../color_templates.php:244
+#: ../color_templates.php:245
 msgid "You must select at least one Color Template."
 msgstr ""
 
-#: ../color_templates.php:277
+#: ../color_templates.php:278
 msgid "Color Template Items [new]"
 msgstr ""
 
-#: ../color_templates.php:288
+#: ../color_templates.php:289
 #, php-format
 msgid "Color Template Items [edit: %s]"
 msgstr ""
 
-#: ../color_templates.php:321
+#: ../color_templates.php:322
 msgid "Delete Color Item"
 msgstr ""
 
-#: ../color_templates.php:348
+#: ../color_templates.php:349
 #, php-format
 msgid "Color Template [edit: %s]"
 msgstr ""
 
-#: ../color_templates.php:350
+#: ../color_templates.php:351
 msgid "Color Template [new]"
 msgstr ""
 
-#: ../color_templates.php:430 ../color_templates.php:443
-#: ../lib/functions.php:2480
+#: ../color_templates.php:432 ../color_templates.php:445
+#: ../lib/functions.php:2491
 msgid "Color Templates"
 msgstr ""
 
-#: ../color_templates.php:546
+#: ../color_templates.php:548
 msgid ""
 "Color Templates that are in use cannot be Deleted. In use is defined as "
 "being referenced by an Aggregate Template."
 msgstr ""
 
-#: ../color_templates.php:571
+#: ../color_templates.php:573
 msgid "No Color Templates Found"
 msgstr ""
 
@@ -2970,19 +2968,19 @@ msgstr ""
 msgid "Data Input Methods [new]"
 msgstr ""
 
-#: ../data_input.php:444 ../include/global_arrays.php:264
+#: ../data_input.php:444 ../include/global_arrays.php:315
 msgid "SNMP Get"
 msgstr ""
 
-#: ../data_input.php:447 ../include/global_arrays.php:265
+#: ../data_input.php:447 ../include/global_arrays.php:316
 msgid "SNMP Query"
 msgstr ""
 
-#: ../data_input.php:450 ../include/global_arrays.php:267
+#: ../data_input.php:450 ../include/global_arrays.php:318
 msgid "Script Query"
 msgstr ""
 
-#: ../data_input.php:453 ../include/global_arrays.php:269
+#: ../data_input.php:453 ../include/global_arrays.php:320
 msgid "Script Query - Script Server"
 msgstr ""
 
@@ -3022,8 +3020,8 @@ msgstr ""
 msgid "Delete Data Input Field"
 msgstr ""
 
-#: ../data_input.php:610 ../include/global_arrays.php:641
-#: ../include/global_arrays.php:809 ../lib/functions.php:2144
+#: ../data_input.php:610 ../include/global_arrays.php:692
+#: ../include/global_arrays.php:860 ../lib/functions.php:2155
 msgid "Data Input Methods"
 msgstr ""
 
@@ -3046,7 +3044,7 @@ msgid ""
 msgstr ""
 
 #: ../data_input.php:724 ../data_source_profiles.php:853
-#: ../data_templates.php:905
+#: ../data_templates.php:912
 msgid "Data Sources Using"
 msgstr ""
 
@@ -3058,9 +3056,9 @@ msgstr ""
 msgid "The number of Data Templates that use this Data Input Method."
 msgstr ""
 
-#: ../data_input.php:726 ../data_queries.php:1147
-#: ../include/global_arrays.php:982 ../include/global_form.php:385
-#: ../include/global_form.php:1296
+#: ../data_input.php:726 ../data_queries.php:1156
+#: ../include/global_arrays.php:984 ../include/global_form.php:385
+#: ../include/global_form.php:1304
 msgid "Data Input Method"
 msgstr ""
 
@@ -3110,9 +3108,14 @@ msgstr ""
 msgid "Associated Data Templates"
 msgstr ""
 
-#: ../data_queries.php:549 ../data_sources.php:832 ../data_templates.php:516
-#: ../include/global_arrays.php:646 ../include/global_form.php:797
-#: ../lib/api_aggregate.php:1215 ../lib/html.php:877
+#: ../data_queries.php:520
+#, php-format
+msgid "Data Template - %s"
+msgstr ""
+
+#: ../data_queries.php:549 ../data_sources.php:881 ../data_templates.php:516
+#: ../include/global_arrays.php:697 ../include/global_form.php:797
+#: ../lib/api_aggregate.php:1215 ../lib/html.php:856
 msgid "Data Source"
 msgstr ""
 
@@ -3120,122 +3123,126 @@ msgstr ""
 msgid "Suggested Values - Graph Names"
 msgstr ""
 
-#: ../data_queries.php:595 ../data_queries.php:688
+#: ../data_queries.php:595 ../data_queries.php:691
 msgid "Equation"
 msgstr ""
 
-#: ../data_queries.php:653 ../data_queries.php:749
-#: ../include/global_form.php:2082 ../include/global_form.php:2124
-#: ../lib/api_automation.php:1333 ../utilities.php:1402
+#: ../data_queries.php:646 ../data_queries.php:745
+msgid "No Suggested Values Found"
+msgstr ""
+
+#: ../data_queries.php:655 ../data_queries.php:754
+#: ../include/global_form.php:2093 ../include/global_form.php:2135
+#: ../lib/api_automation.php:1333 ../utilities.php:1409
 msgid "Field Name"
 msgstr ""
 
-#: ../data_queries.php:659 ../data_queries.php:755
+#: ../data_queries.php:661 ../data_queries.php:760
 msgid "Suggested Value"
 msgstr ""
 
-#: ../data_queries.php:665 ../data_queries.php:761 ../host.php:756
-#: ../host.php:871 ../host_templates.php:515 ../host_templates.php:569
-#: ../lib/html.php:37
+#: ../data_queries.php:667 ../data_queries.php:766 ../host.php:762
+#: ../host.php:879 ../host_templates.php:515 ../host_templates.php:569
+#: ../lib/html.php:37 ../lib/html_filter.php:55
 msgid "Add"
 msgstr ""
 
-#: ../data_queries.php:665
+#: ../data_queries.php:667
 msgid "Add Graph Title Suggested Name"
 msgstr ""
 
-#: ../data_queries.php:674
+#: ../data_queries.php:677
 msgid "Suggested Values - Data Source Names"
 msgstr ""
 
-#: ../data_queries.php:761
+#: ../data_queries.php:766
 msgid "Add Data Source Name Suggested Name"
 msgstr ""
 
-#: ../data_queries.php:864
+#: ../data_queries.php:873
 #, php-format
 msgid "Data Queries [edit: %s]"
 msgstr ""
 
-#: ../data_queries.php:866
+#: ../data_queries.php:875
 msgid "Data Queries [new]"
 msgstr ""
 
-#: ../data_queries.php:886
+#: ../data_queries.php:895
 msgid "Successfully located XML file"
 msgstr ""
 
-#: ../data_queries.php:889
+#: ../data_queries.php:898
 msgid "Could not locate XML file."
 msgstr ""
 
-#: ../data_queries.php:897 ../host.php:679 ../host_templates.php:466
-#: ../lib/functions.php:2198
+#: ../data_queries.php:906 ../host.php:681 ../host_templates.php:466
+#: ../lib/functions.php:2209
 msgid "Associated Graph Templates"
 msgstr ""
 
-#: ../data_queries.php:901 ../graph_templates.php:759 ../graphs_new.php:617
-#: ../host.php:681 ../lib/api_automation.php:563
+#: ../data_queries.php:910 ../graph_templates.php:761 ../graphs_new.php:597
+#: ../host.php:685 ../lib/api_automation.php:563
 msgid "Graph Template Name"
 msgstr ""
 
-#: ../data_queries.php:903
+#: ../data_queries.php:912
 msgid "Mapping ID"
 msgstr ""
 
-#: ../data_queries.php:944
+#: ../data_queries.php:953
 msgid "Mapped Graph Templates with Graphs are read only"
 msgstr ""
 
-#: ../data_queries.php:951
+#: ../data_queries.php:960
 msgid "No Graph Templates Defined."
 msgstr ""
 
-#: ../data_queries.php:975
+#: ../data_queries.php:984
 msgid "Delete Associated Graph"
 msgstr ""
 
-#: ../data_queries.php:1029 ../data_queries.php:1044 ../data_queries.php:1133
-#: ../include/global_arrays.php:640 ../include/global_arrays.php:810
-#: ../lib/api_automation.php:1027 ../lib/functions.php:2180
+#: ../data_queries.php:1038 ../data_queries.php:1053 ../data_queries.php:1142
+#: ../include/global_arrays.php:691 ../include/global_arrays.php:861
+#: ../lib/api_automation.php:1027 ../lib/functions.php:2191
 msgid "Data Queries"
 msgstr ""
 
-#: ../data_queries.php:1142 ../host.php:770 ../utilities.php:1402
+#: ../data_queries.php:1151 ../host.php:776 ../utilities.php:1409
 msgid "Data Query Name"
 msgstr ""
 
-#: ../data_queries.php:1142
+#: ../data_queries.php:1151
 msgid "The name of this Data Query."
 msgstr ""
 
-#: ../data_queries.php:1143 ../graph_templates.php:760
+#: ../data_queries.php:1152 ../graph_templates.php:762
 msgid ""
 "The internal ID for this Graph Template.  Useful when performing automation "
 "or debugging."
 msgstr ""
 
-#: ../data_queries.php:1144
+#: ../data_queries.php:1153
 msgid ""
 "Data Queries that are in use cannot be Deleted. In use is defined as being "
 "referenced by either a Graph or a Graph Template."
 msgstr ""
 
-#: ../data_queries.php:1145
+#: ../data_queries.php:1154
 msgid "The number of Graphs using this Data Query."
 msgstr ""
 
-#: ../data_queries.php:1146
+#: ../data_queries.php:1155
 msgid "The number of Graphs Templates using this Data Query."
 msgstr ""
 
-#: ../data_queries.php:1147
+#: ../data_queries.php:1156
 msgid ""
 "The Data Input Method used to collect data for Data Sources associated with "
 "this Data Query."
 msgstr ""
 
-#: ../data_queries.php:1171
+#: ../data_queries.php:1180
 msgid "No Data Queries Found"
 msgstr ""
 
@@ -3318,9 +3325,10 @@ msgstr ""
 msgid "Steps"
 msgstr ""
 
-#: ../data_source_profiles.php:489 ../graphs_new.php:546
-#: ../include/global_form.php:121 ../lib/html.php:379 ../lib/rrd.php:2667
-#: ../pollers.php:513 ../utilities.php:468 ../utilities.php:1315
+#: ../data_source_profiles.php:489 ../graphs_new.php:526
+#: ../include/global_form.php:121 ../lib/html.php:323 ../lib/html_filter.php:73
+#: ../lib/rrd.php:2677 ../pollers.php:523 ../utilities.php:468
+#: ../utilities.php:1322
 msgid "Rows"
 msgstr ""
 
@@ -3332,8 +3340,8 @@ msgstr ""
 msgid "Delete Data Source Profile Item"
 msgstr ""
 
-#: ../data_source_profiles.php:621 ../include/global_arrays.php:1085
-#: ../include/global_settings.php:1019
+#: ../data_source_profiles.php:621 ../include/global_arrays.php:1087
+#: ../include/global_settings.php:1027
 #, php-format
 msgid "%d Years"
 msgstr ""
@@ -3342,56 +3350,56 @@ msgstr ""
 msgid "1 Year"
 msgstr ""
 
-#: ../data_source_profiles.php:630 ../include/global_arrays.php:1079
+#: ../data_source_profiles.php:630 ../include/global_arrays.php:1081
 #: ../rrdcleaner.php:489
 #, php-format
 msgid "%d Month"
 msgstr ""
 
-#: ../data_source_profiles.php:630 ../include/global_arrays.php:1080
-#: ../include/global_arrays.php:1081 ../include/global_arrays.php:1082
-#: ../include/global_arrays.php:1083 ../rrdcleaner.php:490
+#: ../data_source_profiles.php:630 ../include/global_arrays.php:1082
+#: ../include/global_arrays.php:1083 ../include/global_arrays.php:1084
+#: ../include/global_arrays.php:1085 ../rrdcleaner.php:490
 #: ../rrdcleaner.php:491 ../rrdcleaner.php:492
 #, php-format
 msgid "%d Months"
 msgstr ""
 
-#: ../data_source_profiles.php:639 ../include/global_arrays.php:1077
+#: ../data_source_profiles.php:639 ../include/global_arrays.php:1079
 #: ../rrdcleaner.php:485 ../rrdcleaner.php:486
 #, php-format
 msgid "%d Week"
 msgstr ""
 
-#: ../data_source_profiles.php:639 ../include/global_arrays.php:1078
+#: ../data_source_profiles.php:639 ../include/global_arrays.php:1080
 #: ../rrdcleaner.php:487 ../rrdcleaner.php:488
 #, php-format
 msgid "%d Weeks"
 msgstr ""
 
-#: ../data_source_profiles.php:648 ../include/global_arrays.php:1073
+#: ../data_source_profiles.php:648 ../include/global_arrays.php:1075
 #, php-format
 msgid "%d Day"
 msgstr ""
 
-#: ../data_source_profiles.php:648 ../include/global_arrays.php:1074
-#: ../include/global_arrays.php:1075 ../include/global_arrays.php:1076
-#: ../include/global_settings.php:1014 ../include/global_settings.php:1015
-#: ../include/global_settings.php:1016 ../include/global_settings.php:1017
-#: ../include/global_settings.php:1028 ../include/global_settings.php:1029
-#: ../include/global_settings.php:1030 ../include/global_settings.php:1031
+#: ../data_source_profiles.php:648 ../include/global_arrays.php:1076
+#: ../include/global_arrays.php:1077 ../include/global_arrays.php:1078
+#: ../include/global_settings.php:1022 ../include/global_settings.php:1023
+#: ../include/global_settings.php:1024 ../include/global_settings.php:1025
+#: ../include/global_settings.php:1036 ../include/global_settings.php:1037
+#: ../include/global_settings.php:1038 ../include/global_settings.php:1039
 #, php-format
 msgid "%d Days"
 msgstr ""
 
-#: ../data_source_profiles.php:656 ../include/global_arrays.php:442
-#: ../include/global_arrays.php:477 ../include/global_arrays.php:1114
-#: ../include/global_arrays.php:1135 ../include/global_arrays.php:1168
-#: ../include/global_arrays.php:1177 ../include/global_arrays.php:1203
-#: ../include/global_settings.php:1085
+#: ../data_source_profiles.php:656 ../include/global_arrays.php:493
+#: ../include/global_arrays.php:528 ../include/global_arrays.php:1116
+#: ../include/global_arrays.php:1137 ../include/global_arrays.php:1170
+#: ../include/global_arrays.php:1179 ../include/global_arrays.php:1205
+#: ../include/global_settings.php:1093
 msgid "1 Hour"
 msgstr ""
 
-#: ../data_source_profiles.php:710 ../include/global_arrays.php:817
+#: ../data_source_profiles.php:710 ../include/global_arrays.php:868
 msgid "Data Source Profiles"
 msgstr ""
 
@@ -3399,7 +3407,7 @@ msgstr ""
 msgid "Profiles"
 msgstr ""
 
-#: ../data_source_profiles.php:743 ../data_templates.php:787
+#: ../data_source_profiles.php:743 ../data_templates.php:794
 msgid "Has Data Sources"
 msgstr ""
 
@@ -3425,8 +3433,8 @@ msgstr ""
 msgid "Read Only"
 msgstr ""
 
-#: ../data_source_profiles.php:851 ../data_sources.php:1352
-#: ../include/global_settings.php:847
+#: ../data_source_profiles.php:851 ../data_sources.php:1407
+#: ../include/global_settings.php:855
 msgid "Poller Interval"
 msgstr ""
 
@@ -3457,7 +3465,7 @@ msgstr ""
 msgid "No Data Source Profiles"
 msgstr ""
 
-#: ../data_sources.php:36 ../data_sources.php:470 ../graphs.php:54
+#: ../data_sources.php:36 ../data_sources.php:478 ../graphs.php:54
 msgid "Change Device"
 msgstr ""
 
@@ -3465,25 +3473,25 @@ msgstr ""
 msgid "Reapply Suggested Names"
 msgstr ""
 
-#: ../data_sources.php:438
+#: ../data_sources.php:446
 msgid "Click 'Continue' to delete the following Data Source"
 msgid_plural "Click 'Continue' to delete following Data Sources"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:442
+#: ../data_sources.php:450
 msgid "The following graph is using these data sources:"
 msgid_plural "The following graphs are using these data sources:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:451
+#: ../data_sources.php:459
 msgid "Leave the <strong>Graph</strong> untouched."
 msgid_plural "Leave all <strong>Graphs</strong> untouched."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:452
+#: ../data_sources.php:460
 msgid ""
 "Delete all <strong>Graph Items</strong> that reference this Data Source."
 msgid_plural ""
@@ -3491,52 +3499,52 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:453
+#: ../data_sources.php:461
 msgid "Delete all <strong>Graphs</strong> that reference this Data Source."
 msgid_plural ""
 "Delete all <strong>Graphs</strong> that reference these Data Sources."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:460
+#: ../data_sources.php:468
 msgid "Delete Data Source"
 msgid_plural "Delete Data Sources"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:464
+#: ../data_sources.php:472
 msgid "Choose a new Device for this Data Source and click 'Continue'."
 msgid_plural "Choose a new Device for these Data Sources and click 'Continue'"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:466
+#: ../data_sources.php:474
 msgid "New Device:"
 msgstr ""
 
-#: ../data_sources.php:474
+#: ../data_sources.php:482
 msgid "Click 'Continue' to enable the following Data Source."
 msgid_plural "Click 'Continue' to enable all following Data Sources."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:479
+#: ../data_sources.php:487
 msgid "Enable Data Source"
 msgid_plural "Enable Data Sources"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:483
+#: ../data_sources.php:491
 msgid "Click 'Continue' to disable the following Data Source."
 msgid_plural "Click 'Continue' to disable all following Data Sources."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:488
+#: ../data_sources.php:496
 msgid "Disable Data Source"
 msgstr ""
 
-#: ../data_sources.php:492
+#: ../data_sources.php:500
 msgid ""
 "Click 'Continue' to re-apply the suggested name to the following Data Source."
 msgid_plural ""
@@ -3545,79 +3553,79 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../data_sources.php:497
+#: ../data_sources.php:505
 msgid "Reapply Suggested Naming to Data Source"
 msgstr ""
 
-#: ../data_sources.php:506
+#: ../data_sources.php:514
 msgid "You must select at least one data source."
 msgstr ""
 
-#: ../data_sources.php:562 ../data_templates.php:633
+#: ../data_sources.php:572 ../data_templates.php:631
 #, php-format
 msgid "Custom Data [data input: %s]"
 msgstr ""
 
-#: ../data_sources.php:589
+#: ../data_sources.php:605
 #, php-format
 msgid "(From Device: %s)"
 msgstr ""
 
-#: ../data_sources.php:592
+#: ../data_sources.php:608
 msgid "(From Data Template)"
 msgstr ""
 
-#: ../data_sources.php:593
+#: ../data_sources.php:609
 msgid "Nothing Entered"
 msgstr ""
 
-#: ../data_sources.php:608 ../data_templates.php:677
+#: ../data_sources.php:624 ../data_templates.php:684
 msgid "No Input Fields for the Selected Data Input Source"
 msgstr ""
 
-#: ../data_sources.php:669
+#: ../data_sources.php:700
 #, php-format
 msgid "Data Source %d does not exist."
 msgstr ""
 
-#: ../data_sources.php:674
+#: ../data_sources.php:705
 #, php-format
 msgid "Data Template Selection [edit: %s]"
 msgstr ""
 
-#: ../data_sources.php:680
+#: ../data_sources.php:711
 msgid "Data Template Selection [new]"
 msgstr ""
 
-#: ../data_sources.php:713
+#: ../data_sources.php:744
 msgid "Turn Off Data Source Debug Mode."
 msgstr ""
 
-#: ../data_sources.php:713
+#: ../data_sources.php:744
 msgid "Turn On Data Source Debug Mode."
 msgstr ""
 
-#: ../data_sources.php:714
+#: ../data_sources.php:745
 msgid "Turn Off Data Source Info Mode."
 msgstr ""
 
-#: ../data_sources.php:714
+#: ../data_sources.php:745
 msgid "Turn On Data Source Info Mode."
 msgstr ""
 
-#: ../data_sources.php:717
+#: ../data_sources.php:748
 msgid "Edit Data Template."
 msgstr ""
 
-#: ../data_sources.php:720 ../graphs.php:1287
+#: ../data_sources.php:751 ../graphs.php:1291
 msgid "Edit Device."
 msgstr ""
 
-#: ../data_sources.php:765
+#: ../data_sources.php:814
 msgid "Selected Data Template"
 msgstr ""
 
-#: ../data_sources.php:766
+#: ../data_sources.php:815
 #, php-format
 msgid ""
 "The name given to this data template.  Please note that you may only change "
@@ -3625,142 +3633,142 @@ msgid ""
 "includes identical Data Sources."
 msgstr ""
 
-#: ../data_sources.php:774
+#: ../data_sources.php:823
 msgid "Choose the Device that this Data Source belongs to."
 msgstr ""
 
-#: ../data_sources.php:820
+#: ../data_sources.php:869
 msgid "Supplemental Data Template Data"
 msgstr ""
 
-#: ../data_sources.php:822
+#: ../data_sources.php:871
 msgid "Data Source Fields"
 msgstr ""
 
-#: ../data_sources.php:823
+#: ../data_sources.php:872
 msgid "Data Source Item Fields"
 msgstr ""
 
-#: ../data_sources.php:824
+#: ../data_sources.php:873
 msgid "Custom Data"
 msgstr ""
 
-#: ../data_sources.php:908
+#: ../data_sources.php:957
 #, php-format
 msgid "Data Source Item %s"
 msgstr ""
 
-#: ../data_sources.php:911
+#: ../data_sources.php:960
 msgid "New"
 msgstr ""
 
-#: ../data_sources.php:970
+#: ../data_sources.php:1019
 msgid "Data Source Debug"
 msgstr ""
 
-#: ../data_sources.php:990
+#: ../data_sources.php:1039
 msgid "RRDtool Tune Info"
 msgstr ""
 
-#: ../data_sources.php:1016
+#: ../data_sources.php:1065
 msgid "External"
 msgstr ""
 
-#: ../data_sources.php:1018 ../include/global_arrays.php:467
-#: ../include/global_arrays.php:468 ../include/global_arrays.php:469
-#: ../include/global_arrays.php:789 ../include/global_arrays.php:790
-#: ../include/global_arrays.php:791 ../include/global_arrays.php:792
-#: ../include/global_arrays.php:1157 ../include/global_arrays.php:1158
+#: ../data_sources.php:1067 ../include/global_arrays.php:518
+#: ../include/global_arrays.php:519 ../include/global_arrays.php:520
+#: ../include/global_arrays.php:840 ../include/global_arrays.php:841
+#: ../include/global_arrays.php:842 ../include/global_arrays.php:843
 #: ../include/global_arrays.php:1159 ../include/global_arrays.php:1160
-#: ../include/global_arrays.php:1161 ../include/global_arrays.php:1194
-#: ../include/global_arrays.php:1195 ../include/global_arrays.php:1207
-#: ../include/global_arrays.php:1208 ../include/global_arrays.php:1209
+#: ../include/global_arrays.php:1161 ../include/global_arrays.php:1162
+#: ../include/global_arrays.php:1163 ../include/global_arrays.php:1196
+#: ../include/global_arrays.php:1197 ../include/global_arrays.php:1209
 #: ../include/global_arrays.php:1210 ../include/global_arrays.php:1211
-#: ../include/global_settings.php:1822
+#: ../include/global_arrays.php:1212 ../include/global_arrays.php:1213
+#: ../include/global_settings.php:1830
 #, php-format
 msgid "%d Seconds"
 msgstr ""
 
-#: ../data_sources.php:1020 ../include/global_arrays.php:470
-#: ../include/global_arrays.php:793 ../include/global_arrays.php:1162
-#: ../include/global_arrays.php:1196 ../include/global_arrays.php:1212
-#: ../include/global_settings.php:1079 ../include/global_settings.php:1822
+#: ../data_sources.php:1069 ../include/global_arrays.php:521
+#: ../include/global_arrays.php:844 ../include/global_arrays.php:1164
+#: ../include/global_arrays.php:1198 ../include/global_arrays.php:1214
+#: ../include/global_settings.php:1087 ../include/global_settings.php:1830
 msgid "1 Minute"
 msgstr ""
 
-#: ../data_sources.php:1141 ../graphs_items.php:292
+#: ../data_sources.php:1196 ../graphs_items.php:292
 #, php-format
 msgid "Data Sources [%s]"
 msgstr ""
 
-#: ../data_sources.php:1141
+#: ../data_sources.php:1196
 msgid "No Device"
 msgstr ""
 
-#: ../data_sources.php:1180 ../data_sources.php:1206 ../data_sources.php:1222
-#: ../data_templates.php:757 ../graph_view.php:782 ../graphs_new.php:524
-#: ../lib/clog_webapi.php:321 ../lib/html_graph.php:395
-#: ../lib/html_reports.php:329 ../lib/html_tree.php:841 ../plugins.php:286
-#: ../settings.php:192 ../settings.php:209 ../settings.php:232
+#: ../data_sources.php:1235 ../data_sources.php:1261 ../data_sources.php:1277
+#: ../data_templates.php:764 ../graph_view.php:781 ../graphs_new.php:504
+#: ../lib/clog_webapi.php:331 ../lib/html_graph.php:395
+#: ../lib/html_reports.php:329 ../lib/html_tree.php:842 ../plugins.php:286
+#: ../settings.php:196 ../settings.php:213 ../settings.php:236
 #: ../utilities.php:636 ../utilities.php:1000
 msgid "All"
 msgstr ""
 
-#: ../data_sources.php:1202 ../data_templates.php:753
+#: ../data_sources.php:1257 ../data_templates.php:760
 msgid "Profile"
 msgstr ""
 
-#: ../data_sources.php:1218 ../data_sources.php:1224
+#: ../data_sources.php:1273 ../data_sources.php:1279
 msgid "Orphaned"
 msgstr ""
 
-#: ../data_sources.php:1228 ../data_sources.php:1341 ../host.php:1494
-#: ../include/global_arrays.php:635 ../lib/api_automation.php:275
-#: ../lib/functions.php:2090 ../user_admin.php:1229
-#: ../user_group_admin.php:966 ../utilities.php:273
+#: ../data_sources.php:1283 ../data_sources.php:1396 ../host.php:1502
+#: ../include/global_arrays.php:686 ../lib/api_automation.php:275
+#: ../lib/functions.php:2101 ../user_admin.php:1229 ../user_group_admin.php:966
+#: ../utilities.php:273
 msgid "Data Sources"
 msgstr ""
 
-#: ../data_sources.php:1350 ../utilities.php:1691
+#: ../data_sources.php:1405 ../utilities.php:1698
 msgid "Data Source Name"
 msgstr ""
 
-#: ../data_sources.php:1350
+#: ../data_sources.php:1405
 msgid ""
 "The name of this Data Source. Generally programtically generated from the "
 "Data Template definition."
 msgstr ""
 
-#: ../data_sources.php:1351
+#: ../data_sources.php:1406
 msgid ""
 "The internal database ID for this Data Source. Useful when performing "
 "automation or debugging."
 msgstr ""
 
-#: ../data_sources.php:1352
+#: ../data_sources.php:1407
 msgid "The frequency that data is collected for this Data Source."
 msgstr ""
 
-#: ../data_sources.php:1353
+#: ../data_sources.php:1408
 msgid "If this Data Source is no long in use by Graphs, it can be Deleted."
 msgstr ""
 
-#: ../data_sources.php:1354 ../data_templates.php:927 ../plugins.php:38
+#: ../data_sources.php:1409 ../data_templates.php:934 ../plugins.php:38
 #: ../plugins.php:287
 msgid "Active"
 msgstr ""
 
-#: ../data_sources.php:1354
+#: ../data_sources.php:1409
 msgid ""
 "Whether or not data will be collected for this Data Source. Controlled at "
 "the Data Template level."
 msgstr ""
 
-#: ../data_sources.php:1355
+#: ../data_sources.php:1410
 msgid "The Data Template that this Data Source was based upon."
 msgstr ""
 
-#: ../data_sources.php:1402
+#: ../data_sources.php:1457
 msgid "No Data Sources Found"
 msgstr ""
 
@@ -3830,73 +3838,73 @@ msgstr ""
 msgid "This field is always templated."
 msgstr ""
 
-#: ../data_templates.php:531 ../data_templates.php:605
-#: ../data_templates.php:665
+#: ../data_templates.php:531 ../data_templates.php:603
+#: ../data_templates.php:671
 msgid "Use Per-Data Source Value (Ignore this Value)"
 msgstr ""
 
-#: ../data_templates.php:586
+#: ../data_templates.php:584
 #, php-format
 msgid "Data Source Item [%s]"
 msgstr ""
 
-#: ../data_templates.php:669
+#: ../data_templates.php:676
 msgid "Value will be derived from the device if this field is left empty."
 msgstr ""
 
-#: ../data_templates.php:738 ../data_templates.php:769
-#: ../data_templates.php:893 ../include/global_arrays.php:821
-#: ../lib/functions.php:2072
+#: ../data_templates.php:745 ../data_templates.php:776
+#: ../data_templates.php:900 ../include/global_arrays.php:872
+#: ../lib/functions.php:2083
 msgid "Data Templates"
 msgstr ""
 
-#: ../data_templates.php:902
+#: ../data_templates.php:909
 msgid "Data Template Name"
 msgstr ""
 
-#: ../data_templates.php:902
+#: ../data_templates.php:909
 msgid "The name of this Data Template."
 msgstr ""
 
-#: ../data_templates.php:903
+#: ../data_templates.php:910
 msgid ""
 "The internal database ID for this Data Template.  Useful when performing "
 "automation or debugging."
 msgstr ""
 
-#: ../data_templates.php:904
+#: ../data_templates.php:911
 msgid ""
 "Data Templates that are in use cannot be Deleted.  In use is defined as "
 "being referenced by a Data Source."
 msgstr ""
 
-#: ../data_templates.php:905
+#: ../data_templates.php:912
 msgid "The number of Data Sources using this Data Template."
 msgstr ""
 
-#: ../data_templates.php:906
+#: ../data_templates.php:913
 msgid "Input Method"
 msgstr ""
 
-#: ../data_templates.php:906
+#: ../data_templates.php:913
 msgid "The method that is used to place Data into the Data Source RRDfile."
 msgstr ""
 
-#: ../data_templates.php:907
+#: ../data_templates.php:914
 msgid "Profile Name"
 msgstr ""
 
-#: ../data_templates.php:907
+#: ../data_templates.php:914
 msgid "The default Data Source Profile for this Data Template."
 msgstr ""
 
-#: ../data_templates.php:908
+#: ../data_templates.php:915
 msgid ""
 "Data Sources based on Inactive Data Templates will not be updated when the "
 "poller runs."
 msgstr ""
 
-#: ../data_templates.php:932
+#: ../data_templates.php:939
 msgid "No Data Templates Found"
 msgstr ""
 
@@ -3921,12 +3929,12 @@ msgstr ""
 msgid "GPRINT Presets [new]"
 msgstr ""
 
-#: ../gprint_presets.php:253 ../lib/functions.php:1922
+#: ../gprint_presets.php:253 ../lib/functions.php:1933
 msgid "GPRINT Presets"
 msgstr ""
 
 #: ../gprint_presets.php:268 ../gprint_presets.php:381
-#: ../include/global_arrays.php:663
+#: ../include/global_arrays.php:714
 msgid "GPRINTs"
 msgstr ""
 
@@ -3968,7 +3976,7 @@ msgstr ""
 msgid "Viewing Graph"
 msgstr ""
 
-#: ../graph.php:124 ../lib/html.php:348
+#: ../graph.php:124 ../lib/html.php:292
 msgid "Graph Details, Zooming and Debugging Utilities"
 msgstr ""
 
@@ -3996,9 +4004,9 @@ msgstr ""
 msgid "Graph Data"
 msgstr ""
 
-#: ../graph.php:307 ../graph_realtime.php:267 ../lib/clog_webapi.php:341
-#: ../lib/html_graph.php:319 ../lib/html_tree.php:764 ../lib/html_tree.php:784
-#: ../utilities.php:1020 ../utilities.php:1897
+#: ../graph.php:307 ../graph_realtime.php:267 ../lib/clog_webapi.php:351
+#: ../lib/html_graph.php:319 ../lib/html_tree.php:765 ../lib/html_tree.php:785
+#: ../utilities.php:1020 ../utilities.php:1904
 msgid "Refresh"
 msgstr ""
 
@@ -4026,8 +4034,7 @@ msgstr ""
 msgid "Cacti Real-time Graphing"
 msgstr ""
 
-#: ../graph_realtime.php:253 ../lib/html_graph.php:327
-#: ../lib/html_tree.php:772
+#: ../graph_realtime.php:253 ../lib/html_graph.php:327 ../lib/html_tree.php:773
 msgid "Window"
 msgstr ""
 
@@ -4048,131 +4055,131 @@ msgstr ""
 msgid "Sync Graphs"
 msgstr ""
 
-#: ../graph_templates.php:311
+#: ../graph_templates.php:312
 msgid ""
 "Click 'Continue' to delete the following Graph Template(s).  Any Graph(s) "
 "associated with the Template(s) will become individual Graph(s)."
 msgstr ""
 
-#: ../graph_templates.php:316
+#: ../graph_templates.php:317
 msgid "Delete Graph Template(s)"
 msgstr ""
 
-#: ../graph_templates.php:320
+#: ../graph_templates.php:321
 msgid ""
 "Click 'Continue' to duplicate the following Graph Template(s). You can "
 "optionally change the title format for the new Graph Template(s)."
 msgstr ""
 
-#: ../graph_templates.php:326
+#: ../graph_templates.php:327
 msgid "Duplicate Graph Template(s)"
 msgstr ""
 
-#: ../graph_templates.php:330
+#: ../graph_templates.php:331
 msgid ""
 "Click 'Continue' to resize the following Graph Template(s) and Graph(s) to "
 "the Height and Width below.  The defaults below are maintained in Settings."
 msgstr ""
 
-#: ../graph_templates.php:339 ../lib/html_reports.php:117
+#: ../graph_templates.php:340 ../lib/html_reports.php:117
 msgid "Graph Height"
 msgstr ""
 
-#: ../graph_templates.php:341 ../lib/html_reports.php:109
+#: ../graph_templates.php:342 ../lib/html_reports.php:109
 msgid "Graph Width"
 msgstr ""
 
-#: ../graph_templates.php:346
+#: ../graph_templates.php:347
 msgid "Resize Selected Graph Template(s)"
 msgstr ""
 
-#: ../graph_templates.php:350
+#: ../graph_templates.php:351
 msgid ""
 "Click 'Continue' to Synchronize your Graphs the following Graph Template(s). "
 "This function is important if you have Graphs that exist with multiple "
 "versions of a Graph Template and wish to make them all common in appearance."
 msgstr ""
 
-#: ../graph_templates.php:355
+#: ../graph_templates.php:356
 msgid "Synchronize Graphs to Graph Template(s)"
 msgstr ""
 
-#: ../graph_templates.php:358
+#: ../graph_templates.php:359
 msgid "ERROR: You must select at least one graph template."
 msgstr ""
 
-#: ../graph_templates.php:412
+#: ../graph_templates.php:413
 #, php-format
 msgid "Graph Template Items [edit: %s]"
 msgstr ""
 
-#: ../graph_templates.php:419 ../lib/functions.php:2042
+#: ../graph_templates.php:420 ../lib/functions.php:2053
 msgid "Graph Item Inputs"
 msgstr ""
 
-#: ../graph_templates.php:445
+#: ../graph_templates.php:446
 msgid "No Inputs"
 msgstr ""
 
-#: ../graph_templates.php:490
+#: ../graph_templates.php:491
 #, php-format
 msgid "Template [edit: %s]"
 msgstr ""
 
-#: ../graph_templates.php:492
+#: ../graph_templates.php:493
 msgid "Template [new]"
 msgstr ""
 
-#: ../graph_templates.php:508
+#: ../graph_templates.php:509
 msgid "Graph Template Options"
 msgstr ""
 
-#: ../graph_templates.php:523
+#: ../graph_templates.php:524
 msgid "Use Per-Graph Value (Ignore this Value)"
 msgstr ""
 
-#: ../graph_templates.php:617 ../graph_templates.php:632
-#: ../graph_templates.php:750 ../graphs_new.php:612
-#: ../include/global_arrays.php:820 ../lib/functions.php:2018
+#: ../graph_templates.php:619 ../graph_templates.php:634
+#: ../graph_templates.php:752 ../graphs_new.php:592
+#: ../include/global_arrays.php:871 ../lib/functions.php:2029
 #: ../user_group_admin.php:1101
 msgid "Graph Templates"
 msgstr ""
 
-#: ../graph_templates.php:759
+#: ../graph_templates.php:761
 msgid "The name of this Graph Template."
 msgstr ""
 
-#: ../graph_templates.php:761
+#: ../graph_templates.php:763
 msgid ""
 "Graph Templates that are in use cannot be Deleted.  In use is defined as "
 "being referenced by a Graph."
 msgstr ""
 
-#: ../graph_templates.php:762
+#: ../graph_templates.php:764
 msgid "The number of Graphs using this Graph Template."
 msgstr ""
 
-#: ../graph_templates.php:763
+#: ../graph_templates.php:765
 msgid "The default size of the resulting Graphs."
 msgstr ""
 
-#: ../graph_templates.php:764
+#: ../graph_templates.php:766
 msgid "Image Format"
 msgstr ""
 
-#: ../graph_templates.php:764
+#: ../graph_templates.php:766
 msgid "The default image format for the resulting Graphs."
 msgstr ""
 
-#: ../graph_templates.php:765
+#: ../graph_templates.php:767
 msgid "The vertical label for the resulting Graphs."
 msgstr ""
 
-#: ../graph_templates.php:765
+#: ../graph_templates.php:767
 msgid "Vertical Label"
 msgstr ""
 
-#: ../graph_templates.php:791
+#: ../graph_templates.php:793
 msgid "No Graph Templates Found"
 msgstr ""
 
@@ -4181,12 +4188,8 @@ msgstr ""
 msgid "Graph Item Inputs [edit graph: %s]"
 msgstr ""
 
-#: ../graph_templates_inputs.php:193
+#: ../graph_templates_inputs.php:191
 msgid "Associated Graph Items"
-msgstr ""
-
-#: ../graph_templates_inputs.php:194
-msgid "Select the graph items that you want to accept user input for."
 msgstr ""
 
 #: ../graph_templates_items.php:99 ../graph_templates_items.php:125
@@ -4213,72 +4216,72 @@ msgstr ""
 msgid "Graph Template Items [edit graph: %s]"
 msgstr ""
 
-#: ../graph_view.php:243
+#: ../graph_view.php:242
 msgid "YOU DO NOT HAVE RIGHTS FOR TREE VIEW"
 msgstr ""
 
-#: ../graph_view.php:321
+#: ../graph_view.php:320
 msgid "YOU DO NOT HAVE RIGHTS FOR PREVIEW VIEW"
 msgstr ""
 
-#: ../graph_view.php:327
+#: ../graph_view.php:326
 msgid "Graph Preview Filters"
 msgstr ""
 
-#: ../graph_view.php:327
+#: ../graph_view.php:326
 msgid "[ Custom Graph List Applied - Filtering from List ]"
 msgstr ""
 
-#: ../graph_view.php:423
+#: ../graph_view.php:422
 msgid "YOU DO NOT HAVE RIGHTS FOR LIST VIEW"
 msgstr ""
 
-#: ../graph_view.php:510
+#: ../graph_view.php:509
 msgid "Graph List View Filters"
 msgstr ""
 
-#: ../graph_view.php:510
+#: ../graph_view.php:509
 msgid "[ Custom Graph List Applied - Filter FROM List ]"
 msgstr ""
 
-#: ../graph_view.php:529 ../graph_view.php:771 ../graph_view.php:776
+#: ../graph_view.php:528 ../graph_view.php:770 ../graph_view.php:775
 #: ../lib/html_graph.php:163 ../lib/html_graph.php:384
-#: ../lib/html_graph.php:389 ../lib/html_tree.php:614 ../lib/html_tree.php:830
-#: ../lib/html_tree.php:835
+#: ../lib/html_graph.php:389 ../lib/html_tree.php:615 ../lib/html_tree.php:831
+#: ../lib/html_tree.php:836
 msgid "All Graphs & Templates"
 msgstr ""
 
-#: ../graph_view.php:578 ../graph_view.php:655
+#: ../graph_view.php:577 ../graph_view.php:654
 msgid "View"
 msgstr ""
 
-#: ../graph_view.php:578 ../graph_view.php:655
-#: ../include/global_arrays.php:801 ../lib/clog_webapi.php:231
+#: ../graph_view.php:577 ../graph_view.php:654 ../include/global_arrays.php:852
+#: ../lib/clog_webapi.php:249
 msgid "View Graphs"
 msgstr ""
 
-#: ../graph_view.php:620
+#: ../graph_view.php:619
 msgid "Graph Size"
 msgstr ""
 
-#: ../graph_view.php:634
+#: ../graph_view.php:633
 msgid "Aggregated Device"
 msgstr ""
 
-#: ../graph_view.php:637
+#: ../graph_view.php:636
 msgid "Non-Device"
 msgstr ""
 
-#: ../graph_view.php:638
+#: ../graph_view.php:637
 msgid "Not Applicable"
 msgstr ""
 
-#: ../graph_view.php:773 ../lib/html_graph.php:386 ../lib/html_tree.php:832
-#: ../settings.php:223
+#: ../graph_view.php:772 ../lib/html_graph.php:386 ../lib/html_tree.php:833
+#: ../settings.php:227
 msgid "Templates Selected"
 msgstr ""
 
-#: ../graphs.php:49 ../graphs.php:842 ../lib/functions.php:1892
+#: ../graphs.php:49 ../graphs.php:842 ../lib/functions.php:1903
 msgid "Change Graph Template"
 msgstr ""
 
@@ -4290,7 +4293,7 @@ msgstr ""
 msgid "Create Aggregate from Template"
 msgstr ""
 
-#: ../graphs.php:58 ../graphs.php:1087 ../host.php:43
+#: ../graphs.php:58 ../graphs.php:1091 ../host.php:43
 msgid "Apply Automation Rules"
 msgstr ""
 
@@ -4298,12 +4301,12 @@ msgstr ""
 msgid "Convert to Graph Template"
 msgstr ""
 
-#: ../graphs.php:176 ../graphs_new.php:248 ../graphs_new.php:264
+#: ../graphs.php:176 ../graphs_new.php:228 ../graphs_new.php:244
 #, php-format
 msgid "Created graph: %s"
 msgstr ""
 
-#: ../graphs.php:184 ../graphs_new.php:256 ../graphs_new.php:272
+#: ../graphs.php:184 ../graphs_new.php:236 ../graphs_new.php:252
 msgid "ERROR: no Data Source associated. Check Template"
 msgstr ""
 
@@ -4400,25 +4403,25 @@ msgstr ""
 msgid "The following data sources are in use by these graphs:"
 msgstr ""
 
-#: ../graphs.php:954
+#: ../graphs.php:958
 msgid "Please confirm"
 msgstr ""
 
-#: ../graphs.php:1022
+#: ../graphs.php:1026
 msgid "Resize Selected Graph(s)"
 msgstr ""
 
-#: ../graphs.php:1044
+#: ../graphs.php:1048
 msgid ""
 "Select the Aggregate Template to use and press 'Continue' to create your "
 "Aggregate Graph.  Otherwise press 'Cancel' to return."
 msgstr ""
 
-#: ../graphs.php:1065
+#: ../graphs.php:1069
 msgid "Create Aggregate"
 msgstr ""
 
-#: ../graphs.php:1069
+#: ../graphs.php:1073
 msgid ""
 "There are presently no Aggregate Templates defined for this Graph Template.  "
 "Please either first create an Aggregate Template for the selected Graphs "
@@ -4426,52 +4429,52 @@ msgid ""
 "Graph."
 msgstr ""
 
-#: ../graphs.php:1070
+#: ../graphs.php:1074
 msgid "Press 'Return' to return and select different Graphs."
 msgstr ""
 
-#: ../graphs.php:1082
+#: ../graphs.php:1086
 msgid "Click 'Continue' to apply Automation Rules to the following Graphs."
 msgstr ""
 
-#: ../graphs.php:1098
+#: ../graphs.php:1102
 msgid "You must select at least one Graph."
 msgstr ""
 
-#: ../graphs.php:1238
+#: ../graphs.php:1242
 #, php-format
-msgid "Graph Template Selection [edit: %s]"
+msgid "Graph [edit: %s]"
 msgstr ""
 
-#: ../graphs.php:1244
-msgid "Graph Template Selection [new]"
+#: ../graphs.php:1248
+msgid "Graph [new]"
 msgstr ""
 
-#: ../graphs.php:1269
+#: ../graphs.php:1273
 msgid "Turn Off Graph Debug Mode."
 msgstr ""
 
-#: ../graphs.php:1271
+#: ../graphs.php:1275
 msgid "Turn On Graph Debug Mode."
 msgstr ""
 
-#: ../graphs.php:1284
+#: ../graphs.php:1288
 msgid "Edit Graph Template."
 msgstr ""
 
-#: ../graphs.php:1290
+#: ../graphs.php:1294
 msgid "Unlock Graph."
 msgstr ""
 
-#: ../graphs.php:1292
+#: ../graphs.php:1296
 msgid "Lock Graph."
 msgstr ""
 
-#: ../graphs.php:1316
+#: ../graphs.php:1320
 msgid "Selected Graph Template"
 msgstr ""
 
-#: ../graphs.php:1317
+#: ../graphs.php:1321
 #, php-format
 msgid ""
 "Choose a Graph Template to apply to this Graph. Please note that you may "
@@ -4479,49 +4482,49 @@ msgid ""
 "that it includes identical Data Sources."
 msgstr ""
 
-#: ../graphs.php:1325
+#: ../graphs.php:1329
 msgid "Choose the Device that this Graph belongs to."
 msgstr ""
 
-#: ../graphs.php:1364
+#: ../graphs.php:1368
 msgid "Supplemental Graph Template Data"
 msgstr ""
 
-#: ../graphs.php:1366
+#: ../graphs.php:1370
 msgid "Graph Fields"
 msgstr ""
 
-#: ../graphs.php:1367
+#: ../graphs.php:1371
 msgid "Graph Item Fields"
 msgstr ""
 
-#: ../graphs.php:1599 ../lib/functions.php:1880
+#: ../graphs.php:1640 ../lib/functions.php:1891
 msgid "Graph Management"
 msgstr ""
 
-#: ../graphs.php:1743 ../include/global_form.php:1848
+#: ../graphs.php:1784 ../include/global_form.php:1859
 #: ../lib/html_reports.php:386 ../tree.php:681
 msgid "Graph Name"
 msgstr ""
 
-#: ../graphs.php:1743
+#: ../graphs.php:1784
 msgid ""
 "The Title of this Graph.  Generally programatically generated from the Graph "
 "Template definition or Suggested Naming rules.  The max length of the Title "
 "is controlled under Settings->Visual."
 msgstr ""
 
-#: ../graphs.php:1744
+#: ../graphs.php:1785
 msgid ""
 "The internal database ID for this Graph.  Useful when performing automation "
 "or debugging."
 msgstr ""
 
-#: ../graphs.php:1745
+#: ../graphs.php:1786
 msgid "The Graph Template that this Graph was based upon."
 msgstr ""
 
-#: ../graphs.php:1746
+#: ../graphs.php:1787
 msgid "The size of this Graph when not in Preview mode."
 msgstr ""
 
@@ -4529,8 +4532,8 @@ msgstr ""
 msgid "Data Sources [No Device]"
 msgstr ""
 
-#: ../graphs_items.php:325 ../include/global_arrays.php:981
-#: ../include/global_form.php:1545
+#: ../graphs_items.php:325 ../include/global_arrays.php:983
+#: ../include/global_form.php:1556
 msgid "Data Template"
 msgstr ""
 
@@ -4543,116 +4546,121 @@ msgstr ""
 msgid "Default Settings Saved"
 msgstr ""
 
-#: ../graphs_new.php:322
+#: ../graphs_new.php:281
+#, php-format
+msgid "Create Graph from %s"
+msgstr ""
+
+#: ../graphs_new.php:302
 #, php-format
 msgid "Created %s Graphs from %s"
 msgstr ""
 
-#: ../graphs_new.php:324
+#: ../graphs_new.php:304
 #, php-format
 msgid "Created 1 Graph from %s"
 msgstr ""
 
-#: ../graphs_new.php:365
+#: ../graphs_new.php:345
 #, php-format
 msgid "Graph [Template: %s]"
 msgstr ""
 
-#: ../graphs_new.php:366
+#: ../graphs_new.php:346
 #, php-format
 msgid "Graph Items [Template: %s]"
 msgstr ""
 
-#: ../graphs_new.php:371
+#: ../graphs_new.php:351
 #, php-format
 msgid "Data Source [Template: %s]"
 msgstr ""
 
-#: ../graphs_new.php:381
+#: ../graphs_new.php:361
 #, php-format
 msgid "Custom Data [Template: %s]"
 msgstr ""
 
-#: ../graphs_new.php:466
+#: ../graphs_new.php:446
 #, php-format
 msgid "New Graphs for [ %s ]"
 msgstr ""
 
-#: ../graphs_new.php:469
+#: ../graphs_new.php:449
 msgid "New Graphs for [ All Devices ]"
 msgstr ""
 
-#: ../graphs_new.php:474
+#: ../graphs_new.php:454
 msgid "New Graphs for None Host Type"
 msgstr ""
 
-#: ../graphs_new.php:520
+#: ../graphs_new.php:500
 msgid "Graph Types"
 msgstr ""
 
-#: ../graphs_new.php:525
+#: ../graphs_new.php:505
 msgid "Graph Template Based"
 msgstr ""
 
-#: ../graphs_new.php:561
+#: ../graphs_new.php:541
 msgid "Edit this Device"
 msgstr ""
 
-#: ../graphs_new.php:562
+#: ../graphs_new.php:542
 msgid "Create New Device"
 msgstr ""
 
-#: ../graphs_new.php:618 ../graphs_new.php:892 ../user_admin.php:1576
+#: ../graphs_new.php:598 ../graphs_new.php:881 ../user_admin.php:1576
 #: ../user_group_admin.php:1316
 msgid "Select All"
 msgstr ""
 
-#: ../graphs_new.php:682 ../include/global_arrays.php:627
-#: ../include/global_arrays.php:698 ../lib/html_form.php:1067
-#: ../lib/html_form.php:1080 ../tree.php:1025
+#: ../graphs_new.php:674 ../include/global_arrays.php:678
+#: ../include/global_arrays.php:749 ../lib/html_form.php:1111
+#: ../lib/html_form.php:1124 ../tree.php:1025
 msgid "Create"
 msgstr ""
 
-#: ../graphs_new.php:684
+#: ../graphs_new.php:676
 msgid "(Select a graph type to create)"
 msgstr ""
 
-#: ../graphs_new.php:768
+#: ../graphs_new.php:760
 #, php-format
 msgid "Data Query [%s]"
 msgstr ""
 
-#: ../graphs_new.php:888
+#: ../graphs_new.php:877
 msgid "From there you can get more information."
 msgstr ""
 
-#: ../graphs_new.php:888
+#: ../graphs_new.php:877
 msgid ""
 "This Data Query returned 0 rows, perhaps there was a problem executing this "
 "Data Query."
 msgstr ""
 
-#: ../graphs_new.php:888
+#: ../graphs_new.php:877
 msgid "You can run this Data Query in debug mode"
 msgstr ""
 
-#: ../graphs_new.php:931
+#: ../graphs_new.php:920
 msgid "Search Returned no Rows."
 msgstr ""
 
-#: ../graphs_new.php:936
+#: ../graphs_new.php:925
 msgid "Error in data query."
 msgstr ""
 
-#: ../graphs_new.php:960
+#: ../graphs_new.php:949
 msgid "Select a Graph Type to Create"
 msgstr ""
 
-#: ../graphs_new.php:963
+#: ../graphs_new.php:952
 msgid "Make selection default"
 msgstr ""
 
-#: ../graphs_new.php:963
+#: ../graphs_new.php:952
 msgid "Set Default"
 msgstr ""
 
@@ -4790,179 +4798,178 @@ msgstr ""
 msgid "Contacting Device"
 msgstr ""
 
-#: ../host.php:661
+#: ../host.php:663
 msgid "Data Query Debug Information"
 msgstr ""
 
-#: ../host.php:664 ../templates_import.php:141
+#: ../host.php:666 ../templates_import.php:141
 msgid "Hide"
 msgstr ""
 
-#: ../host.php:731 ../tree.php:1145 ../tree.php:1219 ../tree.php:1306
+#: ../host.php:737 ../tree.php:1145 ../tree.php:1219 ../tree.php:1306
 msgid "Edit"
 msgstr ""
 
-#: ../host.php:731
+#: ../host.php:737
 msgid "Is Being Graphed"
 msgstr ""
 
-#: ../host.php:731
+#: ../host.php:737
 msgid "Not Being Graphed"
 msgstr ""
 
-#: ../host.php:734
+#: ../host.php:740
 msgid "Delete Graph Template Association"
 msgstr ""
 
-#: ../host.php:741 ../host_templates.php:493
+#: ../host.php:747 ../host_templates.php:493
 msgid "No associated graph templates."
 msgstr ""
 
-#: ../host.php:750 ../host_templates.php:502
+#: ../host.php:756 ../host_templates.php:502
 msgid "Add Graph Template"
 msgstr ""
 
-#: ../host.php:756
+#: ../host.php:762
 msgid "Add Graph Template to Device"
 msgstr ""
 
-#: ../host.php:766 ../host_templates.php:525
+#: ../host.php:772 ../host_templates.php:525
 msgid "Associated Data Queries"
 msgstr ""
 
-#: ../host.php:771 ../host.php:865
+#: ../host.php:777 ../host.php:873
 msgid "Re-Index Method"
 msgstr ""
 
-#: ../host.php:773 ../lib/api_automation.php:1212
+#: ../host.php:779 ../lib/api_automation.php:1212
 #: ../lib/api_automation.php:1274 ../lib/api_automation.php:1338
-#: ../lib/functions.php:1898 ../lib/functions.php:1964
-#: ../lib/functions.php:2030 ../lib/functions.php:2066
-#: ../lib/functions.php:2084 ../lib/functions.php:2102
-#: ../lib/functions.php:2120 ../lib/functions.php:2150
-#: ../lib/functions.php:2186 ../lib/functions.php:2216
-#: ../lib/functions.php:2306 ../lib/functions.php:2492
-#: ../lib/functions.php:2516 ../lib/functions.php:2534
-#: ../lib/functions.php:2552 ../lib/functions.php:2570
-#: ../lib/functions.php:2594 ../lib/html_reports.php:1230 ../links.php:377
+#: ../lib/functions.php:1909 ../lib/functions.php:1975
+#: ../lib/functions.php:2041 ../lib/functions.php:2077
+#: ../lib/functions.php:2095 ../lib/functions.php:2113
+#: ../lib/functions.php:2131 ../lib/functions.php:2161
+#: ../lib/functions.php:2197 ../lib/functions.php:2227
+#: ../lib/functions.php:2317 ../lib/functions.php:2503
+#: ../lib/functions.php:2527 ../lib/functions.php:2545
+#: ../lib/functions.php:2563 ../lib/functions.php:2581
+#: ../lib/functions.php:2605 ../lib/html_reports.php:1235 ../links.php:377
 #: ../plugins.php:374
 msgid "Actions"
 msgstr ""
 
-#: ../host.php:832
+#: ../host.php:840
 msgid "Fail"
 msgstr ""
 
-#: ../host.php:832 ../lib/functions.php:3777 ../lib/functions.php:3782
+#: ../host.php:840 ../lib/functions.php:3789 ../lib/functions.php:3794
 msgid "Success"
 msgstr ""
 
-#: ../host.php:835
+#: ../host.php:843
 msgid "Reload Query"
 msgstr ""
 
-#: ../host.php:836
+#: ../host.php:844
 msgid "Verbose Query"
 msgstr ""
 
-#: ../host.php:837
+#: ../host.php:845
 msgid "Remove Query"
 msgstr ""
 
-#: ../host.php:843
+#: ../host.php:851
 msgid "No Associated Data Queries."
 msgstr ""
 
-#: ../host.php:859 ../host_templates.php:559
+#: ../host.php:867 ../host_templates.php:559
 msgid "Add Data Query"
 msgstr ""
 
-#: ../host.php:871
+#: ../host.php:879
 msgid "Add Data Query to Device"
 msgstr ""
 
-#: ../host.php:1006 ../include/global_arrays.php:408
+#: ../host.php:1014 ../include/global_arrays.php:459
 msgid "Ping and SNMP Uptime"
 msgstr ""
 
-#: ../host.php:1007 ../include/global_arrays.php:410
+#: ../host.php:1015 ../include/global_arrays.php:461
 msgid "SNMP Uptime"
 msgstr ""
 
-#: ../host.php:1008 ../include/global_arrays.php:413
+#: ../host.php:1016 ../include/global_arrays.php:464
 msgid "Ping"
 msgstr ""
 
-#: ../host.php:1009 ../include/global_arrays.php:409
+#: ../host.php:1017 ../include/global_arrays.php:460
 msgid "Ping or SNMP Uptime"
 msgstr ""
 
-#: ../host.php:1010 ../include/global_arrays.php:411
+#: ../host.php:1018 ../include/global_arrays.php:462
 msgid "SNMP Desc"
 msgstr ""
 
-#: ../host.php:1011
+#: ../host.php:1019
 msgid "SNMP GetNext"
 msgstr ""
 
-#: ../host.php:1304 ../include/global_settings.php:441
+#: ../host.php:1312 ../include/global_settings.php:441
 msgid "Site"
 msgstr ""
 
-#: ../host.php:1380 ../lib/api_automation.php:164
+#: ../host.php:1388 ../lib/api_automation.php:164
 #: ../lib/api_automation.php:1019
 msgid "Not Up"
 msgstr ""
 
-#: ../host.php:1383 ../lib/api_automation.php:167
-#: ../lib/api_automation.php:1022 ../lib/html_utility.php:809
-#: ../pollers.php:41
+#: ../host.php:1391 ../lib/api_automation.php:167
+#: ../lib/api_automation.php:1022 ../lib/html_utility.php:814 ../pollers.php:41
 msgid "Recovering"
 msgstr ""
 
-#: ../host.php:1384 ../lib/api_automation.php:168
-#: ../lib/api_automation.php:1023 ../lib/html_utility.php:818
-#: ../plugins.php:166 ../utilities.php:2004
+#: ../host.php:1392 ../lib/api_automation.php:168
+#: ../lib/api_automation.php:1023 ../lib/html_utility.php:823
+#: ../plugins.php:166 ../utilities.php:2011
 msgid "Unknown"
 msgstr ""
 
-#: ../host.php:1490 ../lib/api_automation.php:557
+#: ../host.php:1498 ../lib/api_automation.php:557
 msgid "Device Description"
 msgstr ""
 
-#: ../host.php:1490
+#: ../host.php:1498
 msgid "The name by which this Device will be referred to."
 msgstr ""
 
-#: ../host.php:1491
+#: ../host.php:1499
 msgid ""
 "Either an IP address, or hostname.  If a hostname, it must be resolvable by "
 "either DNS, or from your hosts file."
 msgstr ""
 
-#: ../host.php:1491 ../include/global_form.php:1005
-#: ../include/global_form.php:1627 ../lib/api_automation.php:270
+#: ../host.php:1499 ../include/global_form.php:1013
+#: ../include/global_form.php:1638 ../lib/api_automation.php:270
 #: ../lib/api_automation.php:558 ../lib/api_automation.php:809
 #: ../lib/api_automation.php:1138 ../managers.php:225 ../pollers.php:82
-#: ../pollers.php:603 ../user_admin.php:1229 ../user_group_admin.php:966
+#: ../pollers.php:613 ../user_admin.php:1229 ../user_group_admin.php:966
 msgid "Hostname"
 msgstr ""
 
-#: ../host.php:1492
+#: ../host.php:1500
 msgid ""
 "The internal database ID for this Device.  Useful when performing automation "
 "or debugging."
 msgstr ""
 
-#: ../host.php:1493
+#: ../host.php:1501
 msgid "The total number of Graphs generated from this Device."
 msgstr ""
 
-#: ../host.php:1494
+#: ../host.php:1502
 msgid "The total number of Data Sources generated from this Device."
 msgstr ""
 
-#: ../host.php:1495
+#: ../host.php:1503
 msgid ""
 "The monitoring status of the Device based upon ping results.  If this Device "
 "is a special type Device, by using the hostname \"localhost\", or due to the "
@@ -4971,49 +4978,49 @@ msgid ""
 "the data collector and will remain in an \"Unknown\" state."
 msgstr ""
 
-#: ../host.php:1496
+#: ../host.php:1504
 msgid "In State"
 msgstr ""
 
-#: ../host.php:1496
+#: ../host.php:1504
 msgid "The amount of time that this Device has been in its current state."
 msgstr ""
 
-#: ../host.php:1497
+#: ../host.php:1505
 msgid "The current amount of time that the host has been up."
 msgstr ""
 
-#: ../host.php:1498
+#: ../host.php:1506
 msgid "Poll Time"
 msgstr ""
 
-#: ../host.php:1498
+#: ../host.php:1506
 msgid "The amount of time it takes to collect data from this Device."
 msgstr ""
 
-#: ../host.php:1499
+#: ../host.php:1507
 msgid "Current (ms)"
 msgstr ""
 
-#: ../host.php:1499
+#: ../host.php:1507
 msgid "The current ping time in milliseconds to reach the Device."
 msgstr ""
 
-#: ../host.php:1500
+#: ../host.php:1508
 msgid "Average (ms)"
 msgstr ""
 
-#: ../host.php:1500
+#: ../host.php:1508
 msgid ""
 "The average ping time in milliseconds to reach the Device since the counters "
 "were cleared for this Device."
 msgstr ""
 
-#: ../host.php:1501
+#: ../host.php:1509
 msgid "Availability"
 msgstr ""
 
-#: ../host.php:1501
+#: ../host.php:1509
 msgid ""
 "The availability percentage based upon ping results since the counters were "
 "cleared for this Device."
@@ -5104,8 +5111,8 @@ msgid "Add Data Query to Device Template"
 msgstr ""
 
 #: ../host_templates.php:691 ../host_templates.php:706
-#: ../host_templates.php:805 ../include/global_arrays.php:822
-#: ../lib/functions.php:2054
+#: ../host_templates.php:805 ../include/global_arrays.php:873
+#: ../lib/functions.php:2065
 msgid "Device Templates"
 msgstr ""
 
@@ -5164,1385 +5171,1387 @@ msgstr ""
 msgid "You are not permitted to access this section of Cacti."
 msgstr ""
 
-#: ../include/global_arrays.php:29
+#: ../include/global_arrays.php:87
 msgid "Save Successful."
 msgstr ""
 
-#: ../include/global_arrays.php:32
+#: ../include/global_arrays.php:90
 msgid "Save Failed."
 msgstr ""
 
-#: ../include/global_arrays.php:35
+#: ../include/global_arrays.php:93
 msgid "Save Failed: Field Input Error (Check Red Fields)."
 msgstr ""
 
-#: ../include/global_arrays.php:38
+#: ../include/global_arrays.php:96
 msgid "Passwords do not match, please retype."
 msgstr ""
 
-#: ../include/global_arrays.php:41
+#: ../include/global_arrays.php:99
 msgid "You must select at least one field."
 msgstr ""
 
-#: ../include/global_arrays.php:44
+#: ../include/global_arrays.php:102
 msgid ""
 "You must have built in user authentication turned on to use this feature."
 msgstr ""
 
-#: ../include/global_arrays.php:47
+#: ../include/global_arrays.php:105
 msgid "XML parse error."
 msgstr ""
 
-#: ../include/global_arrays.php:50
+#: ../include/global_arrays.php:108
 msgid "Username already in use."
 msgstr ""
 
-#: ../include/global_arrays.php:53
+#: ../include/global_arrays.php:111
 msgid "XML: Cacti version does not exist."
 msgstr ""
 
-#: ../include/global_arrays.php:56
+#: ../include/global_arrays.php:114
 msgid "XML: Hash version does not exist."
 msgstr ""
 
-#: ../include/global_arrays.php:59
+#: ../include/global_arrays.php:117
 msgid "XML: Generated with a newer version of Cacti."
 msgstr ""
 
-#: ../include/global_arrays.php:62
+#: ../include/global_arrays.php:120
 msgid "XML: Cannot locate type code."
 msgstr ""
 
-#: ../include/global_arrays.php:65
+#: ../include/global_arrays.php:123
 msgid "Username already exists."
 msgstr ""
 
-#: ../include/global_arrays.php:68
+#: ../include/global_arrays.php:126
 msgid "Username change not permitted for designated template or guest user."
 msgstr ""
 
-#: ../include/global_arrays.php:71
+#: ../include/global_arrays.php:129
 msgid "User delete not permitted for designated template or guest user."
 msgstr ""
 
-#: ../include/global_arrays.php:74
+#: ../include/global_arrays.php:132
 msgid "User delete not permitted for designated graph export user."
 msgstr ""
 
-#: ../include/global_arrays.php:77
+#: ../include/global_arrays.php:135
 msgid ""
 "Data Template Includes Deleted Data Source Profile.  Please resave the Data "
 "Template with an existing Data Source Profile."
 msgstr ""
 
-#: ../include/global_arrays.php:80
+#: ../include/global_arrays.php:138
 msgid ""
 "Graph Template Includes Deleted GPrint Prefix.  Please run Database Repair "
 "Script to Identify and/or Correct."
 msgstr ""
 
-#: ../include/global_arrays.php:83
+#: ../include/global_arrays.php:141
 msgid ""
 "Graph Template Includes Deleted CDEFs.  Please run Database Repair Script to "
 "Identify and/or Correct."
 msgstr ""
 
-#: ../include/global_arrays.php:86
+#: ../include/global_arrays.php:144
 msgid ""
 "Graph Template Includes Deleted Data Input Method.  Please run Database "
 "Repair Script to Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:89
+#: ../include/global_arrays.php:147
 msgid ""
 "Data Template Not Found during Export.  Please run Database Repair Script to "
 "Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:92
+#: ../include/global_arrays.php:150
 msgid ""
 "Device Template Not Found during Export.  Please run Database Repair Script "
 "to Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:95
+#: ../include/global_arrays.php:153
 msgid ""
 "Data Query Not Found during Export.  Please run Database Repair Script to "
 "Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:98
+#: ../include/global_arrays.php:156
 msgid ""
 "Graph Template Not Found during Export.  Please run Database Repair Script "
 "to Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:101
+#: ../include/global_arrays.php:159
 msgid ""
 "Graph not found.  Either it has been deleted or your database needs repair."
 msgstr ""
 
-#: ../include/global_arrays.php:104
+#: ../include/global_arrays.php:162
 msgid "SNMPv3 Auth Passphrases must be 8 characters or greater."
 msgstr ""
 
-#: ../include/global_arrays.php:107
+#: ../include/global_arrays.php:165
 msgid ""
 "Some Graphs not Updated. Unable to Change Device for Data Query based Graphs."
 msgstr ""
 
-#: ../include/global_arrays.php:110
+#: ../include/global_arrays.php:168
 msgid "Unable to Change Device for Data Query based Graphs."
 msgstr ""
 
-#: ../include/global_arrays.php:113
+#: ../include/global_arrays.php:171
 msgid "Cacti Log purged successfully"
 msgstr ""
 
-#: ../include/global_arrays.php:116
+#: ../include/global_arrays.php:174
 msgid ""
 "Error: If you force a password change, you must also allow the user to "
 "change their password."
 msgstr ""
 
-#: ../include/global_arrays.php:119
+#: ../include/global_arrays.php:177
 msgid "Error: You are not allowed to change your password."
 msgstr ""
 
-#: ../include/global_arrays.php:122
+#: ../include/global_arrays.php:180
 msgid "Error: LDAP/AD based password change not supported."
 msgstr ""
 
-#: ../include/global_arrays.php:125
+#: ../include/global_arrays.php:183
 msgid "Error: Unable to clear log, no write permissions"
 msgstr ""
 
-#: ../include/global_arrays.php:128
+#: ../include/global_arrays.php:186
 msgid "Error: Unable to clear log, file does not exist"
 msgstr ""
 
-#: ../include/global_arrays.php:131
+#: ../include/global_arrays.php:189
 msgid "Invalid Timestamp. Select timestamp in the future."
 msgstr ""
 
-#: ../include/global_arrays.php:134
+#: ../include/global_arrays.php:192
 msgid "Data Collector(s) Synchronized for Offline Operation"
 msgstr ""
 
-#: ../include/global_arrays.php:137
+#: ../include/global_arrays.php:195
 msgid "Data Collector(s) Not found when attempting Synchronization"
 msgstr ""
 
-#: ../include/global_arrays.php:140
+#: ../include/global_arrays.php:198
 msgid "Unable to establish MySQL connection with remote Data Collector."
 msgstr ""
 
-#: ../include/global_arrays.php:143
+#: ../include/global_arrays.php:201
 msgid ""
 "Data Collector Synchronization must be initiated from the main Cacti server."
 msgstr ""
 
-#: ../include/global_arrays.php:146
+#: ../include/global_arrays.php:204
 msgid "Report Saved"
 msgstr ""
 
-#: ../include/global_arrays.php:149
+#: ../include/global_arrays.php:207
 msgid "Report Save Failed"
 msgstr ""
 
-#: ../include/global_arrays.php:152
+#: ../include/global_arrays.php:210
 msgid "Report Item Saved"
 msgstr ""
 
-#: ../include/global_arrays.php:155
+#: ../include/global_arrays.php:213
 msgid "Report Item Save Failed"
 msgstr ""
 
-#: ../include/global_arrays.php:254 ../include/global_arrays.php:567
+#: ../include/global_arrays.php:305 ../include/global_arrays.php:618
 msgid "Function"
 msgstr ""
 
-#: ../include/global_arrays.php:255 ../include/global_arrays.php:569
+#: ../include/global_arrays.php:306 ../include/global_arrays.php:620
 msgid "Special Data Source"
 msgstr ""
 
-#: ../include/global_arrays.php:256 ../include/global_arrays.php:571
+#: ../include/global_arrays.php:307 ../include/global_arrays.php:622
 msgid "Custom String"
 msgstr ""
 
-#: ../include/global_arrays.php:266 ../include/global_arrays.php:273
+#: ../include/global_arrays.php:317 ../include/global_arrays.php:324
 msgid "Script/Command"
 msgstr ""
 
-#: ../include/global_arrays.php:268 ../include/global_arrays.php:274
-#: ../utilities.php:1600
+#: ../include/global_arrays.php:319 ../include/global_arrays.php:325
+#: ../utilities.php:1607
 msgid "Script Server"
 msgstr ""
 
-#: ../include/global_arrays.php:280
+#: ../include/global_arrays.php:331
 msgid "Index Count"
 msgstr ""
 
-#: ../include/global_arrays.php:281
+#: ../include/global_arrays.php:332
 msgid "Verify All"
 msgstr ""
 
-#: ../include/global_arrays.php:285
+#: ../include/global_arrays.php:336
 msgid ""
 "All Re-Indexing will be manual or managed through scripts or Device "
 "Automation."
 msgstr ""
 
-#: ../include/global_arrays.php:286
+#: ../include/global_arrays.php:337
 msgid ""
 "When the Devices SNMP uptime goes backward, a Re-Index will be performed."
 msgstr ""
 
-#: ../include/global_arrays.php:287
+#: ../include/global_arrays.php:338
 msgid "When the Data Query index count changes, a Re-Index will be performed."
 msgstr ""
 
-#: ../include/global_arrays.php:288
+#: ../include/global_arrays.php:339
 msgid "Every polling cycle, a Re-Index will be performed.  Very expensive."
 msgstr ""
 
-#: ../include/global_arrays.php:292
+#: ../include/global_arrays.php:343
 msgid "SNMP Field Name (Dropdown)"
 msgstr ""
 
-#: ../include/global_arrays.php:293
+#: ../include/global_arrays.php:344
 msgid "SNMP Field Value (From User)"
 msgstr ""
 
-#: ../include/global_arrays.php:294
+#: ../include/global_arrays.php:345
 msgid "SNMP Output Type (Dropdown)"
 msgstr ""
 
-#: ../include/global_arrays.php:313 ../include/global_arrays.php:319
+#: ../include/global_arrays.php:364 ../include/global_arrays.php:370
 msgid "Normal"
 msgstr ""
 
-#: ../include/global_arrays.php:314
+#: ../include/global_arrays.php:365
 msgid "Light"
 msgstr ""
 
-#: ../include/global_arrays.php:315 ../include/global_arrays.php:320
+#: ../include/global_arrays.php:366 ../include/global_arrays.php:371
 msgid "Mono"
 msgstr ""
 
-#: ../include/global_arrays.php:324
+#: ../include/global_arrays.php:375
 msgid "North"
 msgstr ""
 
-#: ../include/global_arrays.php:325
+#: ../include/global_arrays.php:376
 msgid "South"
 msgstr ""
 
-#: ../include/global_arrays.php:326
+#: ../include/global_arrays.php:377
 msgid "West"
 msgstr ""
 
-#: ../include/global_arrays.php:327
+#: ../include/global_arrays.php:378
 msgid "East"
 msgstr ""
 
-#: ../include/global_arrays.php:332
+#: ../include/global_arrays.php:383
 msgid "Left"
 msgstr ""
 
-#: ../include/global_arrays.php:333
+#: ../include/global_arrays.php:384
 msgid "Right"
 msgstr ""
 
-#: ../include/global_arrays.php:334
+#: ../include/global_arrays.php:385
 msgid "Justified"
 msgstr ""
 
-#: ../include/global_arrays.php:335
+#: ../include/global_arrays.php:386
 msgid "Center"
 msgstr ""
 
-#: ../include/global_arrays.php:339
+#: ../include/global_arrays.php:390
 msgid "Top -> Down"
 msgstr ""
 
-#: ../include/global_arrays.php:340
+#: ../include/global_arrays.php:391
 msgid "Bottom -> Up"
 msgstr ""
 
-#: ../include/global_arrays.php:344 ../tree.php:1129
+#: ../include/global_arrays.php:395 ../tree.php:1129
 msgid "Numeric"
 msgstr ""
 
-#: ../include/global_arrays.php:345
+#: ../include/global_arrays.php:396
 msgid "Timestamp"
 msgstr ""
 
-#: ../include/global_arrays.php:346
+#: ../include/global_arrays.php:397
 msgid "Duration"
 msgstr ""
 
-#: ../include/global_arrays.php:378
+#: ../include/global_arrays.php:429
 msgid "Not In Use"
 msgstr ""
 
-#: ../include/global_arrays.php:379 ../include/global_arrays.php:380
-#: ../include/global_arrays.php:381 ../include/global_arrays.php:537
-#: ../include/global_arrays.php:538
+#: ../include/global_arrays.php:430 ../include/global_arrays.php:431
+#: ../include/global_arrays.php:432 ../include/global_arrays.php:588
+#: ../include/global_arrays.php:589
 #, php-format
 msgid "Version %d"
 msgstr ""
 
-#: ../include/global_arrays.php:385
+#: ../include/global_arrays.php:436
 msgid "MD5 (default)"
 msgstr ""
 
-#: ../include/global_arrays.php:386
+#: ../include/global_arrays.php:437
 msgid "SHA"
 msgstr ""
 
-#: ../include/global_arrays.php:390
+#: ../include/global_arrays.php:441
 msgid "[None]"
 msgstr ""
 
-#: ../include/global_arrays.php:391
+#: ../include/global_arrays.php:442
 msgid "DES (default)"
 msgstr ""
 
-#: ../include/global_arrays.php:392
+#: ../include/global_arrays.php:443
 msgid "AES"
 msgstr ""
 
-#: ../include/global_arrays.php:401
+#: ../include/global_arrays.php:452
 msgid "Logfile Only"
 msgstr ""
 
-#: ../include/global_arrays.php:402
+#: ../include/global_arrays.php:453
 msgid "Logfile and Syslog/Eventlog"
 msgstr ""
 
-#: ../include/global_arrays.php:403
+#: ../include/global_arrays.php:454
 msgid "Syslog/Eventlog Only"
 msgstr ""
 
-#: ../include/global_arrays.php:412
+#: ../include/global_arrays.php:463
 msgid "SNMP getNext"
 msgstr ""
 
-#: ../include/global_arrays.php:417
+#: ../include/global_arrays.php:468
 msgid "ICMP Ping"
 msgstr ""
 
-#: ../include/global_arrays.php:418
+#: ../include/global_arrays.php:469
 msgid "TCP Ping"
 msgstr ""
 
-#: ../include/global_arrays.php:419
+#: ../include/global_arrays.php:470
 msgid "UDP Ping"
 msgstr ""
 
-#: ../include/global_arrays.php:423
+#: ../include/global_arrays.php:474
 msgid "NONE - Syslog Only if Selected"
 msgstr ""
 
-#: ../include/global_arrays.php:424
+#: ../include/global_arrays.php:475
 msgid "LOW - Statistics and Errors"
 msgstr ""
 
-#: ../include/global_arrays.php:425
+#: ../include/global_arrays.php:476
 msgid "MEDIUM - Statistics, Errors and Results"
 msgstr ""
 
-#: ../include/global_arrays.php:426
+#: ../include/global_arrays.php:477
 msgid "HIGH - Statistics, Errors, Results and Major I/O Events"
 msgstr ""
 
-#: ../include/global_arrays.php:427
+#: ../include/global_arrays.php:478
 msgid "DEBUG - Statistics, Errors, Results, I/O and Program Flow"
 msgstr ""
 
-#: ../include/global_arrays.php:428
+#: ../include/global_arrays.php:479
 msgid "DEVEL - Developer DEBUG Level"
 msgstr ""
 
-#: ../include/global_arrays.php:437
+#: ../include/global_arrays.php:488
 msgid "Selected Poller Interval"
 msgstr ""
 
-#: ../include/global_arrays.php:452 ../include/global_arrays.php:453
-#: ../include/global_arrays.php:454 ../include/global_arrays.php:455
-#: ../include/global_arrays.php:486 ../include/global_arrays.php:487
-#: ../include/global_arrays.php:488 ../include/global_arrays.php:489
+#: ../include/global_arrays.php:503 ../include/global_arrays.php:504
+#: ../include/global_arrays.php:505 ../include/global_arrays.php:506
+#: ../include/global_arrays.php:537 ../include/global_arrays.php:538
+#: ../include/global_arrays.php:539 ../include/global_arrays.php:540
 #, php-format
 msgid "Every %d Seconds"
 msgstr ""
 
-#: ../include/global_arrays.php:456 ../include/global_arrays.php:490
-#: ../include/global_arrays.php:504
+#: ../include/global_arrays.php:507 ../include/global_arrays.php:541
+#: ../include/global_arrays.php:555
 msgid "Every Minute"
 msgstr ""
 
-#: ../include/global_arrays.php:457 ../include/global_arrays.php:458
-#: ../include/global_arrays.php:459 ../include/global_arrays.php:460
-#: ../include/global_arrays.php:491 ../include/global_arrays.php:505
+#: ../include/global_arrays.php:508 ../include/global_arrays.php:509
+#: ../include/global_arrays.php:510 ../include/global_arrays.php:511
+#: ../include/global_arrays.php:542 ../include/global_arrays.php:556
 #, php-format
 msgid "Every %d Minutes"
 msgstr ""
 
-#: ../include/global_arrays.php:461
+#: ../include/global_arrays.php:512
 msgid "Every Hour"
 msgstr ""
 
-#: ../include/global_arrays.php:462 ../include/global_arrays.php:463
-#: ../include/global_arrays.php:1442 ../include/global_arrays.php:1443
+#: ../include/global_arrays.php:513 ../include/global_arrays.php:514
 #: ../include/global_arrays.php:1444 ../include/global_arrays.php:1445
-#: ../include/global_arrays.php:1446 ../include/global_settings.php:1750
-#: ../include/global_settings.php:1751
+#: ../include/global_arrays.php:1446 ../include/global_arrays.php:1447
+#: ../include/global_arrays.php:1448 ../include/global_settings.php:1758
+#: ../include/global_settings.php:1759
 #, php-format
 msgid "Every %d Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:482 ../include/global_settings.php:1090
+#: ../include/global_arrays.php:533 ../include/global_settings.php:1098
 msgid "1 Day"
 msgstr ""
 
-#: ../include/global_arrays.php:495
+#: ../include/global_arrays.php:546
 msgid "1 Thread (default)"
 msgstr ""
 
-#: ../include/global_arrays.php:520
+#: ../include/global_arrays.php:571
 msgid "Builtin Authentication"
 msgstr ""
 
-#: ../include/global_arrays.php:521
+#: ../include/global_arrays.php:572
 msgid "Web Basic Authentication"
 msgstr ""
 
-#: ../include/global_arrays.php:525
+#: ../include/global_arrays.php:576
 msgid "LDAP Authentication"
 msgstr ""
 
-#: ../include/global_arrays.php:526
+#: ../include/global_arrays.php:577
 msgid "Multiple LDAP/AD Domains"
 msgstr ""
 
-#: ../include/global_arrays.php:531
+#: ../include/global_arrays.php:582
 msgid "Active Directory"
 msgstr ""
 
-#: ../include/global_arrays.php:543 ../include/global_settings.php:1309
+#: ../include/global_arrays.php:594 ../include/global_settings.php:1317
 msgid "SSL"
 msgstr ""
 
-#: ../include/global_arrays.php:544 ../include/global_settings.php:1309
+#: ../include/global_arrays.php:595 ../include/global_settings.php:1317
 msgid "TLS"
 msgstr ""
 
-#: ../include/global_arrays.php:548
+#: ../include/global_arrays.php:599
 msgid "No Searching"
 msgstr ""
 
-#: ../include/global_arrays.php:549
+#: ../include/global_arrays.php:600
 msgid "Anonymous Searching"
 msgstr ""
 
-#: ../include/global_arrays.php:550
+#: ../include/global_arrays.php:601
 msgid "Specific Searching"
 msgstr ""
 
-#: ../include/global_arrays.php:563
+#: ../include/global_arrays.php:614
 msgid "Enabled (strict mode)"
 msgstr ""
 
-#: ../include/global_arrays.php:568 ../include/global_form.php:2090
-#: ../include/global_form.php:2132 ../lib/api_automation.php:1210
+#: ../include/global_arrays.php:619 ../include/global_form.php:2101
+#: ../include/global_form.php:2143 ../lib/api_automation.php:1210
 #: ../lib/api_automation.php:1272
 msgid "Operator"
 msgstr ""
 
-#: ../include/global_arrays.php:570
+#: ../include/global_arrays.php:621
 msgid "Another CDEF"
 msgstr ""
 
-#: ../include/global_arrays.php:589
+#: ../include/global_arrays.php:640
 msgid "Inherit Parent Sorting"
 msgstr ""
 
-#: ../include/global_arrays.php:590
+#: ../include/global_arrays.php:641
 msgid "Manual Ordering (No Sorting)"
 msgstr ""
 
-#: ../include/global_arrays.php:591
+#: ../include/global_arrays.php:642
 msgid "Alphabetic Ordering"
 msgstr ""
 
-#: ../include/global_arrays.php:592
+#: ../include/global_arrays.php:643
 msgid "Natural Ordering"
 msgstr ""
 
-#: ../include/global_arrays.php:593
+#: ../include/global_arrays.php:644
 msgid "Numeric Ordering"
 msgstr ""
 
-#: ../include/global_arrays.php:597 ../lib/rrd.php:2602
+#: ../include/global_arrays.php:648 ../lib/rrd.php:2612
 msgid "Header"
 msgstr ""
 
-#: ../include/global_arrays.php:598 ../include/global_arrays.php:645
-#: ../include/global_arrays.php:1267 ../include/global_arrays.php:1431
+#: ../include/global_arrays.php:649 ../include/global_arrays.php:696
+#: ../include/global_arrays.php:1269 ../include/global_arrays.php:1433
 msgid "Graph"
 msgstr ""
 
-#: ../include/global_arrays.php:604 ../tree.php:1295
+#: ../include/global_arrays.php:655 ../tree.php:1295
 msgid "Data Query Index"
 msgstr ""
 
-#: ../include/global_arrays.php:608
+#: ../include/global_arrays.php:659
 msgid "Current Graph Item Data Source"
 msgstr ""
 
-#: ../include/global_arrays.php:609
+#: ../include/global_arrays.php:660
 msgid "Current Graph Item Polling Interval"
 msgstr ""
 
-#: ../include/global_arrays.php:610
+#: ../include/global_arrays.php:661
 msgid "All Data Sources (Do not Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:611
+#: ../include/global_arrays.php:662
 msgid "All Data Sources (Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:612
+#: ../include/global_arrays.php:663
 msgid "All Similar Data Sources (Do not Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:613
+#: ../include/global_arrays.php:664
 msgid "All Similar Data Sources (Do not Include Duplicates) Polling Interval"
 msgstr ""
 
-#: ../include/global_arrays.php:614
+#: ../include/global_arrays.php:665
 msgid "All Similar Data Sources (Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:615
+#: ../include/global_arrays.php:666
 msgid "Current Data Source Item: Minimum Value"
 msgstr ""
 
-#: ../include/global_arrays.php:616
+#: ../include/global_arrays.php:667
 msgid "Current Data Source Item: Maximum Value"
 msgstr ""
 
-#: ../include/global_arrays.php:617
+#: ../include/global_arrays.php:668
 msgid "Graph: Lower Limit"
 msgstr ""
 
-#: ../include/global_arrays.php:618
+#: ../include/global_arrays.php:669
 msgid "Graph: Upper Limit"
 msgstr ""
 
-#: ../include/global_arrays.php:619
+#: ../include/global_arrays.php:670
 msgid "Count of All Data Sources (Do not Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:620
+#: ../include/global_arrays.php:671
 msgid "Count of All Data Sources (Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:621
+#: ../include/global_arrays.php:672
 msgid "Count of All Similar Data Sources (Do not Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:622
+#: ../include/global_arrays.php:673
 msgid "Count of All Similar Data Sources (Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:628
+#: ../include/global_arrays.php:679 ../lib/html_form_template.php:562
+#: ../lib/html_form_template.php:577
 msgid "New Graphs"
 msgstr ""
 
-#: ../include/global_arrays.php:630 ../include/global_arrays.php:682
-#: ../include/global_arrays.php:699
+#: ../include/global_arrays.php:681 ../include/global_arrays.php:733
+#: ../include/global_arrays.php:750
 msgid "Management"
 msgstr ""
 
-#: ../include/global_arrays.php:632 ../sites.php:378 ../sites.php:393
+#: ../include/global_arrays.php:683 ../sites.php:378 ../sites.php:393
 #: ../sites.php:472
 msgid "Sites"
 msgstr ""
 
-#: ../include/global_arrays.php:633 ../include/global_arrays.php:814
+#: ../include/global_arrays.php:684 ../include/global_arrays.php:865
 #: ../tree.php:1476 ../tree.php:1491 ../tree.php:1549 ../user_admin.php:2909
 #: ../user_admin.php:2996 ../user_group_admin.php:1235
 #: ../user_group_admin.php:2441
 msgid "Trees"
 msgstr ""
 
-#: ../include/global_arrays.php:636
+#: ../include/global_arrays.php:687
 msgid "Aggregates"
 msgstr ""
 
-#: ../include/global_arrays.php:638 ../include/global_arrays.php:685
-#: ../include/global_arrays.php:700
+#: ../include/global_arrays.php:689 ../include/global_arrays.php:736
+#: ../include/global_arrays.php:751
 msgid "Data Collection"
 msgstr ""
 
-#: ../include/global_arrays.php:639 ../include/global_arrays.php:686
-#: ../pollers.php:498
+#: ../include/global_arrays.php:690 ../include/global_arrays.php:737
+#: ../pollers.php:508
 msgid "Data Collectors"
 msgstr ""
 
-#: ../include/global_arrays.php:647
+#: ../include/global_arrays.php:698
 msgid "Aggregate"
 msgstr ""
 
-#: ../include/global_arrays.php:650 ../include/global_arrays.php:702
+#: ../include/global_arrays.php:701 ../include/global_arrays.php:753
 #: ../include/global_settings.php:413
 msgid "Automation"
 msgstr ""
 
-#: ../include/global_arrays.php:652
+#: ../include/global_arrays.php:703
 msgid "Discovered Devices"
 msgstr ""
 
-#: ../include/global_arrays.php:653
+#: ../include/global_arrays.php:704
 msgid "Device Rules"
 msgstr ""
 
-#: ../include/global_arrays.php:658 ../include/global_arrays.php:703
-#: ../lib/html_graph.php:255 ../lib/html_tree.php:700
+#: ../include/global_arrays.php:709 ../include/global_arrays.php:754
+#: ../lib/html_filter.php:178 ../lib/html_graph.php:255
+#: ../lib/html_tree.php:701
 msgid "Presets"
 msgstr ""
 
-#: ../include/global_arrays.php:659
+#: ../include/global_arrays.php:710
 msgid "Data Profiles"
 msgstr ""
 
-#: ../include/global_arrays.php:661 ../lib/functions.php:2300 ../vdef.php:651
+#: ../include/global_arrays.php:712 ../lib/functions.php:2311 ../vdef.php:651
 #: ../vdef.php:665 ../vdef.php:836
 msgid "VDEFs"
 msgstr ""
 
-#: ../include/global_arrays.php:665 ../include/global_arrays.php:704
+#: ../include/global_arrays.php:716 ../include/global_arrays.php:755
 msgid "Import/Export"
 msgstr ""
 
-#: ../include/global_arrays.php:666 ../lib/functions.php:2414
+#: ../include/global_arrays.php:717 ../lib/functions.php:2425
 #: ../templates_import.php:115
 msgid "Import Templates"
 msgstr ""
 
-#: ../include/global_arrays.php:667 ../lib/functions.php:2402
+#: ../include/global_arrays.php:718 ../lib/functions.php:2413
 #: ../templates_export.php:94
 msgid "Export Templates"
 msgstr ""
 
-#: ../include/global_arrays.php:669 ../include/global_arrays.php:688
-#: ../include/global_arrays.php:705 ../lib/plugins.php:763
+#: ../include/global_arrays.php:720 ../include/global_arrays.php:739
+#: ../include/global_arrays.php:756 ../lib/plugins.php:763
 msgid "Configuration"
 msgstr ""
 
-#: ../include/global_arrays.php:670 ../include/global_arrays.php:689
+#: ../include/global_arrays.php:721 ../include/global_arrays.php:740
 msgid "Settings"
 msgstr ""
 
-#: ../include/global_arrays.php:671 ../lib/functions.php:2348
+#: ../include/global_arrays.php:722 ../lib/functions.php:2359
 #: ../user_admin.php:2182 ../user_group_admin.php:667
 #: ../user_group_admin.php:2528
 msgid "Users"
 msgstr ""
 
-#: ../include/global_arrays.php:672 ../lib/functions.php:2378
+#: ../include/global_arrays.php:723 ../lib/functions.php:2389
 msgid "User Groups"
 msgstr ""
 
-#: ../include/global_arrays.php:673 ../lib/functions.php:2366
+#: ../include/global_arrays.php:724 ../lib/functions.php:2377
 #: ../user_domains.php:612 ../user_domains.php:705
 msgid "User Domains"
 msgstr ""
 
-#: ../include/global_arrays.php:675 ../include/global_arrays.php:691
-#: ../include/global_arrays.php:706 ../lib/functions.php:2228
+#: ../include/global_arrays.php:726 ../include/global_arrays.php:742
+#: ../include/global_arrays.php:757 ../lib/functions.php:2239
 msgid "Utilities"
 msgstr ""
 
-#: ../include/global_arrays.php:676 ../include/global_arrays.php:692
+#: ../include/global_arrays.php:727 ../include/global_arrays.php:743
 msgid "System Utilities"
 msgstr ""
 
-#: ../include/global_arrays.php:677 ../include/global_arrays.php:720
-#: ../include/global_arrays.php:803 ../links.php:90 ../links.php:301
+#: ../include/global_arrays.php:728 ../include/global_arrays.php:771
+#: ../include/global_arrays.php:854 ../links.php:90 ../links.php:301
 #: ../links.php:370 ../links.php:483
 msgid "External Links"
 msgstr ""
 
-#: ../include/global_arrays.php:729
+#: ../include/global_arrays.php:780
 msgid "All Lines"
 msgstr ""
 
-#: ../include/global_arrays.php:730 ../include/global_arrays.php:731
-#: ../include/global_arrays.php:732 ../include/global_arrays.php:733
-#: ../include/global_arrays.php:734 ../include/global_arrays.php:735
-#: ../include/global_arrays.php:736 ../include/global_arrays.php:737
-#: ../include/global_arrays.php:738 ../include/global_arrays.php:739
-#: ../include/global_arrays.php:740 ../include/global_arrays.php:741
+#: ../include/global_arrays.php:781 ../include/global_arrays.php:782
+#: ../include/global_arrays.php:783 ../include/global_arrays.php:784
+#: ../include/global_arrays.php:785 ../include/global_arrays.php:786
+#: ../include/global_arrays.php:787 ../include/global_arrays.php:788
+#: ../include/global_arrays.php:789 ../include/global_arrays.php:790
+#: ../include/global_arrays.php:791 ../include/global_arrays.php:792
 #, php-format
 msgid "%d Lines"
 msgstr ""
 
-#: ../include/global_arrays.php:796
+#: ../include/global_arrays.php:847
 msgid "Never"
 msgstr ""
 
-#: ../include/global_arrays.php:800
+#: ../include/global_arrays.php:851
 msgid "Console Access"
 msgstr ""
 
-#: ../include/global_arrays.php:802
+#: ../include/global_arrays.php:853
 msgid "Update Profile"
 msgstr ""
 
-#: ../include/global_arrays.php:805 ../user_admin.php:2161
+#: ../include/global_arrays.php:856 ../user_admin.php:2161
 msgid "User Management"
 msgstr ""
 
-#: ../include/global_arrays.php:806
+#: ../include/global_arrays.php:857
 msgid "Settings and Utilities"
 msgstr ""
 
-#: ../include/global_arrays.php:807
+#: ../include/global_arrays.php:858
 msgid "Automation Settings"
 msgstr ""
 
-#: ../include/global_arrays.php:812
+#: ../include/global_arrays.php:863
 msgid "Sites/Devices/Data Sources/Data Collectors"
 msgstr ""
 
-#: ../include/global_arrays.php:815
+#: ../include/global_arrays.php:866
 msgid "Remove Spikes from Graphs"
 msgstr ""
 
-#: ../include/global_arrays.php:818
+#: ../include/global_arrays.php:869
 msgid "Colors/GPrints/CDEFs/VDEFs"
 msgstr ""
 
-#: ../include/global_arrays.php:824
+#: ../include/global_arrays.php:875
 msgid "Export Data"
 msgstr ""
 
-#: ../include/global_arrays.php:825
+#: ../include/global_arrays.php:876
 msgid "Import Data"
 msgstr ""
 
-#: ../include/global_arrays.php:827 ../include/global_settings.php:665
+#: ../include/global_arrays.php:878 ../include/global_settings.php:665
 msgid "Log Management"
 msgstr ""
 
-#: ../include/global_arrays.php:828
+#: ../include/global_arrays.php:879
 msgid "Log Viewing"
 msgstr ""
 
-#: ../include/global_arrays.php:830
+#: ../include/global_arrays.php:881
 msgid "Reports Management"
 msgstr ""
 
-#: ../include/global_arrays.php:831
+#: ../include/global_arrays.php:882
 msgid "Reports Creation"
 msgstr ""
 
-#: ../include/global_arrays.php:978
+#: ../include/global_arrays.php:980
 msgid "CDEF"
 msgstr ""
 
-#: ../include/global_arrays.php:979
+#: ../include/global_arrays.php:981
 msgid "CDEF Item"
 msgstr ""
 
-#: ../include/global_arrays.php:980
+#: ../include/global_arrays.php:982
 msgid "GPRINT Preset"
 msgstr ""
 
-#: ../include/global_arrays.php:983
+#: ../include/global_arrays.php:985
 msgid "Data Input Field"
 msgstr ""
 
-#: ../include/global_arrays.php:984 ../include/global_form.php:394
-#: ../include/global_form.php:1602
+#: ../include/global_arrays.php:986 ../include/global_form.php:394
+#: ../include/global_form.php:1613
 msgid "Data Source Profile"
 msgstr ""
 
-#: ../include/global_arrays.php:985
+#: ../include/global_arrays.php:987
 msgid "Data Template Item"
 msgstr ""
 
-#: ../include/global_arrays.php:987
+#: ../include/global_arrays.php:989
 msgid "Graph Template Item"
 msgstr ""
 
-#: ../include/global_arrays.php:988
+#: ../include/global_arrays.php:990
 msgid "Graph Template Input"
 msgstr ""
 
-#: ../include/global_arrays.php:991
+#: ../include/global_arrays.php:993
 msgid "VDEF"
 msgstr ""
 
-#: ../include/global_arrays.php:992
+#: ../include/global_arrays.php:994
 msgid "VDEF Item"
 msgstr ""
 
-#: ../include/global_arrays.php:1036
+#: ../include/global_arrays.php:1038
 msgid "Last Half Hour"
 msgstr ""
 
-#: ../include/global_arrays.php:1037
+#: ../include/global_arrays.php:1039
 msgid "Last Hour"
 msgstr ""
 
-#: ../include/global_arrays.php:1038 ../include/global_arrays.php:1039
 #: ../include/global_arrays.php:1040 ../include/global_arrays.php:1041
+#: ../include/global_arrays.php:1042 ../include/global_arrays.php:1043
 #, php-format
 msgid "Last %d Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1042
+#: ../include/global_arrays.php:1044
 msgid "Last Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1043 ../include/global_arrays.php:1044
-#: ../include/global_arrays.php:1045
+#: ../include/global_arrays.php:1045 ../include/global_arrays.php:1046
+#: ../include/global_arrays.php:1047
 #, php-format
 msgid "Last %d Days"
 msgstr ""
 
-#: ../include/global_arrays.php:1046
+#: ../include/global_arrays.php:1048
 msgid "Last Week"
 msgstr ""
 
-#: ../include/global_arrays.php:1047
+#: ../include/global_arrays.php:1049
 #, php-format
 msgid "Last %d Weeks"
 msgstr ""
 
-#: ../include/global_arrays.php:1048
+#: ../include/global_arrays.php:1050
 msgid "Last Month"
 msgstr ""
 
-#: ../include/global_arrays.php:1049 ../include/global_arrays.php:1050
 #: ../include/global_arrays.php:1051 ../include/global_arrays.php:1052
+#: ../include/global_arrays.php:1053 ../include/global_arrays.php:1054
 #, php-format
 msgid "Last %d Months"
 msgstr ""
 
-#: ../include/global_arrays.php:1053
+#: ../include/global_arrays.php:1055
 msgid "Last Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1054
+#: ../include/global_arrays.php:1056
 #, php-format
 msgid "Last %d Years"
 msgstr ""
 
-#: ../include/global_arrays.php:1055
+#: ../include/global_arrays.php:1057
 msgid "Day Shift"
 msgstr ""
 
-#: ../include/global_arrays.php:1056
+#: ../include/global_arrays.php:1058
 msgid "This Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1057
+#: ../include/global_arrays.php:1059
 msgid "This Week"
 msgstr ""
 
-#: ../include/global_arrays.php:1058
+#: ../include/global_arrays.php:1060
 msgid "This Month"
 msgstr ""
 
-#: ../include/global_arrays.php:1059
+#: ../include/global_arrays.php:1061
 msgid "This Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1060
+#: ../include/global_arrays.php:1062
 msgid "Previous Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1061
+#: ../include/global_arrays.php:1063
 msgid "Previous Week"
 msgstr ""
 
-#: ../include/global_arrays.php:1062
+#: ../include/global_arrays.php:1064
 msgid "Previous Month"
 msgstr ""
 
-#: ../include/global_arrays.php:1063
+#: ../include/global_arrays.php:1065
 msgid "Previous Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1067
+#: ../include/global_arrays.php:1069
 #, php-format
 msgid "%d Min"
 msgstr ""
 
-#: ../include/global_arrays.php:1084 ../include/global_settings.php:1018
+#: ../include/global_arrays.php:1086 ../include/global_settings.php:1026
 #: ../rrdcleaner.php:493
 #, php-format
 msgid "%d Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1099
+#: ../include/global_arrays.php:1101
 msgid "Month Number, Day, Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1100
+#: ../include/global_arrays.php:1102
 msgid "Month Name, Day, Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1101
+#: ../include/global_arrays.php:1103
 msgid "Day, Month Number, Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1102
+#: ../include/global_arrays.php:1104
 msgid "Day, Month Name, Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1103
+#: ../include/global_arrays.php:1105
 msgid "Year, Month Number, Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1104
+#: ../include/global_arrays.php:1106
 msgid "Year, Month Name, Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1113
+#: ../include/global_arrays.php:1115
 msgid "After Boost"
 msgstr ""
 
-#: ../include/global_arrays.php:1123 ../include/global_arrays.php:1124
 #: ../include/global_arrays.php:1125 ../include/global_arrays.php:1126
-#: ../include/global_arrays.php:1127 ../include/global_arrays.php:1182
-#: ../include/global_arrays.php:1183 ../include/global_arrays.php:1184
+#: ../include/global_arrays.php:1127 ../include/global_arrays.php:1128
+#: ../include/global_arrays.php:1129 ../include/global_arrays.php:1184
 #: ../include/global_arrays.php:1185 ../include/global_arrays.php:1186
+#: ../include/global_arrays.php:1187 ../include/global_arrays.php:1188
 #, php-format
 msgid "%d MBytes"
 msgstr ""
 
-#: ../include/global_arrays.php:1128 ../include/global_arrays.php:1187
+#: ../include/global_arrays.php:1130 ../include/global_arrays.php:1189
 msgid "1 GByte"
 msgstr ""
 
-#: ../include/global_arrays.php:1129 ../include/global_arrays.php:1188
+#: ../include/global_arrays.php:1131 ../include/global_arrays.php:1190
 #, php-format
 msgid "%s GBytes"
 msgstr ""
 
-#: ../include/global_arrays.php:1130 ../include/global_arrays.php:1131
-#: ../include/global_arrays.php:1189 ../include/global_arrays.php:1190
+#: ../include/global_arrays.php:1132 ../include/global_arrays.php:1133
+#: ../include/global_arrays.php:1191 ../include/global_arrays.php:1192
 #, php-format
 msgid "%d GBytes"
 msgstr ""
 
-#: ../include/global_arrays.php:1144
+#: ../include/global_arrays.php:1146
 msgid "2,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1145
+#: ../include/global_arrays.php:1147
 msgid "5,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1146
+#: ../include/global_arrays.php:1148
 msgid "10,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1147
+#: ../include/global_arrays.php:1149
 msgid "15,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1148
+#: ../include/global_arrays.php:1150
 msgid "25,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1149
+#: ../include/global_arrays.php:1151
 msgid "50,000 Data Source Items (Default)"
 msgstr ""
 
-#: ../include/global_arrays.php:1150
+#: ../include/global_arrays.php:1152
 msgid "100,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1151
+#: ../include/global_arrays.php:1153
 msgid "200,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1152
+#: ../include/global_arrays.php:1154
 msgid "400,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1169
+#: ../include/global_arrays.php:1171
 msgid "2 Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1170
+#: ../include/global_arrays.php:1172
 msgid "4 Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1171
+#: ../include/global_arrays.php:1173
 msgid "6 Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1178
+#: ../include/global_arrays.php:1180
 #, php-format
 msgid "%s Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1197
+#: ../include/global_arrays.php:1199
 #, php-format
 msgid "%s Minutes"
 msgstr ""
 
-#: ../include/global_arrays.php:1217
+#: ../include/global_arrays.php:1219
 msgid "1 Megabyte"
 msgstr ""
 
-#: ../include/global_arrays.php:1218 ../include/global_arrays.php:1219
 #: ../include/global_arrays.php:1220 ../include/global_arrays.php:1221
 #: ../include/global_arrays.php:1222 ../include/global_arrays.php:1223
+#: ../include/global_arrays.php:1224 ../include/global_arrays.php:1225
 #, php-format
 msgid "%d Megabytes"
 msgstr ""
 
-#: ../include/global_arrays.php:1235
+#: ../include/global_arrays.php:1237
 msgid "Take Ownership"
 msgstr ""
 
-#: ../include/global_arrays.php:1239
+#: ../include/global_arrays.php:1241
 msgid "Inline PNG Image"
 msgstr ""
 
-#: ../include/global_arrays.php:1245
+#: ../include/global_arrays.php:1247
 msgid "Inline JPEG Image"
 msgstr ""
 
-#: ../include/global_arrays.php:1246
+#: ../include/global_arrays.php:1248
 msgid "Inline GIF Image"
 msgstr ""
 
-#: ../include/global_arrays.php:1249
+#: ../include/global_arrays.php:1251
 msgid "Attached PNG Image"
 msgstr ""
 
-#: ../include/global_arrays.php:1252
+#: ../include/global_arrays.php:1254
 msgid "Attached JPEG Image"
 msgstr ""
 
-#: ../include/global_arrays.php:1253
+#: ../include/global_arrays.php:1255
 msgid "Attached GIF Image"
 msgstr ""
 
-#: ../include/global_arrays.php:1257
+#: ../include/global_arrays.php:1259
 msgid "Inline PNG Image, LN Style"
 msgstr ""
 
-#: ../include/global_arrays.php:1259
+#: ../include/global_arrays.php:1261
 msgid "Inline JPEG Image, LN Style"
 msgstr ""
 
-#: ../include/global_arrays.php:1260
+#: ../include/global_arrays.php:1262
 msgid "Inline GIF Image, LN Style"
 msgstr ""
 
-#: ../include/global_arrays.php:1265
+#: ../include/global_arrays.php:1267
 msgid "Text"
 msgstr ""
 
-#: ../include/global_arrays.php:1266 ../include/global_form.php:2214
+#: ../include/global_arrays.php:1268 ../include/global_form.php:2223
 msgid "Tree"
 msgstr ""
 
-#: ../include/global_arrays.php:1268
+#: ../include/global_arrays.php:1270
 msgid "Horizontal Rule"
 msgstr ""
 
-#: ../include/global_arrays.php:1272
+#: ../include/global_arrays.php:1274
 msgid "left"
 msgstr ""
 
-#: ../include/global_arrays.php:1273
+#: ../include/global_arrays.php:1275
 msgid "center"
 msgstr ""
 
-#: ../include/global_arrays.php:1274
+#: ../include/global_arrays.php:1276
 msgid "right"
 msgstr ""
 
-#: ../include/global_arrays.php:1278
+#: ../include/global_arrays.php:1280
 msgid "Minute(s)"
 msgstr ""
 
-#: ../include/global_arrays.php:1279
+#: ../include/global_arrays.php:1281
 msgid "Hour(s)"
 msgstr ""
 
-#: ../include/global_arrays.php:1280
+#: ../include/global_arrays.php:1282
 msgid "Day(s)"
 msgstr ""
 
-#: ../include/global_arrays.php:1281
+#: ../include/global_arrays.php:1283
 msgid "Week(s)"
 msgstr ""
 
-#: ../include/global_arrays.php:1282
+#: ../include/global_arrays.php:1284
 msgid "Month(s), Day of Month"
 msgstr ""
 
-#: ../include/global_arrays.php:1283
+#: ../include/global_arrays.php:1285
 msgid "Month(s), Day of Week"
 msgstr ""
 
-#: ../include/global_arrays.php:1284
+#: ../include/global_arrays.php:1286
 msgid "Year(s)"
 msgstr ""
 
-#: ../include/global_arrays.php:1288
+#: ../include/global_arrays.php:1290
 msgid "Keep Graph Types"
 msgstr ""
 
-#: ../include/global_arrays.php:1289
+#: ../include/global_arrays.php:1291
 msgid "Keep Type and STACK"
 msgstr ""
 
-#: ../include/global_arrays.php:1290
+#: ../include/global_arrays.php:1292
 msgid "Convert to AREA/STACK Graph"
 msgstr ""
 
-#: ../include/global_arrays.php:1291
+#: ../include/global_arrays.php:1293
 msgid "Convert to LINE1 Graph"
 msgstr ""
 
-#: ../include/global_arrays.php:1292
+#: ../include/global_arrays.php:1294
 msgid "Convert to LINE2 Graph"
 msgstr ""
 
-#: ../include/global_arrays.php:1293
+#: ../include/global_arrays.php:1295
 msgid "Convert to LINE3 Graph"
 msgstr ""
 
-#: ../include/global_arrays.php:1297
+#: ../include/global_arrays.php:1299
 msgid "No Totals"
 msgstr ""
 
-#: ../include/global_arrays.php:1298
+#: ../include/global_arrays.php:1300
 msgid "Print all Legend Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1299
+#: ../include/global_arrays.php:1301
 msgid "Print totaling Legend Items Only"
 msgstr ""
 
-#: ../include/global_arrays.php:1303
+#: ../include/global_arrays.php:1305
 msgid "Total Similar Data Sources"
 msgstr ""
 
-#: ../include/global_arrays.php:1304
+#: ../include/global_arrays.php:1306
 msgid "Total All Data Sources"
 msgstr ""
 
-#: ../include/global_arrays.php:1308
+#: ../include/global_arrays.php:1310
 msgid "No Reordering"
 msgstr ""
 
-#: ../include/global_arrays.php:1309
+#: ../include/global_arrays.php:1311
 msgid "Data Source, Graph"
 msgstr ""
 
-#: ../include/global_arrays.php:1310
+#: ../include/global_arrays.php:1312
 msgid "Graph, Data Source"
 msgstr ""
 
-#: ../include/global_arrays.php:1317
+#: ../include/global_arrays.php:1319
 msgid "contains"
 msgstr ""
 
-#: ../include/global_arrays.php:1318
+#: ../include/global_arrays.php:1320
 msgid "does not contain"
 msgstr ""
 
-#: ../include/global_arrays.php:1319
+#: ../include/global_arrays.php:1321
 msgid "begins with"
 msgstr ""
 
-#: ../include/global_arrays.php:1320
+#: ../include/global_arrays.php:1322
 msgid "does not begin with"
 msgstr ""
 
-#: ../include/global_arrays.php:1321
+#: ../include/global_arrays.php:1323
 msgid "ends with"
 msgstr ""
 
-#: ../include/global_arrays.php:1322
+#: ../include/global_arrays.php:1324
 msgid "does not end with"
 msgstr ""
 
-#: ../include/global_arrays.php:1323
+#: ../include/global_arrays.php:1325
 msgid "matches"
 msgstr ""
 
-#: ../include/global_arrays.php:1324
+#: ../include/global_arrays.php:1326
 msgid "does not match with"
 msgstr ""
 
-#: ../include/global_arrays.php:1325
+#: ../include/global_arrays.php:1327
 msgid "is less than"
 msgstr ""
 
-#: ../include/global_arrays.php:1326
+#: ../include/global_arrays.php:1328
 msgid "is less than or equal"
 msgstr ""
 
-#: ../include/global_arrays.php:1327
+#: ../include/global_arrays.php:1329
 msgid "is greater than"
 msgstr ""
 
-#: ../include/global_arrays.php:1328
+#: ../include/global_arrays.php:1330
 msgid "is greater than or equal"
 msgstr ""
 
-#: ../include/global_arrays.php:1329
+#: ../include/global_arrays.php:1331
 msgid "is unknown"
 msgstr ""
 
-#: ../include/global_arrays.php:1330
+#: ../include/global_arrays.php:1332
 msgid "is not unknown"
 msgstr ""
 
-#: ../include/global_arrays.php:1331
+#: ../include/global_arrays.php:1333
 msgid "is empty"
 msgstr ""
 
-#: ../include/global_arrays.php:1332
+#: ../include/global_arrays.php:1334
 msgid "is not empty"
 msgstr ""
 
-#: ../include/global_arrays.php:1333
+#: ../include/global_arrays.php:1335
 msgid "matches regular expression"
 msgstr ""
 
-#: ../include/global_arrays.php:1334
+#: ../include/global_arrays.php:1336
 msgid "does not match regular expression"
 msgstr ""
 
-#: ../include/global_arrays.php:1436
+#: ../include/global_arrays.php:1438
 msgid "Fixed String"
 msgstr ""
 
-#: ../include/global_arrays.php:1441
+#: ../include/global_arrays.php:1443
 msgid "Every 1 Hour"
 msgstr ""
 
-#: ../include/global_arrays.php:1447
+#: ../include/global_arrays.php:1449
 msgid "Every Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1448
+#: ../include/global_arrays.php:1450
 msgid "Every Week"
 msgstr ""
 
-#: ../include/global_arrays.php:1449 ../include/global_arrays.php:1450
+#: ../include/global_arrays.php:1451 ../include/global_arrays.php:1452
 #, php-format
 msgid "Every %d Weeks"
 msgstr ""
 
-#: ../include/global_arrays.php:1475
+#: ../include/global_arrays.php:1477
 msgctxt "A short textual representation of a month, three letters"
 msgid "Jan"
 msgstr ""
 
-#: ../include/global_arrays.php:1476
+#: ../include/global_arrays.php:1478
 msgctxt "A short textual representation of a month, three letters"
 msgid "Feb"
 msgstr ""
 
-#: ../include/global_arrays.php:1477
+#: ../include/global_arrays.php:1479
 msgctxt "A short textual representation of a month, three letters"
 msgid "Mar"
 msgstr ""
 
-#: ../include/global_arrays.php:1478
+#: ../include/global_arrays.php:1480
 msgctxt "A short textual representation of a month, three letters"
 msgid "Apr"
 msgstr ""
 
-#: ../include/global_arrays.php:1479
+#: ../include/global_arrays.php:1481
 msgctxt "A short textual representation of a month, three letters"
 msgid "May"
 msgstr ""
 
-#: ../include/global_arrays.php:1480
+#: ../include/global_arrays.php:1482
 msgctxt "A short textual representation of a month, three letters"
 msgid "Jun"
 msgstr ""
 
-#: ../include/global_arrays.php:1481
+#: ../include/global_arrays.php:1483
 msgctxt "A short textual representation of a month, three letters"
 msgid "Jul"
 msgstr ""
 
-#: ../include/global_arrays.php:1482
+#: ../include/global_arrays.php:1484
 msgctxt "A short textual representation of a month, three letters"
 msgid "Aug"
 msgstr ""
 
-#: ../include/global_arrays.php:1483
+#: ../include/global_arrays.php:1485
 msgctxt "A short textual representation of a month, three letters"
 msgid "Sep"
 msgstr ""
 
-#: ../include/global_arrays.php:1484
+#: ../include/global_arrays.php:1486
 msgctxt "A short textual representation of a month, three letters"
 msgid "Oct"
 msgstr ""
 
-#: ../include/global_arrays.php:1485
+#: ../include/global_arrays.php:1487
 msgctxt "A short textual representation of a month, three letters"
 msgid "Nov"
 msgstr ""
 
-#: ../include/global_arrays.php:1486
+#: ../include/global_arrays.php:1488
 msgctxt "A short textual representation of a month, three letters"
 msgid "Dec"
 msgstr ""
 
-#: ../include/global_arrays.php:1500
+#: ../include/global_arrays.php:1502
 msgctxt "A textual representation of a day, three letters"
 msgid "Sun"
 msgstr ""
 
-#: ../include/global_arrays.php:1501
+#: ../include/global_arrays.php:1503
 msgctxt "A textual representation of a day, three letters"
 msgid "Mon"
 msgstr ""
 
-#: ../include/global_arrays.php:1502
+#: ../include/global_arrays.php:1504
 msgctxt "A textual representation of a day, three letters"
 msgid "Tue"
 msgstr ""
 
-#: ../include/global_arrays.php:1503
+#: ../include/global_arrays.php:1505
 msgctxt "A textual representation of a day, three letters"
 msgid "Wed"
 msgstr ""
 
-#: ../include/global_arrays.php:1504
+#: ../include/global_arrays.php:1506
 msgctxt "A textual representation of a day, three letters"
 msgid "Thu"
 msgstr ""
 
-#: ../include/global_arrays.php:1505
+#: ../include/global_arrays.php:1507
 msgctxt "A textual representation of a day, three letters"
 msgid "Fri"
 msgstr ""
 
-#: ../include/global_arrays.php:1506
+#: ../include/global_arrays.php:1508
 msgctxt "A textual representation of a day, three letters"
 msgid "Sat"
 msgstr ""
@@ -6763,7 +6772,7 @@ msgstr ""
 msgid "The script/source used to gather data for this data source."
 msgstr ""
 
-#: ../include/global_form.php:396 ../include/global_form.php:1604
+#: ../include/global_form.php:396 ../include/global_form.php:1615
 msgid ""
 "Select the Data Source Profile.  The Data Source Profile controls polling "
 "interval, the data aggregation, and retention policy for the resulting Data "
@@ -7194,7 +7203,7 @@ msgid "Place the legend items in the given vertical order."
 msgstr ""
 
 #: ../include/global_form.php:790 ../lib/api_aggregate.php:1216
-#: ../lib/html.php:878
+#: ../lib/html.php:857
 msgid "Graph Item Type"
 msgstr ""
 
@@ -7218,7 +7227,7 @@ msgstr ""
 msgid "The opacity/alpha channel of the color."
 msgstr ""
 
-#: ../include/global_form.php:826 ../lib/rrd.php:2666
+#: ../include/global_form.php:826 ../lib/rrd.php:2676
 msgid "Consolidation Function"
 msgstr ""
 
@@ -7252,7 +7261,7 @@ msgid ""
 "'value' field."
 msgstr ""
 
-#: ../include/global_form.php:855 ../lib/rrd.php:2636 ../utilities.php:2331
+#: ../include/global_form.php:855 ../lib/rrd.php:2646 ../utilities.php:2338
 msgid "Value"
 msgstr ""
 
@@ -7336,417 +7345,427 @@ msgstr ""
 msgid "The name given to this graph template."
 msgstr ""
 
-#: ../include/global_form.php:955
+#: ../include/global_form.php:938
+msgid "Multiple Instances"
+msgstr ""
+
+#: ../include/global_form.php:939
+msgid ""
+"Check this checkbox if there can be more than one Graph of this type per "
+"Device."
+msgstr ""
+
+#: ../include/global_form.php:963
 msgid ""
 "Enter a name for this graph item input, make sure it is something you "
 "recognize."
 msgstr ""
 
-#: ../include/global_form.php:963
+#: ../include/global_form.php:971
 msgid ""
 "Enter a description for this graph item input to describe what this input is "
 "used for."
 msgstr ""
 
-#: ../include/global_form.php:970
+#: ../include/global_form.php:978
 msgid "Field Type"
 msgstr ""
 
-#: ../include/global_form.php:971
+#: ../include/global_form.php:979
 msgid "How data is to be represented on the graph."
 msgstr ""
 
-#: ../include/global_form.php:994
+#: ../include/global_form.php:1002
 msgid "General Device Options"
 msgstr ""
 
-#: ../include/global_form.php:999
+#: ../include/global_form.php:1007
 msgid "Give this host a meaningful description."
 msgstr ""
 
-#: ../include/global_form.php:1006 ../include/global_form.php:1628
+#: ../include/global_form.php:1014 ../include/global_form.php:1639
 msgid "Fully qualified hostname or IP address for this device."
 msgstr ""
 
-#: ../include/global_form.php:1013
+#: ../include/global_form.php:1021
 msgid "Poller Association"
 msgstr ""
 
-#: ../include/global_form.php:1021
+#: ../include/global_form.php:1029
 msgid "Device Site Association"
 msgstr ""
 
-#: ../include/global_form.php:1022
+#: ../include/global_form.php:1030
 msgid "What Site is this Device associated with."
 msgstr ""
 
-#: ../include/global_form.php:1031
+#: ../include/global_form.php:1039
 msgid ""
 "Choose the Device Template to use to define the default Graph Templates and "
 "Data Queries associated with this Device."
 msgstr ""
 
-#: ../include/global_form.php:1038
+#: ../include/global_form.php:1046
 msgid "Number of Collection Threads"
 msgstr ""
 
-#: ../include/global_form.php:1039
+#: ../include/global_form.php:1047
 msgid ""
 "The number of concurrent threads to use for polling this device.  This "
 "applies to the Spine poller only."
 msgstr ""
 
-#: ../include/global_form.php:1046
+#: ../include/global_form.php:1054
 msgid "Disable Device"
 msgstr ""
 
-#: ../include/global_form.php:1047
+#: ../include/global_form.php:1055
 msgid "Check this box to disable all checks for this host."
 msgstr ""
 
-#: ../include/global_form.php:1060 ../include/global_form.php:1657
+#: ../include/global_form.php:1068 ../include/global_form.php:1668
 msgid "Choose the SNMP version for this device."
 msgstr ""
 
-#: ../include/global_form.php:1068 ../include/global_form.php:1665
+#: ../include/global_form.php:1076 ../include/global_form.php:1676
 msgid "SNMP Community"
 msgstr ""
 
-#: ../include/global_form.php:1069 ../include/global_form.php:1666
+#: ../include/global_form.php:1077 ../include/global_form.php:1677
 msgid "SNMP read community for this device."
 msgstr ""
 
-#: ../include/global_form.php:1088
+#: ../include/global_form.php:1096
 msgid "SNMP v3 authentication pass phrase for this device."
 msgstr ""
 
-#: ../include/global_form.php:1097
+#: ../include/global_form.php:1105
 msgid "Choose the SNMPv3 authentication protocol."
 msgstr ""
 
-#: ../include/global_form.php:1105
+#: ../include/global_form.php:1113
 msgid "Choose the SNMPv3 privacy passphrase."
 msgstr ""
 
-#: ../include/global_form.php:1114
+#: ../include/global_form.php:1122
 msgid "Choose the SNMPv3 privacy protocol."
 msgstr ""
 
-#: ../include/global_form.php:1121
+#: ../include/global_form.php:1129
 msgid "SNMP Context (v3)"
 msgstr ""
 
-#: ../include/global_form.php:1122
+#: ../include/global_form.php:1130
 msgid "Enter the SNMP v3 context to use for this device."
 msgstr ""
 
-#: ../include/global_form.php:1130
+#: ../include/global_form.php:1138
 msgid "SNMP Engine ID (v3)"
 msgstr ""
 
-#: ../include/global_form.php:1131
+#: ../include/global_form.php:1139
 msgid ""
 "Enter the SNMP v3 Engine Id to use for this device. Leave this field empty "
 "to use the SNMP Engine ID being defined per SNMPv3 Notification receiver."
 msgstr ""
 
-#: ../include/global_form.php:1140
+#: ../include/global_form.php:1148
 msgid "Enter the UDP port number to use for SNMP (default is 161)."
 msgstr ""
 
-#: ../include/global_form.php:1157
+#: ../include/global_form.php:1165
 msgid "Maximum OIDs Per Get Request"
 msgstr ""
 
-#: ../include/global_form.php:1166
+#: ../include/global_form.php:1174
 msgid "Availability/Reachability Options"
 msgstr ""
 
-#: ../include/global_form.php:1170 ../include/global_settings.php:547
+#: ../include/global_form.php:1178 ../include/global_settings.php:547
 msgid "Downed Device Detection"
 msgstr ""
 
-#: ../include/global_form.php:1171 ../include/global_settings.php:548
+#: ../include/global_form.php:1179 ../include/global_settings.php:548
 msgid ""
 "The method Cacti will use to determine if a host is available for polling.  "
 "<br><i>NOTE: It is recommended that, at a minimum, SNMP always be selected.</"
 "i>"
 msgstr ""
 
-#: ../include/global_form.php:1180
+#: ../include/global_form.php:1188
 msgid ""
 "The type of ping packet to sent.  <br><i>NOTE: ICMP on Linux/UNIX requires "
 "root privileges.</i>"
 msgstr ""
 
-#: ../include/global_form.php:1217 ../include/global_form.php:1752
+#: ../include/global_form.php:1225 ../include/global_form.php:1763
 msgid "Additional Options"
 msgstr ""
 
-#: ../include/global_form.php:1221 ../include/global_form.php:1757
+#: ../include/global_form.php:1229 ../include/global_form.php:1768
 #: ../pollers.php:70
 msgid "Notes"
 msgstr ""
 
-#: ../include/global_form.php:1222 ../include/global_form.php:1758
+#: ../include/global_form.php:1230 ../include/global_form.php:1769
 msgid "Enter notes to this host."
 msgstr ""
 
-#: ../include/global_form.php:1229
+#: ../include/global_form.php:1237
 msgid "External ID"
 msgstr ""
 
-#: ../include/global_form.php:1230
+#: ../include/global_form.php:1238
 msgid "External ID for linking Cacti data to external monitoring systems."
 msgstr ""
 
-#: ../include/global_form.php:1252
+#: ../include/global_form.php:1260
 msgid "A useful name for this host template."
 msgstr ""
 
-#: ../include/global_form.php:1272
+#: ../include/global_form.php:1280
 msgid "A name for this data query."
 msgstr ""
 
-#: ../include/global_form.php:1280
+#: ../include/global_form.php:1288
 msgid "A description for this data query."
 msgstr ""
 
-#: ../include/global_form.php:1287
+#: ../include/global_form.php:1295
 msgid "XML Path"
 msgstr ""
 
-#: ../include/global_form.php:1288
+#: ../include/global_form.php:1296
 msgid ""
 "The full path to the XML file containing definitions for this data query."
 msgstr ""
 
-#: ../include/global_form.php:1297
+#: ../include/global_form.php:1305
 msgid ""
 "Choose the input method for this Data Query.  This input method defines how "
 "data is collected for each Device associated with the Data Query."
 msgstr ""
 
-#: ../include/global_form.php:1316
+#: ../include/global_form.php:1324
 msgid ""
 "Choose the Graph Template to use for this Data Query Graph Template item."
 msgstr ""
 
-#: ../include/global_form.php:1339
+#: ../include/global_form.php:1350
 msgid "A name for this associated graph."
 msgstr ""
 
-#: ../include/global_form.php:1367
+#: ../include/global_form.php:1378
 msgid "A useful name for this graph tree."
 msgstr ""
 
-#: ../include/global_form.php:1374 ../include/global_form.php:2272
+#: ../include/global_form.php:1385 ../include/global_form.php:2281
 #: ../lib/api_automation.php:1334 ../tree.php:1279
 msgid "Sorting Type"
 msgstr ""
 
-#: ../include/global_form.php:1375 ../include/global_form.php:2273
+#: ../include/global_form.php:1386 ../include/global_form.php:2282
 msgid "Choose how items in this tree will be sorted."
 msgstr ""
 
-#: ../include/global_form.php:1381
+#: ../include/global_form.php:1392
 msgid "Publish"
 msgstr ""
 
-#: ../include/global_form.php:1382
+#: ../include/global_form.php:1393
 msgid "Should this Tree be published for users to access?"
 msgstr ""
 
-#: ../include/global_form.php:1417
+#: ../include/global_form.php:1428
 msgid "An Email Address where the User can be reached."
 msgstr ""
 
-#: ../include/global_form.php:1425
+#: ../include/global_form.php:1436
 msgid ""
 "Enter the password for this user twice. Remember that passwords are case "
 "sensitive!"
 msgstr ""
 
-#: ../include/global_form.php:1433 ../user_group_admin.php:88
+#: ../include/global_form.php:1444 ../user_group_admin.php:88
 msgid "Determines if user is able to login."
 msgstr ""
 
-#: ../include/global_form.php:1439 ../tree.php:1561
+#: ../include/global_form.php:1450 ../tree.php:1561
 msgid "Locked"
 msgstr ""
 
-#: ../include/global_form.php:1440
+#: ../include/global_form.php:1451
 msgid "Determines if the user account is locked."
 msgstr ""
 
-#: ../include/global_form.php:1445
+#: ../include/global_form.php:1456
 msgid "Account Options"
 msgstr ""
 
-#: ../include/global_form.php:1447
+#: ../include/global_form.php:1458
 msgid "Set any user account specific options here."
 msgstr ""
 
-#: ../include/global_form.php:1451
+#: ../include/global_form.php:1462
 msgid "Must Change Password at Next Login"
 msgstr ""
 
-#: ../include/global_form.php:1463
+#: ../include/global_form.php:1474
 msgid "Maintain Custom Graph and User Settings"
 msgstr ""
 
-#: ../include/global_form.php:1470
+#: ../include/global_form.php:1481
 msgid "Graph Options"
 msgstr ""
 
-#: ../include/global_form.php:1472
+#: ../include/global_form.php:1483
 msgid "Set any graph specific options here."
 msgstr ""
 
-#: ../include/global_form.php:1476
+#: ../include/global_form.php:1487
 msgid "User Has Rights to Tree View"
 msgstr ""
 
-#: ../include/global_form.php:1482
+#: ../include/global_form.php:1493
 msgid "User Has Rights to List View"
 msgstr ""
 
-#: ../include/global_form.php:1488
+#: ../include/global_form.php:1499
 msgid "User Has Rights to Preview View"
 msgstr ""
 
-#: ../include/global_form.php:1495 ../user_group_admin.php:130
+#: ../include/global_form.php:1506 ../user_group_admin.php:130
 msgid "Login Options"
 msgstr ""
 
-#: ../include/global_form.php:1498
+#: ../include/global_form.php:1509
 msgid "What to do when this user logs in."
 msgstr ""
 
-#: ../include/global_form.php:1503
+#: ../include/global_form.php:1514
 msgid "Show the page that user pointed their browser to."
 msgstr ""
 
-#: ../include/global_form.php:1507
+#: ../include/global_form.php:1518
 msgid "Show the default console screen."
 msgstr ""
 
-#: ../include/global_form.php:1511
+#: ../include/global_form.php:1522
 msgid "Show the default graph screen."
 msgstr ""
 
-#: ../include/global_form.php:1517 ../utilities.php:765
+#: ../include/global_form.php:1528 ../utilities.php:765
 msgid "Authentication Realm"
 msgstr ""
 
-#: ../include/global_form.php:1518
+#: ../include/global_form.php:1529
 msgid ""
 "Only used if you have LDAP or Web Basic Authentication enabled.  Changing "
 "this to a non-enabled realm will effectively disable the user."
 msgstr ""
 
-#: ../include/global_form.php:1555
+#: ../include/global_form.php:1566
 msgid "Discovery Rules"
 msgstr ""
 
-#: ../include/global_form.php:1573
+#: ../include/global_form.php:1584
 msgid "Import Template from Local File"
 msgstr ""
 
-#: ../include/global_form.php:1574
+#: ../include/global_form.php:1585
 msgid ""
 "If the XML file containing template data is located on your local machine, "
 "select it here."
 msgstr ""
 
-#: ../include/global_form.php:1579
+#: ../include/global_form.php:1590
 msgid "Import Template from Text"
 msgstr ""
 
-#: ../include/global_form.php:1580
+#: ../include/global_form.php:1591
 msgid ""
 "If you have the XML file containing template data as text, you can paste it "
 "into this box to import it."
 msgstr ""
 
-#: ../include/global_form.php:1588
+#: ../include/global_form.php:1599
 msgid "Preview Import Only"
 msgstr ""
 
-#: ../include/global_form.php:1590
+#: ../include/global_form.php:1601
 msgid ""
 "If checked, Cacti will not import the template, but rather compare the "
 "imported Template to the existing Template data.  If you are acceptable of "
 "the change, you can them import."
 msgstr ""
 
-#: ../include/global_form.php:1595
+#: ../include/global_form.php:1606
 msgid "Remove Orphaned Graph Items"
 msgstr ""
 
-#: ../include/global_form.php:1597
+#: ../include/global_form.php:1608
 msgid ""
 "If checked, Cacti will delete any Graph Items from both the Graph Template "
 "and associated Graphs that are not included in the imported Graph Template."
 msgstr ""
 
-#: ../include/global_form.php:1614
+#: ../include/global_form.php:1625
 msgid "General SNMP Entity Options"
 msgstr ""
 
-#: ../include/global_form.php:1620
+#: ../include/global_form.php:1631
 msgid "Give this SNMP entity a meaningful description."
 msgstr ""
 
-#: ../include/global_form.php:1635
+#: ../include/global_form.php:1646
 msgid "Disable SNMP Notification Receiver"
 msgstr ""
 
-#: ../include/global_form.php:1636
+#: ../include/global_form.php:1647
 msgid ""
 "Check this box if you temporary do not want to send SNMP notifications to "
 "this host."
 msgstr ""
 
-#: ../include/global_form.php:1643
+#: ../include/global_form.php:1654
 msgid "Maximum Log Size"
 msgstr ""
 
-#: ../include/global_form.php:1644
+#: ../include/global_form.php:1655
 msgid ""
 "Maximum number of day's notification log entries for this receiver need to "
 "be stored."
 msgstr ""
 
-#: ../include/global_form.php:1684
+#: ../include/global_form.php:1695
 msgid "SNMP Auth Password (v3)"
 msgstr ""
 
-#: ../include/global_form.php:1685
+#: ../include/global_form.php:1696
 msgid "SNMP v3 user password for this device."
 msgstr ""
 
-#: ../include/global_form.php:1694
+#: ../include/global_form.php:1705
 msgid ""
 "Choose the SNMPv3 Authorization Protocol.<br>Note: SHA authentication "
 "support is only available if you have OpenSSL installed."
 msgstr ""
 
-#: ../include/global_form.php:1701
+#: ../include/global_form.php:1712
 msgid "SNMP Privacy Password (v3)"
 msgstr ""
 
-#: ../include/global_form.php:1711
+#: ../include/global_form.php:1722
 msgid ""
 "Choose the SNMPv3 Privacy Protocol.<br>Note: DES/AES encryption support is "
 "only available if you have OpenSSL installed."
 msgstr ""
 
-#: ../include/global_form.php:1717
+#: ../include/global_form.php:1728
 msgid "SNMP Engine ID"
 msgstr ""
 
-#: ../include/global_form.php:1718
+#: ../include/global_form.php:1729
 msgid ""
 "Defines the unique SNMP Engine ID to identify this peer. Following format "
 "will be recommended:<br>FlexibleLength+Enterprise(8000) + IANA-Cacti(5d75) + "
@@ -7754,40 +7773,40 @@ msgid ""
 "locally administrated MAC 02-FF-FF-FF-FF-FF will be used."
 msgstr ""
 
-#: ../include/global_form.php:1727
+#: ../include/global_form.php:1738
 msgid "The UDP port to be used for SNMP traps. Typically, 162."
 msgstr ""
 
-#: ../include/global_form.php:1743
+#: ../include/global_form.php:1754
 msgid "SNMP Message Type"
 msgstr ""
 
-#: ../include/global_form.php:1744
+#: ../include/global_form.php:1755
 msgid ""
 "SNMP traps are always unacknowledged. To send out acknowledged SNMP "
 "notifications, formally called \"INFORMS\", SNMPv2 or above will be required."
 msgstr ""
 
-#: ../include/global_form.php:1776 ../include/global_form.php:2035
+#: ../include/global_form.php:1787 ../include/global_form.php:2046
 #: ../links.php:379
 msgid "Title"
 msgstr ""
 
-#: ../include/global_form.php:1777
+#: ../include/global_form.php:1788
 msgid "The new Title of the aggregated Graph."
 msgstr ""
 
-#: ../include/global_form.php:1784 ../include/global_form.php:1867
-#: ../include/global_form.php:1969
+#: ../include/global_form.php:1795 ../include/global_form.php:1878
+#: ../include/global_form.php:1980
 msgid "Prefix"
 msgstr ""
 
-#: ../include/global_form.php:1785
+#: ../include/global_form.php:1796
 msgid "A Prefix for all GPRINT lines to distinguish e.g. different hosts."
 msgstr ""
 
-#: ../include/global_form.php:1793 ../include/global_form.php:1876
-#: ../include/global_form.php:1978
+#: ../include/global_form.php:1804 ../include/global_form.php:1887
+#: ../include/global_form.php:1989
 msgid ""
 "Use this Option to create e.g. STACKed graphs.<br>AREA/STACK: 1st graph "
 "keeps AREA/STACK items, others convert to STACK<br>LINE1: all items convert "
@@ -7795,236 +7814,236 @@ msgid ""
 "items convert to LINE3 items"
 msgstr ""
 
-#: ../include/global_form.php:1804 ../include/global_form.php:1887
-#: ../include/global_form.php:1989
+#: ../include/global_form.php:1815 ../include/global_form.php:1898
+#: ../include/global_form.php:2000
 msgid "Totaling"
 msgstr ""
 
-#: ../include/global_form.php:1805 ../include/global_form.php:1888
-#: ../include/global_form.php:1990
+#: ../include/global_form.php:1816 ../include/global_form.php:1899
+#: ../include/global_form.php:2001
 msgid ""
 "Please check those Items that shall be totaled in the \"Total\" column, when "
 "selecting any totaling option here."
 msgstr ""
 
-#: ../include/global_form.php:1812 ../include/global_form.php:1896
-#: ../include/global_form.php:1998
+#: ../include/global_form.php:1823 ../include/global_form.php:1907
+#: ../include/global_form.php:2009
 msgid "Total Type"
 msgstr ""
 
-#: ../include/global_form.php:1813 ../include/global_form.php:1897
-#: ../include/global_form.php:1999
+#: ../include/global_form.php:1824 ../include/global_form.php:1908
+#: ../include/global_form.php:2010
 msgid "Which type of totaling shall be performed."
 msgstr ""
 
-#: ../include/global_form.php:1820 ../include/global_form.php:1905
-#: ../include/global_form.php:2007
+#: ../include/global_form.php:1831 ../include/global_form.php:1916
+#: ../include/global_form.php:2018
 msgid "Prefix for GPRINT Totals"
 msgstr ""
 
-#: ../include/global_form.php:1821 ../include/global_form.php:1906
-#: ../include/global_form.php:2008
+#: ../include/global_form.php:1832 ../include/global_form.php:1917
+#: ../include/global_form.php:2019
 msgid "A Prefix for all <strong>totaling</strong> GPRINT lines."
 msgstr ""
 
-#: ../include/global_form.php:1828 ../include/global_form.php:1913
-#: ../include/global_form.php:2015
+#: ../include/global_form.php:1839 ../include/global_form.php:1924
+#: ../include/global_form.php:2026
 msgid "Reorder Type"
 msgstr ""
 
-#: ../include/global_form.php:1829 ../include/global_form.php:1914
-#: ../include/global_form.php:2016
+#: ../include/global_form.php:1840 ../include/global_form.php:1925
+#: ../include/global_form.php:2027
 msgid "Reordering of Graphs."
 msgstr ""
 
-#: ../include/global_form.php:1849
+#: ../include/global_form.php:1860
 msgid "Please name this Aggregate Graph."
 msgstr ""
 
-#: ../include/global_form.php:1856
+#: ../include/global_form.php:1867
 msgid "Propagation Enabled"
 msgstr ""
 
-#: ../include/global_form.php:1857
+#: ../include/global_form.php:1868
 msgid "Is this to carry the template?"
 msgstr ""
 
-#: ../include/global_form.php:1863
+#: ../include/global_form.php:1874
 msgid "Aggregate Graph Settings"
 msgstr ""
 
-#: ../include/global_form.php:1868 ../include/global_form.php:1970
+#: ../include/global_form.php:1879 ../include/global_form.php:1981
 msgid ""
 "A Prefix for all GPRINT lines to distinguish e.g. different hosts.  You may "
 "use both Host as well as Data Query replacement variables in this prefix."
 msgstr ""
 
-#: ../include/global_form.php:1948
+#: ../include/global_form.php:1959
 msgid "Aggregate Template Name"
 msgstr ""
 
-#: ../include/global_form.php:1949
+#: ../include/global_form.php:1960
 msgid "Please name this Aggregate Template."
 msgstr ""
 
-#: ../include/global_form.php:1956
+#: ../include/global_form.php:1967
 msgid "Source Graph Template"
 msgstr ""
 
-#: ../include/global_form.php:1957
+#: ../include/global_form.php:1968
 msgid "The Graph Template that this Aggregate Template is based upon."
 msgstr ""
 
-#: ../include/global_form.php:1965
+#: ../include/global_form.php:1976
 msgid "Aggregate Template Settings"
 msgstr ""
 
-#: ../include/global_form.php:2039
+#: ../include/global_form.php:2050
 msgid "The name of this Color Template."
 msgstr ""
 
-#: ../include/global_form.php:2050
+#: ../include/global_form.php:2061
 msgid "A nice Color"
 msgstr ""
 
-#: ../include/global_form.php:2060
+#: ../include/global_form.php:2071
 msgid "A useful name for this Template."
 msgstr ""
 
-#: ../include/global_form.php:2074 ../include/global_form.php:2116
+#: ../include/global_form.php:2085 ../include/global_form.php:2127
 #: ../lib/api_automation.php:1208 ../lib/api_automation.php:1270
 msgid "Operation"
 msgstr ""
 
-#: ../include/global_form.php:2075 ../include/global_form.php:2117
+#: ../include/global_form.php:2086 ../include/global_form.php:2128
 msgid "Logical operation to combine rules."
 msgstr ""
 
-#: ../include/global_form.php:2083 ../include/global_form.php:2125
+#: ../include/global_form.php:2094 ../include/global_form.php:2136
 msgid "The Field Name that shall be used for this Rule Item."
 msgstr ""
 
-#: ../include/global_form.php:2091 ../include/global_form.php:2133
+#: ../include/global_form.php:2102 ../include/global_form.php:2144
 msgid "Operator."
 msgstr ""
 
-#: ../include/global_form.php:2098 ../include/global_form.php:2140
-#: ../include/global_form.php:2288
+#: ../include/global_form.php:2109 ../include/global_form.php:2151
+#: ../include/global_form.php:2297
 msgid "Matching Pattern"
 msgstr ""
 
-#: ../include/global_form.php:2099 ../include/global_form.php:2141
+#: ../include/global_form.php:2110 ../include/global_form.php:2152
 msgid "The Pattern to be matched against."
 msgstr ""
 
-#: ../include/global_form.php:2107 ../include/global_form.php:2149
-#: ../include/global_form.php:2305
+#: ../include/global_form.php:2118 ../include/global_form.php:2160
+#: ../include/global_form.php:2314
 msgid "Sequence."
 msgstr ""
 
-#: ../include/global_form.php:2158 ../include/global_form.php:2207
+#: ../include/global_form.php:2169 ../include/global_form.php:2216
 msgid "A useful name for this Rule."
 msgstr ""
 
-#: ../include/global_form.php:2166
+#: ../include/global_form.php:2177
 msgid "Choose a Data Query to apply to this rule."
 msgstr ""
 
-#: ../include/global_form.php:2177
+#: ../include/global_form.php:2188
 msgid "Choose any of the available Graph Types to apply to this rule."
 msgstr ""
 
-#: ../include/global_form.php:2194 ../include/global_form.php:2252
+#: ../include/global_form.php:2203 ../include/global_form.php:2261
 msgid "Enable Rule"
 msgstr ""
 
-#: ../include/global_form.php:2195 ../include/global_form.php:2253
+#: ../include/global_form.php:2204 ../include/global_form.php:2262
 msgid "Check this box to enable this rule."
 msgstr ""
 
-#: ../include/global_form.php:2215
+#: ../include/global_form.php:2224
 msgid "Choose a Tree for the new Tree Items."
 msgstr ""
 
-#: ../include/global_form.php:2222
+#: ../include/global_form.php:2231
 msgid "Leaf Item Type"
 msgstr ""
 
-#: ../include/global_form.php:2223
+#: ../include/global_form.php:2232
 msgid "The Item Type that shall be dynamically added to the tree."
 msgstr ""
 
-#: ../include/global_form.php:2230
+#: ../include/global_form.php:2239
 msgid "Graph Grouping Style"
 msgstr ""
 
-#: ../include/global_form.php:2231
+#: ../include/global_form.php:2240
 msgid ""
 "Choose how graphs are grouped when drawn for this particular host on the "
 "tree."
 msgstr ""
 
-#: ../include/global_form.php:2241
+#: ../include/global_form.php:2250
 msgid "Optional: Sub-Tree Item"
 msgstr ""
 
-#: ../include/global_form.php:2242
+#: ../include/global_form.php:2251
 msgid ""
 "Choose a Sub-Tree Item to hook in.<br>Make sure, that it is still there when "
 "this rule is executed!"
 msgstr ""
 
-#: ../include/global_form.php:2263
+#: ../include/global_form.php:2272
 msgid "Header Type"
 msgstr ""
 
-#: ../include/global_form.php:2264
+#: ../include/global_form.php:2273
 msgid "Choose an Object to build a new Sub-header."
 msgstr ""
 
-#: ../include/global_form.php:2280
+#: ../include/global_form.php:2289
 msgid "Propagate Changes"
 msgstr ""
 
-#: ../include/global_form.php:2281
+#: ../include/global_form.php:2290
 msgid ""
 "Propagate all options on this form (except for 'Title') to all child "
 "'Header' items."
 msgstr ""
 
-#: ../include/global_form.php:2289
+#: ../include/global_form.php:2298
 msgid ""
 "The String Pattern (Regular Expression) to match against.<br>Enclosing '/' "
 "must <strong>NOT</strong> be provided!"
 msgstr ""
 
-#: ../include/global_form.php:2296
+#: ../include/global_form.php:2305
 msgid "Replacement Pattern"
 msgstr ""
 
-#: ../include/global_form.php:2297
+#: ../include/global_form.php:2306
 msgid ""
 "The Replacement String Pattern for use as a Tree Header.<br>Refer to a Match "
 "by e.g. <strong>\\${1}</strong> for the first match!"
 msgstr ""
 
-#: ../include/global_languages.php:589
+#: ../include/global_languages.php:592
 msgid " T"
 msgstr ""
 
-#: ../include/global_languages.php:591
+#: ../include/global_languages.php:594
 msgid " G"
 msgstr ""
 
-#: ../include/global_languages.php:593
+#: ../include/global_languages.php:596
 msgid " M"
 msgstr ""
 
-#: ../include/global_languages.php:595
+#: ../include/global_languages.php:598
 msgid " K"
 msgstr ""
 
-#: ../include/global_session.php:91
+#: ../include/global_session.php:91 ../lib/html_filter.php:66
 msgid "Enter a search term"
 msgstr ""
 
@@ -8032,8 +8051,8 @@ msgstr ""
 msgid "Enter a regular expression"
 msgstr ""
 
-#: ../include/global_settings.php:38 ../include/global_settings.php:828
-#: ../include/global_settings.php:932 ../include/global_settings.php:1550
+#: ../include/global_settings.php:38 ../include/global_settings.php:836
+#: ../include/global_settings.php:940 ../include/global_settings.php:1558
 #: ../managers.php:39 ../user_admin.php:1904 ../user_group_admin.php:1642
 msgid "General"
 msgstr ""
@@ -8058,8 +8077,8 @@ msgstr ""
 msgid "Visual"
 msgstr ""
 
-#: ../include/global_settings.php:44 ../lib/functions.php:3767
-#: ../lib/functions.php:3772
+#: ../include/global_settings.php:44 ../lib/functions.php:3779
+#: ../lib/functions.php:3784
 msgid "Authentication"
 msgstr ""
 
@@ -8185,8 +8204,8 @@ msgstr ""
 
 #: ../include/global_settings.php:151
 msgid ""
-"The number of days to retain old logs.  Use 0 to never remove any logs. (0-"
-"365)"
+"The number of days to retain old logs.  Use 0 to never remove any logs. "
+"(0-365)"
 msgstr ""
 
 #: ../include/global_settings.php:157
@@ -8211,7 +8230,7 @@ msgid ""
 "etc if not specified."
 msgstr ""
 
-#: ../include/global_settings.php:174 ../lib/functions.php:2210
+#: ../include/global_settings.php:174 ../lib/functions.php:2221
 #: ../rrdcleaner.php:296
 msgid "RRD Cleaner"
 msgstr ""
@@ -8336,12 +8355,12 @@ msgstr ""
 msgid "Statistics"
 msgstr ""
 
-#: ../include/global_settings.php:277 ../lib/clog_webapi.php:323
+#: ../include/global_settings.php:277 ../lib/clog_webapi.php:333
 #: ../utilities.php:1002
 msgid "Warnings"
 msgstr ""
 
-#: ../include/global_settings.php:281 ../lib/clog_webapi.php:324
+#: ../include/global_settings.php:281 ../lib/clog_webapi.php:334
 #: ../utilities.php:1003
 msgid "Errors"
 msgstr ""
@@ -8410,7 +8429,7 @@ msgid ""
 "another language."
 msgstr ""
 
-#: ../include/global_settings.php:342 ../include/global_settings.php:1804
+#: ../include/global_settings.php:342 ../include/global_settings.php:1812
 msgid "Date Display Format"
 msgstr ""
 
@@ -8418,7 +8437,7 @@ msgstr ""
 msgid "The System default date format to use in Cacti."
 msgstr ""
 
-#: ../include/global_settings.php:349 ../include/global_settings.php:1811
+#: ../include/global_settings.php:349 ../include/global_settings.php:1819
 msgid "Date Separator"
 msgstr ""
 
@@ -8607,7 +8626,7 @@ msgstr ""
 
 #: ../include/global_settings.php:535
 msgid ""
-"The number times the SNMP poller will attempt to reach the host before "
+"The number of times the SNMP poller will attempt to reach the host before "
 "failing."
 msgstr ""
 
@@ -8663,12 +8682,12 @@ msgstr ""
 msgid "Theme Settings"
 msgstr ""
 
-#: ../include/global_settings.php:613 ../include/global_settings.php:756
-#: ../include/global_settings.php:1777
+#: ../include/global_settings.php:613 ../include/global_settings.php:764
+#: ../include/global_settings.php:1785
 msgid "Theme"
 msgstr ""
 
-#: ../include/global_settings.php:614 ../include/global_settings.php:1778
+#: ../include/global_settings.php:614 ../include/global_settings.php:1786
 msgid "Please select one of the available Themes to skin your Cacti with."
 msgstr ""
 
@@ -8733,34 +8752,43 @@ msgid "Default number of lines of the Cacti log file to tail."
 msgstr ""
 
 #: ../include/global_settings.php:677
-msgid "Log Tail Refresh"
+msgid "Maximum number of rows per page"
 msgstr ""
 
 #: ../include/global_settings.php:678
+msgid ""
+"User defined number of lines for the CLOG to tail when selecting 'All lines'."
+msgstr ""
+
+#: ../include/global_settings.php:685
+msgid "Log Tail Refresh"
+msgstr ""
+
+#: ../include/global_settings.php:686
 msgid "How often do you want the Cacti log display to update."
 msgstr ""
 
-#: ../include/global_settings.php:684
+#: ../include/global_settings.php:692
 msgid "RRDtool Graph Watermark"
 msgstr ""
 
-#: ../include/global_settings.php:689
+#: ../include/global_settings.php:697
 msgid "Watermark Text"
 msgstr ""
 
-#: ../include/global_settings.php:690
+#: ../include/global_settings.php:698
 msgid "Test to place at the bottom center of every Graph."
 msgstr ""
 
-#: ../include/global_settings.php:697
+#: ../include/global_settings.php:705
 msgid "Log Viewer Settings"
 msgstr ""
 
-#: ../include/global_settings.php:702
+#: ../include/global_settings.php:710
 msgid "Exclusion Regex"
 msgstr ""
 
-#: ../include/global_settings.php:703
+#: ../include/global_settings.php:711
 msgid ""
 "Any strings that match this regex will be excluded from the user display.\n"
 "\t\t\t\t<strong>For example, if you want to exclude all log lines that "
@@ -8768,41 +8796,41 @@ msgid ""
 "\t\t\t\tyou would type '(Admin || Login)'</strong>"
 msgstr ""
 
-#: ../include/global_settings.php:712
+#: ../include/global_settings.php:720
 msgid "Real-time Graphs"
 msgstr ""
 
-#: ../include/global_settings.php:717
+#: ../include/global_settings.php:725
 msgid "Enable Real-time Graphing"
 msgstr ""
 
-#: ../include/global_settings.php:718
+#: ../include/global_settings.php:726
 msgid ""
 "When an option is checked, users will be able to put Cacti into Real-time "
 "mode."
 msgstr ""
 
-#: ../include/global_settings.php:723 ../lib/html_reports.php:398
+#: ../include/global_settings.php:731 ../lib/html_reports.php:398
 msgid "Graph Timespan"
 msgstr ""
 
-#: ../include/global_settings.php:724
+#: ../include/global_settings.php:732
 msgid "This timespan you wish to see on the default graph."
 msgstr ""
 
-#: ../include/global_settings.php:730 ../utilities.php:1886
+#: ../include/global_settings.php:738 ../utilities.php:1893
 msgid "Refresh Interval"
 msgstr ""
 
-#: ../include/global_settings.php:731
+#: ../include/global_settings.php:739
 msgid "This is the time between graph updates."
 msgstr ""
 
-#: ../include/global_settings.php:737
+#: ../include/global_settings.php:745
 msgid "Cache Directory"
 msgstr ""
 
-#: ../include/global_settings.php:738
+#: ../include/global_settings.php:746
 msgid ""
 "This is the location, on the web server where the RRDfiles and PNG files "
 "will be cached.\n"
@@ -8811,130 +8839,130 @@ msgid ""
 "folder"
 msgstr ""
 
-#: ../include/global_settings.php:747
+#: ../include/global_settings.php:755
 msgid "RRDtool Graph Font Control"
 msgstr ""
 
-#: ../include/global_settings.php:752
+#: ../include/global_settings.php:760
 msgid "Font Selection Method"
 msgstr ""
 
-#: ../include/global_settings.php:753
+#: ../include/global_settings.php:761
 msgid "How do you wish fonts to be handled by default?"
 msgstr ""
 
-#: ../include/global_settings.php:756
+#: ../include/global_settings.php:764
 msgid "System"
 msgstr ""
 
-#: ../include/global_settings.php:759
+#: ../include/global_settings.php:767
 msgid "Default Font"
 msgstr ""
 
-#: ../include/global_settings.php:760
+#: ../include/global_settings.php:768
 msgid ""
 "When not using Theme based font control, the Pangon font-config font name to "
 "use for all Graphs. Optionally, you may leave blank and control font "
 "settings on a per object basis."
 msgstr ""
 
-#: ../include/global_settings.php:762 ../include/global_settings.php:777
-#: ../include/global_settings.php:792 ../include/global_settings.php:807
-#: ../include/global_settings.php:822
+#: ../include/global_settings.php:770 ../include/global_settings.php:785
+#: ../include/global_settings.php:800 ../include/global_settings.php:815
+#: ../include/global_settings.php:830
 msgid "Enter Valid Font Config Value"
 msgstr ""
 
-#: ../include/global_settings.php:766 ../include/global_settings.php:1962
+#: ../include/global_settings.php:774 ../include/global_settings.php:1970
 msgid "Title Font Size"
 msgstr ""
 
-#: ../include/global_settings.php:767 ../include/global_settings.php:1963
+#: ../include/global_settings.php:775 ../include/global_settings.php:1971
 msgid "The size of the font used for Graph Titles"
 msgstr ""
 
-#: ../include/global_settings.php:774
+#: ../include/global_settings.php:782
 msgid "Title Font Setting"
 msgstr ""
 
-#: ../include/global_settings.php:775
+#: ../include/global_settings.php:783
 msgid ""
 "The font to use for Graph Titles.  Enter either a valid True Type Font file "
 "or valid Pango font-config value."
 msgstr ""
 
-#: ../include/global_settings.php:781 ../include/global_settings.php:1975
+#: ../include/global_settings.php:789 ../include/global_settings.php:1983
 msgid "Legend Font Size"
 msgstr ""
 
-#: ../include/global_settings.php:782 ../include/global_settings.php:1976
+#: ../include/global_settings.php:790 ../include/global_settings.php:1984
 msgid "The size of the font used for Graph Legend items"
 msgstr ""
 
-#: ../include/global_settings.php:789
+#: ../include/global_settings.php:797
 msgid "Legend Font Setting"
 msgstr ""
 
-#: ../include/global_settings.php:790
+#: ../include/global_settings.php:798
 msgid ""
 "The font to use for Graph Legends.  Enter either a valid True Type Font file "
 "or valid Pango font-config value."
 msgstr ""
 
-#: ../include/global_settings.php:796 ../include/global_settings.php:1988
+#: ../include/global_settings.php:804 ../include/global_settings.php:1996
 msgid "Axis Font Size"
 msgstr ""
 
-#: ../include/global_settings.php:797 ../include/global_settings.php:1989
+#: ../include/global_settings.php:805 ../include/global_settings.php:1997
 msgid "The size of the font used for Graph Axis"
 msgstr ""
 
-#: ../include/global_settings.php:804
+#: ../include/global_settings.php:812
 msgid "Axis Font Setting"
 msgstr ""
 
-#: ../include/global_settings.php:805
+#: ../include/global_settings.php:813
 msgid ""
 "The font to use for Graph Axis items.  Enter either a valid True Type Font "
 "file or valid Pango font-config value."
 msgstr ""
 
-#: ../include/global_settings.php:811 ../include/global_settings.php:2001
+#: ../include/global_settings.php:819 ../include/global_settings.php:2009
 msgid "Unit Font Size"
 msgstr ""
 
-#: ../include/global_settings.php:812 ../include/global_settings.php:2002
+#: ../include/global_settings.php:820 ../include/global_settings.php:2010
 msgid "The size of the font used for Graph Units"
 msgstr ""
 
-#: ../include/global_settings.php:819
+#: ../include/global_settings.php:827
 msgid "Unit Font Setting"
 msgstr ""
 
-#: ../include/global_settings.php:820
+#: ../include/global_settings.php:828
 msgid ""
 "The font to use for Graph Unit items.  Enter either a valid True Type Font "
 "file or valid Pango font-config value."
 msgstr ""
 
-#: ../include/global_settings.php:833
+#: ../include/global_settings.php:841
 msgid "Data Collection Enabled"
 msgstr ""
 
-#: ../include/global_settings.php:834
+#: ../include/global_settings.php:842
 msgid "If you wish to stop the polling process completely, uncheck this box."
 msgstr ""
 
-#: ../include/global_settings.php:840
+#: ../include/global_settings.php:848
 msgid "Poller Type"
 msgstr ""
 
-#: ../include/global_settings.php:841
+#: ../include/global_settings.php:849
 msgid ""
 "The poller type to use.  This setting will take effect at next polling "
 "interval."
 msgstr ""
 
-#: ../include/global_settings.php:848
+#: ../include/global_settings.php:856
 msgid ""
 "The polling interval in use.  This setting will effect how often RRDfiles "
 "are checked and updated.\n"
@@ -8942,104 +8970,104 @@ msgid ""
 "poller cache.  Failure to do so, may result in lost data.</u></strong>"
 msgstr ""
 
-#: ../include/global_settings.php:855
+#: ../include/global_settings.php:863
 msgid "Cron Interval"
 msgstr ""
 
-#: ../include/global_settings.php:856
+#: ../include/global_settings.php:864
 msgid ""
 "The cron interval in use.  You need to set this setting to the interval that "
 "your cron or scheduled task is currently running."
 msgstr ""
 
-#: ../include/global_settings.php:862
+#: ../include/global_settings.php:870
 msgid "Maximum Concurrent Poller Processes"
 msgstr ""
 
-#: ../include/global_settings.php:863
+#: ../include/global_settings.php:871
 msgid ""
 "The number of concurrent processes to execute.  Using a higher number when "
 "using cmd.php will improve performance.  Performance improvements in spine "
 "are best resolved with the threads parameter"
 msgstr ""
 
-#: ../include/global_settings.php:870
+#: ../include/global_settings.php:878
 msgid "Balance Process Load"
 msgstr ""
 
-#: ../include/global_settings.php:871
+#: ../include/global_settings.php:879
 msgid ""
 "If you choose this option, Cacti will attempt to balance the load of each "
 "poller process by equally distributing poller items per process."
 msgstr ""
 
-#: ../include/global_settings.php:876
+#: ../include/global_settings.php:884
 msgid "Disable increasing OID Check"
 msgstr ""
 
-#: ../include/global_settings.php:877
+#: ../include/global_settings.php:885
 msgid "Controls disabling check for increasing OID while walking OID tree."
 msgstr ""
 
-#: ../include/global_settings.php:882
+#: ../include/global_settings.php:890
 msgid "Spine Specific Execution Parameters"
 msgstr ""
 
-#: ../include/global_settings.php:887
+#: ../include/global_settings.php:895
 msgid "Invalid Data Logging"
 msgstr ""
 
-#: ../include/global_settings.php:888
+#: ../include/global_settings.php:896
 msgid ""
 "How would you like Spine output errors logged?  The options are: 'Detailed' "
 "which is similar to cmd.php logging; 'Summary' which provides the number of "
 "output errors per host; and 'None', which does not provide error counts."
 msgstr ""
 
-#: ../include/global_settings.php:893 ../utilities.php:193
+#: ../include/global_settings.php:901 ../utilities.php:193
 msgid "Summary"
 msgstr ""
 
-#: ../include/global_settings.php:894
+#: ../include/global_settings.php:902
 msgid "Detailed"
 msgstr ""
 
-#: ../include/global_settings.php:898
+#: ../include/global_settings.php:906
 msgid "Maximum Threads per Process"
 msgstr ""
 
-#: ../include/global_settings.php:899
+#: ../include/global_settings.php:907
 msgid ""
 "The maximum threads allowed per process.  Using a higher number when using "
 "Spine will improve performance."
 msgstr ""
 
-#: ../include/global_settings.php:906
+#: ../include/global_settings.php:914
 msgid "Number of PHP Script Servers"
 msgstr ""
 
-#: ../include/global_settings.php:907
+#: ../include/global_settings.php:915
 msgid ""
 "The number of concurrent script server processes to run per Spine process.  "
 "Settings between 1 and 10 are accepted.  This parameter will help if you are "
 "running several threads and script server scripts."
 msgstr ""
 
-#: ../include/global_settings.php:914
+#: ../include/global_settings.php:922
 msgid "Script and Script Server Timeout Value"
 msgstr ""
 
-#: ../include/global_settings.php:915
+#: ../include/global_settings.php:923
 msgid ""
 "The maximum time that Cacti will wait on a script to complete.  This timeout "
 "value is in seconds"
 msgstr ""
 
-#: ../include/global_settings.php:922
+#: ../include/global_settings.php:930
 msgid "The Maximum SNMP OIDs Per SNMP Get Request"
 msgstr ""
 
-#: ../include/global_settings.php:923
+#: ../include/global_settings.php:931
 msgid ""
 "The maximum number of SNMP get OIDs to issue per snmpbulkwalk request.  "
 "Increasing this value speeds poller performance over slow links.  The "
@@ -9047,11 +9075,11 @@ msgid ""
 "snmpbulkwalk"
 msgstr ""
 
-#: ../include/global_settings.php:937
+#: ../include/global_settings.php:945
 msgid "Authentication Method"
 msgstr ""
 
-#: ../include/global_settings.php:938
+#: ../include/global_settings.php:946
 msgid ""
 "<blockquote><i>None</i> - No authentication will be used, all users will "
 "have full access.<br><br><i>Built-in Authentication</i> - Cacti handles user "
@@ -9070,229 +9098,229 @@ msgid ""
 "LDAP module is required to utilize this method.</blockquote>"
 msgstr ""
 
-#: ../include/global_settings.php:944
+#: ../include/global_settings.php:952
 msgid "Support Authentication Cookies"
 msgstr ""
 
-#: ../include/global_settings.php:945
+#: ../include/global_settings.php:953
 msgid ""
 "If a user authenticates and selects 'Keep me signed in', an authentication "
 "cookie will be created on the user's computer allowing that user to stay "
 "logged in.  The authentication cookie expires after 90 days of non-use."
 msgstr ""
 
-#: ../include/global_settings.php:950
+#: ../include/global_settings.php:958
 msgid "Special Users"
 msgstr ""
 
-#: ../include/global_settings.php:955
+#: ../include/global_settings.php:963
 msgid "Guest User"
 msgstr ""
 
-#: ../include/global_settings.php:956
+#: ../include/global_settings.php:964
 msgid "The name of the guest user for viewing graphs; is 'No User' by default."
 msgstr ""
 
-#: ../include/global_settings.php:958 ../include/global_settings.php:966
+#: ../include/global_settings.php:966 ../include/global_settings.php:974
 #: ../user_domains.php:335
 msgid "No User"
 msgstr ""
 
-#: ../include/global_settings.php:963 ../user_domains.php:331
+#: ../include/global_settings.php:971 ../user_domains.php:331
 msgid "User Template"
 msgstr ""
 
-#: ../include/global_settings.php:964
+#: ../include/global_settings.php:972
 msgid ""
 "The name of the user that cacti will use as a template for new Web Basic and "
 "LDAP users; is 'guest' by default."
 msgstr ""
 
-#: ../include/global_settings.php:971
+#: ../include/global_settings.php:979
 msgid "Local Account Complexity Requirements"
 msgstr ""
 
-#: ../include/global_settings.php:976
+#: ../include/global_settings.php:984
 msgid "Minimum Length"
 msgstr ""
 
-#: ../include/global_settings.php:977
+#: ../include/global_settings.php:985
 msgid "This is minimal length of allowed passwords."
 msgstr ""
 
-#: ../include/global_settings.php:984
+#: ../include/global_settings.php:992
 msgid "Require Mix Case"
 msgstr ""
 
-#: ../include/global_settings.php:985
+#: ../include/global_settings.php:993
 msgid ""
 "This will require new passwords to contains both lower and upper-case "
 "characters."
 msgstr ""
 
-#: ../include/global_settings.php:990
+#: ../include/global_settings.php:998
 msgid "Require Number"
 msgstr ""
 
-#: ../include/global_settings.php:991
+#: ../include/global_settings.php:999
 msgid ""
 "This will require new passwords to contain at least 1 numerical character."
 msgstr ""
 
-#: ../include/global_settings.php:996
+#: ../include/global_settings.php:1004
 msgid "Require Special Character"
 msgstr ""
 
-#: ../include/global_settings.php:997
+#: ../include/global_settings.php:1005
 msgid ""
 "This will require new passwords to contain at least 1 special character."
 msgstr ""
 
-#: ../include/global_settings.php:1002
+#: ../include/global_settings.php:1010
 msgid "Force Complexity Upon Old Passwords"
 msgstr ""
 
-#: ../include/global_settings.php:1003
+#: ../include/global_settings.php:1011
 msgid ""
 "This will require all old passwords to also meet the new complexity "
 "requirements upon login.  If not met, it will force a password change."
 msgstr ""
 
-#: ../include/global_settings.php:1008
+#: ../include/global_settings.php:1016
 msgid "Expire Inactive Accounts"
 msgstr ""
 
-#: ../include/global_settings.php:1009
+#: ../include/global_settings.php:1017
 msgid ""
 "This is maximum number of days before inactive accounts are disabled.  The "
 "Admin account is excluded from this policy."
 msgstr ""
 
-#: ../include/global_settings.php:1022
+#: ../include/global_settings.php:1030
 msgid "Expire Password"
 msgstr ""
 
-#: ../include/global_settings.php:1023
+#: ../include/global_settings.php:1031
 msgid "This is maximum number of days before a password is set to expire."
 msgstr ""
 
-#: ../include/global_settings.php:1034
+#: ../include/global_settings.php:1042
 msgid "Password History"
 msgstr ""
 
-#: ../include/global_settings.php:1035
+#: ../include/global_settings.php:1043
 msgid "Remember this number of old passwords and disallow re-using them."
 msgstr ""
 
-#: ../include/global_settings.php:1040
+#: ../include/global_settings.php:1048
 msgid "1 Change"
 msgstr ""
 
-#: ../include/global_settings.php:1041 ../include/global_settings.php:1042
-#: ../include/global_settings.php:1043 ../include/global_settings.php:1044
-#: ../include/global_settings.php:1045 ../include/global_settings.php:1046
-#: ../include/global_settings.php:1047 ../include/global_settings.php:1048
 #: ../include/global_settings.php:1049 ../include/global_settings.php:1050
-#: ../include/global_settings.php:1051
+#: ../include/global_settings.php:1051 ../include/global_settings.php:1052
+#: ../include/global_settings.php:1053 ../include/global_settings.php:1054
+#: ../include/global_settings.php:1055 ../include/global_settings.php:1056
+#: ../include/global_settings.php:1057 ../include/global_settings.php:1058
+#: ../include/global_settings.php:1059
 #, php-format
 msgid "%d Changes"
 msgstr ""
 
-#: ../include/global_settings.php:1054
+#: ../include/global_settings.php:1062
 msgid "Account Locking"
 msgstr ""
 
-#: ../include/global_settings.php:1059
+#: ../include/global_settings.php:1067
 msgid "Lock Accounts"
 msgstr ""
 
-#: ../include/global_settings.php:1060
+#: ../include/global_settings.php:1068
 msgid "Lock an account after this many failed attempts in 1 hour."
 msgstr ""
 
-#: ../include/global_settings.php:1065
+#: ../include/global_settings.php:1073
 msgid "1 Attempt"
 msgstr ""
 
-#: ../include/global_settings.php:1066 ../include/global_settings.php:1067
-#: ../include/global_settings.php:1068 ../include/global_settings.php:1069
-#: ../include/global_settings.php:1070
+#: ../include/global_settings.php:1074 ../include/global_settings.php:1075
+#: ../include/global_settings.php:1076 ../include/global_settings.php:1077
+#: ../include/global_settings.php:1078
 #, php-format
 msgid "%d Attempts"
 msgstr ""
 
-#: ../include/global_settings.php:1073
+#: ../include/global_settings.php:1081
 msgid "Auto Unlock"
 msgstr ""
 
-#: ../include/global_settings.php:1074
+#: ../include/global_settings.php:1082
 msgid ""
 "An account will automatically be unlocked after this many minutes.  Even if "
 "the correct password is entered, the account will not unlock until this time "
 "limit has been met.  Max of 1440 minutes (1 Day)"
 msgstr ""
 
-#: ../include/global_settings.php:1093
+#: ../include/global_settings.php:1101
 msgid "LDAP General Settings"
 msgstr ""
 
-#: ../include/global_settings.php:1097 ../user_domains.php:358
+#: ../include/global_settings.php:1105 ../user_domains.php:358
 msgid "Server"
 msgstr ""
 
-#: ../include/global_settings.php:1098
+#: ../include/global_settings.php:1106
 msgid "The DNS hostname or IP address of the server."
 msgstr ""
 
-#: ../include/global_settings.php:1103 ../user_domains.php:366
+#: ../include/global_settings.php:1111 ../user_domains.php:366
 msgid "Port Standard"
 msgstr ""
 
-#: ../include/global_settings.php:1104
+#: ../include/global_settings.php:1112
 msgid "TCP/UDP port for Non-SSL communications."
 msgstr ""
 
-#: ../include/global_settings.php:1111 ../user_domains.php:375
+#: ../include/global_settings.php:1119 ../user_domains.php:375
 msgid "Port SSL"
 msgstr ""
 
-#: ../include/global_settings.php:1112 ../user_domains.php:376
+#: ../include/global_settings.php:1120 ../user_domains.php:376
 msgid "TCP/UDP port for SSL communications."
 msgstr ""
 
-#: ../include/global_settings.php:1119 ../user_domains.php:384
+#: ../include/global_settings.php:1127 ../user_domains.php:384
 msgid "Protocol Version"
 msgstr ""
 
-#: ../include/global_settings.php:1120 ../user_domains.php:385
+#: ../include/global_settings.php:1128 ../user_domains.php:385
 msgid "Protocol Version that the server supports."
 msgstr ""
 
-#: ../include/global_settings.php:1126 ../user_domains.php:391
+#: ../include/global_settings.php:1134 ../user_domains.php:391
 msgid "Encryption"
 msgstr ""
 
-#: ../include/global_settings.php:1127 ../user_domains.php:392
+#: ../include/global_settings.php:1135 ../user_domains.php:392
 msgid ""
 "Encryption that the server supports. TLS is only supported by Protocol "
 "Version 3."
 msgstr ""
 
-#: ../include/global_settings.php:1133 ../user_domains.php:398
+#: ../include/global_settings.php:1141 ../user_domains.php:398
 msgid "Referrals"
 msgstr ""
 
-#: ../include/global_settings.php:1134 ../user_domains.php:399
+#: ../include/global_settings.php:1142 ../user_domains.php:399
 msgid ""
 "Enable or Disable LDAP referrals.  If disabled, it may increase the speed of "
 "searches."
 msgstr ""
 
-#: ../include/global_settings.php:1140 ../user_domains.php:405
+#: ../include/global_settings.php:1148 ../user_domains.php:405
 msgid "Mode"
 msgstr ""
 
-#: ../include/global_settings.php:1141
+#: ../include/global_settings.php:1149
 msgid ""
 "Mode which cacti will attempt to authenticate against the LDAP server."
 "<blockquote><i>No Searching</i> - No Distinguished Name (DN) searching "
@@ -9304,11 +9332,11 @@ msgid ""
 "Specific Password for binding to locate the user's Distinguished Name (DN)."
 msgstr ""
 
-#: ../include/global_settings.php:1147 ../user_domains.php:412
+#: ../include/global_settings.php:1155 ../user_domains.php:412
 msgid "Distinguished Name (DN)"
 msgstr ""
 
-#: ../include/global_settings.php:1148 ../user_domains.php:413
+#: ../include/global_settings.php:1156 ../user_domains.php:413
 msgid ""
 "Distinguished Name syntax, such as for windows: <i>\"&lt;username&gt;"
 "@win2kdomain.local\"</i> or for OpenLDAP: <i>\"uid=&lt;username&gt;,"
@@ -9317,372 +9345,372 @@ msgid ""
 "in \"No Searching\" mode."
 msgstr ""
 
-#: ../include/global_settings.php:1153 ../user_domains.php:419
+#: ../include/global_settings.php:1161 ../user_domains.php:419
 msgid "Require Group Membership"
 msgstr ""
 
-#: ../include/global_settings.php:1154 ../user_domains.php:420
+#: ../include/global_settings.php:1162 ../user_domains.php:420
 msgid ""
 "Require user to be member of group to authenticate. Group settings must be "
 "set for this to work, enabling without proper group settings will cause "
 "authentication failure."
 msgstr ""
 
-#: ../include/global_settings.php:1159 ../user_domains.php:425
+#: ../include/global_settings.php:1167 ../user_domains.php:425
 msgid "LDAP Group Settings"
 msgstr ""
 
-#: ../include/global_settings.php:1163 ../user_domains.php:429
+#: ../include/global_settings.php:1171 ../user_domains.php:429
 msgid "Group Distinguished Name (DN)"
 msgstr ""
 
-#: ../include/global_settings.php:1164 ../user_domains.php:430
+#: ../include/global_settings.php:1172 ../user_domains.php:430
 msgid "Distinguished Name of the group that user must have membership."
 msgstr ""
 
-#: ../include/global_settings.php:1169 ../user_domains.php:436
+#: ../include/global_settings.php:1177 ../user_domains.php:436
 msgid "Group Member Attribute"
 msgstr ""
 
-#: ../include/global_settings.php:1170 ../user_domains.php:437
+#: ../include/global_settings.php:1178 ../user_domains.php:437
 msgid "Name of the attribute that contains the usernames of the members."
 msgstr ""
 
-#: ../include/global_settings.php:1175 ../user_domains.php:443
+#: ../include/global_settings.php:1183 ../user_domains.php:443
 msgid "Group Member Type"
 msgstr ""
 
-#: ../include/global_settings.php:1176 ../user_domains.php:444
+#: ../include/global_settings.php:1184 ../user_domains.php:444
 msgid ""
 "Defines if users use full Distinguished Name or just Username in the defined "
 "Group Member Attribute."
 msgstr ""
 
-#: ../include/global_settings.php:1179
+#: ../include/global_settings.php:1187
 msgid "Distinguished Name"
 msgstr ""
 
-#: ../include/global_settings.php:1182 ../user_domains.php:450
+#: ../include/global_settings.php:1190 ../user_domains.php:450
 msgid "LDAP Specific Search Settings"
 msgstr ""
 
-#: ../include/global_settings.php:1186 ../user_domains.php:454
+#: ../include/global_settings.php:1194 ../user_domains.php:454
 msgid "Search Base"
 msgstr ""
 
-#: ../include/global_settings.php:1187
+#: ../include/global_settings.php:1195
 msgid ""
 "Search base for searching the LDAP directory, such as <i>'dc=win2kdomain,"
 "dc=local'</i> or <i>'ou=people,dc=domain,dc=local'</i>."
 msgstr ""
 
-#: ../include/global_settings.php:1192 ../user_domains.php:461
+#: ../include/global_settings.php:1200 ../user_domains.php:461
 msgid "Search Filter"
 msgstr ""
 
-#: ../include/global_settings.php:1193
+#: ../include/global_settings.php:1201
 msgid ""
 "Search filter to use to locate the user in the LDAP directory, such as for "
 "windows: <i>'(&amp;(objectclass=user)(objectcategory=user)"
-"(userPrincipalName=&lt;username&gt;*))'</i> or for OpenLDAP: <i>'(&"
-"(objectClass=account)(uid=&lt;username&gt))'</i>.  '&lt;username&gt' is "
-"replaced with the username that was supplied at the login prompt. "
+"(userPrincipalName=&lt;username&gt;*))'</i> or for OpenLDAP: "
+"<i>'(&(objectClass=account)(uid=&lt;username&gt))'</i>.  '&lt;username&gt' "
+"is replaced with the username that was supplied at the login prompt. "
 msgstr ""
 
-#: ../include/global_settings.php:1198 ../user_domains.php:468
+#: ../include/global_settings.php:1206 ../user_domains.php:468
 msgid "Search Distinguished Name (DN)"
 msgstr ""
 
-#: ../include/global_settings.php:1199 ../user_domains.php:469
+#: ../include/global_settings.php:1207 ../user_domains.php:469
 msgid ""
 "Distinguished Name for Specific Searching binding to the LDAP directory."
 msgstr ""
 
-#: ../include/global_settings.php:1204 ../user_domains.php:475
+#: ../include/global_settings.php:1212 ../user_domains.php:475
 msgid "Search Password"
 msgstr ""
 
-#: ../include/global_settings.php:1205 ../user_domains.php:476
+#: ../include/global_settings.php:1213 ../user_domains.php:476
 msgid "Password for Specific Searching binding to the LDAP directory."
 msgstr ""
 
-#: ../include/global_settings.php:1212
+#: ../include/global_settings.php:1220
 msgid "URL Linking"
 msgstr ""
 
-#: ../include/global_settings.php:1217
+#: ../include/global_settings.php:1225
 msgid "Server Base URL"
 msgstr ""
 
-#: ../include/global_settings.php:1218
+#: ../include/global_settings.php:1226
 msgid ""
 "This is a the server location that will be used for links to the Cacti site."
 msgstr ""
 
-#: ../include/global_settings.php:1225
+#: ../include/global_settings.php:1233
 msgid ""
 "Emailing Options<div id=\"emailtest\" class=\"emailtest textSubHeaderDark"
 "\">Send a Test Email</div>"
 msgstr ""
 
-#: ../include/global_settings.php:1229
+#: ../include/global_settings.php:1237
 msgid "Test Email"
 msgstr ""
 
-#: ../include/global_settings.php:1230
+#: ../include/global_settings.php:1238
 msgid ""
 "This is a Email account used for sending a test message to ensure everything "
 "is working properly."
 msgstr ""
 
-#: ../include/global_settings.php:1235
+#: ../include/global_settings.php:1243
 msgid "Mail Services"
 msgstr ""
 
-#: ../include/global_settings.php:1236
+#: ../include/global_settings.php:1244
 msgid "Which mail service to use in order to send mail"
 msgstr ""
 
-#: ../include/global_settings.php:1238 ../include/global_settings.php:1239
+#: ../include/global_settings.php:1246 ../include/global_settings.php:1247
 msgid "PHP Mail() Function"
 msgstr ""
 
-#: ../include/global_settings.php:1239 ../lib/functions.php:3755
+#: ../include/global_settings.php:1247 ../lib/functions.php:3767
 msgid "SMTP"
 msgstr ""
 
-#: ../include/global_settings.php:1239 ../lib/functions.php:3750
+#: ../include/global_settings.php:1247 ../lib/functions.php:3762
 msgid "Sendmail"
 msgstr ""
 
-#: ../include/global_settings.php:1242 ../lib/html_reports.php:186
+#: ../include/global_settings.php:1250 ../lib/html_reports.php:186
 msgid "From Email Address"
 msgstr ""
 
-#: ../include/global_settings.php:1243
+#: ../include/global_settings.php:1251
 msgid "This is the Email address that the Email will appear from."
 msgstr ""
 
-#: ../include/global_settings.php:1248 ../lib/html_reports.php:178
+#: ../include/global_settings.php:1256 ../lib/html_reports.php:178
 msgid "From Name"
 msgstr ""
 
-#: ../include/global_settings.php:1249
+#: ../include/global_settings.php:1257
 msgid "This is the actual name that the Email will appear from."
 msgstr ""
 
-#: ../include/global_settings.php:1254
+#: ../include/global_settings.php:1262
 msgid "Word Wrap"
 msgstr ""
 
-#: ../include/global_settings.php:1255
+#: ../include/global_settings.php:1263
 msgid ""
 "This is how many characters will be allowed before a line in the Email is "
 "automatically word wrapped. (0 = Disabled)"
 msgstr ""
 
-#: ../include/global_settings.php:1262
+#: ../include/global_settings.php:1270
 msgid "Sendmail Options"
 msgstr ""
 
-#: ../include/global_settings.php:1267 ../lib/functions.php:3750
+#: ../include/global_settings.php:1275 ../lib/functions.php:3762
 msgid "Sendmail Path"
 msgstr ""
 
-#: ../include/global_settings.php:1268
+#: ../include/global_settings.php:1276
 msgid ""
 "This is the path to sendmail on your server. (Only used if Sendmail is "
 "selected as the Mail Service)"
 msgstr ""
 
-#: ../include/global_settings.php:1274
+#: ../include/global_settings.php:1282
 msgid "SMTP Options"
 msgstr ""
 
-#: ../include/global_settings.php:1279
+#: ../include/global_settings.php:1287
 msgid "SMTP Hostname"
 msgstr ""
 
-#: ../include/global_settings.php:1280
+#: ../include/global_settings.php:1288
 msgid ""
 "This is the hostname/IP of the SMTP Server you will send the Email to. For "
 "failover, separate your hosts using a semi-colon."
 msgstr ""
 
-#: ../include/global_settings.php:1286
+#: ../include/global_settings.php:1294
 msgid "SMTP Port"
 msgstr ""
 
-#: ../include/global_settings.php:1287
+#: ../include/global_settings.php:1295
 msgid "The port on the SMTP Server to use."
 msgstr ""
 
-#: ../include/global_settings.php:1294
+#: ../include/global_settings.php:1302
 msgid "SMTP Username"
 msgstr ""
 
-#: ../include/global_settings.php:1295
+#: ../include/global_settings.php:1303
 msgid ""
 "The username to authenticate with when sending via SMTP. (Leave blank if you "
 "do not require authentication.)"
 msgstr ""
 
-#: ../include/global_settings.php:1300
+#: ../include/global_settings.php:1308
 msgid "SMTP Password"
 msgstr ""
 
-#: ../include/global_settings.php:1301
+#: ../include/global_settings.php:1309
 msgid ""
 "The password to authenticate with when sending via SMTP. (Leave blank if you "
 "do not require authentication.)"
 msgstr ""
 
-#: ../include/global_settings.php:1306
+#: ../include/global_settings.php:1314
 msgid "SMTP Security"
 msgstr ""
 
-#: ../include/global_settings.php:1307
+#: ../include/global_settings.php:1315
 msgid "The encryption method to use for the Email."
 msgstr ""
 
-#: ../include/global_settings.php:1313
+#: ../include/global_settings.php:1321
 msgid "SMTP Timeout"
 msgstr ""
 
-#: ../include/global_settings.php:1314
+#: ../include/global_settings.php:1322
 msgid "Please enter the SMTP timeout in seconds."
 msgstr ""
 
-#: ../include/global_settings.php:1321
+#: ../include/global_settings.php:1329
 msgid "Reporting Presets"
 msgstr ""
 
-#: ../include/global_settings.php:1326
+#: ../include/global_settings.php:1334
 msgid "Default Graph Image Format"
 msgstr ""
 
-#: ../include/global_settings.php:1327
+#: ../include/global_settings.php:1335
 msgid ""
 "When creating a new report, what image type should be used for the inline "
 "graphs."
 msgstr ""
 
-#: ../include/global_settings.php:1333
+#: ../include/global_settings.php:1341
 msgid "Maximum E-Mail Size"
 msgstr ""
 
-#: ../include/global_settings.php:1334
+#: ../include/global_settings.php:1342
 msgid "The maximum size of the E-Mail message including all attachements."
 msgstr ""
 
-#: ../include/global_settings.php:1340
+#: ../include/global_settings.php:1348
 msgid "Poller Logging Level for Cacti Reporting"
 msgstr ""
 
-#: ../include/global_settings.php:1341
+#: ../include/global_settings.php:1349
 msgid ""
 "What level of detail do you want sent to the log file. WARNING: Leaving in "
 "any other status than NONE or LOW can exhaust your disk space rapidly."
 msgstr ""
 
-#: ../include/global_settings.php:1347
+#: ../include/global_settings.php:1355
 msgid "Enable Lotus Notes (R) tweak"
 msgstr ""
 
-#: ../include/global_settings.php:1348
+#: ../include/global_settings.php:1356
 msgid "Enable code tweak for specific handling of Lotus Notes Mail Clients."
 msgstr ""
 
-#: ../include/global_settings.php:1353
+#: ../include/global_settings.php:1361
 msgid "DNS Options"
 msgstr ""
 
-#: ../include/global_settings.php:1358
+#: ../include/global_settings.php:1366
 msgid "Primary DNS IP Address"
 msgstr ""
 
-#: ../include/global_settings.php:1359
+#: ../include/global_settings.php:1367
 msgid "Enter the primary DNS IP Address to utilize for reverse lookups."
 msgstr ""
 
-#: ../include/global_settings.php:1365
+#: ../include/global_settings.php:1373
 msgid "Secondary DNS IP Address"
 msgstr ""
 
-#: ../include/global_settings.php:1366
+#: ../include/global_settings.php:1374
 msgid "Enter the secondary DNS IP Address to utilize for reverse lookups."
 msgstr ""
 
-#: ../include/global_settings.php:1372
+#: ../include/global_settings.php:1380
 msgid "DNS Timeout"
 msgstr ""
 
-#: ../include/global_settings.php:1373
+#: ../include/global_settings.php:1381
 msgid ""
 "Please enter the DNS timeout in milliseconds.  Cacti uses a PHP based DNS "
 "resolver."
 msgstr ""
 
-#: ../include/global_settings.php:1382
+#: ../include/global_settings.php:1390
 msgid "Data Sources Statistics"
 msgstr ""
 
-#: ../include/global_settings.php:1387
+#: ../include/global_settings.php:1395
 msgid "Enable Data Source Statistics Collection"
 msgstr ""
 
-#: ../include/global_settings.php:1388
+#: ../include/global_settings.php:1396
 msgid "Should Data Source Statistics be collected for this Cacti system?"
 msgstr ""
 
-#: ../include/global_settings.php:1393
+#: ../include/global_settings.php:1401
 msgid "Daily Update Frequency"
 msgstr ""
 
-#: ../include/global_settings.php:1394
+#: ../include/global_settings.php:1402
 msgid "How frequent should Daily Stats be updated?"
 msgstr ""
 
-#: ../include/global_settings.php:1400
+#: ../include/global_settings.php:1408
 msgid "Hourly Average Window"
 msgstr ""
 
-#: ../include/global_settings.php:1401
+#: ../include/global_settings.php:1409
 msgid ""
 "The number of consecutive hours that represent the hourly\n"
 "\t\t\taverage.  Keep in mind that a setting too high can result in very "
 "large memory tables"
 msgstr ""
 
-#: ../include/global_settings.php:1408
+#: ../include/global_settings.php:1416
 msgid "Maintenance Time"
 msgstr ""
 
-#: ../include/global_settings.php:1409
+#: ../include/global_settings.php:1417
 msgid ""
 "What time of day should Weekly, Monthly, and Yearly Data be updated?  Format "
 "is HH:MM [am/pm]"
 msgstr ""
 
-#: ../include/global_settings.php:1416
+#: ../include/global_settings.php:1424
 msgid "Memory Limit for Data Source Statistics Data Collector"
 msgstr ""
 
-#: ../include/global_settings.php:1417
+#: ../include/global_settings.php:1425
 msgid ""
 "The maximum amount of memory for the Cacti Poller and Data Source Statistics "
 "Poller"
 msgstr ""
 
-#: ../include/global_settings.php:1423
+#: ../include/global_settings.php:1431
 msgid "Debugging"
 msgstr ""
 
-#: ../include/global_settings.php:1428
+#: ../include/global_settings.php:1436
 msgid "Enable Single RRDtool Pipe"
 msgstr ""
 
-#: ../include/global_settings.php:1429
+#: ../include/global_settings.php:1437
 msgid ""
 "Using a single pipe will speed the RRDtool process by 10x.  However, RRDtool "
 "crashes\n"
@@ -9690,11 +9718,11 @@ msgid ""
 "RRDfile."
 msgstr ""
 
-#: ../include/global_settings.php:1435
+#: ../include/global_settings.php:1443
 msgid "Enable Partial Reference Data Retrieve"
 msgstr ""
 
-#: ../include/global_settings.php:1436
+#: ../include/global_settings.php:1444
 msgid ""
 "If using a large system, it may be beneficial for you to only gather data as "
 "needed\n"
@@ -9702,54 +9730,54 @@ msgid ""
 "Statistics will gather data this way."
 msgstr ""
 
-#: ../include/global_settings.php:1444
+#: ../include/global_settings.php:1452
 msgid "On-demand RRD Update Settings"
 msgstr ""
 
-#: ../include/global_settings.php:1449
+#: ../include/global_settings.php:1457
 msgid "Enable On-demand RRD Updating"
 msgstr ""
 
-#: ../include/global_settings.php:1450
+#: ../include/global_settings.php:1458
 msgid ""
 "Should Boost enable on demand RRD updating in Cacti?  If you disable, this "
 "change will not take effect until after the next polling cycle."
 msgstr ""
 
-#: ../include/global_settings.php:1455
+#: ../include/global_settings.php:1463
 msgid "System Level RRD Updater"
 msgstr ""
 
-#: ../include/global_settings.php:1456
+#: ../include/global_settings.php:1464
 msgid ""
 "Before RRD On-demand Update Can be Cleared, a poller run must always pass"
 msgstr ""
 
-#: ../include/global_settings.php:1461
+#: ../include/global_settings.php:1469
 msgid "How Often Should Boost Update All RRDs"
 msgstr ""
 
-#: ../include/global_settings.php:1462
+#: ../include/global_settings.php:1470
 msgid ""
 "When you enable boost, your RRD files are only updated when they are "
 "requested by a user, or when this time period elapses."
 msgstr ""
 
-#: ../include/global_settings.php:1469
+#: ../include/global_settings.php:1477
 msgid "Maximum Records"
 msgstr ""
 
-#: ../include/global_settings.php:1470
+#: ../include/global_settings.php:1478
 msgid ""
 "If the boost output table exceeds this size, in records, an update will take "
 "place."
 msgstr ""
 
-#: ../include/global_settings.php:1477
+#: ../include/global_settings.php:1485
 msgid "Maximum Data Source Items Per Pass"
 msgstr ""
 
-#: ../include/global_settings.php:1478
+#: ../include/global_settings.php:1486
 msgid ""
 "To optimize performance, the boost RRD updater needs to know how many Data "
 "Source Items\n"
@@ -9760,11 +9788,11 @@ msgid ""
 "\t\t\tnumber.  The default value is 50000."
 msgstr ""
 
-#: ../include/global_settings.php:1487
+#: ../include/global_settings.php:1495
 msgid "Maximum Argument Length"
 msgstr ""
 
-#: ../include/global_settings.php:1488
+#: ../include/global_settings.php:1496
 msgid ""
 "When boost sends update commands to RRDtool, it must not exceed the "
 "operating systems\n"
@@ -9774,155 +9802,155 @@ msgid ""
 "Linux 2.6.23++ unlimited"
 msgstr ""
 
-#: ../include/global_settings.php:1497
+#: ../include/global_settings.php:1505
 msgid "Memory Limit for Boost and Poller"
 msgstr ""
 
-#: ../include/global_settings.php:1498
+#: ../include/global_settings.php:1506
 msgid "The maximum amount of memory for the Cacti Poller and Boosts Poller"
 msgstr ""
 
-#: ../include/global_settings.php:1504
+#: ../include/global_settings.php:1512
 msgid "Maximum RRD Update Script Run Time"
 msgstr ""
 
-#: ../include/global_settings.php:1505
+#: ../include/global_settings.php:1513
 msgid ""
 "The maximum boot poller run time allowed prior to boost issuing warning\n"
 "\t\t\tmessages relative to possible hardware/software issues preventing "
 "proper updates."
 msgstr ""
 
-#: ../include/global_settings.php:1512
+#: ../include/global_settings.php:1520
 msgid "Enable direct population of poller_output_boost table"
 msgstr ""
 
-#: ../include/global_settings.php:1513
+#: ../include/global_settings.php:1521
 msgid ""
 "Enables direct insert of records into poller output boost with results in a "
 "25% time reduction in each poll cycle."
 msgstr ""
 
-#: ../include/global_settings.php:1518 ../utilities.php:2132
+#: ../include/global_settings.php:1526 ../utilities.php:2139
 msgid "Image Caching"
 msgstr ""
 
-#: ../include/global_settings.php:1523
+#: ../include/global_settings.php:1531
 msgid "Enable Image Caching"
 msgstr ""
 
-#: ../include/global_settings.php:1524
+#: ../include/global_settings.php:1532
 msgid "Should image caching be enabled?"
 msgstr ""
 
-#: ../include/global_settings.php:1529
+#: ../include/global_settings.php:1537
 msgid "Location for Image Files"
 msgstr ""
 
-#: ../include/global_settings.php:1530
+#: ../include/global_settings.php:1538
 msgid ""
 "Specify the location where Boost should place your image files.  These files "
 "will be automatically purged by the poller when they expire."
 msgstr ""
 
-#: ../include/global_settings.php:1536
+#: ../include/global_settings.php:1544
 msgid "Process Interlocking"
 msgstr ""
 
-#: ../include/global_settings.php:1541
+#: ../include/global_settings.php:1549
 msgid "Boost Debug Log"
 msgstr ""
 
-#: ../include/global_settings.php:1542
+#: ../include/global_settings.php:1550
 msgid ""
 "If this field is non-blank, Boost will log RRDupdate output from the boost"
 "\tpoller process."
 msgstr ""
 
-#: ../include/global_settings.php:1556
+#: ../include/global_settings.php:1564
 msgid ""
 "Choose if RRDs will be stored locally or being handled by an external "
 "RRDtool proxy server."
 msgstr ""
 
-#: ../include/global_settings.php:1559 ../include/global_settings.php:1567
+#: ../include/global_settings.php:1567 ../include/global_settings.php:1575
 msgid "RRDtool Proxy Server"
 msgstr ""
 
-#: ../include/global_settings.php:1562
+#: ../include/global_settings.php:1570
 msgid "Structured RRD Path (/host_id/local_data_id.rrd)"
 msgstr ""
 
-#: ../include/global_settings.php:1563
+#: ../include/global_settings.php:1571
 msgid "Use a separate subfolder for each hosts RRD files."
 msgstr ""
 
-#: ../include/global_settings.php:1572 ../include/global_settings.php:1604
+#: ../include/global_settings.php:1580 ../include/global_settings.php:1612
 msgid "Proxy Server"
 msgstr ""
 
-#: ../include/global_settings.php:1573
+#: ../include/global_settings.php:1581
 msgid "The DNS hostname or IP address of the RRDtool proxy server."
 msgstr ""
 
-#: ../include/global_settings.php:1578 ../include/global_settings.php:1610
+#: ../include/global_settings.php:1586 ../include/global_settings.php:1618
 msgid "Proxy Port Number"
 msgstr ""
 
-#: ../include/global_settings.php:1579
+#: ../include/global_settings.php:1587
 msgid "TCP port for encrypted communication."
 msgstr ""
 
-#: ../include/global_settings.php:1586 ../include/global_settings.php:1618
+#: ../include/global_settings.php:1594 ../include/global_settings.php:1626
 #: ../utilities.php:248
 msgid "RSA Fingerprint"
 msgstr ""
 
-#: ../include/global_settings.php:1587
+#: ../include/global_settings.php:1595
 msgid ""
 "The fingerprint of the current public RSA key the proxy is using. This is "
 "required to establish a trusted connection."
 msgstr ""
 
-#: ../include/global_settings.php:1594
+#: ../include/global_settings.php:1602
 msgid "RRDtool Proxy Server - Backup"
 msgstr ""
 
-#: ../include/global_settings.php:1599
+#: ../include/global_settings.php:1607
 msgid "Load Balancing"
 msgstr ""
 
-#: ../include/global_settings.php:1600
+#: ../include/global_settings.php:1608
 msgid ""
 "If both main and backup proxy are receivable this option allows to spread "
 "all requests against RRDtool."
 msgstr ""
 
-#: ../include/global_settings.php:1605
+#: ../include/global_settings.php:1613
 msgid ""
 "The DNS hostname or IP address of the RRDtool backup proxy server if proxy "
 "is running in MSR mode."
 msgstr ""
 
-#: ../include/global_settings.php:1611
+#: ../include/global_settings.php:1619
 msgid "TCP port for encrypted communication with the backup proxy."
 msgstr ""
 
-#: ../include/global_settings.php:1619
+#: ../include/global_settings.php:1627
 msgid ""
 "The fingerprint of the current public RSA key the backup proxy is using. "
 "This required to establish a trusted connection."
 msgstr ""
 
-#: ../include/global_settings.php:1628
+#: ../include/global_settings.php:1636
 msgid "Spike Kill Settings"
 msgstr ""
 
-#: ../include/global_settings.php:1633
+#: ../include/global_settings.php:1641
 msgid "Removal Method"
 msgstr ""
 
-#: ../include/global_settings.php:1634
+#: ../include/global_settings.php:1642
 msgid ""
 "There are two removal methods.  The first, Standard Deviation, will remove "
 "any\n"
@@ -9935,19 +9963,19 @@ msgid ""
 "\t\t\tto be excluded from the Variance Average calculation."
 msgstr ""
 
-#: ../include/global_settings.php:1641
+#: ../include/global_settings.php:1649
 msgid "Standard Deviation"
 msgstr ""
 
-#: ../include/global_settings.php:1641
+#: ../include/global_settings.php:1649
 msgid "Variance Based w/Outliers Removed"
 msgstr ""
 
-#: ../include/global_settings.php:1644 ../lib/html.php:1740
+#: ../include/global_settings.php:1652 ../lib/html.php:1719
 msgid "Replacement Method"
 msgstr ""
 
-#: ../include/global_settings.php:1645
+#: ../include/global_settings.php:1653
 msgid ""
 "There are three replacement methods.  The first method replaces the spike "
 "with the\n"
@@ -9956,23 +9984,23 @@ msgid ""
 "\t\t\tThe last replaces the spike with the last known good value found."
 msgstr ""
 
-#: ../include/global_settings.php:1650 ../lib/html.php:1741
+#: ../include/global_settings.php:1658 ../lib/html.php:1720
 msgid "Average"
 msgstr ""
 
-#: ../include/global_settings.php:1650 ../lib/html.php:1743
+#: ../include/global_settings.php:1658 ../lib/html.php:1722
 msgid "Last Known Good"
 msgstr ""
 
-#: ../include/global_settings.php:1650
+#: ../include/global_settings.php:1658
 msgid "NaN's"
 msgstr ""
 
-#: ../include/global_settings.php:1653
+#: ../include/global_settings.php:1661
 msgid "Number of Standard Deviations"
 msgstr ""
 
-#: ../include/global_settings.php:1654
+#: ../include/global_settings.php:1662
 msgid ""
 "Any value that is this many standard deviations above the average will be "
 "excluded.\n"
@@ -9981,20 +10009,20 @@ msgid ""
 "\t\t\tthan 5 Standard Deviations."
 msgstr ""
 
-#: ../include/global_settings.php:1660 ../include/global_settings.php:1661
-#: ../include/global_settings.php:1662 ../include/global_settings.php:1663
-#: ../include/global_settings.php:1664 ../include/global_settings.php:1665
-#: ../include/global_settings.php:1666 ../include/global_settings.php:1667
 #: ../include/global_settings.php:1668 ../include/global_settings.php:1669
+#: ../include/global_settings.php:1670 ../include/global_settings.php:1671
+#: ../include/global_settings.php:1672 ../include/global_settings.php:1673
+#: ../include/global_settings.php:1674 ../include/global_settings.php:1675
+#: ../include/global_settings.php:1676 ../include/global_settings.php:1677
 #, php-format
 msgid "%d Standard Deviations"
 msgstr ""
 
-#: ../include/global_settings.php:1673 ../lib/html.php:1752
+#: ../include/global_settings.php:1681 ../lib/html.php:1731
 msgid "Variance Percentage"
 msgstr ""
 
-#: ../include/global_settings.php:1674
+#: ../include/global_settings.php:1682
 #, php-format
 msgid ""
 "This value represents the percentage above the adjusted sample average once "
@@ -10004,11 +10032,11 @@ msgid ""
 "\t\t\twould remove any sample above the quantity of 100 from the graph."
 msgstr ""
 
-#: ../include/global_settings.php:1695
+#: ../include/global_settings.php:1703
 msgid "Variance Number of Outliers"
 msgstr ""
 
-#: ../include/global_settings.php:1696
+#: ../include/global_settings.php:1704
 msgid ""
 "This value represents the number of high and low average samples will be "
 "removed from the\n"
@@ -10017,70 +10045,70 @@ msgid ""
 "\t\t\tand bottom 5 averages are removed."
 msgstr ""
 
-#: ../include/global_settings.php:1702 ../include/global_settings.php:1703
-#: ../include/global_settings.php:1704 ../include/global_settings.php:1705
-#: ../include/global_settings.php:1706 ../include/global_settings.php:1707
-#: ../include/global_settings.php:1708 ../include/global_settings.php:1709
+#: ../include/global_settings.php:1710 ../include/global_settings.php:1711
+#: ../include/global_settings.php:1712 ../include/global_settings.php:1713
+#: ../include/global_settings.php:1714 ../include/global_settings.php:1715
+#: ../include/global_settings.php:1716 ../include/global_settings.php:1717
 #, php-format
 msgid "%d High/Low Samples"
 msgstr ""
 
-#: ../include/global_settings.php:1713
+#: ../include/global_settings.php:1721
 msgid "Max Kills Per RRA"
 msgstr ""
 
-#: ../include/global_settings.php:1714
+#: ../include/global_settings.php:1722
 msgid ""
 "This value represents the maximum number of spikes to remove from a Graph "
 "RRA."
 msgstr ""
 
-#: ../include/global_settings.php:1718 ../include/global_settings.php:1719
-#: ../include/global_settings.php:1720 ../include/global_settings.php:1721
-#: ../include/global_settings.php:1722 ../include/global_settings.php:1723
-#: ../include/global_settings.php:1724 ../include/global_settings.php:1725
+#: ../include/global_settings.php:1726 ../include/global_settings.php:1727
+#: ../include/global_settings.php:1728 ../include/global_settings.php:1729
+#: ../include/global_settings.php:1730 ../include/global_settings.php:1731
+#: ../include/global_settings.php:1732 ../include/global_settings.php:1733
 #, php-format
 msgid "%d Samples"
 msgstr ""
 
-#: ../include/global_settings.php:1729
+#: ../include/global_settings.php:1737
 msgid "RRDfile Backup Directory"
 msgstr ""
 
-#: ../include/global_settings.php:1730
+#: ../include/global_settings.php:1738
 msgid ""
 "If this directory is not empty, then your original RRDfiles will be backed\n"
 "\t\t\tup to this location."
 msgstr ""
 
-#: ../include/global_settings.php:1738
+#: ../include/global_settings.php:1746
 msgid "Batch Spike Kill Settings"
 msgstr ""
 
-#: ../include/global_settings.php:1743
+#: ../include/global_settings.php:1751
 msgid "Removal Schedule"
 msgstr ""
 
-#: ../include/global_settings.php:1744
+#: ../include/global_settings.php:1752
 msgid ""
 "Do you wish to periodically remove spikes from your graphs?  If so, select "
 "the frequency\n"
 "\t\t\tbelow."
 msgstr ""
 
-#: ../include/global_settings.php:1752
+#: ../include/global_settings.php:1760
 msgid "Once a Day"
 msgstr ""
 
-#: ../include/global_settings.php:1753
+#: ../include/global_settings.php:1761
 msgid "Every Other Day"
 msgstr ""
 
-#: ../include/global_settings.php:1757
+#: ../include/global_settings.php:1765
 msgid "Base Time"
 msgstr ""
 
-#: ../include/global_settings.php:1758
+#: ../include/global_settings.php:1766
 msgid ""
 "The Base Time for Spike removal to occur.  For example, if you use '12:00am' "
 "and you choose\n"
@@ -10088,245 +10116,245 @@ msgid ""
 "every day."
 msgstr ""
 
-#: ../include/global_settings.php:1766
+#: ../include/global_settings.php:1774
 msgid "Graph Templates to Spike Kill"
 msgstr ""
 
-#: ../include/global_settings.php:1768
+#: ../include/global_settings.php:1776
 msgid ""
 "When performing batch spike removal, only the templates selected below will "
 "be acted on."
 msgstr ""
 
-#: ../include/global_settings.php:1784
+#: ../include/global_settings.php:1792
 msgid "Default View Mode"
 msgstr ""
 
-#: ../include/global_settings.php:1785
+#: ../include/global_settings.php:1793
 msgid ""
 "Which Graph mode you want displayed by default when you first visit the "
 "Graphs page?"
 msgstr ""
 
-#: ../include/global_settings.php:1791
+#: ../include/global_settings.php:1799
 msgid "User Language"
 msgstr ""
 
-#: ../include/global_settings.php:1792
+#: ../include/global_settings.php:1800
 msgid "Defines the preferred GUI language."
 msgstr ""
 
-#: ../include/global_settings.php:1798
+#: ../include/global_settings.php:1806
 msgid "Show Graph Title"
 msgstr ""
 
-#: ../include/global_settings.php:1799
+#: ../include/global_settings.php:1807
 msgid ""
 "Display the graph title on the page so that it may be searched using the "
 "browser."
 msgstr ""
 
-#: ../include/global_settings.php:1805
+#: ../include/global_settings.php:1813
 msgid "The date format to use in Cacti."
 msgstr ""
 
-#: ../include/global_settings.php:1812
+#: ../include/global_settings.php:1820
 msgid "The date separator to be used in Cacti."
 msgstr ""
 
-#: ../include/global_settings.php:1818
+#: ../include/global_settings.php:1826
 msgid "Page Refresh"
 msgstr ""
 
-#: ../include/global_settings.php:1819
+#: ../include/global_settings.php:1827
 msgid "The number of seconds between automatic page refreshes."
 msgstr ""
 
-#: ../include/global_settings.php:1825
+#: ../include/global_settings.php:1833
 msgid "Preview Graphs Per Page"
 msgstr ""
 
-#: ../include/global_settings.php:1826 ../include/global_settings.php:1941
+#: ../include/global_settings.php:1834 ../include/global_settings.php:1949
 msgid "The number of graphs to display on one page in preview mode."
 msgstr ""
 
-#: ../include/global_settings.php:1834
+#: ../include/global_settings.php:1842
 msgid "Default Time Range"
 msgstr ""
 
-#: ../include/global_settings.php:1835
+#: ../include/global_settings.php:1843
 msgid "The default RRA to use in rare occasions."
 msgstr ""
 
-#: ../include/global_settings.php:1841
+#: ../include/global_settings.php:1849
 msgid "Default Graph View Timespan"
 msgstr ""
 
-#: ../include/global_settings.php:1842
+#: ../include/global_settings.php:1850
 msgid "The default timespan you wish to be displayed when you display graphs"
 msgstr ""
 
-#: ../include/global_settings.php:1848
+#: ../include/global_settings.php:1856
 msgid "Default Graph View Timeshift"
 msgstr ""
 
-#: ../include/global_settings.php:1849
+#: ../include/global_settings.php:1857
 msgid "The default timeshift you wish to be displayed when you display graphs"
 msgstr ""
 
-#: ../include/global_settings.php:1855
+#: ../include/global_settings.php:1863
 msgid "Allow Graph to extend to Future"
 msgstr ""
 
-#: ../include/global_settings.php:1856
+#: ../include/global_settings.php:1864
 msgid "When displaying Graphs, allow Graph Dates to extend 'to future'"
 msgstr ""
 
-#: ../include/global_settings.php:1861
+#: ../include/global_settings.php:1869
 msgid "First Day of the Week"
 msgstr ""
 
-#: ../include/global_settings.php:1862
+#: ../include/global_settings.php:1870
 msgid "The first Day of the Week for weekly Graph Displays"
 msgstr ""
 
-#: ../include/global_settings.php:1868
+#: ../include/global_settings.php:1876
 msgid "Start of Daily Shift"
 msgstr ""
 
-#: ../include/global_settings.php:1869
+#: ../include/global_settings.php:1877
 msgid "Start Time of the Daily Shift."
 msgstr ""
 
-#: ../include/global_settings.php:1876
+#: ../include/global_settings.php:1884
 msgid "End of Daily Shift"
 msgstr ""
 
-#: ../include/global_settings.php:1877
+#: ../include/global_settings.php:1885
 msgid "End Time of the Daily Shift."
 msgstr ""
 
-#: ../include/global_settings.php:1886
+#: ../include/global_settings.php:1894
 msgid "Thumbnail Sections"
 msgstr ""
 
-#: ../include/global_settings.php:1887
+#: ../include/global_settings.php:1895
 msgid "Which portions of Cacti display Thumbnails by default."
 msgstr ""
 
-#: ../include/global_settings.php:1891 ../lib/functions.php:1852
+#: ../include/global_settings.php:1899 ../lib/functions.php:1863
 msgid "Preview Mode"
 msgstr ""
 
-#: ../include/global_settings.php:1901
+#: ../include/global_settings.php:1909
 msgid "Preview Thumbnail Columns"
 msgstr ""
 
-#: ../include/global_settings.php:1902
+#: ../include/global_settings.php:1910
 msgid ""
 "The number of columns to use when displaying Thumbnail graphs in Preview "
 "mode."
 msgstr ""
 
-#: ../include/global_settings.php:1905 ../include/global_settings.php:1912
+#: ../include/global_settings.php:1913 ../include/global_settings.php:1920
 #: ../lib/html_graph.php:231 ../lib/html_graph.php:232
 #: ../lib/html_graph.php:233 ../lib/html_graph.php:234
-#: ../lib/html_graph.php:235 ../lib/html_tree.php:676 ../lib/html_tree.php:677
-#: ../lib/html_tree.php:678 ../lib/html_tree.php:679 ../lib/html_tree.php:680
+#: ../lib/html_graph.php:235 ../lib/html_tree.php:677 ../lib/html_tree.php:678
+#: ../lib/html_tree.php:679 ../lib/html_tree.php:680 ../lib/html_tree.php:681
 #, php-format
 msgid "%d Columns"
 msgstr ""
 
-#: ../include/global_settings.php:1905 ../include/global_settings.php:1912
+#: ../include/global_settings.php:1913 ../include/global_settings.php:1920
 msgid "1 Column"
 msgstr ""
 
-#: ../include/global_settings.php:1908
+#: ../include/global_settings.php:1916
 msgid "Tree View Thumbnail Columns"
 msgstr ""
 
-#: ../include/global_settings.php:1909
+#: ../include/global_settings.php:1917
 msgid ""
 "The number of columns to use when displaying Thumbnail graphs in Tree mode."
 msgstr ""
 
-#: ../include/global_settings.php:1915
+#: ../include/global_settings.php:1923
 msgid "Thumbnail Height"
 msgstr ""
 
-#: ../include/global_settings.php:1916
+#: ../include/global_settings.php:1924
 msgid "The height of Thumbnail graphs in pixels."
 msgstr ""
 
-#: ../include/global_settings.php:1923
+#: ../include/global_settings.php:1931
 msgid "Thumbnail Width"
 msgstr ""
 
-#: ../include/global_settings.php:1924
+#: ../include/global_settings.php:1932
 msgid "The width of Thumbnail graphs in pixels."
 msgstr ""
 
-#: ../include/global_settings.php:1933
+#: ../include/global_settings.php:1941
 msgid "Default Tree"
 msgstr ""
 
-#: ../include/global_settings.php:1934
+#: ../include/global_settings.php:1942
 msgid "The default graph tree to use when displaying graphs in tree mode."
 msgstr ""
 
-#: ../include/global_settings.php:1940
+#: ../include/global_settings.php:1948
 msgid "Graphs Per Page"
 msgstr ""
 
-#: ../include/global_settings.php:1947
+#: ../include/global_settings.php:1955
 msgid "Expand Devices"
 msgstr ""
 
-#: ../include/global_settings.php:1948
+#: ../include/global_settings.php:1956
 msgid ""
 "Choose whether to expand the Graph Templates and Data Queries used by a "
 "Device on Tree."
 msgstr ""
 
-#: ../include/global_settings.php:1955
+#: ../include/global_settings.php:1963
 msgid "Use Custom Fonts"
 msgstr ""
 
-#: ../include/global_settings.php:1956
+#: ../include/global_settings.php:1964
 msgid ""
 "Choose whether to use your own custom fonts and font sizes or utilize the "
 "system defaults."
 msgstr ""
 
-#: ../include/global_settings.php:1969
+#: ../include/global_settings.php:1977
 msgid "Title Font File"
 msgstr ""
 
-#: ../include/global_settings.php:1970
+#: ../include/global_settings.php:1978
 msgid "The font file to use for Graph Titles"
 msgstr ""
 
-#: ../include/global_settings.php:1982
+#: ../include/global_settings.php:1990
 msgid "Legend Font File"
 msgstr ""
 
-#: ../include/global_settings.php:1983
+#: ../include/global_settings.php:1991
 msgid "The font file to be used for Graph Legend items"
 msgstr ""
 
-#: ../include/global_settings.php:1995
+#: ../include/global_settings.php:2003
 msgid "Axis Font File"
 msgstr ""
 
-#: ../include/global_settings.php:1996
+#: ../include/global_settings.php:2004
 msgid "The font file to be used for Graph Axis items"
 msgstr ""
 
-#: ../include/global_settings.php:2008
+#: ../include/global_settings.php:2016
 msgid "Unit Font File"
 msgstr ""
 
-#: ../include/global_settings.php:2009
+#: ../include/global_settings.php:2017
 msgid "The font file to be used for Graph Unit items"
 msgstr ""
 
@@ -10395,19 +10423,19 @@ msgid ""
 "will work so long as the Remote Data Collector is in <b>'online'</b> mode."
 msgstr ""
 
-#: ../install/index.php:57 ../install/index.php:62 ../install/index.php:67
-#: ../install/index.php:307 ../lib/html_utility.php:815
+#: ../install/index.php:51 ../install/index.php:56 ../install/index.php:61
+#: ../install/index.php:302 ../lib/html_utility.php:820
 msgid "Error"
 msgstr ""
 
-#: ../install/index.php:59
+#: ../install/index.php:53
 #, php-format
 msgid ""
 "This installation is already up-to-date. Click <a href=\"%s\">here</a> to "
 "use Cacti."
 msgstr ""
 
-#: ../install/index.php:64
+#: ../install/index.php:58
 #, php-format
 msgid ""
 "You are attempting to install Cacti %s onto a 0.6.x database. To continue, "
@@ -10415,7 +10443,7 @@ msgid ""
 "\"include/config.php\" to point to the new database."
 msgstr ""
 
-#: ../install/index.php:69
+#: ../install/index.php:63
 #, php-format
 msgid ""
 "You have created a new database, but have not yet imported the 'cacti.sql' "
@@ -10427,22 +10455,22 @@ msgid ""
 "Cacti database."
 msgstr ""
 
-#: ../install/index.php:71
+#: ../install/index.php:65
 #, php-format
 msgid ""
 "In Cacti %s, you must also import MySQL TimeZone information into MySQL and "
 "grant the Cacti user SELECT access to the mysql.time_zone_name table"
 msgstr ""
 
-#: ../install/index.php:74
+#: ../install/index.php:68
 msgid "On Linux/UNIX, do the following:"
 msgstr ""
 
-#: ../install/index.php:74
+#: ../install/index.php:68
 msgid "mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root -p mysql"
 msgstr ""
 
-#: ../install/index.php:76
+#: ../install/index.php:70
 msgid ""
 "On Windows, you must follow the instructions here <a target='_blank' "
 "href='https://dev.mysql.com/downloads/timezones.html'>Time zone description "
@@ -10450,35 +10478,35 @@ msgid ""
 "grant the Cacti user access to the tables:"
 msgstr ""
 
-#: ../install/index.php:78
+#: ../install/index.php:72
 #, php-format
 msgid ""
 "GRANT SELECT ON mysql.time_zone_name to '%s'@'localhost' IDENTIFIED BY '%s'"
 msgstr ""
 
-#: ../install/index.php:309
+#: ../install/index.php:304
 #, php-format
 msgid ""
 "Invalid Cacti version <strong>%1$s</strong>, cannot upgrade to <strong>%2$s</"
 "strong>"
 msgstr ""
 
-#: ../install/index.php:536
+#: ../install/index.php:410
 msgid "Cacti Installation Wizard"
 msgstr ""
 
-#: ../install/index.php:544
+#: ../install/index.php:418
 msgid "License Agreement"
 msgstr ""
 
-#: ../install/index.php:546
+#: ../install/index.php:420
 msgid ""
 "Thanks for taking the time to download and install Cacti, the complete "
 "graphing solution for your network. Before you can start making cool graphs, "
 "there are a few pieces of data that Cacti needs to know."
 msgstr ""
 
-#: ../install/index.php:547
+#: ../install/index.php:421
 #, php-format
 msgid ""
 "Make sure you have read and followed the required steps needed to install "
@@ -10486,39 +10514,39 @@ msgid ""
 "\">Unix</a> and <a href=\"%2$s\">Win32</a>-based operating systems."
 msgstr ""
 
-#: ../install/index.php:548
+#: ../install/index.php:422
 #, php-format
 msgid ""
 "Also, if this is an upgrade, be sure to reading the <a href=\"%s\">Upgrade</"
 "a> information file."
 msgstr ""
 
-#: ../install/index.php:549
+#: ../install/index.php:423
 msgid ""
 "Cacti is licensed under the GNU General Public License, you must agree to "
 "its provisions before continuing:"
 msgstr ""
 
-#: ../install/index.php:567
+#: ../install/index.php:441
 msgid "Pre-installation Checks"
 msgstr ""
 
-#: ../install/index.php:568
+#: ../install/index.php:442
 msgid "MySQL TimeZone Support"
 msgstr ""
 
-#: ../install/index.php:573 ../install/index.php:577 ../install/index.php:764
-#: ../install/index.php:772
+#: ../install/index.php:447 ../install/index.php:451 ../install/index.php:638
+#: ../install/index.php:646
 msgid "ERROR:"
 msgstr ""
 
-#: ../install/index.php:573
+#: ../install/index.php:447
 msgid ""
 "Your MySQL TimeZone database is not populated.  Please populate this "
 "database before proceeding."
 msgstr ""
 
-#: ../install/index.php:577
+#: ../install/index.php:451
 msgid ""
 "Your Cacti database login account does not have access to the MySQL TimeZone "
 "database.  Please provide the Cacti database account \"select\" access to "
@@ -10526,17 +10554,17 @@ msgid ""
 "TimeZone information before proceeding."
 msgstr ""
 
-#: ../install/index.php:582
+#: ../install/index.php:456
 msgid ""
 "Your Cacti database account has access to the MySQL TimeZone database and "
 "that database is populated with global TimeZone information."
 msgstr ""
 
-#: ../install/index.php:585
+#: ../install/index.php:459
 msgid "Required PHP Module Support"
 msgstr ""
 
-#: ../install/index.php:587
+#: ../install/index.php:461
 msgid ""
 "Cacti requires several PHP Modules to be installed to work properly. If any "
 "of these are not installed, you will be unable to continue the installation "
@@ -10546,146 +10574,146 @@ msgid ""
 "you have any questions."
 msgstr ""
 
-#: ../install/index.php:589
+#: ../install/index.php:463
 msgid ""
 "The following PHP extensions are mandatory, and MUST be installed before "
 "continuing your Cacti install."
 msgstr ""
 
-#: ../install/index.php:591
+#: ../install/index.php:465
 msgid "Required PHP Modules"
 msgstr ""
 
-#: ../install/index.php:592 ../install/index.php:669 ../plugins.php:41
+#: ../install/index.php:466 ../install/index.php:543 ../plugins.php:41
 #: ../plugins.php:288 ../utilities.php:415
 msgid "Installed"
 msgstr ""
 
-#: ../install/index.php:592
+#: ../install/index.php:466
 msgid "Required"
 msgstr ""
 
-#: ../install/index.php:594 ../utilities.php:387
+#: ../install/index.php:468 ../utilities.php:387
 msgid "PHP Version"
 msgstr ""
 
-#: ../install/index.php:659
+#: ../install/index.php:533
 msgid "Optional PHP Module Support"
 msgstr ""
 
-#: ../install/index.php:661
+#: ../install/index.php:535
 msgid ""
 "The following PHP extensions are recommended, and should be installed before "
 "continuing your Cacti install."
 msgstr ""
 
-#: ../install/index.php:668
+#: ../install/index.php:542
 msgid "Optional Modules"
 msgstr ""
 
-#: ../install/index.php:669
+#: ../install/index.php:543
 msgid "Optional"
 msgstr ""
 
-#: ../install/index.php:679
+#: ../install/index.php:553
 msgid ""
 "These MySQL performance tuning settings will help your Cacti system perform "
 "better without issues for a longer time."
 msgstr ""
 
-#: ../install/index.php:681
+#: ../install/index.php:555
 msgid "Recommended MySQL System Variable Settings"
 msgstr ""
 
-#: ../install/index.php:686
+#: ../install/index.php:560
 msgid "Installation Type"
 msgstr ""
 
-#: ../install/index.php:688
+#: ../install/index.php:562
 msgid "Please select the type of installation"
 msgstr ""
 
-#: ../install/index.php:690
+#: ../install/index.php:564
 msgid "Note that when upgrading, you only will receive the Upgrade selection."
 msgstr ""
 
-#: ../install/index.php:692
+#: ../install/index.php:566
 msgid "You have three Cacti installation options to choose from:"
 msgstr ""
 
-#: ../install/index.php:695
+#: ../install/index.php:569
 msgid "Choose this for the Primary Cacti Web Site."
 msgstr ""
 
-#: ../install/index.php:695 ../install/index.php:709
+#: ../install/index.php:569 ../install/index.php:583
 msgid "New Primary Server"
 msgstr ""
 
-#: ../install/index.php:696 ../install/index.php:710
+#: ../install/index.php:570 ../install/index.php:584
 msgid "New Remote Poller"
 msgstr ""
 
-#: ../install/index.php:696
+#: ../install/index.php:570
 msgid ""
 "Remote Pollers are used to access networks that are not readily accessible "
 "to the Primary Cacti Web Site."
 msgstr ""
 
-#: ../install/index.php:697 ../install/index.php:703
+#: ../install/index.php:571 ../install/index.php:577
 msgid "Upgrade Previous Cacti"
 msgstr ""
 
-#: ../install/index.php:697
+#: ../install/index.php:571
 msgid "Use this option to upgrade a previous release of Cacti"
 msgstr ""
 
-#: ../install/index.php:716
+#: ../install/index.php:590
 msgid ""
 "WARNING - If you are upgrading from a previous version please close all "
 "Cacti browser sessions and clear cache before continuing"
 msgstr ""
 
-#: ../install/index.php:719
+#: ../install/index.php:593
 msgid ""
 "The following information has been determined from Cacti's configuration "
 "file. If it is not correct, please edit \"include/config.php\" before "
 "continuing."
 msgstr ""
 
-#: ../install/index.php:723
+#: ../install/index.php:597
 msgid "Local Cacti database connection information"
 msgstr ""
 
-#: ../install/index.php:725 ../install/index.php:754
+#: ../install/index.php:599 ../install/index.php:628
 #, php-format
 msgid "Database: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:726 ../install/index.php:755
+#: ../install/index.php:600 ../install/index.php:629
 #, php-format
 msgid "Database User: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:727 ../install/index.php:756
+#: ../install/index.php:601 ../install/index.php:630
 #, php-format
 msgid "Database Hostname: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:728 ../install/index.php:757
+#: ../install/index.php:602 ../install/index.php:631
 #, php-format
 msgid "Port: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:729 ../install/index.php:758
+#: ../install/index.php:603 ../install/index.php:632
 #, php-format
 msgid "Server Operating System Type: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:752 ../install/index.php:761
+#: ../install/index.php:626 ../install/index.php:635
 msgid "Remote Poller Cacti database connection information"
 msgstr ""
 
-#: ../install/index.php:764
+#: ../install/index.php:638
 msgid ""
 "Your config.php file must be writable by \n"
 "\t\t\t\t\t\t\t\t\tthe web server during install in order to configure the "
@@ -10695,7 +10723,7 @@ msgid ""
 "\t\t\t\t\t\t\t\t\tpossible security issues."
 msgstr ""
 
-#: ../install/index.php:772
+#: ../install/index.php:646
 msgid ""
 "Your Remote Cacti Poller information has not \n"
 "\t\t\t\t\t\t\t\t\tbeen included in your config.php file.  Please review the "
@@ -10707,15 +10735,15 @@ msgid ""
 "\t\t\t\t\t\t\t\t\tCorrect this and try again."
 msgstr ""
 
-#: ../install/index.php:778
+#: ../install/index.php:652
 msgid "The variables that must be set include the following:"
 msgstr ""
 
-#: ../install/index.php:789
+#: ../install/index.php:663
 msgid "You must also set the $poller_id variable in the config.php."
 msgstr ""
 
-#: ../install/index.php:791
+#: ../install/index.php:665
 msgid ""
 "Once you have the variables set in the config.php file, you must also\n"
 "\t\t\t\t\t\t\t\t\tgrant the $rdatabase_username access to the Cacti "
@@ -10726,31 +10754,31 @@ msgid ""
 "install."
 msgstr ""
 
-#: ../install/index.php:815 ../install/index.php:831 ../lib/html.php:398
+#: ../install/index.php:689 ../install/index.php:705 ../lib/html.php:342
 msgid "Next"
 msgstr ""
 
-#: ../install/index.php:840
+#: ../install/index.php:714
 msgid "Upgrade"
 msgstr ""
 
-#: ../install/index.php:853
+#: ../install/index.php:727
 msgid "Remote Database: "
 msgstr ""
 
-#: ../install/index.php:864
+#: ../install/index.php:738
 msgid "Critical Binary Locations and Versions"
 msgstr ""
 
-#: ../install/index.php:866
+#: ../install/index.php:740
 msgid "Make sure all of these values are correct before continuing."
 msgstr ""
 
-#: ../install/index.php:924
+#: ../install/index.php:798
 msgid "Directory Permission Checks"
 msgstr ""
 
-#: ../install/index.php:926
+#: ../install/index.php:800
 msgid ""
 "Please ensure the directory permissions below are correct before "
 "proceeding.  During the install, these directories need to be owned by the "
@@ -10761,69 +10789,68 @@ msgid ""
 "be used from the command line after the install is complete."
 msgstr ""
 
-#: ../install/index.php:929
+#: ../install/index.php:803
 msgid ""
 "After the install is complete, you can make some of these directories read "
 "only to increase security."
 msgstr ""
 
-#: ../install/index.php:931
+#: ../install/index.php:805
 msgid ""
 "These directories will be required to stay read writable after the install "
 "so that the Cacti remote synchronization process can update them as the Main "
 "Cacti Web Site changes"
 msgstr ""
 
-#: ../install/index.php:962
+#: ../install/index.php:836
 msgid "Required Writable at Install Time Only"
 msgstr ""
 
-#: ../install/index.php:965 ../install/index.php:975 ../install/index.php:985
+#: ../install/index.php:839 ../install/index.php:849 ../install/index.php:859
 msgid "Writable"
 msgstr ""
 
-#: ../install/index.php:967 ../install/index.php:977 ../install/index.php:987
+#: ../install/index.php:841 ../install/index.php:851 ../install/index.php:861
 msgid "Not Writable"
 msgstr ""
 
-#: ../install/index.php:972 ../install/index.php:982
+#: ../install/index.php:846 ../install/index.php:856
 msgid "Required Writable after Install Complete"
 msgstr ""
 
-#: ../install/index.php:995
+#: ../install/index.php:869
 #, php-format
 msgid ""
 "Make sure your webserver has read and write access to the entire folder "
 "structure.<br> Example: chown -R apache.apache %s/resource/"
 msgstr ""
 
-#: ../install/index.php:996
+#: ../install/index.php:870
 msgid ""
 "For SELINUX-users make sure that you have the correct permissions or set "
 "'setenforce 0' temporarily."
 msgstr ""
 
-#: ../install/index.php:998
+#: ../install/index.php:872
 msgid "Check Permissions"
 msgstr ""
 
-#: ../install/index.php:1000
+#: ../install/index.php:874
 msgid "All folders are writable"
 msgstr ""
 
-#: ../install/index.php:1006
+#: ../install/index.php:880
 msgid ""
 "If you are installing packages, once the packages are installed, you should "
 "change the scripts directory back to read only as this presents some "
 "exposure to the web site."
 msgstr ""
 
-#: ../install/index.php:1006 ../install/index.php:1012
-#: ../install/index.php:1048
+#: ../install/index.php:880 ../install/index.php:886 ../install/index.php:922
 msgid "NOTE:"
 msgstr ""
 
-#: ../install/index.php:1012
+#: ../install/index.php:886
 msgid ""
 "For remote pollers, it is critical that\n"
 "\t\t\t\t\t\t\t\tthe paths that you will be updating frequently, including "
@@ -10833,11 +10860,11 @@ msgid ""
 "\t\t\t\t\t\t\t\tupdate these paths from the main web server content."
 msgstr ""
 
-#: ../install/index.php:1022
+#: ../install/index.php:896
 msgid "Template Setup"
 msgstr ""
 
-#: ../install/index.php:1024
+#: ../install/index.php:898
 msgid ""
 "Please select the Device Templates that you wish to use after the Install.  "
 "If you Operating System is Windows, you need to ensure that you select the "
@@ -10845,7 +10872,7 @@ msgid ""
 "sure you select the 'Local Linux Machine' Device Template."
 msgstr ""
 
-#: ../install/index.php:1026
+#: ../install/index.php:900
 msgid ""
 "Device Templates allow you to monitor and graph a vast assortment of data "
 "within Cacti.  After you select the desired Device Templates, press 'Finish' "
@@ -10853,45 +10880,45 @@ msgid ""
 "importation of the Device Templates can take a few minutes."
 msgstr ""
 
-#: ../install/index.php:1032 ../plugins.php:378
+#: ../install/index.php:906 ../plugins.php:378
 msgid "Author"
 msgstr ""
 
-#: ../install/index.php:1032
+#: ../install/index.php:906
 msgid "Homepage"
 msgstr ""
 
-#: ../install/index.php:1050
+#: ../install/index.php:924
 msgid ""
 "Press 'Finish' to complete the installation process after selecting your "
 "Device Templates."
 msgstr ""
 
-#: ../install/index.php:1054
+#: ../install/index.php:928
 msgid "Upgrade Results"
 msgstr ""
 
-#: ../install/index.php:1056
+#: ../install/index.php:930
 msgid "You Cacti database has been upgraded.  You can view the results below."
 msgstr ""
 
-#: ../install/index.php:1063
+#: ../install/index.php:938
 msgid "[Fail]"
 msgstr ""
 
-#: ../install/index.php:1064
+#: ../install/index.php:939
 msgid "[Success]"
 msgstr ""
 
-#: ../install/index.php:1065
+#: ../install/index.php:940
 msgid "[Not Ran]"
 msgstr ""
 
-#: ../install/index.php:1091
+#: ../install/index.php:965
 msgid "No SQL queries have been executed."
 msgstr ""
 
-#: ../install/index.php:1095
+#: ../install/index.php:969
 msgid ""
 "One or more of the SQL queries needed to upgraded your Cacti installation "
 "has failed. Please see below for more details. Your Cacti MySQL user must "
@@ -10900,53 +10927,53 @@ msgid ""
 "to ensure that you do not have a permissions problem."
 msgstr ""
 
-#: ../install/index.php:1095 ../utilities.php:2003 ../utilities.php:2004
-#: ../utilities.php:2007 ../utilities.php:2008
+#: ../install/index.php:969 ../utilities.php:2010 ../utilities.php:2011
+#: ../utilities.php:2014 ../utilities.php:2015
 msgid "WARNING:"
 msgstr ""
 
-#: ../install/index.php:1102
+#: ../install/index.php:976
 msgid "Important Upgrade Notice"
 msgstr ""
 
-#: ../install/index.php:1103
+#: ../install/index.php:977
 msgid ""
 "Before you continue with the installation, you <strong>must</strong> update "
 "your <tt>/etc/crontab</tt> file to point to <tt>poller.php</tt> instead of "
 "<tt>cmd.php</tt>."
 msgstr ""
 
-#: ../install/index.php:1104
+#: ../install/index.php:978
 msgid ""
 "See the sample crontab entry below with the change made in red. Your crontab "
 "line will look slightly different based upon your setup."
 msgstr ""
 
-#: ../install/index.php:1106
+#: ../install/index.php:980
 msgid "Once you have made this change, please click Finish to continue."
 msgstr ""
 
-#: ../install/index.php:1113
+#: ../install/index.php:987
 msgctxt "Dialog: previous"
 msgid "Previous"
 msgstr ""
 
-#: ../install/index.php:1114
+#: ../install/index.php:988
 msgctxt "Dialog: complete"
 msgid "Finish"
 msgstr ""
 
-#: ../install/index.php:1114
+#: ../install/index.php:988
 msgctxt "Dialog: go to the next page"
 msgid "Next"
 msgstr ""
 
-#: ../install/index.php:1115
+#: ../install/index.php:989
 msgctxt "Dialog: test connection"
 msgid "Test Connection"
 msgstr ""
 
-#: ../install/index.php:1115
+#: ../install/index.php:989
 msgid "Test remote database connection"
 msgstr ""
 
@@ -10972,20 +10999,24 @@ msgid ""
 "graphs."
 msgstr ""
 
-#: ../lib/api_aggregate.php:1210 ../lib/functions.php:1904
+#: ../lib/api_aggregate.php:1210 ../lib/functions.php:1915
 msgid "Graph Items"
 msgstr ""
 
-#: ../lib/api_aggregate.php:1210 ../lib/functions.php:2036
+#: ../lib/api_aggregate.php:1210 ../lib/functions.php:2047
 msgid "Graph Template Items"
 msgstr ""
 
-#: ../lib/api_aggregate.php:1214 ../lib/html.php:876
+#: ../lib/api_aggregate.php:1214 ../lib/html.php:855
 msgid "Graph Item"
 msgstr ""
 
-#: ../lib/api_aggregate.php:1217 ../lib/html.php:879
+#: ../lib/api_aggregate.php:1217 ../lib/html.php:858
 msgid "CF Type"
+msgstr ""
+
+#: ../lib/api_aggregate.php:1218 ../lib/html.php:860
+msgid "Item Color"
 msgstr ""
 
 #: ../lib/api_aggregate.php:1219
@@ -11001,9 +11032,9 @@ msgid "Matching Devices"
 msgstr ""
 
 #: ../lib/api_automation.php:139 ../lib/api_automation.php:994
-#: ../lib/html_reports.php:309 ../lib/html_reports.php:1230
-#: ../lib/html_reports.php:1486 ../lib/html_reports.php:1497
-#: ../lib/rrd.php:2631 ../utilities.php:301 ../utilities.php:2331
+#: ../lib/html_reports.php:309 ../lib/html_reports.php:1235
+#: ../lib/html_reports.php:1491 ../lib/html_reports.php:1502
+#: ../lib/rrd.php:2641 ../utilities.php:301 ../utilities.php:2338
 msgid "Type"
 msgstr ""
 
@@ -11158,8 +11189,8 @@ msgstr ""
 msgid "Contact:"
 msgstr ""
 
-#: ../lib/api_device.php:480 ../lib/functions.php:3780
-#: ../lib/functions.php:3782
+#: ../lib/api_device.php:480 ../lib/functions.php:3792
+#: ../lib/functions.php:3794
 msgid "Ping Results"
 msgstr ""
 
@@ -11171,63 +11202,65 @@ msgstr ""
 msgid "Web Basic"
 msgstr ""
 
-#: ../lib/clog_webapi.php:123
+#: ../lib/clog_webapi.php:124
 msgid ""
 "Click 'Continue' to purge the Cacti log file.<br><br><br>Note: If logging is "
 "set to Cacti and Syslog, the log information will remain in Syslog."
 msgstr ""
 
-#: ../lib/clog_webapi.php:129
+#: ../lib/clog_webapi.php:130
 msgid "Purge cacti.log"
 msgstr ""
 
-#: ../lib/clog_webapi.php:155 ../utilities.php:975
+#: ../lib/clog_webapi.php:156 ../utilities.php:975
 msgid "Log Filters"
 msgstr ""
 
-#: ../lib/clog_webapi.php:178
+#: ../lib/clog_webapi.php:183
 #, php-format
 msgid "Log [Total Lines: %d %s - Additional Filter in Affect]"
 msgstr ""
 
-#: ../lib/clog_webapi.php:180
+#: ../lib/clog_webapi.php:185
 #, php-format
 msgid "Log [Total Lines: %d %s - No Other Filter in Affect]"
 msgstr ""
 
-#: ../lib/clog_webapi.php:282 ../utilities.php:1133
-msgid "LINE LIMIT OF 1000 LINES REACHED!!"
+#: ../lib/clog_webapi.php:195 ../utilities.php:1084 ../utilities.php:1403
+#: ../utilities.php:1611 ../utilities.php:1691 ../utilities.php:2332
+#: ../utilities.php:2542
+msgid "Entries"
 msgstr ""
 
-#: ../lib/clog_webapi.php:305 ../utilities.php:984
+#: ../lib/clog_webapi.php:311 ../utilities.php:984
 msgid "Tail Lines"
 msgstr ""
 
-#: ../lib/clog_webapi.php:317 ../utilities.php:996
+#: ../lib/clog_webapi.php:327 ../utilities.php:996
 msgid "Message Type"
 msgstr ""
 
-#: ../lib/clog_webapi.php:322 ../utilities.php:1001
+#: ../lib/clog_webapi.php:332 ../utilities.php:1001
 msgid "Stats"
 msgstr ""
 
-#: ../lib/clog_webapi.php:325 ../utilities.php:1004
+#: ../lib/clog_webapi.php:335 ../utilities.php:1004
 msgid "Debug"
 msgstr ""
 
-#: ../lib/clog_webapi.php:326 ../utilities.php:1005
+#: ../lib/clog_webapi.php:336 ../utilities.php:1005
 msgid "SQL Calls"
 msgstr ""
 
-#: ../lib/clog_webapi.php:353 ../utilities.php:1032
+#: ../lib/clog_webapi.php:367 ../utilities.php:1032
 msgid "Display Order"
 msgstr ""
 
-#: ../lib/clog_webapi.php:357 ../utilities.php:1036
+#: ../lib/clog_webapi.php:371 ../utilities.php:1036
 msgid "Newest First"
 msgstr ""
 
-#: ../lib/clog_webapi.php:358 ../utilities.php:1037
+#: ../lib/clog_webapi.php:372 ../utilities.php:1037
 msgid "Oldest First"
 msgstr ""
 
@@ -11236,505 +11269,517 @@ msgstr ""
 msgid "Error %s is not readable"
 msgstr ""
 
-#: ../lib/functions.php:1790 ../lib/functions.php:1795
+#: ../lib/functions.php:1801 ../lib/functions.php:1806
 msgid "Logged in as"
 msgstr ""
 
-#: ../lib/functions.php:1790
+#: ../lib/functions.php:1801
 msgid "Login as Regular User"
 msgstr ""
 
-#: ../lib/functions.php:1790
+#: ../lib/functions.php:1801
 msgid "guest"
 msgstr ""
 
-#: ../lib/functions.php:1797
+#: ../lib/functions.php:1808
 msgid "Edit Profile"
 msgstr ""
 
-#: ../lib/functions.php:1799
+#: ../lib/functions.php:1810
 msgid "Logout"
 msgstr ""
 
-#: ../lib/functions.php:1816 ../lib/functions.php:1822
+#: ../lib/functions.php:1827 ../lib/functions.php:1833
 msgid "User Profile (Edit)"
 msgstr ""
 
-#: ../lib/functions.php:1834 ../lib/functions.php:1840
+#: ../lib/functions.php:1845 ../lib/functions.php:1851
 msgid "Tree Mode"
 msgstr ""
 
-#: ../lib/functions.php:1846
+#: ../lib/functions.php:1857
 msgid "List Mode"
 msgstr ""
 
-#: ../lib/functions.php:1868 ../lib/functions.php:1874
-#: ../lib/functions.php:2728 ../lib/html.php:1320 ../lib/html.php:1392
+#: ../lib/functions.php:1879 ../lib/functions.php:1885
+#: ../lib/functions.php:2739 ../lib/html.php:1299 ../lib/html.php:1371
 #: ../links.php:344 ../user_admin.php:1636 ../user_group_admin.php:1374
 msgid "Console"
 msgstr ""
 
-#: ../lib/functions.php:1886 ../lib/functions.php:1928
-#: ../lib/functions.php:1946 ../lib/functions.php:2000
-#: ../lib/functions.php:2012 ../lib/functions.php:2024
-#: ../lib/functions.php:2060 ../lib/functions.php:2078
-#: ../lib/functions.php:2096 ../lib/functions.php:2114
-#: ../lib/functions.php:2132 ../lib/functions.php:2156
-#: ../lib/functions.php:2192 ../lib/functions.php:2312
-#: ../lib/functions.php:2336 ../lib/functions.php:2354
-#: ../lib/functions.php:2372 ../lib/functions.php:2384
-#: ../lib/functions.php:2486 ../lib/functions.php:2510
-#: ../lib/functions.php:2528 ../lib/functions.php:2546
-#: ../lib/functions.php:2564 ../lib/functions.php:2588
+#: ../lib/functions.php:1897 ../lib/functions.php:1939
+#: ../lib/functions.php:1957 ../lib/functions.php:2011
+#: ../lib/functions.php:2023 ../lib/functions.php:2035
+#: ../lib/functions.php:2071 ../lib/functions.php:2089
+#: ../lib/functions.php:2107 ../lib/functions.php:2125
+#: ../lib/functions.php:2143 ../lib/functions.php:2167
+#: ../lib/functions.php:2203 ../lib/functions.php:2323
+#: ../lib/functions.php:2347 ../lib/functions.php:2365
+#: ../lib/functions.php:2383 ../lib/functions.php:2395
+#: ../lib/functions.php:2497 ../lib/functions.php:2521
+#: ../lib/functions.php:2539 ../lib/functions.php:2557
+#: ../lib/functions.php:2575 ../lib/functions.php:2599
 msgid "(Edit)"
 msgstr ""
 
-#: ../lib/functions.php:1910
+#: ../lib/functions.php:1921
 msgid "Create New Graphs"
 msgstr ""
 
-#: ../lib/functions.php:1916
+#: ../lib/functions.php:1927
 msgid "Create Graphs from Data Query"
 msgstr ""
 
-#: ../lib/functions.php:1934 ../lib/functions.php:1952
-#: ../lib/functions.php:2048 ../lib/functions.php:2138
-#: ../lib/functions.php:2162 ../lib/functions.php:2318
+#: ../lib/functions.php:1945 ../lib/functions.php:1963
+#: ../lib/functions.php:2059 ../lib/functions.php:2149
+#: ../lib/functions.php:2173 ../lib/functions.php:2329
 msgid "(Remove)"
 msgstr ""
 
-#: ../lib/functions.php:1970 ../lib/functions.php:1976
-#: ../lib/functions.php:1982 ../lib/functions.php:1988
-#: ../lib/functions.php:2252
+#: ../lib/functions.php:1981 ../lib/functions.php:1987
+#: ../lib/functions.php:1993 ../lib/functions.php:1999
+#: ../lib/functions.php:2263
 msgid "View Cacti Log"
 msgstr ""
 
-#: ../lib/functions.php:1994
+#: ../lib/functions.php:2005
 msgid "Graph Trees"
 msgstr ""
 
-#: ../lib/functions.php:2126
+#: ../lib/functions.php:2137
 msgid "Round Robin Archives"
 msgstr ""
 
-#: ../lib/functions.php:2168
+#: ../lib/functions.php:2179
 msgid "Data Input Fields"
 msgstr ""
 
-#: ../lib/functions.php:2174 ../lib/functions.php:2204
+#: ../lib/functions.php:2185 ../lib/functions.php:2215
 msgid "(Remove Item)"
 msgstr ""
 
-#: ../lib/functions.php:2222
+#: ../lib/functions.php:2233
 msgid "List unused Files"
 msgstr ""
 
-#: ../lib/functions.php:2234 ../lib/functions.php:2246 ../utilities.php:1773
+#: ../lib/functions.php:2245 ../lib/functions.php:2257 ../utilities.php:1780
 msgid "View Poller Cache"
 msgstr ""
 
-#: ../lib/functions.php:2240 ../utilities.php:1777
+#: ../lib/functions.php:2251 ../utilities.php:1784
 msgid "View Data Query Cache"
 msgstr ""
 
-#: ../lib/functions.php:2258 ../utilities.php:1161
+#: ../lib/functions.php:2269 ../utilities.php:1168
 msgid "Clear Cacti Log"
 msgstr ""
 
-#: ../lib/functions.php:2264 ../utilities.php:1766
+#: ../lib/functions.php:2275 ../utilities.php:1773
 msgid "View User Log"
 msgstr ""
 
-#: ../lib/functions.php:2270
+#: ../lib/functions.php:2281
 msgid "Clear User Log"
 msgstr ""
 
-#: ../lib/functions.php:2276 ../utilities.php:1757
+#: ../lib/functions.php:2287 ../utilities.php:1764
 msgid "Technical Support"
 msgstr ""
 
-#: ../lib/functions.php:2282 ../utilities.php:1870
+#: ../lib/functions.php:2293 ../utilities.php:1877
 msgid "Boost Status"
 msgstr ""
 
-#: ../lib/functions.php:2288
+#: ../lib/functions.php:2299
 msgid "View SNMP Agent Cache"
 msgstr ""
 
-#: ../lib/functions.php:2294
+#: ../lib/functions.php:2305
 msgid "View SNMP Agent Notification Log"
 msgstr ""
 
-#: ../lib/functions.php:2324
+#: ../lib/functions.php:2335
 msgid "VDEF Items"
 msgstr ""
 
-#: ../lib/functions.php:2330
+#: ../lib/functions.php:2341
 msgid "View SNMP Notification Receivers"
 msgstr ""
 
-#: ../lib/functions.php:2342
+#: ../lib/functions.php:2353
 msgid "Cacti Settings"
 msgstr ""
 
-#: ../lib/functions.php:2360 ../lib/functions.php:2390
+#: ../lib/functions.php:2371 ../lib/functions.php:2401
 msgid "(Action)"
 msgstr ""
 
-#: ../lib/functions.php:2408
+#: ../lib/functions.php:2419
 msgid "Export Results"
 msgstr ""
 
-#: ../lib/functions.php:2420 ../lib/functions.php:2450 ../lib/html.php:1341
-#: ../lib/html.php:1343 ../lib/html.php:1417
+#: ../lib/functions.php:2431 ../lib/functions.php:2461 ../lib/html.php:1320
+#: ../lib/html.php:1322 ../lib/html.php:1396
 msgid "Reporting"
 msgstr ""
 
-#: ../lib/functions.php:2426 ../lib/functions.php:2456
+#: ../lib/functions.php:2437 ../lib/functions.php:2467
 msgid "Report Add"
 msgstr ""
 
-#: ../lib/functions.php:2432 ../lib/functions.php:2462
+#: ../lib/functions.php:2443 ../lib/functions.php:2473
 msgid "Report Delete"
 msgstr ""
 
-#: ../lib/functions.php:2438 ../lib/functions.php:2468
+#: ../lib/functions.php:2449 ../lib/functions.php:2479
 msgid "Report Edit"
 msgstr ""
 
-#: ../lib/functions.php:2444 ../lib/functions.php:2474
+#: ../lib/functions.php:2455 ../lib/functions.php:2485
 msgid "Report Edit Item"
 msgstr ""
 
-#: ../lib/functions.php:2498
+#: ../lib/functions.php:2509
 msgid "Color Template Items"
 msgstr ""
 
-#: ../lib/functions.php:2540
+#: ../lib/functions.php:2551
 msgid "Aggregate Items"
 msgstr ""
 
-#: ../lib/functions.php:2576
+#: ../lib/functions.php:2587
 msgid "Graph Rule Items"
 msgstr ""
 
-#: ../lib/functions.php:2600
+#: ../lib/functions.php:2611
 msgid "Tree Rule Items"
 msgstr ""
 
-#: ../lib/functions.php:2699
+#: ../lib/functions.php:2696
+msgid "Leaf"
+msgstr ""
+
+#: ../lib/functions.php:2710
 msgid "Non Query Based"
 msgstr ""
 
-#: ../lib/functions.php:3402
+#: ../lib/functions.php:3414
 msgid ""
 "Mailer Error: No <b>TO</b> address set!!<br>If using the <i>Test Mail</i> "
 "link, please set the <b>Alert e-mail</b> setting."
 msgstr ""
 
-#: ../lib/functions.php:3714
+#: ../lib/functions.php:3726
 #, php-format
 msgid "Authentication failed: %s"
 msgstr ""
 
-#: ../lib/functions.php:3718
+#: ../lib/functions.php:3730
 #, php-format
 msgid "HELO failed: %s"
 msgstr ""
 
-#: ../lib/functions.php:3721
+#: ../lib/functions.php:3733
 #, php-format
 msgid "Connect failed: %s"
 msgstr ""
 
-#: ../lib/functions.php:3724
+#: ../lib/functions.php:3736
 msgid "SMTP error: "
 msgstr ""
 
-#: ../lib/functions.php:3737
+#: ../lib/functions.php:3749
 msgid ""
 "This is a test message generated from Cacti.  This message was sent to test "
 "the configuration of your Mail Settings."
 msgstr ""
 
-#: ../lib/functions.php:3738
+#: ../lib/functions.php:3750
 msgid "Your email settings are currently set as follows"
 msgstr ""
 
-#: ../lib/functions.php:3739
+#: ../lib/functions.php:3751
 msgid "Method"
 msgstr ""
 
-#: ../lib/functions.php:3741
+#: ../lib/functions.php:3753
 msgid "Checking Configuration...<br>"
 msgstr ""
 
-#: ../lib/functions.php:3748
+#: ../lib/functions.php:3760
 msgid "PHP's Mailer Class"
 msgstr ""
 
-#: ../lib/functions.php:3754
+#: ../lib/functions.php:3766
 msgid "Method: SMTP"
 msgstr ""
 
-#: ../lib/functions.php:3769
+#: ../lib/functions.php:3781
 msgid "Not Shown for Security Reasons"
 msgstr ""
 
-#: ../lib/functions.php:3770
+#: ../lib/functions.php:3782
 msgid "Security"
 msgstr ""
 
-#: ../lib/functions.php:3777
+#: ../lib/functions.php:3789
 msgid "Ping Results:"
 msgstr ""
 
-#: ../lib/functions.php:3790
+#: ../lib/functions.php:3802
 msgid "Creating Message Text..."
 msgstr ""
 
-#: ../lib/functions.php:3793
+#: ../lib/functions.php:3805
 msgid "Sending Message..."
 msgstr ""
 
-#: ../lib/functions.php:3797
+#: ../lib/functions.php:3809
 msgid "Cacti Test Message"
 msgstr ""
 
-#: ../lib/functions.php:3799
+#: ../lib/functions.php:3811
 msgid "Success!"
 msgstr ""
 
-#: ../lib/functions.php:3802
+#: ../lib/functions.php:3814
 msgid "Message Not Sent due to ping failure."
 msgstr ""
 
-#: ../lib/html.php:128 ../lib/html_tree.php:579 ../lib/html_tree.php:582
-#: ../lib/html_tree.php:585
-msgid "Graph Template:"
-msgstr ""
-
-#: ../lib/html.php:157 ../lib/html.php:289
+#: ../lib/html.php:233
 msgid "Data Query:"
 msgstr ""
 
-#: ../lib/html.php:349
+#: ../lib/html.php:293
 msgid "CSV Export of Graph Data"
 msgstr ""
 
-#: ../lib/html.php:350
+#: ../lib/html.php:294
 msgid "Time Graph View"
 msgstr ""
 
-#: ../lib/html.php:352
+#: ../lib/html.php:296
 msgid "Click to view just this Graph in Real-time"
 msgstr ""
 
-#: ../lib/html.php:355
+#: ../lib/html.php:299
 msgid "Kill Spikes in Graphs"
 msgstr ""
 
-#: ../lib/html.php:392
+#: ../lib/html.php:336
 msgid "Previous"
 msgstr ""
 
-#: ../lib/html.php:395
+#: ../lib/html.php:339
 #, php-format
 msgid "%d to %d of %s [ %s ]"
 msgstr ""
 
-#: ../lib/html.php:404
+#: ../lib/html.php:348
 #, php-format
 msgid "All %d %s"
 msgstr ""
 
-#: ../lib/html.php:410
+#: ../lib/html.php:354
 #, php-format
 msgid "No %s Found"
 msgstr ""
 
-#: ../lib/html.php:722 ../lib/html.php:782
+#: ../lib/html.php:674 ../lib/html.php:761
 msgid "Select All Rows"
 msgstr ""
 
-#: ../lib/html.php:880
+#: ../lib/html.php:859
 msgid "Alpha %"
 msgstr ""
 
-#: ../lib/html.php:921
+#: ../lib/html.php:900
 msgid "No Task"
 msgstr ""
 
-#: ../lib/html.php:1165
+#: ../lib/html.php:1144
 msgid "Choose an action"
 msgstr ""
 
-#: ../lib/html.php:1175
+#: ../lib/html.php:1154
 msgid "Execute Action"
 msgstr ""
 
-#: ../lib/html.php:1350 ../lib/html.php:1352 ../lib/html.php:1428
+#: ../lib/html.php:1329 ../lib/html.php:1331 ../lib/html.php:1407
 msgid "Cacti Log"
 msgstr ""
 
-#: ../lib/html.php:1742
+#: ../lib/html.php:1721
 msgid "Nan's"
 msgstr ""
 
-#: ../lib/html.php:1746
+#: ../lib/html.php:1725
 msgid "Standard Deviations"
 msgstr ""
 
-#: ../lib/html.php:1748
+#: ../lib/html.php:1727
 #, php-format
 msgid "%s Standard Deviations"
 msgstr ""
 
-#: ../lib/html.php:1758
+#: ../lib/html.php:1737
 msgid "Variance Outliers"
 msgstr ""
 
-#: ../lib/html.php:1760
+#: ../lib/html.php:1739
 #, php-format
 msgid "%d Outliers"
 msgstr ""
 
-#: ../lib/html.php:1764
+#: ../lib/html.php:1743
 msgid "Kills Per RRA"
 msgstr ""
 
-#: ../lib/html.php:1766
+#: ../lib/html.php:1745
 #, php-format
 msgid "%d Spikes"
 msgstr ""
 
-#: ../lib/html.php:1773
+#: ../lib/html.php:1752
 msgid "Remove StdDev"
 msgstr ""
 
-#: ../lib/html.php:1774
+#: ../lib/html.php:1753
 msgid "Remove Variance"
 msgstr ""
 
-#: ../lib/html.php:1775
+#: ../lib/html.php:1754
 msgid "Gap Fill Range"
 msgstr ""
 
-#: ../lib/html.php:1776
+#: ../lib/html.php:1755
 msgid "Float Range"
 msgstr ""
 
-#: ../lib/html.php:1777
+#: ../lib/html.php:1756
 msgid "Dry Run StdDev"
 msgstr ""
 
-#: ../lib/html.php:1778
+#: ../lib/html.php:1757
 msgid "Dry Run Variance"
 msgstr ""
 
-#: ../lib/html.php:1779
+#: ../lib/html.php:1758
 msgid "Dry Run Gap Fill Range"
 msgstr ""
 
-#: ../lib/html.php:1780
+#: ../lib/html.php:1759
 msgid "Dry Run Float Range"
 msgstr ""
 
-#: ../lib/html_form.php:463
+#: ../lib/html_filter.php:82
+msgid "Apply filter to table"
+msgstr ""
+
+#: ../lib/html_filter.php:87
+msgid "Reset filter to default values"
+msgstr ""
+
+#: ../lib/html_form.php:509
 msgid "File Found"
 msgstr ""
 
-#: ../lib/html_form.php:465
+#: ../lib/html_form.php:511
 msgid "Path is a Directory and not a File"
 msgstr ""
 
-#: ../lib/html_form.php:469
+#: ../lib/html_form.php:515
 msgid "File is Not Found"
 msgstr ""
 
-#: ../lib/html_form.php:472
+#: ../lib/html_form.php:518
 msgid "Enter a valid file path"
 msgstr ""
 
-#: ../lib/html_form.php:508
+#: ../lib/html_form.php:554
 msgid "Directory Found"
 msgstr ""
 
-#: ../lib/html_form.php:510
+#: ../lib/html_form.php:556
 msgid "Path is a File and not a Directory"
 msgstr ""
 
-#: ../lib/html_form.php:514
+#: ../lib/html_form.php:560
 msgid "Directory is Not found"
 msgstr ""
 
-#: ../lib/html_form.php:517
+#: ../lib/html_form.php:563
 msgid "Enter a valid directory path"
 msgstr ""
 
-#: ../lib/html_form.php:1012
+#: ../lib/html_form.php:1056
 msgid "NO FONT VERIFICATION POSSIBLE"
 msgstr ""
 
-#: ../lib/html_graph.php:197 ../lib/html_tree.php:648
+#: ../lib/html_form_template.php:562 ../lib/html_form_template.php:577
+#, php-format
+msgid "Data Query Data Sources must be created through %s"
+msgstr ""
+
+#: ../lib/html_graph.php:197 ../lib/html_tree.php:649
 msgid ""
 "Save the current Graphs, Columns, Thumbnail, Preset, and Timeshift "
 "preferences to your profile"
 msgstr ""
 
-#: ../lib/html_graph.php:226 ../lib/html_tree.php:671
+#: ../lib/html_graph.php:226 ../lib/html_tree.php:672
 msgid "Columns"
 msgstr ""
 
-#: ../lib/html_graph.php:230 ../lib/html_tree.php:675
+#: ../lib/html_graph.php:230 ../lib/html_tree.php:676
 #, php-format
 msgid "%d Column"
 msgstr ""
 
 #: ../lib/html_graph.php:239 ../lib/html_reports.php:125
-#: ../lib/html_tree.php:684
+#: ../lib/html_tree.php:685
 msgid "Thumbnails"
 msgstr ""
 
-#: ../lib/html_graph.php:261 ../lib/html_tree.php:706
+#: ../lib/html_graph.php:261 ../lib/html_tree.php:707
 msgid "Custom"
 msgstr ""
 
-#: ../lib/html_graph.php:282 ../lib/html_reports.php:1484
-#: ../lib/html_reports.php:1495 ../lib/html_tree.php:727
+#: ../lib/html_graph.php:282 ../lib/html_reports.php:1489
+#: ../lib/html_reports.php:1500 ../lib/html_tree.php:728
 msgid "From"
 msgstr ""
 
-#: ../lib/html_graph.php:288 ../lib/html_tree.php:733
+#: ../lib/html_graph.php:288 ../lib/html_tree.php:734
 msgid "Start Date Selector"
 msgstr ""
 
-#: ../lib/html_graph.php:291 ../lib/html_reports.php:1485
-#: ../lib/html_reports.php:1496 ../lib/html_tree.php:736
+#: ../lib/html_graph.php:291 ../lib/html_reports.php:1490
+#: ../lib/html_reports.php:1501 ../lib/html_tree.php:737
 msgid "To"
 msgstr ""
 
-#: ../lib/html_graph.php:297 ../lib/html_tree.php:742
+#: ../lib/html_graph.php:297 ../lib/html_tree.php:743
 msgid "End Date Selector"
 msgstr ""
 
-#: ../lib/html_graph.php:300 ../lib/html_tree.php:745
+#: ../lib/html_graph.php:300 ../lib/html_tree.php:746
 msgid "Shift Time Backward"
 msgstr ""
 
-#: ../lib/html_graph.php:303 ../lib/html_tree.php:748
+#: ../lib/html_graph.php:303 ../lib/html_tree.php:749
 msgid "Define Shifting Interval"
 msgstr ""
 
-#: ../lib/html_graph.php:316 ../lib/html_tree.php:761
+#: ../lib/html_graph.php:316 ../lib/html_tree.php:762
 msgid "Shift Time Forward"
 msgstr ""
 
-#: ../lib/html_graph.php:319 ../lib/html_tree.php:764
+#: ../lib/html_graph.php:319 ../lib/html_tree.php:765
 msgid "Refresh selected time span"
 msgstr ""
 
-#: ../lib/html_graph.php:322 ../lib/html_tree.php:767
+#: ../lib/html_graph.php:322 ../lib/html_tree.php:768
 msgid "Return to the default time span"
 msgstr ""
 
@@ -11742,11 +11787,11 @@ msgstr ""
 msgid "Interval"
 msgstr ""
 
-#: ../lib/html_graph.php:351 ../lib/html_tree.php:796
+#: ../lib/html_graph.php:351 ../lib/html_tree.php:797
 msgid "Stop"
 msgstr ""
 
-#: ../lib/html_reports.php:35 ../lib/html_reports.php:1479
+#: ../lib/html_reports.php:35 ../lib/html_reports.php:1484
 msgid "Report Name"
 msgstr ""
 
@@ -11881,10 +11926,10 @@ msgstr ""
 
 #: ../lib/html_reports.php:157
 msgid ""
-"e.g. If the Report Interval is 'Month(s)', then '2' indicates Every '2 Month"
-"(s) from the next Mailtime.' Lastly, if using the Month(s) Report Intervals, "
-"the 'Day of Week' and the 'Day of Month' are both calculated based upon the "
-"Mailtime you specify above."
+"e.g. If the Report Interval is 'Month(s)', then '2' indicates Every '2 "
+"Month(s) from the next Mailtime.' Lastly, if using the Month(s) Report "
+"Intervals, the 'Day of Week' and the 'Day of Month' are both calculated "
+"based upon the Mailtime you specify above."
 msgstr ""
 
 #: ../lib/html_reports.php:165
@@ -11999,7 +12044,7 @@ msgstr ""
 msgid "Graph Start Time equals Graph End Time minus given timespan"
 msgstr ""
 
-#: ../lib/html_reports.php:406 ../lib/html_reports.php:1230
+#: ../lib/html_reports.php:406 ../lib/html_reports.php:1235
 msgid "Alignment"
 msgstr ""
 
@@ -12015,7 +12060,7 @@ msgstr ""
 msgid "Enter descriptive Text"
 msgstr ""
 
-#: ../lib/html_reports.php:420 ../lib/html_reports.php:1230
+#: ../lib/html_reports.php:420 ../lib/html_reports.php:1235
 msgid "Font Size"
 msgstr ""
 
@@ -12023,221 +12068,227 @@ msgstr ""
 msgid "Font Size of the Item"
 msgstr ""
 
-#: ../lib/html_reports.php:484
+#: ../lib/html_reports.php:485
 msgid "Date/Time moved to the same time Tomorrow"
 msgstr ""
 
-#: ../lib/html_reports.php:666
+#: ../lib/html_reports.php:668
 msgid "You must select at least one Report."
 msgstr ""
 
-#: ../lib/html_reports.php:674
+#: ../lib/html_reports.php:676
 msgid "Click 'Continue' to delete the following Report(s)."
 msgstr ""
 
-#: ../lib/html_reports.php:681
+#: ../lib/html_reports.php:683
 msgid "Click 'Continue' to take ownership of the following Report(s)."
 msgstr ""
 
-#: ../lib/html_reports.php:688
+#: ../lib/html_reports.php:690
 msgid ""
 "Click 'Continue' to duplicate the following Report(s).  You may optionally "
 "change the title for the new Reports"
 msgstr ""
 
-#: ../lib/html_reports.php:690
+#: ../lib/html_reports.php:692
 msgid "Name Format:"
 msgstr ""
 
-#: ../lib/html_reports.php:700
+#: ../lib/html_reports.php:702
 msgid "Click 'Continue' to enable the following Report(s)."
 msgstr ""
 
-#: ../lib/html_reports.php:702
+#: ../lib/html_reports.php:704
 msgid ""
 "Please be certain that those Report(s) have successfully been tested first!"
 msgstr ""
 
-#: ../lib/html_reports.php:708
+#: ../lib/html_reports.php:710
 msgid "Click 'Continue' to disable the following Reports."
 msgstr ""
 
-#: ../lib/html_reports.php:715
+#: ../lib/html_reports.php:717
 msgid "Click 'Continue' to send the following Report(s) now."
 msgstr ""
 
-#: ../lib/html_reports.php:761
+#: ../lib/html_reports.php:763
 #, php-format
 msgid "Unable to send Report '%d'.  Please set destination e-mail addresses"
 msgstr ""
 
-#: ../lib/html_reports.php:766
+#: ../lib/html_reports.php:768
 #, php-format
 msgid "Unable to send Report '%s'.  Please set an e-mail subject"
 msgstr ""
 
-#: ../lib/html_reports.php:771
+#: ../lib/html_reports.php:773
 #, php-format
 msgid "Unable to send Report '%s'.  Please set an e-mail From Name"
 msgstr ""
 
-#: ../lib/html_reports.php:776
+#: ../lib/html_reports.php:778
 #, php-format
 msgid "Unable to send Report '%s'.  Please set an e-mail from address"
 msgstr ""
 
-#: ../lib/html_reports.php:1084 ../user_admin.php:1920
+#: ../lib/html_reports.php:834
+#, php-format
+msgid "Report Item [edit Report: %s]"
+msgstr ""
+
+#: ../lib/html_reports.php:836
+#, php-format
+msgid "Report Item [new Report: %s]"
+msgstr ""
+
+#: ../lib/html_reports.php:1087 ../user_admin.php:1920
 #, php-format
 msgid "[edit: %s]"
 msgstr ""
 
-#: ../lib/html_reports.php:1085
+#: ../lib/html_reports.php:1088
 msgid "Events"
 msgstr ""
 
-#: ../lib/html_reports.php:1087 ../lib/import.php:1799 ../user_admin.php:1922
+#: ../lib/html_reports.php:1090 ../lib/import.php:1803 ../user_admin.php:1922
 msgid "[new]"
 msgstr ""
 
-#: ../lib/html_reports.php:1119
+#: ../lib/html_reports.php:1122
 msgid "Send Report"
 msgstr ""
 
-#: ../lib/html_reports.php:1128
-msgid "Report Details"
-msgstr ""
-
-#: ../lib/html_reports.php:1174
-msgid "Report Items"
-msgstr ""
-
-#: ../lib/html_reports.php:1195
+#: ../lib/html_reports.php:1200
 msgid "Scheduled Events"
 msgstr ""
 
-#: ../lib/html_reports.php:1206
+#: ../lib/html_reports.php:1211
 msgid "Report Preview"
 msgstr ""
 
-#: ../lib/html_reports.php:1230
+#: ../lib/html_reports.php:1235
 msgid "Item Details"
 msgstr ""
 
-#: ../lib/html_reports.php:1230
+#: ../lib/html_reports.php:1235
 msgid "Timespan"
 msgstr ""
 
-#: ../lib/html_reports.php:1265
+#: ../lib/html_reports.php:1270
 msgid "(All Branches)"
 msgstr ""
 
-#: ../lib/html_reports.php:1267
+#: ../lib/html_reports.php:1272
 msgid "(Current Branch)"
 msgstr ""
 
-#: ../lib/html_reports.php:1302
+#: ../lib/html_reports.php:1307
 msgid "No Report Items"
 msgstr ""
 
-#: ../lib/html_reports.php:1376
+#: ../lib/html_reports.php:1381
 msgid "Administrator Level"
 msgstr ""
 
-#: ../lib/html_reports.php:1376
+#: ../lib/html_reports.php:1381
 #, php-format
 msgid "Reports [%s]"
 msgstr ""
 
-#: ../lib/html_reports.php:1376
+#: ../lib/html_reports.php:1381
 msgid "User Level"
 msgstr ""
 
-#: ../lib/html_reports.php:1471
+#: ../lib/html_reports.php:1476
 msgid "Reports"
 msgstr ""
 
-#: ../lib/html_reports.php:1480 ../tree.php:1562
+#: ../lib/html_reports.php:1485 ../tree.php:1562
 msgid "Owner"
 msgstr ""
 
-#: ../lib/html_reports.php:1481 ../lib/html_reports.php:1492
+#: ../lib/html_reports.php:1486 ../lib/html_reports.php:1497
 msgid "Frequency"
 msgstr ""
 
-#: ../lib/html_reports.php:1482 ../lib/html_reports.php:1493
+#: ../lib/html_reports.php:1487 ../lib/html_reports.php:1498
 msgid "Last Run"
 msgstr ""
 
-#: ../lib/html_reports.php:1483 ../lib/html_reports.php:1494
+#: ../lib/html_reports.php:1488 ../lib/html_reports.php:1499
 msgid "Next Run"
 msgstr ""
 
-#: ../lib/html_reports.php:1491
+#: ../lib/html_reports.php:1496
 msgid "Report Title"
 msgstr ""
 
-#: ../lib/html_reports.php:1519
+#: ../lib/html_reports.php:1524
 msgid "Multiple"
 msgstr ""
 
-#: ../lib/html_reports.php:1520
+#: ../lib/html_reports.php:1525
 msgid "Invalid"
 msgstr ""
 
-#: ../lib/html_reports.php:1527
+#: ../lib/html_reports.php:1532
 msgid "No Reports Found"
 msgstr ""
 
-#: ../lib/html_tree.php:590 ../lib/reports.php:873
+#: ../lib/html_tree.php:580 ../lib/html_tree.php:583 ../lib/html_tree.php:586
+msgid "Graph Template:"
+msgstr ""
+
+#: ../lib/html_tree.php:591 ../lib/reports.php:873
 msgid "Tree:"
 msgstr ""
 
-#: ../lib/html_tree.php:591 ../lib/reports.php:878
+#: ../lib/html_tree.php:592 ../lib/reports.php:878
 msgid "Leaf:"
 msgstr ""
 
-#: ../lib/html_tree.php:592
+#: ../lib/html_tree.php:593
 msgid "Device:"
 msgstr ""
 
-#: ../lib/html_tree.php:595
+#: ../lib/html_tree.php:596
 msgid "Applied"
 msgstr ""
 
-#: ../lib/html_tree.php:595
+#: ../lib/html_tree.php:596
 msgid "Filter"
 msgstr ""
 
-#: ../lib/html_tree.php:595
+#: ../lib/html_tree.php:596
 msgid "Graph Filters"
 msgstr ""
 
-#: ../lib/html_tree.php:641
+#: ../lib/html_tree.php:642
 msgid "Set/Refresh Filter"
 msgstr ""
 
-#: ../lib/html_utility.php:427 ../lib/html_utility.php:643
+#: ../lib/html_utility.php:419 ../lib/html_utility.php:635
 #, php-format
 msgid "The search term \"%s\" is not valid. Error is %s"
 msgstr ""
 
-#: ../lib/html_utility.php:754
+#: ../lib/html_utility.php:766
 msgid "There was an internal error!"
 msgstr ""
 
-#: ../lib/html_utility.php:755
+#: ../lib/html_utility.php:767
 msgid "Backtrack limit was exhausted!"
 msgstr ""
 
-#: ../lib/html_utility.php:756
+#: ../lib/html_utility.php:768
 msgid "Recursion limit was exhausted!"
 msgstr ""
 
-#: ../lib/html_utility.php:757
+#: ../lib/html_utility.php:769
 msgid "Bad UTF-8 error!"
 msgstr ""
 
-#: ../lib/html_utility.php:758
+#: ../lib/html_utility.php:770
 msgid "Bad UTF-8 offset error!"
 msgstr ""
 
@@ -12261,63 +12312,63 @@ msgstr ""
 msgid "writable"
 msgstr ""
 
-#: ../lib/import.php:1760
+#: ../lib/import.php:1764
 msgid "Import Preview Results"
 msgstr ""
 
-#: ../lib/import.php:1760
+#: ../lib/import.php:1764
 msgid "Import Results"
 msgstr ""
 
-#: ../lib/import.php:1764
+#: ../lib/import.php:1768
 msgid "Cacti would make the following changes if the Package was imported:"
 msgstr ""
 
-#: ../lib/import.php:1766
+#: ../lib/import.php:1770
 msgid "Cacti has imported the following items for the Package:"
 msgstr ""
 
-#: ../lib/import.php:1769
+#: ../lib/import.php:1773
 msgid "Package Files"
 msgstr ""
 
-#: ../lib/import.php:1773
+#: ../lib/import.php:1777
 msgid "[preview] "
 msgstr ""
 
-#: ../lib/import.php:1778
+#: ../lib/import.php:1782
 msgid "Cacti would make the following changes if the Template was imported:"
 msgstr ""
 
-#: ../lib/import.php:1780
+#: ../lib/import.php:1784
 msgid "Cacti has imported the following items for the Template:"
 msgstr ""
 
-#: ../lib/import.php:1789
+#: ../lib/import.php:1793
 msgid "[success]"
 msgstr ""
 
-#: ../lib/import.php:1791
+#: ../lib/import.php:1795
 msgid "[fail]"
 msgstr ""
 
-#: ../lib/import.php:1793
+#: ../lib/import.php:1797
 msgid "[preview]"
 msgstr ""
 
-#: ../lib/import.php:1797
+#: ../lib/import.php:1801
 msgid "[updated]"
 msgstr ""
 
-#: ../lib/import.php:1801
+#: ../lib/import.php:1805
 msgid "[unchanged]"
 msgstr ""
 
-#: ../lib/import.php:1837
+#: ../lib/import.php:1841
 msgid "Found Dependency:"
 msgstr ""
 
-#: ../lib/import.php:1839
+#: ../lib/import.php:1843
 msgid "Unmet Dependency:"
 msgstr ""
 
@@ -12475,7 +12526,7 @@ msgstr ""
 msgid "Plugin cannot be installed."
 msgstr ""
 
-#: ../lib/plugins.php:763 ../lib/plugins.php:770
+#: ../lib/plugins.php:763 ../lib/plugins.php:770 ../plugins.php:267
 msgid "Plugin Management"
 msgstr ""
 
@@ -12533,172 +12584,172 @@ msgstr ""
 msgid "Required RRD step size is '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2422
+#: ../lib/rrd.php:2440
 #, php-format
 msgid "Type for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2427
+#: ../lib/rrd.php:2445
 #, php-format
 msgid "Heartbeat for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2435
+#: ../lib/rrd.php:2453
 #, php-format
 msgid "RRD minimum for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2468
+#: ../lib/rrd.php:2477
 #, php-format
 msgid "RRD maximum for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2478
+#: ../lib/rrd.php:2487
 #, php-format
 msgid "DS '%s' missing in RRDfile"
 msgstr ""
 
-#: ../lib/rrd.php:2487
+#: ../lib/rrd.php:2496
 #, php-format
 msgid "DS '%s' missing in Cacti definition"
 msgstr ""
 
-#: ../lib/rrd.php:2504 ../lib/rrd.php:2505
+#: ../lib/rrd.php:2513 ../lib/rrd.php:2514
 #, php-format
 msgid "Cacti RRA '%s' has same CF/steps (%s, %s) as '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2519 ../lib/rrd.php:2520
+#: ../lib/rrd.php:2528 ../lib/rrd.php:2529
 #, php-format
 msgid "File RRA '%s' has same CF/steps (%s, %s) as '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2550
+#: ../lib/rrd.php:2560
 #, php-format
 msgid "XFF for cacti RRA id '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2554
+#: ../lib/rrd.php:2564
 #, php-format
 msgid "Number of rows for Cacti RRA id '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2570
+#: ../lib/rrd.php:2580
 #, php-format
 msgid "RRA '%s' missing in RRDfile"
 msgstr ""
 
-#: ../lib/rrd.php:2579
+#: ../lib/rrd.php:2589
 #, php-format
 msgid "RRA '%s' missing in Cacti definition"
 msgstr ""
 
-#: ../lib/rrd.php:2598
+#: ../lib/rrd.php:2608
 msgid "RRD File Information"
 msgstr ""
 
-#: ../lib/rrd.php:2630
+#: ../lib/rrd.php:2640
 msgid "Data Source Items"
 msgstr ""
 
-#: ../lib/rrd.php:2632
+#: ../lib/rrd.php:2642
 msgid "Minimal Heartbeat"
 msgstr ""
 
-#: ../lib/rrd.php:2633
+#: ../lib/rrd.php:2643
 msgid "Min"
 msgstr ""
 
-#: ../lib/rrd.php:2634
+#: ../lib/rrd.php:2644
 msgid "Max"
 msgstr ""
 
-#: ../lib/rrd.php:2635
+#: ../lib/rrd.php:2645
 msgid "Last DS"
 msgstr ""
 
-#: ../lib/rrd.php:2637
+#: ../lib/rrd.php:2647
 msgid "Unknown Sec"
 msgstr ""
 
-#: ../lib/rrd.php:2665
+#: ../lib/rrd.php:2675
 msgid "Round Robin Archive"
 msgstr ""
 
-#: ../lib/rrd.php:2668
+#: ../lib/rrd.php:2678
 msgid "Cur Row"
 msgstr ""
 
-#: ../lib/rrd.php:2669
+#: ../lib/rrd.php:2679
 msgid "PDP per Row"
 msgstr ""
 
-#: ../lib/rrd.php:2670
+#: ../lib/rrd.php:2680
 msgid "X Files Factor"
 msgstr ""
 
-#: ../lib/rrd.php:2671
+#: ../lib/rrd.php:2681
 msgid "CDP Prep Value (0)"
 msgstr ""
 
-#: ../lib/rrd.php:2672
+#: ../lib/rrd.php:2682
 msgid "CDP Unknown Data points (0)"
 msgstr ""
 
-#: ../lib/rrd.php:2749
+#: ../lib/rrd.php:2759
 #, php-format
 msgid "rename %s to %s"
 msgstr ""
 
-#: ../lib/rrd.php:2799
+#: ../lib/rrd.php:2809
 msgid "Error while parsing the XML of rrdtool dump"
 msgstr ""
 
-#: ../lib/rrd.php:2831 ../lib/rrd.php:2886 ../lib/rrd.php:2942
+#: ../lib/rrd.php:2841 ../lib/rrd.php:2896 ../lib/rrd.php:2952
 #, php-format
 msgid "ERROR while writing XML file: %s"
 msgstr ""
 
-#: ../lib/rrd.php:2840
+#: ../lib/rrd.php:2850
 #, php-format
 msgid "Added Data Source(s) to RRDfile: %s"
 msgstr ""
 
-#: ../lib/rrd.php:2842 ../lib/rrd.php:2897
+#: ../lib/rrd.php:2852 ../lib/rrd.php:2907
 #, php-format
 msgid "ERROR: RRDfile %s not writeable"
 msgstr ""
 
-#: ../lib/rrd.php:2869 ../lib/rrd.php:2925
+#: ../lib/rrd.php:2879 ../lib/rrd.php:2935
 msgid "Error while parsing the XML of RRDtool dump"
 msgstr ""
 
-#: ../lib/rrd.php:2895
+#: ../lib/rrd.php:2905
 #, php-format
 msgid "Deleted RRA(s) from RRDfile: %s"
 msgstr ""
 
-#: ../lib/rrd.php:2951
+#: ../lib/rrd.php:2961
 #, php-format
 msgid "Deleted rra(s) from rrd file: %s"
 msgstr ""
 
-#: ../lib/rrd.php:2953
+#: ../lib/rrd.php:2963
 #, php-format
 msgid "ERROR: RRD file %s not writeable"
 msgstr ""
 
-#: ../lib/rrd.php:3158
+#: ../lib/rrd.php:3168
 #, php-format
 msgid "RRA (CF=%s, ROWS=%d, PDP_PER_ROW=%d, XFF=%1.2f) removed from RRD file\n"
 msgstr ""
 
-#: ../lib/rrd.php:3192
+#: ../lib/rrd.php:3202
 #, php-format
 msgid "RRA (CF=%s, ROWS=%d, PDP_PER_ROW=%d, XFF=%1.2f) adding to RRD file\n"
 msgstr ""
 
-#: ../lib/utility.php:635
+#: ../lib/utility.php:640
 msgid ""
 "MySQL 5.6+ and MariaDB 10.0+ are great releases, and are very good versions "
 "to choose. Make sure you\n"
@@ -12707,13 +12758,13 @@ msgid ""
 "\t\t\t\tissue that was casuing spine many issues with reliability."
 msgstr ""
 
-#: ../lib/utility.php:649 ../lib/utility.php:687
+#: ../lib/utility.php:654 ../lib/utility.php:692
 #, php-format
 msgid ""
 "It is recommended that you enable InnoDB in any %s version greater than 5.1."
 msgstr ""
 
-#: ../lib/utility.php:662
+#: ../lib/utility.php:667
 msgid ""
 "When using Cacti with languages other than English, it is important to use\n"
 "\t\t\t\t\tthe utf8_general_ci collation type as some characters take more "
@@ -12726,7 +12777,7 @@ msgid ""
 "other languages."
 msgstr ""
 
-#: ../lib/utility.php:672
+#: ../lib/utility.php:677
 msgid ""
 "When using Cacti with languages other than English, it is important ot use\n"
 "\t\t\t\t\tthe utf8 character set as some characters take more than a single "
@@ -12739,21 +12790,21 @@ msgid ""
 "other languages."
 msgstr ""
 
-#: ../lib/utility.php:700
+#: ../lib/utility.php:705
 msgid ""
 "When using Cacti with languages other than English, it is important to use\n"
 "\t\t\t\t\tthe utf8mb4_unicode_ci collation type as some characters take more "
 "than a single byte."
 msgstr ""
 
-#: ../lib/utility.php:707
+#: ../lib/utility.php:712
 msgid ""
 "When using Cacti with languages other than English, it is important ot use\n"
 "\t\t\t\t\tthe utf8mb4 character set as some characters take more than a "
 "single byte."
 msgstr ""
 
-#: ../lib/utility.php:717
+#: ../lib/utility.php:722
 #, php-format
 msgid ""
 "Depending on the number of logins and use of spine data collector, \n"
@@ -12765,7 +12816,7 @@ msgid ""
 "\t\t\t\tconcurrent login accounts."
 msgstr ""
 
-#: ../lib/utility.php:726
+#: ../lib/utility.php:731
 #, php-format
 msgid ""
 "If using the Cacti Performance Booster and choosing a memory storage "
@@ -12788,32 +12839,32 @@ msgid ""
 "Boost Status."
 msgstr ""
 
-#: ../lib/utility.php:739
+#: ../lib/utility.php:744
 msgid ""
 "Keeping the table cache larger means less file open/close operations when\n"
 "\t\t\t\tusing innodb_file_per_table."
 msgstr ""
 
-#: ../lib/utility.php:745
+#: ../lib/utility.php:750
 msgid ""
 "With Remote polling capabilities, large amounts of data \n"
 "\t\t\t\twill be synced from the main server to the remote pollers.  \n"
 "\t\t\t\tTherefore, keep this value at or above 16M."
 msgstr ""
 
-#: ../lib/utility.php:752
+#: ../lib/utility.php:757
 msgid ""
 "When executing subqueries, having a larger temporary table size, \n"
 "\t\t\t\tkeep those temporary tables in memory."
 msgstr ""
 
-#: ../lib/utility.php:758
+#: ../lib/utility.php:763
 msgid ""
 "When performing joins, if they are below this size, they will \n"
 "\t\t\t\tbe kept in memory and never written to a temporary file."
 msgstr ""
 
-#: ../lib/utility.php:764
+#: ../lib/utility.php:769
 #, php-format
 msgid ""
 "When using InnoDB storage it is important to keep your table spaces\n"
@@ -12825,7 +12876,7 @@ msgid ""
 "InnoDB tables."
 msgstr ""
 
-#: ../lib/utility.php:772
+#: ../lib/utility.php:777
 #, php-format
 msgid ""
 "InnoDB will hold as much tables and indexes in system memory as is "
@@ -12840,27 +12891,27 @@ msgid ""
 "systems size."
 msgstr ""
 
-#: ../lib/utility.php:781
+#: ../lib/utility.php:786
 #, php-format
 msgid ""
 "With modern SSD type storage, this operation actually degrades the disk\n"
 "\t\t\t\tmore rapidly and adds a 50% overhead on all write operations."
 msgstr ""
 
-#: ../lib/utility.php:787
+#: ../lib/utility.php:792
 msgid ""
 "This is where metadata is stored. If you had a lot of tables, it would be "
 "useful to increase this."
 msgstr ""
 
-#: ../lib/utility.php:792
+#: ../lib/utility.php:797
 msgid ""
 "Rogue queries should not for the database to go offline to others.  Kill "
 "these\n"
 "\t\t\t\tqueries before they kill your system."
 msgstr ""
 
-#: ../lib/utility.php:802
+#: ../lib/utility.php:807
 #, php-format
 msgid ""
 "Setting this value to 2 means that you will flush all transactions every\n"
@@ -12868,14 +12919,14 @@ msgid ""
 "less often."
 msgstr ""
 
-#: ../lib/utility.php:808
+#: ../lib/utility.php:813
 msgid ""
 "With modern SSD type storage, having multiple io threads is advantageous "
 "for\n"
 "\t\t\t\t\tapplications with high io characteristics."
 msgstr ""
 
-#: ../lib/utility.php:817
+#: ../lib/utility.php:822
 #, php-format
 msgid ""
 "As of %s %s, the you can control how often %s flushes transactions to disk.  "
@@ -12883,21 +12934,21 @@ msgid ""
 "than 1 can allow disk I/O to be more sequential"
 msgstr ""
 
-#: ../lib/utility.php:822
+#: ../lib/utility.php:827
 msgid ""
 "With modern SSD type storage, having multiple read io threads is "
 "advantageous for\n"
 "\t\t\t\t\tapplications with high io characteristics."
 msgstr ""
 
-#: ../lib/utility.php:828
+#: ../lib/utility.php:833
 msgid ""
 "With modern SSD type storage, having multiple write io threads is "
 "advantageous for\n"
 "\t\t\t\t\tapplications with high io characteristics."
 msgstr ""
 
-#: ../lib/utility.php:834
+#: ../lib/utility.php:839
 #, php-format
 msgid ""
 "%s will divide the innodb_buffer_pool into memory regions to improve "
@@ -12908,16 +12959,16 @@ msgid ""
 "64."
 msgstr ""
 
-#: ../lib/utility.php:841
+#: ../lib/utility.php:846
 #, php-format
 msgid "%s Tuning"
 msgstr ""
 
-#: ../lib/utility.php:841
+#: ../lib/utility.php:846
 msgid "Documentation"
 msgstr ""
 
-#: ../lib/utility.php:841
+#: ../lib/utility.php:846
 msgid "Note: Many changes below require a database restart"
 msgstr ""
 
@@ -13100,7 +13151,7 @@ msgstr ""
 msgid "Logs"
 msgstr ""
 
-#: ../managers.php:141 ../utilities.php:1814
+#: ../managers.php:141 ../utilities.php:1821
 msgid "SNMP Notification Receivers"
 msgstr ""
 
@@ -13126,8 +13177,8 @@ msgstr ""
 msgid "SNMP Notification Receiver [new]"
 msgstr ""
 
-#: ../managers.php:518 ../managers.php:607 ../utilities.php:2256
-#: ../utilities.php:2331
+#: ../managers.php:518 ../managers.php:607 ../utilities.php:2263
+#: ../utilities.php:2338
 msgid "MIB"
 msgstr ""
 
@@ -13135,7 +13186,7 @@ msgstr ""
 msgid "Kind"
 msgstr ""
 
-#: ../managers.php:607 ../utilities.php:2331
+#: ../managers.php:607 ../utilities.php:2338
 msgid "Max-Access"
 msgstr ""
 
@@ -13143,7 +13194,7 @@ msgstr ""
 msgid "Monitored"
 msgstr ""
 
-#: ../managers.php:607 ../utilities.php:1402 ../utilities.php:2331
+#: ../managers.php:607 ../utilities.php:1409 ../utilities.php:2338
 msgid "OID"
 msgstr ""
 
@@ -13151,23 +13202,23 @@ msgstr ""
 msgid "No SNMP Notifications"
 msgstr ""
 
-#: ../managers.php:728 ../utilities.php:2509
+#: ../managers.php:728 ../utilities.php:2516
 msgid "Severity"
 msgstr ""
 
-#: ../managers.php:747 ../utilities.php:2552
+#: ../managers.php:747 ../utilities.php:2559
 msgid "Purge Notification Log"
 msgstr ""
 
-#: ../managers.php:795 ../utilities.php:2606
+#: ../managers.php:795 ../utilities.php:2613
 msgid "Notification"
 msgstr ""
 
-#: ../managers.php:795 ../utilities.php:2606
+#: ../managers.php:795 ../utilities.php:2613
 msgid "Time"
 msgstr ""
 
-#: ../managers.php:795 ../utilities.php:2606
+#: ../managers.php:795 ../utilities.php:2613
 msgid "Varbinds"
 msgstr ""
 
@@ -13175,7 +13226,7 @@ msgstr ""
 msgid "Severity Level"
 msgstr ""
 
-#: ../managers.php:819 ../utilities.php:2628
+#: ../managers.php:819 ../utilities.php:2635
 msgid "No SNMP Notification Log Entries"
 msgstr ""
 
@@ -13243,11 +13294,6 @@ msgstr ""
 
 #: ../plugins.php:167
 msgid "Not Stated"
-msgstr ""
-
-#: ../plugins.php:267
-#, php-format
-msgid "Plugin Management (Cacti Version: %s)"
 msgstr ""
 
 #: ../plugins.php:289
@@ -13496,79 +13542,94 @@ msgstr ""
 msgid "Site [new]"
 msgstr ""
 
-#: ../pollers.php:601
+#: ../pollers.php:379
+msgid ""
+"Remote Data Collectors must be able to communicate to the Main Data "
+"Collector, and vice versa.  Use this button to verify that the Main Data "
+"Collector can communicate to this Remote Data Collector."
+msgstr ""
+
+#: ../pollers.php:387
+msgid "Test Connection"
+msgstr ""
+
+#: ../pollers.php:387
+msgid "Test Database Connection"
+msgstr ""
+
+#: ../pollers.php:611
 msgid "Collector Name"
 msgstr ""
 
-#: ../pollers.php:601
+#: ../pollers.php:611
 msgid "The Name of this Data Collector."
 msgstr ""
 
-#: ../pollers.php:602
+#: ../pollers.php:612
 msgid "The unique id associated with this Data Collector."
 msgstr ""
 
-#: ../pollers.php:603
+#: ../pollers.php:613
 msgid "The Hostname where the Data Collector is running."
 msgstr ""
 
-#: ../pollers.php:604
+#: ../pollers.php:614
 msgid "The Status of this Data Collector."
 msgstr ""
 
-#: ../pollers.php:605
+#: ../pollers.php:615
 msgid "Polling Time"
 msgstr ""
 
-#: ../pollers.php:605
+#: ../pollers.php:615
 msgid "The last data collection time for this Data Collector."
 msgstr ""
 
-#: ../pollers.php:606
+#: ../pollers.php:616
 msgid "The number of Devices associated with this Data Collector."
 msgstr ""
 
-#: ../pollers.php:607
+#: ../pollers.php:617
 msgid "SNMP Gets"
 msgstr ""
 
-#: ../pollers.php:607
+#: ../pollers.php:617
 msgid "The number of SNMP gets associated with this Collector."
 msgstr ""
 
-#: ../pollers.php:608
+#: ../pollers.php:618
 msgid "Scripts"
 msgstr ""
 
-#: ../pollers.php:608
+#: ../pollers.php:618
 msgid "The number of script calls associated with this Data Collector."
 msgstr ""
 
-#: ../pollers.php:609
+#: ../pollers.php:619
 msgid "Servers"
 msgstr ""
 
-#: ../pollers.php:609
+#: ../pollers.php:619
 msgid "The number of script server calls associated with this Data Collector."
 msgstr ""
 
-#: ../pollers.php:610
+#: ../pollers.php:620
 msgid "Last Finished"
 msgstr ""
 
-#: ../pollers.php:610
+#: ../pollers.php:620
 msgid "The last time this Data Collector completed."
 msgstr ""
 
-#: ../pollers.php:611
+#: ../pollers.php:621
 msgid "Last Update"
 msgstr ""
 
-#: ../pollers.php:611
+#: ../pollers.php:621
 msgid "The last time this Data Collector checked in with the main Cacti site."
 msgstr ""
 
-#: ../pollers.php:646
+#: ../pollers.php:656
 msgid "No Data Collectors Found"
 msgstr ""
 
@@ -13670,35 +13731,35 @@ msgstr ""
 msgid "Cacti Settings (%s)"
 msgstr ""
 
-#: ../settings.php:187
+#: ../settings.php:191
 msgid "Select Plugin(s)"
 msgstr ""
 
-#: ../settings.php:189
+#: ../settings.php:193
 msgid "Plugins Selected"
 msgstr ""
 
-#: ../settings.php:204
+#: ../settings.php:208
 msgid "Select File(s)"
 msgstr ""
 
-#: ../settings.php:206
+#: ../settings.php:210
 msgid "Files Selected"
 msgstr ""
 
-#: ../settings.php:221
+#: ../settings.php:225
 msgid "Select Template(s)"
 msgstr ""
 
-#: ../settings.php:226
+#: ../settings.php:230
 msgid "All Templates Selected"
 msgstr ""
 
-#: ../settings.php:277
+#: ../settings.php:281
 msgid "Poller Interval must be less than Cron Interval"
 msgstr ""
 
-#: ../settings.php:299
+#: ../settings.php:303
 msgid "Test Email Results"
 msgstr ""
 
@@ -14653,9 +14714,9 @@ msgstr ""
 msgid ""
 "Search filter to use to locate the user in the LDAP directory, such as for "
 "windows: <i>\"(&amp;(objectclass=user)(objectcategory=user)"
-"(userPrincipalName=&lt;username&gt;*))\"</i> or for OpenLDAP: <i>\"(&"
-"(objectClass=account)(uid=&lt;username&gt))\"</i>.  \"&lt;username&gt\" is "
-"replaced with the username that was supplied at the login prompt."
+"(userPrincipalName=&lt;username&gt;*))\"</i> or for OpenLDAP: <i>"
+"\"(&(objectClass=account)(uid=&lt;username&gt))\"</i>.  \"&lt;username&gt\" "
+"is replaced with the username that was supplied at the login prompt."
 msgstr ""
 
 #: ../user_domains.php:501
@@ -14921,8 +14982,8 @@ msgstr ""
 #: ../utilities.php:174
 #, php-format
 msgid ""
-"ERROR: RRDtool 1.2.x+ does not support the GIF images format, but %d\" graph"
-"(s) and/or templates have GIF set as the image format."
+"ERROR: RRDtool 1.2.x+ does not support the GIF images format, but %d\" "
+"graph(s) and/or templates have GIF set as the image format."
 msgstr ""
 
 #: ../utilities.php:194
@@ -15111,21 +15172,21 @@ msgstr ""
 msgid "Attempts"
 msgstr ""
 
-#: ../utilities.php:676 ../utilities.php:1009 ../utilities.php:1330
-#: ../utilities.php:1577 ../utilities.php:2286 ../utilities.php:2550
+#: ../utilities.php:676 ../utilities.php:1009 ../utilities.php:1337
+#: ../utilities.php:1584 ../utilities.php:2293 ../utilities.php:2557
 #: ../vdef.php:686
 msgctxt "Button: use filter settings"
 msgid "Go"
 msgstr ""
 
-#: ../utilities.php:679 ../utilities.php:1012 ../utilities.php:1333
-#: ../utilities.php:1580 ../utilities.php:2289 ../utilities.php:2551
+#: ../utilities.php:679 ../utilities.php:1012 ../utilities.php:1340
+#: ../utilities.php:1587 ../utilities.php:2296 ../utilities.php:2558
 #: ../vdef.php:689
 msgctxt "Button: reset filter settings"
 msgid "Clear"
 msgstr ""
 
-#: ../utilities.php:682 ../utilities.php:1015 ../utilities.php:2552
+#: ../utilities.php:682 ../utilities.php:1015 ../utilities.php:2559
 msgctxt "Button: delete all table entries"
 msgid "Purge"
 msgstr ""
@@ -15150,417 +15211,412 @@ msgstr ""
 msgid "Purge Log"
 msgstr ""
 
-#: ../utilities.php:1068
+#: ../utilities.php:1072
 #, php-format
 msgid "Log [Total Lines: %d - Non-Matching Items Hidden]"
 msgstr ""
 
-#: ../utilities.php:1070
+#: ../utilities.php:1074
 #, php-format
 msgid "Log [Total Lines: %d - All Items Shown]"
 msgstr ""
 
-#: ../utilities.php:1166
+#: ../utilities.php:1173
 #, php-format
 msgid "%s - WEBUI: Cacti Log Cleared from Web Management Interface."
 msgstr ""
 
-#: ../utilities.php:1168
+#: ../utilities.php:1175
 msgid "Cacti Log Cleared"
 msgstr ""
 
-#: ../utilities.php:1170
+#: ../utilities.php:1177
 msgid "Error: Unable to clear log, no write permissions."
 msgstr ""
 
-#: ../utilities.php:1173
+#: ../utilities.php:1180
 msgid "Error: Unable to clear log, file does not exist."
 msgstr ""
 
-#: ../utilities.php:1266
+#: ../utilities.php:1273
 msgid "Data Query Cache Items"
 msgstr ""
 
-#: ../utilities.php:1282
+#: ../utilities.php:1289
 msgid "Query Name"
 msgstr ""
 
-#: ../utilities.php:1396 ../utilities.php:1604 ../utilities.php:1684
-#: ../utilities.php:2325 ../utilities.php:2535
-msgid "Entries"
-msgstr ""
-
-#: ../utilities.php:1402
+#: ../utilities.php:1409
 msgid "Field Value"
 msgstr ""
 
-#: ../utilities.php:1402
+#: ../utilities.php:1409
 msgid "Index"
 msgstr ""
 
-#: ../utilities.php:1538
+#: ../utilities.php:1545
 msgid "Poller Cache Items"
 msgstr ""
 
-#: ../utilities.php:1599
+#: ../utilities.php:1606
 msgid "Script"
 msgstr ""
 
-#: ../utilities.php:1715 ../utilities.php:1720
+#: ../utilities.php:1722 ../utilities.php:1727
 msgid "SNMP Version:"
 msgstr ""
 
-#: ../utilities.php:1716
+#: ../utilities.php:1723
 msgid "Community:"
 msgstr ""
 
-#: ../utilities.php:1717 ../utilities.php:1721
+#: ../utilities.php:1724 ../utilities.php:1728
 msgid "OID:"
 msgstr ""
 
-#: ../utilities.php:1721
+#: ../utilities.php:1728
 msgid "User:"
 msgstr ""
 
-#: ../utilities.php:1724
+#: ../utilities.php:1731
 msgid "Script:"
 msgstr ""
 
-#: ../utilities.php:1726
+#: ../utilities.php:1733
 msgid "Script Server:"
 msgstr ""
 
-#: ../utilities.php:1739
+#: ../utilities.php:1746
 msgid "RRD:"
 msgstr ""
 
-#: ../utilities.php:1758
+#: ../utilities.php:1765
 msgid "Tecnical Support"
 msgstr ""
 
-#: ../utilities.php:1760
+#: ../utilities.php:1767
 msgid ""
 "Cacti technical support page.  Used by developers and technical support "
 "persons to assist with issues in Cacti.  Includes checks for common "
 "configuration issues."
 msgstr ""
 
-#: ../utilities.php:1762
+#: ../utilities.php:1769
 msgid "Log Administration"
 msgstr ""
 
-#: ../utilities.php:1764
+#: ../utilities.php:1771
 msgid ""
 "The Cacti Log stores statistic, error and other message depending on system "
 "settings.  This information can be used to identify problems with the poller "
 "and application."
 msgstr ""
 
-#: ../utilities.php:1768
+#: ../utilities.php:1775
 msgid ""
 "Allows Administrators to browse the user log.  Administrators can filter and "
 "export the log as well."
 msgstr ""
 
-#: ../utilities.php:1772
+#: ../utilities.php:1779
 msgid "Poller Cache Administration"
 msgstr ""
 
-#: ../utilities.php:1775
+#: ../utilities.php:1782
 msgid ""
 "This is the data that is being passed to the poller each time it runs. This "
 "data is then in turn executed/interpreted and the results are fed into the "
 "RRDfiles for graphing or the database for display."
 msgstr ""
 
-#: ../utilities.php:1779
+#: ../utilities.php:1786
 msgid ""
 "The Data Query Cache stores information gathered from Data Query input "
 "types. The values from these fields can be used in the text area of Graphs "
 "for Legends, Vertical Labels, and GPRINTS as well as in CDEF's."
 msgstr ""
 
-#: ../utilities.php:1781
+#: ../utilities.php:1788
 msgid "Rebuild Poller Cache"
 msgstr ""
 
-#: ../utilities.php:1783
+#: ../utilities.php:1790
 msgid ""
 "The poller cache will be cleared and re-generated if you select this option. "
 "Sometimes host/data source data can get out of sync with the cache in which "
 "case it makes sense to clear the cache and start over."
 msgstr ""
 
-#: ../utilities.php:1787
+#: ../utilities.php:1794
 msgid "Boost Utilities"
 msgstr ""
 
-#: ../utilities.php:1788
+#: ../utilities.php:1795
 msgid "View Boost Status"
 msgstr ""
 
-#: ../utilities.php:1790
+#: ../utilities.php:1797
 msgid ""
 "This menu pick allows you to view various boost settings and statistics "
 "associated with the current running Boost configuration."
 msgstr ""
 
-#: ../utilities.php:1794
+#: ../utilities.php:1801
 msgid "RRD Utilities"
 msgstr ""
 
-#: ../utilities.php:1795
+#: ../utilities.php:1802
 msgid "RRDfile Cleaner"
 msgstr ""
 
-#: ../utilities.php:1797
+#: ../utilities.php:1804
 msgid ""
 "When you delete Data Sources from Cacti, the corresponding RRDfiles are not "
 "removed automatically.  Use this utility to facilitate the removal of these "
 "old files."
 msgstr ""
 
-#: ../utilities.php:1801
+#: ../utilities.php:1808
 msgid "SNMPAgent Utilities"
 msgstr ""
 
-#: ../utilities.php:1802
+#: ../utilities.php:1809
 msgid "View SNMPAgent Cache"
 msgstr ""
 
-#: ../utilities.php:1804
+#: ../utilities.php:1811
 msgid "This shows all objects being handled by the SNMPAgent."
 msgstr ""
 
-#: ../utilities.php:1806
+#: ../utilities.php:1813
 msgid "Rebuild SNMPAgent Cache"
 msgstr ""
 
-#: ../utilities.php:1808
+#: ../utilities.php:1815
 msgid ""
 "The SNMP cache will be cleared and re-generated if you select this option. "
 "Note that it takes another poller run to restore the SNMP cache completely."
 msgstr ""
 
-#: ../utilities.php:1810
+#: ../utilities.php:1817
 msgid "View SNMPAgent Notification Log"
 msgstr ""
 
-#: ../utilities.php:1812
+#: ../utilities.php:1819
 msgid ""
 "This menu pick allows you to view the latest events SNMPAgent has handled in "
 "relation to the registered notification receivers."
 msgstr ""
 
-#: ../utilities.php:1816
+#: ../utilities.php:1823
 msgid "Allows Administrators to maintain SNMP notification receivers."
 msgstr ""
 
-#: ../utilities.php:1822
+#: ../utilities.php:1829
 msgid "Cacti System Utilities"
 msgstr ""
 
-#: ../utilities.php:1946
+#: ../utilities.php:1953
 msgid "Overrun Warning"
 msgstr ""
 
-#: ../utilities.php:1947
+#: ../utilities.php:1954
 msgid "Timed Out"
 msgstr ""
 
-#: ../utilities.php:1948
+#: ../utilities.php:1955
 msgid "Other"
 msgstr ""
 
-#: ../utilities.php:1950
+#: ../utilities.php:1957
 msgid "Never Run"
 msgstr ""
 
-#: ../utilities.php:2003
+#: ../utilities.php:2010
 msgid "Cannot open directory"
 msgstr ""
 
-#: ../utilities.php:2007
+#: ../utilities.php:2014
 msgid "Directory Does NOT Exist!!"
 msgstr ""
 
-#: ../utilities.php:2014
+#: ../utilities.php:2021
 msgid "Current Boost Status"
 msgstr ""
 
-#: ../utilities.php:2017
+#: ../utilities.php:2024
 msgid "Boost On-demand Updating:"
 msgstr ""
 
-#: ../utilities.php:2020
+#: ../utilities.php:2027
 msgid "Total Data Sources:"
 msgstr ""
 
-#: ../utilities.php:2024
+#: ../utilities.php:2031
 msgid "Pending Boost Records:"
 msgstr ""
 
-#: ../utilities.php:2027
+#: ../utilities.php:2034
 msgid "Archived Boost Records:"
 msgstr ""
 
-#: ../utilities.php:2030
+#: ../utilities.php:2037
 msgid "Total Boost Records:"
 msgstr ""
 
-#: ../utilities.php:2034
+#: ../utilities.php:2041
 msgid "Boost Storage Statistics"
 msgstr ""
 
-#: ../utilities.php:2038
+#: ../utilities.php:2045
 msgid "Database Engine:"
 msgstr ""
 
-#: ../utilities.php:2042
+#: ../utilities.php:2049
 msgid "Current Boost Table(s) Size:"
 msgstr ""
 
-#: ../utilities.php:2046
+#: ../utilities.php:2053
 msgid "Avg Bytes/Record:"
 msgstr ""
 
-#: ../utilities.php:2074
+#: ../utilities.php:2081
 #, php-format
 msgid "%d Bytes"
 msgstr ""
 
-#: ../utilities.php:2074
+#: ../utilities.php:2081
 msgid "Max Record Length:"
 msgstr ""
 
-#: ../utilities.php:2080 ../utilities.php:2081
+#: ../utilities.php:2087 ../utilities.php:2088
 msgid "Unlimited"
 msgstr ""
 
-#: ../utilities.php:2086
+#: ../utilities.php:2093
 msgid "Max Allowed Boost Table Size:"
 msgstr ""
 
-#: ../utilities.php:2090
+#: ../utilities.php:2097
 msgid "Estimated Maximum Records:"
 msgstr ""
 
-#: ../utilities.php:2093
+#: ../utilities.php:2100
 msgid "Runtime Statistics"
 msgstr ""
 
-#: ../utilities.php:2096
+#: ../utilities.php:2103
 msgid "Last Start Time:"
 msgstr ""
 
-#: ../utilities.php:2099
+#: ../utilities.php:2106
 msgid "Last Run Duration:"
 msgstr ""
 
-#: ../utilities.php:2100
+#: ../utilities.php:2107
 #, php-format
 msgid "%d minutes"
 msgstr ""
 
-#: ../utilities.php:2100
+#: ../utilities.php:2107
 #, php-format
 msgid "%d seconds"
 msgstr ""
 
-#: ../utilities.php:2101
+#: ../utilities.php:2108
 #, php-format
 msgid "%0.2f percent of update frequency)"
 msgstr ""
 
-#: ../utilities.php:2105
+#: ../utilities.php:2112
 msgid "RRD Updates:"
 msgstr ""
 
-#: ../utilities.php:2108 ../utilities.php:2114
+#: ../utilities.php:2115 ../utilities.php:2121
 msgid "MBytes"
 msgstr ""
 
-#: ../utilities.php:2108
+#: ../utilities.php:2115
 msgid "Peak Poller Memory:"
 msgstr ""
 
-#: ../utilities.php:2111
+#: ../utilities.php:2118
 msgid "Detailed Runtime Timers:"
 msgstr ""
 
-#: ../utilities.php:2114
+#: ../utilities.php:2121
 msgid "Max Poller Memory Allowed:"
 msgstr ""
 
-#: ../utilities.php:2117
+#: ../utilities.php:2124
 msgid "Run Time Configuration"
 msgstr ""
 
-#: ../utilities.php:2120
+#: ../utilities.php:2127
 msgid "Update Frequency:"
 msgstr ""
 
-#: ../utilities.php:2123
+#: ../utilities.php:2130
 msgid "Next Start Time:"
 msgstr ""
 
-#: ../utilities.php:2126
+#: ../utilities.php:2133
 msgid "Maximum Records:"
 msgstr ""
 
-#: ../utilities.php:2126
+#: ../utilities.php:2133
 msgid "Records"
 msgstr ""
 
-#: ../utilities.php:2129
+#: ../utilities.php:2136
 msgid "Maximum Allowed Runtime:"
 msgstr ""
 
-#: ../utilities.php:2135
+#: ../utilities.php:2142
 msgid "Image Caching Status:"
 msgstr ""
 
-#: ../utilities.php:2138
+#: ../utilities.php:2145
 msgid "Cache Directory:"
 msgstr ""
 
-#: ../utilities.php:2141
+#: ../utilities.php:2148
 msgid "Cached Files:"
 msgstr ""
 
-#: ../utilities.php:2144
+#: ../utilities.php:2151
 msgid "Cached Files Size:"
 msgstr ""
 
-#: ../utilities.php:2241
+#: ../utilities.php:2248
 msgid "SNMPAgent Cache"
 msgstr ""
 
-#: ../utilities.php:2271
+#: ../utilities.php:2278
 msgid "OIDs"
 msgstr ""
 
-#: ../utilities.php:2351
+#: ../utilities.php:2358
 msgid "Column Data"
 msgstr ""
 
-#: ../utilities.php:2351
+#: ../utilities.php:2358
 msgid "Scalar"
 msgstr ""
 
-#: ../utilities.php:2494
+#: ../utilities.php:2501
 msgid "SNMPAgent Notification Log"
 msgstr ""
 
-#: ../utilities.php:2522 ../utilities.php:2606
+#: ../utilities.php:2529 ../utilities.php:2613
 msgid "Receiver"
 msgstr ""
 
-#: ../utilities.php:2598
+#: ../utilities.php:2605
 msgid "Log Entries"
 msgstr ""
 
-#: ../utilities.php:2613
+#: ../utilities.php:2620
 #, php-format
 msgid "Severity Level: %s"
 msgstr ""
@@ -15599,6 +15655,10 @@ msgstr ""
 
 #: ../vdef.php:325
 msgid "Click 'Continue' to delete the following VDEF's."
+msgstr ""
+
+#: ../vdef.php:385
+msgid "VDEF Preview"
 msgstr ""
 
 #: ../vdef.php:390


### PR DESCRIPTION
(First ever pull request for me, so hopefully I'm doing it correctly.)
A trivial grammar correction in the displayed text for devices. The text can be found (using the 'Modern' theme) by selecting the 'Console' tab, then 'Settings', and then the 'Device Defaults' tab. It is the 'Retries' entry in the 'SNMP Defaults' section. The correction also brings it inline with the 'Ping Retry Count' text a bit further down the page.
I also ran the 'locales/update-pot.sh' script, to update the 'po/cacti.pot' file. I'm not sure how i18n works, but assumed this was the right thing to do.