### PR TITLE
Update snmp.php to handle more nicely HEX value returned by net-snmp

### DIFF
--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -23,7 +23,7 @@
  +-------------------------------------------------------------------------+
 */
 
-define('REGEXP_SNMP_TRIM', '/(hex|counter(32|64)|gauge|gauge(32|64)|float|ipaddress|string|integer):/i');
+define("REGEXP_SNMP_TRIM", "/(hex|counter(32|64)|gauge|gauge(32|64)|float|ipaddress|string|integer):|(up|down)\(|\)$/i");
 
 define('SNMP_METHOD_PHP', 1);
 define('SNMP_METHOD_BINARY', 2);
@@ -858,15 +858,19 @@ function format_snmp_string($string, $snmp_oid_included) {
 		}
 
 		/* convert the hex string into an ascii string */
-		foreach($parts as $part) {
-			if ($mac == false) {
-				if ($part == '00') break;
+                foreach($parts as $part) {
+                        if ($mac == false) {
+                                $output .= ($output != '' ? ':' : '');
+                                if ($part == '00') {
+                                  $output .= '00';
+                                } else  {
+                                  $output .= str_pad($part, 2, "0", STR_PAD_LEFT);
+                                }
 
-				$output .= chr(hexdec($part));
-			} else {
-				$output .= ($output != '' ? ':' : '') . $part;
-			}
-		}
+                        } else {
+                                $output .= ($output != '' ? ':' : '') . $part;
+                        }
+                }
 
 		if (is_numeric($output)) {
 			$string = number_format($output, 0, '', '');


### PR DESCRIPTION
proposition of change to be able to handle correctly some hex data receive on SNMP, like:
00:00:00:28 or 0A:00:2E:28 
on the current release the 00 are dropped, and something the string send back to the caller are empty.
With this proposal the 00 is kept and returned as hex value, like the other char.

I also change the REGEXP_SNMP_TRIM to be able to handle correctly the status of an interface who can give up or down status, and now it's not handle correctly