### PR TITLE
Further fix for #670 allowing 'dq_' template ids.

### DIFF
--- a/graphs.php
+++ b/graphs.php
@@ -830,7 +830,7 @@ function form_actions() {
 						LIMIT 1', 
 						array(get_request_var('template_id')));
 
-					$ttemplate = str_replace(array('cg_', 'sg_'), '', get_nfilter_request_var('template_id'));
+					$ttemplate = str_replace(array('cg_', 'sg_', 'dq_'), '', get_nfilter_request_var('template_id'));
 
 					$graph['graph_template_id'] = input_validate_input_number($ttemplate);
 


### PR DESCRIPTION
The fix for issue #670 didn't include template ids which begin with 'dq_'. This pull request simply adds 'dq_' to the list of prefixes which are removed prior to validation.