### PR TITLE
Text corrections for graph templates

### DIFF
--- a/include/global_form.php
+++ b/include/global_form.php
@@ -721,7 +721,7 @@ $struct_graph = array(
 		'none_value' => __('None'),
 		'description' => __('When you setup the right axis labeling, apply a rule to the data format.  Supported formats include "numeric" where
 			data is treated as numeric, "timestamp" where values are interpreted as UNIX timestamps (number of seconds since January 1970)
-			and expressed using strftime format (default is "%Y-%m-%d %H:%M:%S").  See also --units-length and --left-axis-format.  Finally
+			and expressed using strftime format (default is "%Y-%m-%d %H:%M:%S").  See also --units-length and --right-axis-format.  Finally
 			"duration" where values are interpreted as duration in milliseconds.  Formatting follows the rules of valstrfduration qualified PRINT/GPRINT.'),
 		),
 	'left_axis_formatter' => array(
@@ -730,10 +730,10 @@ $struct_graph = array(
 		'array' => $rrd_axis_formatters,
 		'default' => '0',
 		'none_value' => __('None'),
-		'description' => __('When you setup the right axis labeling, apply a rule to the data format.  Supported formats include "numeric" where
+		'description' => __('When you setup the left axis labeling, apply a rule to the data format.  Supported formats include "numeric" where
 			data is treated as numeric, "timestamp" where values are interpreted as UNIX timestamps (number of seconds since January 1970)
-			and expressed using strftime format (default is "%Y-%m-%d %H:%M:%S").  See also --units-length and --left-axis-format.  Finally
-			"duration" where values are interpreted as duration in milliseconds.  Formatting follows the rules of valstrfduration qualified PRINT/GPRINT.'),
+			and expressed using strftime format (default is "%Y-%m-%d %H:%M:%S").  See also --units-length.  Finally "duration" where values
+			are interpreted as duration in milliseconds.  Formatting follows the rules of valstrfduration qualified PRINT/GPRINT.'),
 		),
 	'legend_header' => array(
 		'friendly_name' => __('Legend Options'),

--- a/locales/po/cacti.pot
+++ b/locales/po/cacti.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-10 17:14+0100\n"
+"POT-Creation-Date: 2017-05-18 17:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: ../about.php:29 ../lib/functions.php:2407
+#: ../about.php:29 ../lib/functions.php:2424
 msgid "About Cacti"
 msgstr ""
 
@@ -98,19 +98,19 @@ msgstr ""
 #: ../automation_templates.php:29 ../automation_tree_rules.php:32
 #: ../cdef.php:29 ../cdef.php:619 ../color.php:28 ../color_templates.php:28
 #: ../color_templates.php:122 ../data_input.php:29 ../data_input.php:490
-#: ../data_input.php:528 ../data_queries.php:30 ../data_queries.php:637
-#: ../data_queries.php:735 ../data_queries.php:949
+#: ../data_input.php:528 ../data_queries.php:30 ../data_queries.php:638
+#: ../data_queries.php:736 ../data_queries.php:950
 #: ../data_source_profiles.php:29 ../data_source_profiles.php:513
 #: ../data_sources.php:35 ../data_sources.php:942 ../data_templates.php:33
 #: ../data_templates.php:571 ../gprint_presets.php:28 ../graph_templates.php:33
 #: ../graph_templates.php:440 ../graphs.php:44 ../host.php:38
 #: ../host_templates.php:30 ../host_templates.php:485 ../host_templates.php:542
-#: ../lib/api_automation.php:1246 ../lib/api_automation.php:1309
-#: ../lib/api_automation.php:1373 ../lib/html.php:970 ../lib/html_form.php:1096
-#: ../lib/html_reports.php:1303 ../links.php:28 ../managers.php:28
-#: ../pollers.php:29 ../sites.php:28 ../tree.php:1051 ../tree.php:1204
-#: ../tree.php:1264 ../user_admin.php:28 ../user_domains.php:29
-#: ../user_group_admin.php:30 ../vdef.php:29
+#: ../include/global_arrays.php:1234 ../lib/api_automation.php:1246
+#: ../lib/api_automation.php:1309 ../lib/api_automation.php:1373
+#: ../lib/html.php:970 ../lib/html_form.php:1096 ../lib/html_reports.php:1291
+#: ../links.php:28 ../managers.php:28 ../pollers.php:29 ../sites.php:28
+#: ../tree.php:1051 ../tree.php:1204 ../tree.php:1264 ../user_admin.php:28
+#: ../user_domains.php:29 ../user_group_admin.php:30 ../vdef.php:29
 msgid "Delete"
 msgstr ""
 
@@ -157,10 +157,10 @@ msgstr ""
 #: ../data_templates.php:368 ../data_templates.php:384
 #: ../gprint_presets.php:153 ../graph_templates.php:317
 #: ../graph_templates.php:327 ../graph_templates.php:347
-#: ../graph_templates.php:356 ../graphs.php:818 ../graphs.php:842
-#: ../graphs.php:853 ../graphs.php:864 ../graphs.php:879 ../graphs.php:902
-#: ../graphs.php:1026 ../graphs.php:1069 ../graphs.php:1091 ../graphs.php:1099
-#: ../graphs.php:1532 ../host.php:381 ../host.php:390 ../host.php:432
+#: ../graph_templates.php:356 ../graphs.php:818 ../graphs.php:845
+#: ../graphs.php:856 ../graphs.php:867 ../graphs.php:882 ../graphs.php:905
+#: ../graphs.php:1029 ../graphs.php:1072 ../graphs.php:1094 ../graphs.php:1102
+#: ../graphs.php:1535 ../host.php:381 ../host.php:390 ../host.php:432
 #: ../host.php:441 ../host.php:450 ../host.php:464 ../host.php:478
 #: ../host.php:487 ../host.php:495 ../host_templates.php:261
 #: ../host_templates.php:275 ../host_templates.php:286
@@ -168,7 +168,7 @@ msgstr ""
 #: ../lib/clog_webapi.php:129 ../lib/html_form.php:1095
 #: ../lib/html_form.php:1107 ../lib/html_form.php:1118
 #: ../lib/html_utility.php:198 ../links.php:196 ../links.php:205
-#: ../links.php:214 ../managers.php:1002 ../managers.php:1059
+#: ../links.php:214 ../managers.php:1012 ../managers.php:1069
 #: ../pollers.php:288 ../pollers.php:297 ../pollers.php:306 ../pollers.php:315
 #: ../sites.php:280 ../tree.php:490 ../tree.php:499 ../tree.php:508
 #: ../user_admin.php:350 ../user_admin.php:390 ../user_admin.php:401
@@ -198,16 +198,16 @@ msgstr ""
 #: ../data_templates.php:368 ../data_templates.php:384
 #: ../gprint_presets.php:153 ../graph_templates.php:317
 #: ../graph_templates.php:327 ../graph_templates.php:347
-#: ../graph_templates.php:356 ../graphs.php:818 ../graphs.php:842
-#: ../graphs.php:853 ../graphs.php:864 ../graphs.php:879 ../graphs.php:902
-#: ../graphs.php:1026 ../graphs.php:1069 ../graphs.php:1091 ../graphs.php:1099
+#: ../graph_templates.php:356 ../graphs.php:818 ../graphs.php:845
+#: ../graphs.php:856 ../graphs.php:867 ../graphs.php:882 ../graphs.php:905
+#: ../graphs.php:1029 ../graphs.php:1072 ../graphs.php:1094 ../graphs.php:1102
 #: ../host.php:381 ../host.php:390 ../host.php:432 ../host.php:441
 #: ../host.php:450 ../host.php:464 ../host.php:478 ../host.php:487
 #: ../host.php:495 ../host_templates.php:261 ../host_templates.php:275
 #: ../host_templates.php:286 ../host_templates.php:335
 #: ../host_templates.php:395 ../lib/clog_webapi.php:130
-#: ../lib/html_reports.php:671 ../lib/html_utility.php:198 ../links.php:196
-#: ../links.php:205 ../links.php:214 ../managers.php:1002 ../managers.php:1059
+#: ../lib/html_reports.php:643 ../lib/html_utility.php:198 ../links.php:196
+#: ../links.php:205 ../links.php:214 ../managers.php:1012 ../managers.php:1069
 #: ../pollers.php:288 ../pollers.php:297 ../pollers.php:306 ../pollers.php:315
 #: ../sites.php:280 ../tree.php:490 ../tree.php:499 ../tree.php:508
 #: ../user_admin.php:350 ../user_admin.php:390 ../user_admin.php:401
@@ -247,10 +247,10 @@ msgstr ""
 #: ../color_templates.php:246 ../data_input.php:221 ../data_queries.php:325
 #: ../data_source_profiles.php:280 ../data_sources.php:515
 #: ../data_templates.php:388 ../gprint_presets.php:157
-#: ../graph_templates.php:360 ../graphs.php:1028 ../graphs.php:1078
-#: ../graphs.php:1081 ../graphs.php:1104 ../host.php:499
+#: ../graph_templates.php:360 ../graphs.php:1031 ../graphs.php:1081
+#: ../graphs.php:1084 ../graphs.php:1107 ../host.php:499
 #: ../host_templates.php:290 ../include/auth.php:115 ../lib/html_form.php:1116
-#: ../lib/html_utility.php:196 ../links.php:218 ../managers.php:1062
+#: ../lib/html_utility.php:196 ../links.php:218 ../managers.php:1072
 #: ../permission_denied.php:30 ../permission_denied.php:32 ../pollers.php:319
 #: ../sites.php:284 ../tree.php:512 ../user_admin.php:439
 #: ../user_domains.php:258 ../user_group_admin.php:491 ../vdef.php:284
@@ -327,7 +327,7 @@ msgstr ""
 msgid "Destination Branch:"
 msgstr ""
 
-#: ../aggregate_graphs.php:438 ../graphs.php:879
+#: ../aggregate_graphs.php:438 ../graphs.php:882
 msgid "Place Graph(s) on Tree"
 msgstr ""
 
@@ -335,28 +335,28 @@ msgstr ""
 msgid "You must select at least one graph."
 msgstr ""
 
-#: ../aggregate_graphs.php:476 ../graphs.php:1137
+#: ../aggregate_graphs.php:476 ../graphs.php:1140
 msgid "Graph Items [new]"
 msgstr ""
 
-#: ../aggregate_graphs.php:492 ../graphs.php:1157
+#: ../aggregate_graphs.php:492 ../graphs.php:1160
 #, php-format
 msgid "Graph Items [edit: %s]"
 msgstr ""
 
 #: ../aggregate_graphs.php:560 ../aggregate_graphs.php:563
-#: ../lib/html_reports.php:1088 ../lib/html_reports.php:1093
-#: ../lib/html_reports.php:1132 ../utilities.php:1699
+#: ../lib/html_reports.php:1060 ../lib/html_reports.php:1065
+#: ../lib/html_reports.php:1104 ../utilities.php:1699
 msgid "Details"
 msgstr ""
 
-#: ../aggregate_graphs.php:560 ../lib/html_reports.php:1088
-#: ../lib/html_reports.php:1179 ../utilities.php:306
+#: ../aggregate_graphs.php:560 ../lib/html_reports.php:1060
+#: ../lib/html_reports.php:1151 ../utilities.php:306
 msgid "Items"
 msgstr ""
 
 #: ../aggregate_graphs.php:560 ../aggregate_graphs.php:563 ../lib/html.php:1559
-#: ../lib/html_reports.php:1088
+#: ../lib/html_reports.php:1060
 msgid "Preview"
 msgstr ""
 
@@ -377,11 +377,11 @@ msgstr ""
 msgid "Aggregate Preview [%s]"
 msgstr ""
 
-#: ../aggregate_graphs.php:633 ../graph.php:431 ../graphs.php:1395
+#: ../aggregate_graphs.php:633 ../graph.php:431 ../graphs.php:1398
 msgid "RRDTool Command:"
 msgstr ""
 
-#: ../aggregate_graphs.php:635 ../graph.php:434 ../graphs.php:1397
+#: ../aggregate_graphs.php:635 ../graph.php:434 ../graphs.php:1400
 msgid "RRDTool Says:"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "All Items"
 msgstr ""
 
-#: ../aggregate_graphs.php:825 ../graphs.php:1411 ../lib/api_aggregate.php:1367
+#: ../aggregate_graphs.php:825 ../graphs.php:1414 ../lib/api_aggregate.php:1367
 msgid "Graph Configuration"
 msgstr ""
 
@@ -422,23 +422,23 @@ msgstr ""
 #: ../automation_networks.php:1082 ../automation_snmp.php:828
 #: ../automation_templates.php:412 ../automation_tree_rules.php:715
 #: ../cdef.php:722 ../color.php:529 ../color_templates.php:439
-#: ../data_input.php:619 ../data_queries.php:1047
+#: ../data_input.php:619 ../data_queries.php:1048
 #: ../data_source_profiles.php:719 ../data_sources.php:1251
 #: ../data_templates.php:754 ../gprint_presets.php:262
 #: ../graph_templates.php:628 ../graph_view.php:517 ../graph_view.php:818
-#: ../graphs.php:1684 ../graphs_new.php:548 ../host.php:1375
+#: ../graphs.php:1687 ../graphs_new.php:548 ../host.php:1375
 #: ../host_templates.php:700 ../lib/api_automation.php:133
 #: ../lib/api_automation.php:460 ../lib/api_automation.php:683
 #: ../lib/api_automation.php:988 ../lib/clog_webapi.php:380
 #: ../lib/html_filter.php:63 ../lib/html_graph.php:206
-#: ../lib/html_graph.php:432 ../lib/html_reports.php:1388
-#: ../lib/html_tree.php:605 ../lib/html_tree.php:879 ../links.php:309
-#: ../managers.php:150 ../managers.php:533 ../managers.php:722
+#: ../lib/html_graph.php:432 ../lib/html_reports.php:1378
+#: ../lib/html_tree.php:121 ../lib/html_tree.php:605 ../lib/html_tree.php:879
+#: ../links.php:309 ../managers.php:150 ../managers.php:533 ../managers.php:724
 #: ../plugins.php:276 ../pollers.php:517 ../rrdcleaner.php:475
 #: ../settings.php:204 ../settings.php:221 ../settings.php:267 ../sites.php:387
-#: ../tree.php:633 ../tree.php:668 ../tree.php:1485 ../user_admin.php:2176
-#: ../user_admin.php:2514 ../user_admin.php:2623 ../user_admin.php:2711
-#: ../user_admin.php:2816 ../user_admin.php:2903 ../user_admin.php:2990
+#: ../tree.php:633 ../tree.php:668 ../tree.php:1485 ../user_admin.php:2193
+#: ../user_admin.php:2531 ../user_admin.php:2640 ../user_admin.php:2728
+#: ../user_admin.php:2833 ../user_admin.php:2920 ../user_admin.php:3007
 #: ../user_domains.php:621 ../user_group_admin.php:1806
 #: ../user_group_admin.php:2133 ../user_group_admin.php:2243
 #: ../user_group_admin.php:2348 ../user_group_admin.php:2435
@@ -450,13 +450,13 @@ msgstr ""
 
 #: ../aggregate_graphs.php:1013 ../aggregate_graphs.php:1111
 #: ../aggregate_graphs.php:1354 ../color_templates.php:549
-#: ../graph_view.php:395 ../graph_view.php:556 ../graphs.php:1690
-#: ../host.php:1501 ../include/global_arrays.php:685
-#: ../include/global_arrays.php:864 ../lib/api_automation.php:274
-#: ../lib/functions.php:1839 ../lib/html.php:1308 ../lib/html.php:1310
+#: ../graph_view.php:395 ../graph_view.php:556 ../graphs.php:1693
+#: ../host.php:1501 ../include/global_arrays.php:686
+#: ../include/global_arrays.php:865 ../lib/api_automation.php:274
+#: ../lib/functions.php:1856 ../lib/html.php:1308 ../lib/html.php:1310
 #: ../lib/html.php:1383 ../lib/html_graph.php:212 ../lib/html_tree.php:658
-#: ../lib/html_tree.php:1076 ../tree.php:1568 ../user_admin.php:1229
-#: ../user_admin.php:2542 ../user_group_admin.php:813
+#: ../lib/html_tree.php:1076 ../tree.php:1568 ../user_admin.php:998
+#: ../user_admin.php:1242 ../user_admin.php:2559 ../user_group_admin.php:813
 #: ../user_group_admin.php:966 ../user_group_admin.php:2161
 #: ../utilities.php:268
 msgid "Graphs"
@@ -467,19 +467,19 @@ msgstr ""
 #: ../automation_graph_rules.php:743 ../automation_networks.php:1071
 #: ../automation_snmp.php:838 ../automation_templates.php:422
 #: ../automation_tree_rules.php:735 ../cdef.php:732 ../color.php:539
-#: ../color_templates.php:453 ../data_input.php:629 ../data_queries.php:1057
+#: ../color_templates.php:453 ../data_input.php:629 ../data_queries.php:1058
 #: ../data_source_profiles.php:729 ../data_source_profiles.php:848
 #: ../data_sources.php:1287 ../data_templates.php:780 ../gprint_presets.php:272
-#: ../graph_templates.php:638 ../graph_view.php:560 ../graphs.php:1694
+#: ../graph_templates.php:638 ../graph_view.php:560 ../graphs.php:1697
 #: ../graphs_new.php:530 ../host.php:1400 ../host_templates.php:710
 #: ../include/global_form.php:79 ../lib/api_automation.php:176
 #: ../lib/api_automation.php:470 ../lib/api_automation.php:693
-#: ../lib/api_automation.php:1031 ../lib/html_reports.php:1408 ../links.php:319
+#: ../lib/api_automation.php:1031 ../lib/html_reports.php:1398 ../links.php:319
 #: ../managers.php:160 ../managers.php:543 ../plugins.php:299
 #: ../pollers.php:527 ../rrdcleaner.php:501 ../sites.php:397 ../tree.php:1495
-#: ../user_admin.php:2186 ../user_admin.php:2546 ../user_admin.php:2633
-#: ../user_admin.php:2739 ../user_admin.php:2826 ../user_admin.php:2913
-#: ../user_admin.php:3000 ../user_domains.php:32 ../user_domains.php:631
+#: ../user_admin.php:2203 ../user_admin.php:2563 ../user_admin.php:2650
+#: ../user_admin.php:2756 ../user_admin.php:2843 ../user_admin.php:2930
+#: ../user_admin.php:3017 ../user_domains.php:32 ../user_domains.php:631
 #: ../user_domains.php:716 ../user_group_admin.php:1816
 #: ../user_group_admin.php:2165 ../user_group_admin.php:2271
 #: ../user_group_admin.php:2358 ../user_group_admin.php:2445
@@ -498,36 +498,36 @@ msgstr ""
 #: ../automation_graph_rules.php:754 ../automation_networks.php:1082
 #: ../automation_snmp.php:849 ../automation_templates.php:433
 #: ../automation_tree_rules.php:746 ../cdef.php:749 ../color.php:562
-#: ../color_templates.php:472 ../data_input.php:640 ../data_queries.php:1068
+#: ../color_templates.php:472 ../data_input.php:640 ../data_queries.php:1069
 #: ../data_source_profiles.php:746 ../data_sources.php:1241
 #: ../data_templates.php:797 ../gprint_presets.php:289
-#: ../graph_templates.php:655 ../graph_view.php:571 ../graphs.php:1674
+#: ../graph_templates.php:655 ../graph_view.php:571 ../graphs.php:1677
 #: ../graphs_new.php:554 ../host.php:1365 ../host_templates.php:727
 #: ../lib/api_automation.php:187 ../lib/api_automation.php:452
 #: ../lib/api_automation.php:704 ../lib/api_automation.php:1042
 #: ../lib/clog_webapi.php:340 ../lib/html.php:1154 ../lib/html_filter.php:81
-#: ../lib/html_graph.php:190 ../lib/html_reports.php:1418
+#: ../lib/html_graph.php:190 ../lib/html_reports.php:1408
 #: ../lib/html_tree.php:642 ../links.php:328 ../managers.php:171
-#: ../managers.php:554 ../managers.php:741 ../plugins.php:310
-#: ../pollers.php:538 ../sites.php:408 ../tree.php:1506 ../user_admin.php:2197
-#: ../user_admin.php:2563 ../user_admin.php:2650 ../user_admin.php:2756
-#: ../user_admin.php:2843 ../user_admin.php:2930 ../user_admin.php:3017
+#: ../managers.php:554 ../managers.php:743 ../plugins.php:310
+#: ../pollers.php:538 ../sites.php:408 ../tree.php:1506 ../user_admin.php:2214
+#: ../user_admin.php:2580 ../user_admin.php:2667 ../user_admin.php:2773
+#: ../user_admin.php:2860 ../user_admin.php:2947 ../user_admin.php:3034
 msgid "Go"
 msgstr ""
 
 #: ../aggregate_graphs.php:1034 ../aggregate_graphs.php:1369
 #: ../automation_devices.php:468 ../automation_snmp.php:849
 #: ../automation_templates.php:433 ../cdef.php:749 ../color.php:562
-#: ../data_input.php:640 ../data_queries.php:1068
+#: ../data_input.php:640 ../data_queries.php:1069
 #: ../data_source_profiles.php:746 ../data_sources.php:1241
 #: ../data_templates.php:797 ../gprint_presets.php:289
-#: ../graph_templates.php:655 ../graph_view.php:571 ../graphs.php:1674
+#: ../graph_templates.php:655 ../graph_view.php:571 ../graphs.php:1677
 #: ../graphs_new.php:554 ../host.php:1365 ../host_templates.php:727
 #: ../lib/html_graph.php:190 ../managers.php:171 ../managers.php:554
-#: ../managers.php:741 ../plugins.php:310 ../pollers.php:538 ../sites.php:408
-#: ../tree.php:1506 ../user_admin.php:2197 ../user_admin.php:2563
-#: ../user_admin.php:2650 ../user_admin.php:2756 ../user_admin.php:2843
-#: ../user_admin.php:2930 ../user_admin.php:3017 ../user_domains.php:642
+#: ../managers.php:743 ../plugins.php:310 ../pollers.php:538 ../sites.php:408
+#: ../tree.php:1506 ../user_admin.php:2214 ../user_admin.php:2580
+#: ../user_admin.php:2667 ../user_admin.php:2773 ../user_admin.php:2860
+#: ../user_admin.php:2947 ../user_admin.php:3034 ../user_domains.php:642
 #: ../user_group_admin.php:1827 ../user_group_admin.php:2182
 #: ../user_group_admin.php:2288 ../user_group_admin.php:2375
 #: ../user_group_admin.php:2462 ../user_group_admin.php:2549
@@ -541,37 +541,37 @@ msgstr ""
 #: ../automation_graph_rules.php:757 ../automation_networks.php:1085
 #: ../automation_snmp.php:852 ../automation_templates.php:436
 #: ../automation_tree_rules.php:749 ../cdef.php:752 ../color.php:565
-#: ../color_templates.php:475 ../data_input.php:643 ../data_queries.php:1071
+#: ../color_templates.php:475 ../data_input.php:643 ../data_queries.php:1072
 #: ../data_source_profiles.php:749 ../data_sources.php:1244
 #: ../data_templates.php:800 ../gprint_presets.php:292
-#: ../graph_templates.php:658 ../graph_view.php:574 ../graphs.php:1677
+#: ../graph_templates.php:658 ../graph_view.php:574 ../graphs.php:1680
 #: ../graphs_new.php:555 ../host.php:1368 ../host_templates.php:730
 #: ../lib/api_automation.php:190 ../lib/api_automation.php:455
 #: ../lib/api_automation.php:707 ../lib/api_automation.php:1045
 #: ../lib/clog_webapi.php:343 ../lib/html_filter.php:86
 #: ../lib/html_graph.php:193 ../lib/html_graph.php:322
-#: ../lib/html_reports.php:1421 ../lib/html_tree.php:645
+#: ../lib/html_reports.php:1411 ../lib/html_tree.php:645
 #: ../lib/html_tree.php:768 ../links.php:331 ../managers.php:174
-#: ../managers.php:557 ../managers.php:744 ../plugins.php:313
-#: ../pollers.php:541 ../sites.php:411 ../tree.php:1509 ../user_admin.php:2200
-#: ../user_admin.php:2566 ../user_admin.php:2653 ../user_admin.php:2759
-#: ../user_admin.php:2846 ../user_admin.php:2933 ../user_admin.php:3020
+#: ../managers.php:557 ../managers.php:746 ../plugins.php:313
+#: ../pollers.php:541 ../sites.php:411 ../tree.php:1509 ../user_admin.php:2217
+#: ../user_admin.php:2583 ../user_admin.php:2670 ../user_admin.php:2776
+#: ../user_admin.php:2863 ../user_admin.php:2950 ../user_admin.php:3037
 #: ../user_domains.php:645
 msgid "Clear"
 msgstr ""
 
 #: ../aggregate_graphs.php:1037 ../aggregate_graphs.php:1372
 #: ../automation_snmp.php:852 ../automation_templates.php:436 ../cdef.php:752
-#: ../color.php:565 ../data_input.php:643 ../data_queries.php:1071
+#: ../color.php:565 ../data_input.php:643 ../data_queries.php:1072
 #: ../data_source_profiles.php:749 ../data_sources.php:1244
 #: ../data_templates.php:800 ../gprint_presets.php:292
-#: ../graph_templates.php:658 ../graph_view.php:574 ../graphs.php:1677
+#: ../graph_templates.php:658 ../graph_view.php:574 ../graphs.php:1680
 #: ../graphs_new.php:555 ../host.php:1368 ../host_templates.php:730
 #: ../lib/html_graph.php:193 ../lib/html_tree.php:645 ../managers.php:174
-#: ../managers.php:557 ../managers.php:744 ../plugins.php:313
-#: ../pollers.php:541 ../sites.php:411 ../tree.php:1509 ../user_admin.php:2200
-#: ../user_admin.php:2566 ../user_admin.php:2653 ../user_admin.php:2759
-#: ../user_admin.php:2846 ../user_admin.php:2933 ../user_admin.php:3020
+#: ../managers.php:557 ../managers.php:746 ../plugins.php:313
+#: ../pollers.php:541 ../sites.php:411 ../tree.php:1509 ../user_admin.php:2217
+#: ../user_admin.php:2583 ../user_admin.php:2670 ../user_admin.php:2776
+#: ../user_admin.php:2863 ../user_admin.php:2950 ../user_admin.php:3037
 #: ../user_domains.php:645 ../user_group_admin.php:1830
 #: ../user_group_admin.php:2185 ../user_group_admin.php:2291
 #: ../user_group_admin.php:2378 ../user_group_admin.php:2465
@@ -582,19 +582,19 @@ msgid "Clear Filters"
 msgstr ""
 
 #: ../aggregate_graphs.php:1116 ../aggregate_graphs.php:1435
-#: ../graph_view.php:619 ../graphs.php:1055 ../lib/api_automation.php:561
+#: ../graph_view.php:619 ../graphs.php:1058 ../lib/api_automation.php:561
 #: ../user_admin.php:1006 ../user_group_admin.php:821
 msgid "Graph Title"
 msgstr ""
 
 #: ../aggregate_graphs.php:1117 ../aggregate_graphs.php:1436
 #: ../automation_graph_rules.php:856 ../automation_tree_rules.php:843
-#: ../data_queries.php:1152 ../data_sources.php:1406 ../data_templates.php:910
-#: ../graph_templates.php:762 ../graphs.php:1785 ../host.php:1500
+#: ../data_queries.php:1153 ../data_sources.php:1406 ../data_templates.php:910
+#: ../graph_templates.php:762 ../graphs.php:1788 ../host.php:1500
 #: ../host_templates.php:815 ../lib/api_automation.php:273 ../pollers.php:612
 #: ../sites.php:482 ../tree.php:1559 ../user_admin.php:1006
-#: ../user_admin.php:1101 ../user_admin.php:1229 ../user_admin.php:1371
-#: ../user_admin.php:1504 ../user_group_admin.php:675
+#: ../user_admin.php:1101 ../user_admin.php:1242 ../user_admin.php:1384
+#: ../user_admin.php:1521 ../user_group_admin.php:675
 #: ../user_group_admin.php:821 ../user_group_admin.php:966
 #: ../user_group_admin.php:1109 ../user_group_admin.php:1243
 msgid "ID"
@@ -605,51 +605,51 @@ msgid "Included in Aggregate"
 msgstr ""
 
 #: ../aggregate_graphs.php:1119 ../aggregate_graphs.php:1438
-#: ../graph_templates.php:765 ../graphs.php:1787
+#: ../graph_templates.php:765 ../graphs.php:1790
 msgid "Size"
 msgstr ""
 
 #: ../aggregate_graphs.php:1129 ../cdef.php:869 ../color.php:722
 #: ../color.php:724 ../color_templates.php:566 ../data_input.php:741
-#: ../data_queries.php:1172 ../data_source_profiles.php:876
+#: ../data_queries.php:1173 ../data_source_profiles.php:876
 #: ../data_source_profiles.php:877 ../data_sources.php:1450
 #: ../data_sources.php:1451 ../data_templates.php:930 ../gprint_presets.php:411
 #: ../graph_templates.php:783 ../host_templates.php:834
-#: ../include/global_settings.php:398 ../install/index.php:527
-#: ../install/index.php:548 ../tree.php:1593 ../tree.php:1594
-#: ../user_admin.php:2268 ../user_domains.php:731 ../user_group_admin.php:1897
-#: ../vdef.php:864
+#: ../include/global_settings.php:398 ../include/global_settings.php:1254
+#: ../install/index.php:527 ../install/index.php:548 ../tree.php:1593
+#: ../tree.php:1594 ../user_admin.php:2285 ../user_domains.php:731
+#: ../user_group_admin.php:1897 ../vdef.php:864
 msgid "No"
 msgstr ""
 
 #: ../aggregate_graphs.php:1129 ../cdef.php:869 ../color.php:722
 #: ../color.php:724 ../color_templates.php:566 ../data_input.php:741
-#: ../data_queries.php:1172 ../data_source_profiles.php:876
+#: ../data_queries.php:1173 ../data_source_profiles.php:876
 #: ../data_source_profiles.php:877 ../data_sources.php:1450
 #: ../data_sources.php:1451 ../data_templates.php:930 ../gprint_presets.php:411
 #: ../graph_templates.php:783 ../host_templates.php:834
-#: ../include/global_settings.php:398 ../install/index.php:526
-#: ../install/index.php:527 ../install/index.php:547 ../install/index.php:548
-#: ../tree.php:1593 ../tree.php:1594 ../user_admin.php:2266
-#: ../user_domains.php:729 ../user_domains.php:731 ../user_group_admin.php:1895
-#: ../vdef.php:864
+#: ../include/global_settings.php:398 ../include/global_settings.php:1254
+#: ../install/index.php:526 ../install/index.php:527 ../install/index.php:547
+#: ../install/index.php:548 ../tree.php:1593 ../tree.php:1594
+#: ../user_admin.php:2283 ../user_domains.php:729 ../user_domains.php:731
+#: ../user_group_admin.php:1895 ../vdef.php:864
 msgid "Yes"
 msgstr ""
 
-#: ../aggregate_graphs.php:1135 ../graphs.php:1807
+#: ../aggregate_graphs.php:1135 ../graphs.php:1810
 #: ../lib/api_automation.php:588
 msgid "No Graphs Found"
 msgstr ""
 
 #: ../aggregate_graphs.php:1317 ../aggregate_graphs.php:1426
-#: ../lib/functions.php:2533
+#: ../lib/functions.php:2550
 msgid "Aggregate Graphs"
 msgstr ""
 
 #: ../aggregate_graphs.php:1332 ../data_sources.php:1206 ../graph_view.php:524
-#: ../graphs.php:1650 ../host.php:1347 ../lib/api_automation.php:434
+#: ../graphs.php:1653 ../host.php:1347 ../lib/api_automation.php:434
 #: ../lib/html_graph.php:159 ../lib/html_tree.php:611 ../rrdcleaner.php:351
-#: ../user_admin.php:2520 ../user_admin.php:2717 ../user_group_admin.php:2139
+#: ../user_admin.php:2537 ../user_admin.php:2734 ../user_group_admin.php:2139
 #: ../user_group_admin.php:2249 ../utilities.php:1555
 msgid "Template"
 msgstr ""
@@ -658,13 +658,13 @@ msgstr ""
 #: ../automation_devices.php:488 ../automation_devices.php:503
 #: ../automation_devices.php:518 ../automation_graph_rules.php:711
 #: ../automation_graph_rules.php:733 ../data_sources.php:1210
-#: ../graphs.php:1654 ../graphs_items.php:308 ../graphs_items.php:329
+#: ../graphs.php:1657 ../graphs_items.php:308 ../graphs_items.php:329
 #: ../host.php:1316 ../host.php:1334 ../host.php:1351 ../host.php:1385
 #: ../lib/api_automation.php:143 ../lib/api_automation.php:161
 #: ../lib/api_automation.php:421 ../lib/api_automation.php:438
 #: ../lib/api_automation.php:998 ../lib/api_automation.php:1016
-#: ../lib/html.php:1633 ../lib/html_reports.php:1398 ../managers.php:522
-#: ../managers.php:732 ../user_admin.php:2524 ../user_admin.php:2721
+#: ../lib/html.php:1633 ../lib/html_reports.php:1388 ../managers.php:522
+#: ../managers.php:734 ../user_admin.php:2541 ../user_admin.php:2738
 #: ../user_group_admin.php:2143 ../user_group_admin.php:2253
 #: ../utilities.php:654 ../utilities.php:1293 ../utilities.php:1559
 #: ../utilities.php:1604 ../utilities.php:2267 ../utilities.php:2520
@@ -677,11 +677,11 @@ msgstr ""
 #: ../automation_networks.php:421 ../automation_networks.php:633
 #: ../automation_tree_rules.php:855 ../data_sources.php:824
 #: ../data_sources.php:1211 ../data_sources.php:1436 ../data_templates.php:932
-#: ../graph_view.php:782 ../graphs.php:1323 ../graphs.php:1655
+#: ../graph_view.php:782 ../graphs.php:1326 ../graphs.php:1658
 #: ../graphs_items.php:309 ../graphs_items.php:330 ../host.php:1013
-#: ../host.php:1317 ../host.php:1352 ../include/global_arrays.php:329
-#: ../include/global_arrays.php:382 ../include/global_arrays.php:458
-#: ../include/global_arrays.php:570 ../include/global_arrays.php:593
+#: ../host.php:1317 ../host.php:1352 ../include/global_arrays.php:330
+#: ../include/global_arrays.php:383 ../include/global_arrays.php:459
+#: ../include/global_arrays.php:571 ../include/global_arrays.php:594
 #: ../include/global_arrays.php:1318 ../include/global_form.php:389
 #: ../include/global_form.php:712 ../include/global_form.php:721
 #: ../include/global_form.php:732 ../include/global_form.php:775
@@ -690,15 +690,15 @@ msgstr ""
 #: ../include/global_form.php:1032 ../include/global_form.php:1041
 #: ../include/global_form.php:2097 ../include/global_form.php:2139
 #: ../include/global_settings.php:445 ../include/global_settings.php:453
-#: ../include/global_settings.php:900 ../include/global_settings.php:1317
+#: ../include/global_settings.php:900 ../include/global_settings.php:1324
 #: ../lib/api_automation.php:144 ../lib/api_automation.php:422
 #: ../lib/api_automation.php:439 ../lib/api_automation.php:576
 #: ../lib/api_automation.php:999 ../lib/html.php:1634 ../lib/html_form.php:315
-#: ../lib/html_graph.php:396 ../lib/html_reports.php:320
-#: ../lib/html_reports.php:362 ../lib/html_reports.php:373
-#: ../lib/html_reports.php:381 ../lib/html_reports.php:390
+#: ../lib/html_graph.php:396 ../lib/html_reports.php:280
+#: ../lib/html_reports.php:328 ../lib/html_reports.php:340
+#: ../lib/html_reports.php:349 ../lib/html_reports.php:359
 #: ../lib/html_tree.php:843 ../settings.php:197 ../settings.php:214
-#: ../settings.php:237 ../user_admin.php:2525 ../user_admin.php:2722
+#: ../settings.php:237 ../user_admin.php:2542 ../user_admin.php:2739
 #: ../user_group_admin.php:2144 ../user_group_admin.php:2254
 #: ../utilities.php:1560
 msgid "None"
@@ -712,7 +712,7 @@ msgstr ""
 msgid "The internal database identifier for this object"
 msgstr ""
 
-#: ../aggregate_graphs.php:1437 ../graphs.php:1059
+#: ../aggregate_graphs.php:1437 ../graphs.php:1062
 msgid "Aggregate Template"
 msgstr ""
 
@@ -754,14 +754,14 @@ msgid "Aggregate Template [new]"
 msgstr ""
 
 #: ../aggregate_templates.php:531 ../aggregate_templates.php:631
-#: ../lib/functions.php:2515
+#: ../lib/functions.php:2532
 msgid "Aggregate Templates"
 msgstr ""
 
 #: ../aggregate_templates.php:544 ../automation_templates.php:418
 #: ../automation_templates.php:503 ../color_templates.php:550
-#: ../include/global_arrays.php:694 ../include/global_arrays.php:752
-#: ../install/index.php:905 ../user_admin.php:2822 ../user_group_admin.php:2354
+#: ../include/global_arrays.php:695 ../include/global_arrays.php:753
+#: ../install/index.php:898 ../user_admin.php:2839 ../user_group_admin.php:2354
 msgid "Templates"
 msgstr ""
 
@@ -782,7 +782,7 @@ msgid ""
 msgstr ""
 
 #: ../aggregate_templates.php:641 ../cdef.php:852 ../color.php:699
-#: ../color_templates.php:548 ../data_input.php:723 ../data_queries.php:1153
+#: ../color_templates.php:548 ../data_input.php:723 ../data_queries.php:1154
 #: ../data_source_profiles.php:849 ../data_sources.php:1408
 #: ../data_templates.php:911 ../gprint_presets.php:392
 #: ../graph_templates.php:763 ../host_templates.php:816 ../vdef.php:846
@@ -790,15 +790,15 @@ msgid "Deletable"
 msgstr ""
 
 #: ../aggregate_templates.php:642 ../cdef.php:853 ../color.php:700
-#: ../data_queries.php:911 ../data_queries.php:1154 ../gprint_presets.php:393
+#: ../data_queries.php:912 ../data_queries.php:1155 ../gprint_presets.php:393
 #: ../graph_templates.php:764 ../vdef.php:847
 msgid "Graphs Using"
 msgstr ""
 
 #: ../aggregate_templates.php:643 ../graph_view.php:619
-#: ../include/global_arrays.php:654 ../include/global_arrays.php:988
+#: ../include/global_arrays.php:655 ../include/global_arrays.php:989
 #: ../include/global_form.php:1323 ../include/global_form.php:1551
-#: ../lib/html_reports.php:377 ../tree.php:1286
+#: ../lib/html_reports.php:345 ../tree.php:1286
 msgid "Graph Template"
 msgstr ""
 
@@ -854,7 +854,7 @@ msgid "Cannot be reused for %d password changes"
 msgstr ""
 
 #: ../auth_changepassword.php:258 ../auth_changepassword.php:284
-#: ../include/global_form.php:1468 ../lib/functions.php:1809
+#: ../include/global_form.php:1468 ../lib/functions.php:1826
 msgid "Change Password"
 msgstr ""
 
@@ -938,25 +938,25 @@ msgid "Enter your Username and Password below"
 msgstr ""
 
 #: ../auth_login.php:570 ../auth_login.php:573
-#: ../include/global_settings.php:1187 ../lib/functions.php:3780
+#: ../include/global_settings.php:1187 ../lib/functions.php:3801
 msgid "Username"
 msgstr ""
 
 #: ../auth_login.php:578 ../include/global_form.php:1435
-#: ../lib/functions.php:3781
+#: ../lib/functions.php:3802
 msgid "Password"
 msgstr ""
 
-#: ../auth_login.php:590 ../include/global_settings.php:1567
-#: ../lib/auth.php:285 ../lib/auth.php:297 ../lib/auth.php:308
+#: ../auth_login.php:590 ../include/global_settings.php:1574
+#: ../lib/auth.php:287 ../lib/auth.php:299 ../lib/auth.php:310
 msgid "Local"
 msgstr ""
 
-#: ../auth_login.php:594 ../include/global_arrays.php:581 ../lib/auth.php:309
+#: ../auth_login.php:594 ../include/global_arrays.php:582 ../lib/auth.php:311
 msgid "LDAP"
 msgstr ""
 
-#: ../auth_login.php:605 ../user_admin.php:2249 ../user_group_admin.php:675
+#: ../auth_login.php:605 ../user_admin.php:2266 ../user_group_admin.php:675
 msgid "Realm"
 msgstr ""
 
@@ -980,24 +980,24 @@ msgstr ""
 msgid "User Account Details"
 msgstr ""
 
-#: ../auth_profile.php:161 ../include/global_arrays.php:564
-#: ../include/global_settings.php:1903 ../lib/html.php:1519
+#: ../auth_profile.php:161 ../include/global_arrays.php:565
+#: ../include/global_settings.php:1910 ../lib/html.php:1519
 #: ../lib/html.php:1541
 msgid "Tree View"
 msgstr ""
 
-#: ../auth_profile.php:165 ../include/global_arrays.php:565
+#: ../auth_profile.php:165 ../include/global_arrays.php:566
 #: ../lib/html.php:1526 ../lib/html.php:1550
 msgid "List View"
 msgstr ""
 
-#: ../auth_profile.php:169 ../include/global_arrays.php:566
+#: ../auth_profile.php:169 ../include/global_arrays.php:567
 #: ../lib/html.php:1533
 msgid "Preview View"
 msgstr ""
 
 #: ../auth_profile.php:182 ../include/global_form.php:1411
-#: ../user_admin.php:2246
+#: ../user_admin.php:2263
 msgid "User Name"
 msgstr ""
 
@@ -1006,7 +1006,7 @@ msgid "The login name for this user."
 msgstr ""
 
 #: ../auth_profile.php:190 ../include/global_form.php:1419
-#: ../user_admin.php:2247 ../user_group_admin.php:675 ../utilities.php:764
+#: ../user_admin.php:2264 ../user_group_admin.php:675 ../utilities.php:764
 msgid "Full Name"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Clear all your Login Session Tokens."
 msgstr ""
 
-#: ../auth_profile.php:239 ../user_admin.php:1911 ../user_group_admin.php:1649
+#: ../auth_profile.php:239 ../user_admin.php:1928 ../user_group_admin.php:1649
 msgid "User Settings"
 msgstr ""
 
@@ -1089,11 +1089,12 @@ msgid "Added to Cacti"
 msgstr ""
 
 #: ../automation_devices.php:106 ../automation_devices.php:108
-#: ../data_sources.php:822 ../graph_view.php:619 ../graphs.php:1328
-#: ../graphs_items.php:304 ../include/global_arrays.php:650
-#: ../include/global_arrays.php:695 ../include/global_arrays.php:1434
-#: ../lib/api_automation.php:417 ../lib/functions.php:3775 ../lib/html.php:1629
-#: ../lib/html.php:1659 ../lib/html_reports.php:368 ../utilities.php:1409
+#: ../data_sources.php:822 ../graph_view.php:619 ../graphs.php:1331
+#: ../graphs_items.php:304 ../include/global_arrays.php:651
+#: ../include/global_arrays.php:696 ../include/global_arrays.php:1434
+#: ../lib/api_automation.php:417 ../lib/functions.php:3796 ../lib/html.php:1629
+#: ../lib/html.php:1659 ../lib/html_reports.php:335 ../lib/html_tree.php:349
+#: ../lib/html_tree.php:377 ../utilities.php:1409
 msgid "Device"
 msgstr ""
 
@@ -1127,12 +1128,12 @@ msgid "You must select at least one Device."
 msgstr ""
 
 #: ../automation_devices.php:239 ../automation_devices.php:529 ../host.php:1303
-#: ../host.php:1396 ../host.php:1489 ../include/global_arrays.php:682
-#: ../include/global_arrays.php:734 ../lib/api_automation.php:172
-#: ../lib/api_automation.php:466 ../lib/functions.php:2119 ../pollers.php:616
-#: ../sites.php:483 ../tree.php:1567 ../user_admin.php:2735
-#: ../user_group_admin.php:958 ../user_group_admin.php:2267
-#: ../utilities.php:263
+#: ../host.php:1396 ../host.php:1489 ../include/global_arrays.php:683
+#: ../include/global_arrays.php:735 ../lib/api_automation.php:172
+#: ../lib/api_automation.php:466 ../lib/functions.php:2136 ../pollers.php:616
+#: ../sites.php:483 ../tree.php:1567 ../user_admin.php:1234
+#: ../user_admin.php:2752 ../user_group_admin.php:958
+#: ../user_group_admin.php:2267 ../utilities.php:263
 msgid "Devices"
 msgstr ""
 
@@ -1148,7 +1149,7 @@ msgstr ""
 msgid "SNMP Name"
 msgstr ""
 
-#: ../automation_devices.php:251 ../include/global_settings.php:1563
+#: ../automation_devices.php:251 ../include/global_settings.php:1570
 msgid "Location"
 msgstr ""
 
@@ -1158,10 +1159,10 @@ msgstr ""
 
 #: ../automation_devices.php:253 ../include/global_form.php:970
 #: ../include/global_form.php:1006 ../include/global_form.php:1287
-#: ../include/global_form.php:1630 ../install/index.php:906
+#: ../include/global_form.php:1630 ../install/index.php:899
 #: ../lib/api_automation.php:269 ../lib/api_automation.php:1137
 #: ../managers.php:222 ../tree.php:647 ../user_admin.php:1101
-#: ../user_admin.php:1229 ../user_group_admin.php:966
+#: ../user_admin.php:1242 ../user_group_admin.php:966
 #: ../user_group_admin.php:1883
 msgid "Description"
 msgstr ""
@@ -1171,7 +1172,7 @@ msgid "OS"
 msgstr ""
 
 #: ../automation_devices.php:255 ../host.php:1505
-#: ../include/global_arrays.php:330
+#: ../include/global_arrays.php:331
 msgid "Uptime"
 msgstr ""
 
@@ -1186,9 +1187,9 @@ msgstr ""
 #: ../data_templates.php:915 ../host.php:686 ../host.php:778 ../host.php:1381
 #: ../host.php:1503 ../lib/api_automation.php:157 ../lib/api_automation.php:271
 #: ../lib/api_automation.php:560 ../lib/api_automation.php:1012
-#: ../lib/api_automation.php:1140 ../lib/html_reports.php:1394
+#: ../lib/api_automation.php:1140 ../lib/html_reports.php:1384
 #: ../managers.php:224 ../plugins.php:282 ../plugins.php:377 ../pollers.php:614
-#: ../user_admin.php:1229 ../user_group_admin.php:966
+#: ../user_admin.php:1242 ../user_group_admin.php:966
 msgid "Status"
 msgstr ""
 
@@ -1225,7 +1226,7 @@ msgid "Export to a file"
 msgstr ""
 
 #: ../automation_devices.php:477 ../lib/clog_webapi.php:120
-#: ../lib/clog_webapi.php:346 ../managers.php:747
+#: ../lib/clog_webapi.php:346 ../managers.php:749
 msgid "Purge"
 msgstr ""
 
@@ -1236,23 +1237,24 @@ msgstr ""
 #: ../automation_graph_rules.php:29 ../automation_snmp.php:30
 #: ../automation_tree_rules.php:29 ../cdef.php:30 ../color_templates.php:29
 #: ../data_templates.php:34 ../graph_templates.php:34 ../graphs.php:63
-#: ../host_templates.php:31 ../vdef.php:30
+#: ../host_templates.php:31 ../include/global_arrays.php:1231 ../vdef.php:30
 msgid "Duplicate"
 msgstr ""
 
 #: ../automation_graph_rules.php:30 ../automation_networks.php:33
 #: ../automation_tree_rules.php:30 ../data_sources.php:38 ../host.php:39
-#: ../include/global_settings.php:1145 ../links.php:29 ../managers.php:29
-#: ../managers.php:35 ../plugins.php:29 ../pollers.php:31 ../user_admin.php:30
-#: ../user_domains.php:31 ../user_domains.php:402 ../user_group_admin.php:32
+#: ../include/global_arrays.php:1232 ../include/global_settings.php:1145
+#: ../links.php:29 ../managers.php:29 ../managers.php:35 ../plugins.php:29
+#: ../pollers.php:31 ../user_admin.php:30 ../user_domains.php:31
+#: ../user_domains.php:402 ../user_group_admin.php:32
 msgid "Enable"
 msgstr ""
 
 #: ../automation_graph_rules.php:31 ../automation_networks.php:32
 #: ../automation_tree_rules.php:31 ../data_sources.php:39 ../host.php:40
-#: ../links.php:30 ../managers.php:30 ../managers.php:34 ../plugins.php:30
-#: ../pollers.php:30 ../user_admin.php:31 ../user_domains.php:30
-#: ../user_group_admin.php:33
+#: ../include/global_arrays.php:1233 ../links.php:30 ../managers.php:30
+#: ../managers.php:34 ../plugins.php:30 ../pollers.php:30 ../user_admin.php:31
+#: ../user_domains.php:30 ../user_group_admin.php:33
 msgid "Disable"
 msgstr ""
 
@@ -1267,7 +1269,7 @@ msgid ""
 msgstr ""
 
 #: ../automation_graph_rules.php:260 ../automation_tree_rules.php:262
-#: ../graphs.php:848 ../graphs.php:859
+#: ../graphs.php:851 ../graphs.php:862
 msgid "Title Format"
 msgstr ""
 
@@ -1340,13 +1342,13 @@ msgid "Graph Creation Criteria"
 msgstr ""
 
 #: ../automation_graph_rules.php:692 ../automation_graph_rules.php:739
-#: ../automation_graph_rules.php:846 ../include/global_arrays.php:705
-#: ../include/global_form.php:1571 ../lib/functions.php:2569
+#: ../automation_graph_rules.php:846 ../include/global_arrays.php:706
+#: ../include/global_form.php:1571 ../lib/functions.php:2586
 msgid "Graph Rules"
 msgstr ""
 
 #: ../automation_graph_rules.php:707 ../automation_graph_rules.php:857
-#: ../include/global_arrays.php:991 ../include/global_form.php:1561
+#: ../include/global_arrays.php:992 ../include/global_form.php:1561
 #: ../include/global_form.php:2176
 msgid "Data Query"
 msgstr ""
@@ -1354,13 +1356,13 @@ msgstr ""
 #: ../automation_graph_rules.php:734 ../automation_graph_rules.php:859
 #: ../automation_networks.php:496 ../automation_tree_rules.php:848
 #: ../automation_tree_rules.php:866 ../data_sources.php:1236 ../host.php:1386
-#: ../include/global_arrays.php:613 ../include/global_form.php:1443
+#: ../include/global_arrays.php:614 ../include/global_form.php:1443
 #: ../include/global_settings.php:339 ../lib/api_automation.php:162
-#: ../lib/api_automation.php:1017 ../lib/html_reports.php:1399
-#: ../lib/html_reports.php:1492 ../lib/html_reports.php:1503
-#: ../lib/html_reports.php:1526 ../links.php:381 ../managers.php:249
-#: ../managers.php:626 ../user_admin.php:1101 ../user_admin.php:1113
-#: ../user_admin.php:2248 ../user_domains.php:341 ../user_domains.php:718
+#: ../lib/api_automation.php:1017 ../lib/html_reports.php:1389
+#: ../lib/html_reports.php:1482 ../lib/html_reports.php:1493
+#: ../lib/html_reports.php:1529 ../links.php:381 ../managers.php:249
+#: ../managers.php:628 ../user_admin.php:1101 ../user_admin.php:1113
+#: ../user_admin.php:2265 ../user_domains.php:341 ../user_domains.php:718
 #: ../user_group_admin.php:87 ../user_group_admin.php:675
 #: ../user_group_admin.php:690 ../user_group_admin.php:1887
 #: ../utilities.php:2142
@@ -1369,15 +1371,15 @@ msgstr ""
 
 #: ../automation_graph_rules.php:735 ../automation_networks.php:979
 #: ../automation_tree_rules.php:866 ../data_sources.php:1237
-#: ../data_templates.php:934 ../host.php:1387 ../include/global_arrays.php:612
-#: ../include/global_arrays.php:1158 ../include/global_arrays.php:1442
+#: ../data_templates.php:934 ../host.php:1387 ../include/global_arrays.php:613
+#: ../include/global_arrays.php:1159 ../include/global_arrays.php:1442
 #: ../include/global_settings.php:339 ../include/global_settings.php:1021
 #: ../include/global_settings.php:1035 ../include/global_settings.php:1047
 #: ../include/global_settings.php:1072 ../include/global_settings.php:1086
-#: ../include/global_settings.php:1145 ../include/global_settings.php:1757
+#: ../include/global_settings.php:1145 ../include/global_settings.php:1764
 #: ../lib/api_automation.php:163 ../lib/api_automation.php:1018
-#: ../lib/html_reports.php:1400 ../lib/html_reports.php:1526
-#: ../lib/html_utility.php:807 ../managers.php:249 ../managers.php:626
+#: ../lib/html_reports.php:1390 ../lib/html_reports.php:1529
+#: ../lib/html_utility.php:807 ../managers.php:249 ../managers.php:628
 #: ../pollers.php:40 ../user_admin.php:1113 ../user_domains.php:402
 #: ../user_group_admin.php:690 ../utilities.php:2142
 msgid "Disabled"
@@ -1469,7 +1471,7 @@ msgid "Manual"
 msgstr ""
 
 #: ../automation_networks.php:379 ../automation_networks.php:953
-#: ../include/global_arrays.php:499
+#: ../include/global_arrays.php:500
 msgid "Daily"
 msgstr ""
 
@@ -1501,8 +1503,8 @@ msgid "General Settings"
 msgstr ""
 
 #: ../automation_networks.php:400 ../automation_snmp.php:645
-#: ../data_input.php:468 ../data_input.php:502 ../data_queries.php:593
-#: ../data_queries.php:689 ../data_queries.php:909
+#: ../data_input.php:468 ../data_input.php:502 ../data_queries.php:594
+#: ../data_queries.php:690 ../data_queries.php:910
 #: ../data_source_profiles.php:486 ../graph_templates.php:423
 #: ../include/global_form.php:35 ../include/global_form.php:104
 #: ../include/global_form.php:154 ../include/global_form.php:174
@@ -1513,7 +1515,7 @@ msgstr ""
 #: ../include/global_form.php:1349 ../include/global_form.php:1377
 #: ../include/global_form.php:2070 ../include/global_form.php:2168
 #: ../include/global_form.php:2215 ../install/index.php:466
-#: ../install/index.php:543 ../install/index.php:906 ../lib/vdef.php:74
+#: ../install/index.php:543 ../install/index.php:899 ../lib/vdef.php:74
 #: ../managers.php:607 ../pollers.php:52 ../sites.php:40 ../user_admin.php:1101
 #: ../user_domains.php:317 ../utilities.php:466 ../utilities.php:2338
 msgid "Name"
@@ -1606,9 +1608,9 @@ msgstr ""
 #: ../automation_networks.php:466 ../automation_networks.php:467
 #: ../automation_networks.php:468 ../automation_networks.php:469
 #: ../automation_networks.php:470 ../automation_networks.php:471
-#: ../automation_networks.php:472 ../include/global_arrays.php:547
-#: ../include/global_arrays.php:548 ../include/global_arrays.php:549
-#: ../include/global_arrays.php:550 ../include/global_arrays.php:551
+#: ../automation_networks.php:472 ../include/global_arrays.php:548
+#: ../include/global_arrays.php:549 ../include/global_arrays.php:550
+#: ../include/global_arrays.php:551 ../include/global_arrays.php:552
 #, php-format
 msgid "%d Threads"
 msgstr ""
@@ -1628,44 +1630,44 @@ msgstr ""
 
 #: ../automation_networks.php:483 ../automation_networks.php:484
 #: ../automation_networks.php:485 ../automation_networks.php:486
-#: ../data_sources.php:1071 ../include/global_arrays.php:489
-#: ../include/global_arrays.php:490 ../include/global_arrays.php:491
-#: ../include/global_arrays.php:492 ../include/global_arrays.php:522
-#: ../include/global_arrays.php:523 ../include/global_arrays.php:524
-#: ../include/global_arrays.php:525 ../include/global_arrays.php:526
-#: ../include/global_arrays.php:527 ../include/global_arrays.php:845
-#: ../include/global_arrays.php:846 ../include/global_arrays.php:1165
-#: ../include/global_arrays.php:1169 ../include/global_arrays.php:1177
-#: ../include/global_arrays.php:1178 ../include/global_arrays.php:1200
-#: ../include/global_arrays.php:1201 ../include/global_arrays.php:1202
-#: ../include/global_arrays.php:1203 ../include/global_arrays.php:1204
-#: ../include/global_arrays.php:1215 ../include/global_settings.php:1088
+#: ../data_sources.php:1071 ../include/global_arrays.php:490
+#: ../include/global_arrays.php:491 ../include/global_arrays.php:492
+#: ../include/global_arrays.php:493 ../include/global_arrays.php:523
+#: ../include/global_arrays.php:524 ../include/global_arrays.php:525
+#: ../include/global_arrays.php:526 ../include/global_arrays.php:527
+#: ../include/global_arrays.php:528 ../include/global_arrays.php:846
+#: ../include/global_arrays.php:847 ../include/global_arrays.php:1166
+#: ../include/global_arrays.php:1170 ../include/global_arrays.php:1178
+#: ../include/global_arrays.php:1179 ../include/global_arrays.php:1201
+#: ../include/global_arrays.php:1202 ../include/global_arrays.php:1203
+#: ../include/global_arrays.php:1204 ../include/global_arrays.php:1205
+#: ../include/global_arrays.php:1216 ../include/global_settings.php:1088
 #: ../include/global_settings.php:1089 ../include/global_settings.php:1090
 #: ../include/global_settings.php:1091 ../include/global_settings.php:1092
-#: ../include/global_settings.php:1830
+#: ../include/global_settings.php:1837
 #, php-format
 msgid "%d Minutes"
 msgstr ""
 
-#: ../automation_networks.php:487 ../include/global_arrays.php:1070
+#: ../automation_networks.php:487 ../include/global_arrays.php:1071
 #, php-format
 msgid "%d Hour"
 msgstr ""
 
 #: ../automation_networks.php:488 ../automation_networks.php:489
 #: ../automation_networks.php:490 ../data_source_profiles.php:656
-#: ../include/global_arrays.php:494 ../include/global_arrays.php:495
-#: ../include/global_arrays.php:496 ../include/global_arrays.php:497
-#: ../include/global_arrays.php:498 ../include/global_arrays.php:529
-#: ../include/global_arrays.php:530 ../include/global_arrays.php:531
-#: ../include/global_arrays.php:532 ../include/global_arrays.php:1071
-#: ../include/global_arrays.php:1072 ../include/global_arrays.php:1073
-#: ../include/global_arrays.php:1074 ../include/global_arrays.php:1117
-#: ../include/global_arrays.php:1118 ../include/global_arrays.php:1119
-#: ../include/global_arrays.php:1120 ../include/global_arrays.php:1121
-#: ../include/global_arrays.php:1138 ../include/global_arrays.php:1139
-#: ../include/global_arrays.php:1140 ../include/global_arrays.php:1141
-#: ../include/global_arrays.php:1142 ../include/global_settings.php:1094
+#: ../include/global_arrays.php:495 ../include/global_arrays.php:496
+#: ../include/global_arrays.php:497 ../include/global_arrays.php:498
+#: ../include/global_arrays.php:499 ../include/global_arrays.php:530
+#: ../include/global_arrays.php:531 ../include/global_arrays.php:532
+#: ../include/global_arrays.php:533 ../include/global_arrays.php:1072
+#: ../include/global_arrays.php:1073 ../include/global_arrays.php:1074
+#: ../include/global_arrays.php:1075 ../include/global_arrays.php:1118
+#: ../include/global_arrays.php:1119 ../include/global_arrays.php:1120
+#: ../include/global_arrays.php:1121 ../include/global_arrays.php:1122
+#: ../include/global_arrays.php:1139 ../include/global_arrays.php:1140
+#: ../include/global_arrays.php:1141 ../include/global_arrays.php:1142
+#: ../include/global_arrays.php:1143 ../include/global_settings.php:1094
 #: ../include/global_settings.php:1095 ../include/global_settings.php:1096
 #: ../include/global_settings.php:1097
 #, php-format
@@ -1862,7 +1864,7 @@ msgstr ""
 msgid "Reachability Settings"
 msgstr ""
 
-#: ../automation_networks.php:630 ../include/global_arrays.php:707
+#: ../automation_networks.php:630 ../include/global_arrays.php:708
 #: ../include/global_form.php:1062 ../include/global_form.php:1662
 msgid "SNMP Options"
 msgstr ""
@@ -1956,7 +1958,7 @@ msgid "Network Filters"
 msgstr ""
 
 #: ../automation_networks.php:943 ../automation_networks.php:1067
-#: ../include/global_arrays.php:702
+#: ../include/global_arrays.php:703
 msgid "Networks"
 msgstr ""
 
@@ -2015,7 +2017,7 @@ msgstr ""
 #: ../automation_networks.php:1030 ../automation_snmp.php:705
 #: ../automation_snmp.php:706 ../automation_snmp.php:707
 #: ../automation_snmp.php:708 ../automation_snmp.php:709
-#: ../automation_snmp.php:710 ../lib/html.php:937 ../user_admin.php:2261
+#: ../automation_snmp.php:710 ../lib/html.php:937 ../user_admin.php:2278
 #: ../utilities.php:406 ../utilities.php:792 ../utilities.php:2015
 #: ../utilities.php:2115 ../utilities.php:2118 ../utilities.php:2121
 #: ../utilities.php:2127 ../utilities.php:2358
@@ -2198,11 +2200,11 @@ msgstr ""
 #: ../include/global_form.php:2117 ../include/global_form.php:2159
 #: ../include/global_form.php:2313 ../lib/api_automation.php:1207
 #: ../lib/api_automation.php:1269 ../lib/api_automation.php:1332
-#: ../lib/html_reports.php:428 ../lib/html_reports.php:1235
+#: ../lib/html_reports.php:399 ../lib/html_reports.php:1210
 msgid "Sequence"
 msgstr ""
 
-#: ../automation_snmp.php:545 ../lib/html_reports.php:429
+#: ../automation_snmp.php:545 ../lib/html_reports.php:400
 msgid "Sequence of Item."
 msgstr ""
 
@@ -2225,7 +2227,7 @@ msgstr ""
 
 #: ../automation_snmp.php:674 ../cdef.php:584 ../lib/api_automation.php:1206
 #: ../lib/api_automation.php:1268 ../lib/api_automation.php:1331
-#: ../lib/html_reports.php:1235 ../vdef.php:564
+#: ../lib/html_reports.php:1209 ../vdef.php:564
 msgid "Item"
 msgstr ""
 
@@ -2239,7 +2241,7 @@ msgstr ""
 msgid "Community"
 msgstr ""
 
-#: ../automation_snmp.php:677 ../lib/functions.php:3776
+#: ../automation_snmp.php:677 ../lib/functions.php:3797
 msgid "Port"
 msgstr ""
 
@@ -2279,7 +2281,7 @@ msgstr ""
 msgid "Context"
 msgstr ""
 
-#: ../automation_snmp.php:687 ../data_queries.php:913 ../utilities.php:1600
+#: ../automation_snmp.php:687 ../data_queries.php:914 ../utilities.php:1600
 msgid "Action"
 msgstr ""
 
@@ -2288,19 +2290,19 @@ msgid "none"
 msgstr ""
 
 #: ../automation_snmp.php:715 ../automation_templates.php:545 ../cdef.php:607
-#: ../color_templates.php:110 ../data_queries.php:623 ../data_queries.php:721
+#: ../color_templates.php:110 ../data_queries.php:624 ../data_queries.php:722
 #: ../lib/api_automation.php:1233 ../lib/api_automation.php:1296
 #: ../lib/api_automation.php:1360 ../lib/html.php:959
-#: ../lib/html_reports.php:1301 ../tree.php:1578 ../tree.php:1582
-#: ../tree.php:1585 ../tree.php:1586 ../vdef.php:588
+#: ../lib/html_reports.php:1284 ../lib/html_reports.php:1286 ../tree.php:1578
+#: ../tree.php:1582 ../tree.php:1585 ../tree.php:1586 ../vdef.php:588
 msgid "Move Down"
 msgstr ""
 
 #: ../automation_snmp.php:721 ../automation_templates.php:551 ../cdef.php:613
-#: ../color_templates.php:116 ../data_queries.php:628 ../data_queries.php:726
+#: ../color_templates.php:116 ../data_queries.php:629 ../data_queries.php:727
 #: ../lib/api_automation.php:1239 ../lib/api_automation.php:1302
 #: ../lib/api_automation.php:1366 ../lib/html.php:964
-#: ../lib/html_reports.php:1301 ../vdef.php:594
+#: ../lib/html_reports.php:1286 ../lib/html_reports.php:1288 ../vdef.php:594
 msgid "Move Up"
 msgstr ""
 
@@ -2360,9 +2362,9 @@ msgstr ""
 msgid "You must select at least one Automation Template."
 msgstr ""
 
-#: ../automation_templates.php:300 ../include/global_arrays.php:992
+#: ../automation_templates.php:300 ../include/global_arrays.php:993
 #: ../include/global_form.php:1038 ../include/global_form.php:1546
-#: ../lib/html_reports.php:359
+#: ../lib/html_reports.php:325
 msgid "Device Template"
 msgstr ""
 
@@ -2420,8 +2422,8 @@ msgstr ""
 msgid "Device Automation Templates"
 msgstr ""
 
-#: ../automation_templates.php:512 ../data_sources.php:1410 ../graphs.php:1786
-#: ../user_admin.php:1371 ../user_group_admin.php:1109
+#: ../automation_templates.php:512 ../data_sources.php:1410 ../graphs.php:1789
+#: ../user_admin.php:1384 ../user_group_admin.php:1109
 msgid "Template Name"
 msgstr ""
 
@@ -2429,8 +2431,8 @@ msgstr ""
 msgid "System ObjectId Match"
 msgstr ""
 
-#: ../automation_templates.php:520 ../data_queries.php:594
-#: ../data_queries.php:690 ../links.php:382 ../tree.php:1563
+#: ../automation_templates.php:520 ../data_queries.php:595
+#: ../data_queries.php:691 ../links.php:382 ../tree.php:1563
 msgid "Order"
 msgstr ""
 
@@ -2475,8 +2477,8 @@ msgid "Tree Rules Selection [new]"
 msgstr ""
 
 #: ../automation_tree_rules.php:706 ../automation_tree_rules.php:731
-#: ../automation_tree_rules.php:833 ../include/global_arrays.php:706
-#: ../include/global_form.php:1576 ../lib/functions.php:2593
+#: ../automation_tree_rules.php:833 ../include/global_arrays.php:707
+#: ../include/global_form.php:1576 ../lib/functions.php:2610
 msgid "Tree Rules"
 msgstr ""
 
@@ -2583,7 +2585,7 @@ msgstr ""
 msgid "CDEF [new]"
 msgstr ""
 
-#: ../cdef.php:581 ../lib/functions.php:1969
+#: ../cdef.php:581 ../lib/functions.php:1986
 msgid "CDEF Items"
 msgstr ""
 
@@ -2601,7 +2603,7 @@ msgid "Delete CDEF Item"
 msgstr ""
 
 #: ../cdef.php:713 ../cdef.php:728 ../cdef.php:842
-#: ../include/global_arrays.php:711 ../lib/functions.php:1951
+#: ../include/global_arrays.php:712 ../lib/functions.php:1968
 msgid "CDEFs"
 msgstr ""
 
@@ -2624,7 +2626,7 @@ msgid "The number of Graphs using this CDEF."
 msgstr ""
 
 #: ../cdef.php:854 ../color.php:701 ../data_input.php:725
-#: ../data_queries.php:1155 ../data_source_profiles.php:854
+#: ../data_queries.php:1156 ../data_source_profiles.php:854
 #: ../gprint_presets.php:394 ../vdef.php:848
 msgid "Templates Using"
 msgstr ""
@@ -2722,8 +2724,8 @@ msgstr ""
 msgid "Colors [new]"
 msgstr ""
 
-#: ../color.php:520 ../color.php:535 ../include/global_arrays.php:713
-#: ../lib/functions.php:2017
+#: ../color.php:520 ../color.php:535 ../include/global_arrays.php:714
+#: ../lib/functions.php:2034
 msgid "Colors"
 msgstr ""
 
@@ -2763,7 +2765,7 @@ msgstr ""
 msgid "Named Color"
 msgstr ""
 
-#: ../color.php:698 ../color_templates.php:73 ../include/global_arrays.php:699
+#: ../color.php:698 ../color_templates.php:73 ../include/global_arrays.php:700
 #: ../include/global_form.php:812 ../include/global_form.php:2058
 msgid "Color"
 msgstr ""
@@ -2867,7 +2869,7 @@ msgid "Color Template [new]"
 msgstr ""
 
 #: ../color_templates.php:432 ../color_templates.php:445
-#: ../lib/functions.php:2491
+#: ../lib/functions.php:2508
 msgid "Color Templates"
 msgstr ""
 
@@ -2968,19 +2970,19 @@ msgstr ""
 msgid "Data Input Methods [new]"
 msgstr ""
 
-#: ../data_input.php:444 ../include/global_arrays.php:315
+#: ../data_input.php:444 ../include/global_arrays.php:316
 msgid "SNMP Get"
 msgstr ""
 
-#: ../data_input.php:447 ../include/global_arrays.php:316
+#: ../data_input.php:447 ../include/global_arrays.php:317
 msgid "SNMP Query"
 msgstr ""
 
-#: ../data_input.php:450 ../include/global_arrays.php:318
+#: ../data_input.php:450 ../include/global_arrays.php:319
 msgid "Script Query"
 msgstr ""
 
-#: ../data_input.php:453 ../include/global_arrays.php:320
+#: ../data_input.php:453 ../include/global_arrays.php:321
 msgid "Script Query - Script Server"
 msgstr ""
 
@@ -3020,8 +3022,8 @@ msgstr ""
 msgid "Delete Data Input Field"
 msgstr ""
 
-#: ../data_input.php:610 ../include/global_arrays.php:692
-#: ../include/global_arrays.php:860 ../lib/functions.php:2155
+#: ../data_input.php:610 ../include/global_arrays.php:693
+#: ../include/global_arrays.php:861 ../lib/functions.php:2172
 msgid "Data Input Methods"
 msgstr ""
 
@@ -3056,8 +3058,8 @@ msgstr ""
 msgid "The number of Data Templates that use this Data Input Method."
 msgstr ""
 
-#: ../data_input.php:726 ../data_queries.php:1156
-#: ../include/global_arrays.php:984 ../include/global_form.php:385
+#: ../data_input.php:726 ../data_queries.php:1157
+#: ../include/global_arrays.php:985 ../include/global_form.php:385
 #: ../include/global_form.php:1304
 msgid "Data Input Method"
 msgstr ""
@@ -3113,136 +3115,136 @@ msgstr ""
 msgid "Data Template - %s"
 msgstr ""
 
-#: ../data_queries.php:549 ../data_sources.php:881 ../data_templates.php:516
-#: ../include/global_arrays.php:697 ../include/global_form.php:797
+#: ../data_queries.php:550 ../data_sources.php:881 ../data_templates.php:516
+#: ../include/global_arrays.php:698 ../include/global_form.php:797
 #: ../lib/api_aggregate.php:1215 ../lib/html.php:856
 msgid "Data Source"
 msgstr ""
 
-#: ../data_queries.php:584
+#: ../data_queries.php:585
 msgid "Suggested Values - Graph Names"
 msgstr ""
 
-#: ../data_queries.php:595 ../data_queries.php:691
+#: ../data_queries.php:596 ../data_queries.php:692
 msgid "Equation"
 msgstr ""
 
-#: ../data_queries.php:646 ../data_queries.php:745
+#: ../data_queries.php:647 ../data_queries.php:746
 msgid "No Suggested Values Found"
 msgstr ""
 
-#: ../data_queries.php:655 ../data_queries.php:754
+#: ../data_queries.php:656 ../data_queries.php:755
 #: ../include/global_form.php:2093 ../include/global_form.php:2135
 #: ../lib/api_automation.php:1333 ../utilities.php:1409
 msgid "Field Name"
 msgstr ""
 
-#: ../data_queries.php:661 ../data_queries.php:760
+#: ../data_queries.php:662 ../data_queries.php:761
 msgid "Suggested Value"
 msgstr ""
 
-#: ../data_queries.php:667 ../data_queries.php:766 ../host.php:762
+#: ../data_queries.php:668 ../data_queries.php:767 ../host.php:762
 #: ../host.php:879 ../host_templates.php:515 ../host_templates.php:569
 #: ../lib/html.php:37 ../lib/html_filter.php:55
 msgid "Add"
 msgstr ""
 
-#: ../data_queries.php:667
+#: ../data_queries.php:668
 msgid "Add Graph Title Suggested Name"
 msgstr ""
 
-#: ../data_queries.php:677
+#: ../data_queries.php:678
 msgid "Suggested Values - Data Source Names"
 msgstr ""
 
-#: ../data_queries.php:766
+#: ../data_queries.php:767
 msgid "Add Data Source Name Suggested Name"
 msgstr ""
 
-#: ../data_queries.php:873
+#: ../data_queries.php:874
 #, php-format
 msgid "Data Queries [edit: %s]"
 msgstr ""
 
-#: ../data_queries.php:875
+#: ../data_queries.php:876
 msgid "Data Queries [new]"
 msgstr ""
 
-#: ../data_queries.php:895
+#: ../data_queries.php:896
 msgid "Successfully located XML file"
 msgstr ""
 
-#: ../data_queries.php:898
+#: ../data_queries.php:899
 msgid "Could not locate XML file."
 msgstr ""
 
-#: ../data_queries.php:906 ../host.php:681 ../host_templates.php:466
-#: ../lib/functions.php:2209
+#: ../data_queries.php:907 ../host.php:681 ../host_templates.php:466
+#: ../lib/functions.php:2226
 msgid "Associated Graph Templates"
 msgstr ""
 
-#: ../data_queries.php:910 ../graph_templates.php:761 ../graphs_new.php:597
+#: ../data_queries.php:911 ../graph_templates.php:761 ../graphs_new.php:597
 #: ../host.php:685 ../lib/api_automation.php:563
 msgid "Graph Template Name"
 msgstr ""
 
-#: ../data_queries.php:912
+#: ../data_queries.php:913
 msgid "Mapping ID"
 msgstr ""
 
-#: ../data_queries.php:953
+#: ../data_queries.php:954
 msgid "Mapped Graph Templates with Graphs are read only"
 msgstr ""
 
-#: ../data_queries.php:960
+#: ../data_queries.php:961
 msgid "No Graph Templates Defined."
 msgstr ""
 
-#: ../data_queries.php:984
+#: ../data_queries.php:985
 msgid "Delete Associated Graph"
 msgstr ""
 
-#: ../data_queries.php:1038 ../data_queries.php:1053 ../data_queries.php:1142
-#: ../include/global_arrays.php:691 ../include/global_arrays.php:861
-#: ../lib/api_automation.php:1027 ../lib/functions.php:2191
+#: ../data_queries.php:1039 ../data_queries.php:1054 ../data_queries.php:1143
+#: ../include/global_arrays.php:692 ../include/global_arrays.php:862
+#: ../lib/api_automation.php:1027 ../lib/functions.php:2208
 msgid "Data Queries"
 msgstr ""
 
-#: ../data_queries.php:1151 ../host.php:776 ../utilities.php:1409
+#: ../data_queries.php:1152 ../host.php:776 ../utilities.php:1409
 msgid "Data Query Name"
 msgstr ""
 
-#: ../data_queries.php:1151
+#: ../data_queries.php:1152
 msgid "The name of this Data Query."
 msgstr ""
 
-#: ../data_queries.php:1152 ../graph_templates.php:762
+#: ../data_queries.php:1153 ../graph_templates.php:762
 msgid ""
 "The internal ID for this Graph Template.  Useful when performing automation "
 "or debugging."
 msgstr ""
 
-#: ../data_queries.php:1153
+#: ../data_queries.php:1154
 msgid ""
 "Data Queries that are in use cannot be Deleted. In use is defined as being "
 "referenced by either a Graph or a Graph Template."
 msgstr ""
 
-#: ../data_queries.php:1154
+#: ../data_queries.php:1155
 msgid "The number of Graphs using this Data Query."
 msgstr ""
 
-#: ../data_queries.php:1155
+#: ../data_queries.php:1156
 msgid "The number of Graphs Templates using this Data Query."
 msgstr ""
 
-#: ../data_queries.php:1156
+#: ../data_queries.php:1157
 msgid ""
 "The Data Input Method used to collect data for Data Sources associated with "
 "this Data Query."
 msgstr ""
 
-#: ../data_queries.php:1180
+#: ../data_queries.php:1181
 msgid "No Data Queries Found"
 msgstr ""
 
@@ -3327,7 +3329,7 @@ msgstr ""
 
 #: ../data_source_profiles.php:489 ../graphs_new.php:526
 #: ../include/global_form.php:121 ../lib/html.php:323 ../lib/html_filter.php:73
-#: ../lib/rrd.php:2677 ../pollers.php:523 ../utilities.php:468
+#: ../lib/rrd.php:2689 ../pollers.php:523 ../utilities.php:468
 #: ../utilities.php:1322
 msgid "Rows"
 msgstr ""
@@ -3340,7 +3342,7 @@ msgstr ""
 msgid "Delete Data Source Profile Item"
 msgstr ""
 
-#: ../data_source_profiles.php:621 ../include/global_arrays.php:1087
+#: ../data_source_profiles.php:621 ../include/global_arrays.php:1088
 #: ../include/global_settings.php:1027
 #, php-format
 msgid "%d Years"
@@ -3350,39 +3352,39 @@ msgstr ""
 msgid "1 Year"
 msgstr ""
 
-#: ../data_source_profiles.php:630 ../include/global_arrays.php:1081
+#: ../data_source_profiles.php:630 ../include/global_arrays.php:1082
 #: ../rrdcleaner.php:489
 #, php-format
 msgid "%d Month"
 msgstr ""
 
-#: ../data_source_profiles.php:630 ../include/global_arrays.php:1082
-#: ../include/global_arrays.php:1083 ../include/global_arrays.php:1084
-#: ../include/global_arrays.php:1085 ../rrdcleaner.php:490
+#: ../data_source_profiles.php:630 ../include/global_arrays.php:1083
+#: ../include/global_arrays.php:1084 ../include/global_arrays.php:1085
+#: ../include/global_arrays.php:1086 ../rrdcleaner.php:490
 #: ../rrdcleaner.php:491 ../rrdcleaner.php:492
 #, php-format
 msgid "%d Months"
 msgstr ""
 
-#: ../data_source_profiles.php:639 ../include/global_arrays.php:1079
+#: ../data_source_profiles.php:639 ../include/global_arrays.php:1080
 #: ../rrdcleaner.php:485 ../rrdcleaner.php:486
 #, php-format
 msgid "%d Week"
 msgstr ""
 
-#: ../data_source_profiles.php:639 ../include/global_arrays.php:1080
+#: ../data_source_profiles.php:639 ../include/global_arrays.php:1081
 #: ../rrdcleaner.php:487 ../rrdcleaner.php:488
 #, php-format
 msgid "%d Weeks"
 msgstr ""
 
-#: ../data_source_profiles.php:648 ../include/global_arrays.php:1075
+#: ../data_source_profiles.php:648 ../include/global_arrays.php:1076
 #, php-format
 msgid "%d Day"
 msgstr ""
 
-#: ../data_source_profiles.php:648 ../include/global_arrays.php:1076
-#: ../include/global_arrays.php:1077 ../include/global_arrays.php:1078
+#: ../data_source_profiles.php:648 ../include/global_arrays.php:1077
+#: ../include/global_arrays.php:1078 ../include/global_arrays.php:1079
 #: ../include/global_settings.php:1022 ../include/global_settings.php:1023
 #: ../include/global_settings.php:1024 ../include/global_settings.php:1025
 #: ../include/global_settings.php:1036 ../include/global_settings.php:1037
@@ -3391,15 +3393,15 @@ msgstr ""
 msgid "%d Days"
 msgstr ""
 
-#: ../data_source_profiles.php:656 ../include/global_arrays.php:493
-#: ../include/global_arrays.php:528 ../include/global_arrays.php:1116
-#: ../include/global_arrays.php:1137 ../include/global_arrays.php:1170
-#: ../include/global_arrays.php:1179 ../include/global_arrays.php:1205
+#: ../data_source_profiles.php:656 ../include/global_arrays.php:494
+#: ../include/global_arrays.php:529 ../include/global_arrays.php:1117
+#: ../include/global_arrays.php:1138 ../include/global_arrays.php:1171
+#: ../include/global_arrays.php:1180 ../include/global_arrays.php:1206
 #: ../include/global_settings.php:1093
 msgid "1 Hour"
 msgstr ""
 
-#: ../data_source_profiles.php:710 ../include/global_arrays.php:868
+#: ../data_source_profiles.php:710 ../include/global_arrays.php:869
 msgid "Data Source Profiles"
 msgstr ""
 
@@ -3617,7 +3619,7 @@ msgstr ""
 msgid "Edit Data Template."
 msgstr ""
 
-#: ../data_sources.php:751 ../graphs.php:1291
+#: ../data_sources.php:751 ../graphs.php:1294
 msgid "Edit Device."
 msgstr ""
 
@@ -3674,25 +3676,25 @@ msgstr ""
 msgid "External"
 msgstr ""
 
-#: ../data_sources.php:1067 ../include/global_arrays.php:518
-#: ../include/global_arrays.php:519 ../include/global_arrays.php:520
-#: ../include/global_arrays.php:840 ../include/global_arrays.php:841
-#: ../include/global_arrays.php:842 ../include/global_arrays.php:843
-#: ../include/global_arrays.php:1159 ../include/global_arrays.php:1160
-#: ../include/global_arrays.php:1161 ../include/global_arrays.php:1162
-#: ../include/global_arrays.php:1163 ../include/global_arrays.php:1196
-#: ../include/global_arrays.php:1197 ../include/global_arrays.php:1209
-#: ../include/global_arrays.php:1210 ../include/global_arrays.php:1211
-#: ../include/global_arrays.php:1212 ../include/global_arrays.php:1213
-#: ../include/global_settings.php:1830
+#: ../data_sources.php:1067 ../include/global_arrays.php:519
+#: ../include/global_arrays.php:520 ../include/global_arrays.php:521
+#: ../include/global_arrays.php:841 ../include/global_arrays.php:842
+#: ../include/global_arrays.php:843 ../include/global_arrays.php:844
+#: ../include/global_arrays.php:1160 ../include/global_arrays.php:1161
+#: ../include/global_arrays.php:1162 ../include/global_arrays.php:1163
+#: ../include/global_arrays.php:1164 ../include/global_arrays.php:1197
+#: ../include/global_arrays.php:1198 ../include/global_arrays.php:1210
+#: ../include/global_arrays.php:1211 ../include/global_arrays.php:1212
+#: ../include/global_arrays.php:1213 ../include/global_arrays.php:1214
+#: ../include/global_settings.php:1837
 #, php-format
 msgid "%d Seconds"
 msgstr ""
 
-#: ../data_sources.php:1069 ../include/global_arrays.php:521
-#: ../include/global_arrays.php:844 ../include/global_arrays.php:1164
-#: ../include/global_arrays.php:1198 ../include/global_arrays.php:1214
-#: ../include/global_settings.php:1087 ../include/global_settings.php:1830
+#: ../data_sources.php:1069 ../include/global_arrays.php:522
+#: ../include/global_arrays.php:845 ../include/global_arrays.php:1165
+#: ../include/global_arrays.php:1199 ../include/global_arrays.php:1215
+#: ../include/global_settings.php:1087 ../include/global_settings.php:1837
 msgid "1 Minute"
 msgstr ""
 
@@ -3708,7 +3710,7 @@ msgstr ""
 #: ../data_sources.php:1235 ../data_sources.php:1261 ../data_sources.php:1277
 #: ../data_templates.php:764 ../graph_view.php:781 ../graphs_new.php:504
 #: ../lib/clog_webapi.php:331 ../lib/html_graph.php:395
-#: ../lib/html_reports.php:329 ../lib/html_tree.php:842 ../plugins.php:286
+#: ../lib/html_reports.php:290 ../lib/html_tree.php:842 ../plugins.php:286
 #: ../settings.php:196 ../settings.php:213 ../settings.php:236
 #: ../utilities.php:636 ../utilities.php:1000
 msgid "All"
@@ -3723,8 +3725,8 @@ msgid "Orphaned"
 msgstr ""
 
 #: ../data_sources.php:1283 ../data_sources.php:1396 ../host.php:1502
-#: ../include/global_arrays.php:686 ../lib/api_automation.php:275
-#: ../lib/functions.php:2101 ../user_admin.php:1229 ../user_group_admin.php:966
+#: ../include/global_arrays.php:687 ../lib/api_automation.php:275
+#: ../lib/functions.php:2118 ../user_admin.php:1242 ../user_group_admin.php:966
 #: ../utilities.php:273
 msgid "Data Sources"
 msgstr ""
@@ -3853,8 +3855,8 @@ msgid "Value will be derived from the device if this field is left empty."
 msgstr ""
 
 #: ../data_templates.php:745 ../data_templates.php:776
-#: ../data_templates.php:900 ../include/global_arrays.php:872
-#: ../lib/functions.php:2083
+#: ../data_templates.php:900 ../include/global_arrays.php:873
+#: ../lib/functions.php:2100
 msgid "Data Templates"
 msgstr ""
 
@@ -3929,12 +3931,12 @@ msgstr ""
 msgid "GPRINT Presets [new]"
 msgstr ""
 
-#: ../gprint_presets.php:253 ../lib/functions.php:1933
+#: ../gprint_presets.php:253 ../lib/functions.php:1950
 msgid "GPRINT Presets"
 msgstr ""
 
 #: ../gprint_presets.php:268 ../gprint_presets.php:381
-#: ../include/global_arrays.php:714
+#: ../include/global_arrays.php:715
 msgid "GPRINTs"
 msgstr ""
 
@@ -4113,7 +4115,7 @@ msgstr ""
 msgid "Graph Template Items [edit: %s]"
 msgstr ""
 
-#: ../graph_templates.php:420 ../lib/functions.php:2053
+#: ../graph_templates.php:420 ../lib/functions.php:2070
 msgid "Graph Item Inputs"
 msgstr ""
 
@@ -4140,8 +4142,8 @@ msgstr ""
 
 #: ../graph_templates.php:619 ../graph_templates.php:634
 #: ../graph_templates.php:752 ../graphs_new.php:592
-#: ../include/global_arrays.php:871 ../lib/functions.php:2029
-#: ../user_group_admin.php:1101
+#: ../include/global_arrays.php:872 ../lib/functions.php:2046
+#: ../user_admin.php:1376 ../user_group_admin.php:1101
 msgid "Graph Templates"
 msgstr ""
 
@@ -4255,7 +4257,7 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: ../graph_view.php:577 ../graph_view.php:654 ../include/global_arrays.php:852
+#: ../graph_view.php:577 ../graph_view.php:654 ../include/global_arrays.php:853
 #: ../lib/clog_webapi.php:249
 msgid "View Graphs"
 msgstr ""
@@ -4281,7 +4283,7 @@ msgstr ""
 msgid "Templates Selected"
 msgstr ""
 
-#: ../graphs.php:49 ../graphs.php:842 ../lib/functions.php:1903
+#: ../graphs.php:49 ../graphs.php:845 ../lib/functions.php:1920
 msgid "Change Graph Template"
 msgstr ""
 
@@ -4293,11 +4295,11 @@ msgstr ""
 msgid "Create Aggregate from Template"
 msgstr ""
 
-#: ../graphs.php:58 ../graphs.php:1091 ../host.php:43
+#: ../graphs.php:58 ../graphs.php:1094 ../host.php:43
 msgid "Apply Automation Rules"
 msgstr ""
 
-#: ../graphs.php:64 ../graphs.php:864
+#: ../graphs.php:64 ../graphs.php:867
 msgid "Convert to Graph Template"
 msgstr ""
 
@@ -4343,85 +4345,85 @@ msgstr ""
 msgid "New Graph Template"
 msgstr ""
 
-#: ../graphs.php:846
+#: ../graphs.php:849
 msgid ""
 "Click 'Continue' to duplicate the following Graph(s). You can optionally "
 "change the title format for the new Graph(s)."
 msgstr ""
 
-#: ../graphs.php:849
+#: ../graphs.php:852
 msgid "<graph_title> (1)"
 msgstr ""
 
-#: ../graphs.php:853
+#: ../graphs.php:856
 msgid "Duplicate Graph(s)"
 msgstr ""
 
-#: ../graphs.php:857
+#: ../graphs.php:860
 msgid ""
 "Click 'Continue' to convert the following Graph(s) into Graph Template(s).  "
 "You can optionally change the title format for the new Graph Template(s)."
 msgstr ""
 
-#: ../graphs.php:860
+#: ../graphs.php:863
 msgid "<graph_title> Template"
 msgstr ""
 
-#: ../graphs.php:868
+#: ../graphs.php:871
 msgid ""
 "Click 'Continue' to place the following Graph(s) under the Tree Branch "
 "selected below."
 msgstr ""
 
-#: ../graphs.php:870
+#: ../graphs.php:873
 msgid "Destination Branch"
 msgstr ""
 
-#: ../graphs.php:883
+#: ../graphs.php:886
 msgid "Choose a new Device for these Graph(s) and click 'Continue'."
 msgstr ""
 
-#: ../graphs.php:885
+#: ../graphs.php:888
 msgid "New Device"
 msgstr ""
 
-#: ../graphs.php:897
+#: ../graphs.php:900
 msgid ""
 "Click 'Continue' to re-apply suggested naming to the following Graph(s)."
 msgstr ""
 
-#: ../graphs.php:902
+#: ../graphs.php:905
 msgid "Reapply Suggested Naming to Graph(s)"
 msgstr ""
 
-#: ../graphs.php:918
+#: ../graphs.php:921
 msgid ""
 "Click 'Continue' to create an Aggregate Graph from the selected Graph(s)."
 msgstr ""
 
-#: ../graphs.php:925
+#: ../graphs.php:928
 msgid "The following data sources are in use by these graphs:"
 msgstr ""
 
-#: ../graphs.php:958
+#: ../graphs.php:961
 msgid "Please confirm"
 msgstr ""
 
-#: ../graphs.php:1026
+#: ../graphs.php:1029
 msgid "Resize Selected Graph(s)"
 msgstr ""
 
-#: ../graphs.php:1048
+#: ../graphs.php:1051
 msgid ""
 "Select the Aggregate Template to use and press 'Continue' to create your "
 "Aggregate Graph.  Otherwise press 'Cancel' to return."
 msgstr ""
 
-#: ../graphs.php:1069
+#: ../graphs.php:1072
 msgid "Create Aggregate"
 msgstr ""
 
-#: ../graphs.php:1073
+#: ../graphs.php:1076
 msgid ""
 "There are presently no Aggregate Templates defined for this Graph Template.  "
 "Please either first create an Aggregate Template for the selected Graphs "
@@ -4429,52 +4431,52 @@ msgid ""
 "Graph."
 msgstr ""
 
-#: ../graphs.php:1074
+#: ../graphs.php:1077
 msgid "Press 'Return' to return and select different Graphs."
 msgstr ""
 
-#: ../graphs.php:1086
+#: ../graphs.php:1089
 msgid "Click 'Continue' to apply Automation Rules to the following Graphs."
 msgstr ""
 
-#: ../graphs.php:1102
+#: ../graphs.php:1105
 msgid "You must select at least one Graph."
 msgstr ""
 
-#: ../graphs.php:1242
+#: ../graphs.php:1245
 #, php-format
 msgid "Graph [edit: %s]"
 msgstr ""
 
-#: ../graphs.php:1248
+#: ../graphs.php:1251
 msgid "Graph [new]"
 msgstr ""
 
-#: ../graphs.php:1273
+#: ../graphs.php:1276
 msgid "Turn Off Graph Debug Mode."
 msgstr ""
 
-#: ../graphs.php:1275
+#: ../graphs.php:1278
 msgid "Turn On Graph Debug Mode."
 msgstr ""
 
-#: ../graphs.php:1288
+#: ../graphs.php:1291
 msgid "Edit Graph Template."
 msgstr ""
 
-#: ../graphs.php:1294
+#: ../graphs.php:1297
 msgid "Unlock Graph."
 msgstr ""
 
-#: ../graphs.php:1296
+#: ../graphs.php:1299
 msgid "Lock Graph."
 msgstr ""
 
-#: ../graphs.php:1320
+#: ../graphs.php:1323
 msgid "Selected Graph Template"
 msgstr ""
 
-#: ../graphs.php:1321
+#: ../graphs.php:1324
 #, php-format
 msgid ""
 "Choose a Graph Template to apply to this Graph. Please note that you may "
@@ -4482,49 +4484,49 @@ msgid ""
 "that it includes identical Data Sources."
 msgstr ""
 
-#: ../graphs.php:1329
+#: ../graphs.php:1332
 msgid "Choose the Device that this Graph belongs to."
 msgstr ""
 
-#: ../graphs.php:1368
+#: ../graphs.php:1371
 msgid "Supplemental Graph Template Data"
 msgstr ""
 
-#: ../graphs.php:1370
+#: ../graphs.php:1373
 msgid "Graph Fields"
 msgstr ""
 
-#: ../graphs.php:1371
+#: ../graphs.php:1374
 msgid "Graph Item Fields"
 msgstr ""
 
-#: ../graphs.php:1640 ../lib/functions.php:1891
+#: ../graphs.php:1643 ../lib/functions.php:1908
 msgid "Graph Management"
 msgstr ""
 
-#: ../graphs.php:1784 ../include/global_form.php:1859
-#: ../lib/html_reports.php:386 ../tree.php:681
+#: ../graphs.php:1787 ../include/global_form.php:1859
+#: ../lib/html_reports.php:355 ../tree.php:681
 msgid "Graph Name"
 msgstr ""
 
-#: ../graphs.php:1784
+#: ../graphs.php:1787
 msgid ""
 "The Title of this Graph.  Generally programatically generated from the Graph "
 "Template definition or Suggested Naming rules.  The max length of the Title "
 "is controlled under Settings->Visual."
 msgstr ""
 
-#: ../graphs.php:1785
+#: ../graphs.php:1788
 msgid ""
 "The internal database ID for this Graph.  Useful when performing automation "
 "or debugging."
 msgstr ""
 
-#: ../graphs.php:1786
+#: ../graphs.php:1789
 msgid "The Graph Template that this Graph was based upon."
 msgstr ""
 
-#: ../graphs.php:1787
+#: ../graphs.php:1790
 msgid "The size of this Graph when not in Preview mode."
 msgstr ""
 
@@ -4532,7 +4534,7 @@ msgstr ""
 msgid "Data Sources [No Device]"
 msgstr ""
 
-#: ../graphs_items.php:325 ../include/global_arrays.php:983
+#: ../graphs_items.php:325 ../include/global_arrays.php:984
 #: ../include/global_form.php:1556
 msgid "Data Template"
 msgstr ""
@@ -4610,13 +4612,13 @@ msgstr ""
 msgid "Create New Device"
 msgstr ""
 
-#: ../graphs_new.php:598 ../graphs_new.php:881 ../user_admin.php:1576
+#: ../graphs_new.php:598 ../graphs_new.php:880 ../user_admin.php:1593
 #: ../user_group_admin.php:1316
 msgid "Select All"
 msgstr ""
 
-#: ../graphs_new.php:674 ../include/global_arrays.php:678
-#: ../include/global_arrays.php:749 ../lib/html_form.php:1111
+#: ../graphs_new.php:674 ../include/global_arrays.php:679
+#: ../include/global_arrays.php:750 ../lib/html_form.php:1111
 #: ../lib/html_form.php:1124 ../tree.php:1025
 msgid "Create"
 msgstr ""
@@ -4630,37 +4632,37 @@ msgstr ""
 msgid "Data Query [%s]"
 msgstr ""
 
-#: ../graphs_new.php:877
+#: ../graphs_new.php:876
 msgid "From there you can get more information."
 msgstr ""
 
-#: ../graphs_new.php:877
+#: ../graphs_new.php:876
 msgid ""
 "This Data Query returned 0 rows, perhaps there was a problem executing this "
 "Data Query."
 msgstr ""
 
-#: ../graphs_new.php:877
+#: ../graphs_new.php:876
 msgid "You can run this Data Query in debug mode"
 msgstr ""
 
-#: ../graphs_new.php:920
+#: ../graphs_new.php:919
 msgid "Search Returned no Rows."
 msgstr ""
 
-#: ../graphs_new.php:925
+#: ../graphs_new.php:924
 msgid "Error in data query."
 msgstr ""
 
-#: ../graphs_new.php:949
+#: ../graphs_new.php:948
 msgid "Select a Graph Type to Create"
 msgstr ""
 
-#: ../graphs_new.php:952
+#: ../graphs_new.php:951
 msgid "Make selection default"
 msgstr ""
 
-#: ../graphs_new.php:952
+#: ../graphs_new.php:951
 msgid "Set Default"
 msgstr ""
 
@@ -4844,15 +4846,15 @@ msgstr ""
 
 #: ../host.php:779 ../lib/api_automation.php:1212
 #: ../lib/api_automation.php:1274 ../lib/api_automation.php:1338
-#: ../lib/functions.php:1909 ../lib/functions.php:1975
-#: ../lib/functions.php:2041 ../lib/functions.php:2077
-#: ../lib/functions.php:2095 ../lib/functions.php:2113
-#: ../lib/functions.php:2131 ../lib/functions.php:2161
-#: ../lib/functions.php:2197 ../lib/functions.php:2227
-#: ../lib/functions.php:2317 ../lib/functions.php:2503
-#: ../lib/functions.php:2527 ../lib/functions.php:2545
-#: ../lib/functions.php:2563 ../lib/functions.php:2581
-#: ../lib/functions.php:2605 ../lib/html_reports.php:1235 ../links.php:377
+#: ../lib/functions.php:1926 ../lib/functions.php:1992
+#: ../lib/functions.php:2058 ../lib/functions.php:2094
+#: ../lib/functions.php:2112 ../lib/functions.php:2130
+#: ../lib/functions.php:2148 ../lib/functions.php:2178
+#: ../lib/functions.php:2214 ../lib/functions.php:2244
+#: ../lib/functions.php:2334 ../lib/functions.php:2520
+#: ../lib/functions.php:2544 ../lib/functions.php:2562
+#: ../lib/functions.php:2580 ../lib/functions.php:2598
+#: ../lib/functions.php:2622 ../lib/html_reports.php:1216 ../links.php:377
 #: ../plugins.php:374
 msgid "Actions"
 msgstr ""
@@ -4861,7 +4863,7 @@ msgstr ""
 msgid "Fail"
 msgstr ""
 
-#: ../host.php:840 ../lib/functions.php:3789 ../lib/functions.php:3794
+#: ../host.php:840 ../lib/functions.php:3811 ../lib/functions.php:3816
 msgid "Success"
 msgstr ""
 
@@ -4889,23 +4891,23 @@ msgstr ""
 msgid "Add Data Query to Device"
 msgstr ""
 
-#: ../host.php:1014 ../include/global_arrays.php:459
+#: ../host.php:1014 ../include/global_arrays.php:460
 msgid "Ping and SNMP Uptime"
 msgstr ""
 
-#: ../host.php:1015 ../include/global_arrays.php:461
+#: ../host.php:1015 ../include/global_arrays.php:462
 msgid "SNMP Uptime"
 msgstr ""
 
-#: ../host.php:1016 ../include/global_arrays.php:464
+#: ../host.php:1016 ../include/global_arrays.php:465
 msgid "Ping"
 msgstr ""
 
-#: ../host.php:1017 ../include/global_arrays.php:460
+#: ../host.php:1017 ../include/global_arrays.php:461
 msgid "Ping or SNMP Uptime"
 msgstr ""
 
-#: ../host.php:1018 ../include/global_arrays.php:462
+#: ../host.php:1018 ../include/global_arrays.php:463
 msgid "SNMP Desc"
 msgstr ""
 
@@ -4951,7 +4953,7 @@ msgstr ""
 #: ../include/global_form.php:1638 ../lib/api_automation.php:270
 #: ../lib/api_automation.php:558 ../lib/api_automation.php:809
 #: ../lib/api_automation.php:1138 ../managers.php:225 ../pollers.php:82
-#: ../pollers.php:613 ../user_admin.php:1229 ../user_group_admin.php:966
+#: ../pollers.php:613 ../user_admin.php:1242 ../user_group_admin.php:966
 msgid "Hostname"
 msgstr ""
 
@@ -5111,8 +5113,8 @@ msgid "Add Data Query to Device Template"
 msgstr ""
 
 #: ../host_templates.php:691 ../host_templates.php:706
-#: ../host_templates.php:805 ../include/global_arrays.php:873
-#: ../lib/functions.php:2065
+#: ../host_templates.php:805 ../include/global_arrays.php:874
+#: ../lib/functions.php:2082
 msgid "Device Templates"
 msgstr ""
 
@@ -5171,1060 +5173,1065 @@ msgstr ""
 msgid "You are not permitted to access this section of Cacti."
 msgstr ""
 
-#: ../include/global_arrays.php:87
+#: ../include/global_arrays.php:88
 msgid "Save Successful."
 msgstr ""
 
-#: ../include/global_arrays.php:90
+#: ../include/global_arrays.php:91
 msgid "Save Failed."
 msgstr ""
 
-#: ../include/global_arrays.php:93
+#: ../include/global_arrays.php:94
 msgid "Save Failed: Field Input Error (Check Red Fields)."
 msgstr ""
 
-#: ../include/global_arrays.php:96
+#: ../include/global_arrays.php:97
 msgid "Passwords do not match, please retype."
 msgstr ""
 
-#: ../include/global_arrays.php:99
+#: ../include/global_arrays.php:100
 msgid "You must select at least one field."
 msgstr ""
 
-#: ../include/global_arrays.php:102
+#: ../include/global_arrays.php:103
 msgid ""
 "You must have built in user authentication turned on to use this feature."
 msgstr ""
 
-#: ../include/global_arrays.php:105
+#: ../include/global_arrays.php:106
 msgid "XML parse error."
 msgstr ""
 
-#: ../include/global_arrays.php:108
+#: ../include/global_arrays.php:109
 msgid "Username already in use."
 msgstr ""
 
-#: ../include/global_arrays.php:111
+#: ../include/global_arrays.php:112
 msgid "XML: Cacti version does not exist."
 msgstr ""
 
-#: ../include/global_arrays.php:114
+#: ../include/global_arrays.php:115
 msgid "XML: Hash version does not exist."
 msgstr ""
 
-#: ../include/global_arrays.php:117
+#: ../include/global_arrays.php:118
 msgid "XML: Generated with a newer version of Cacti."
 msgstr ""
 
-#: ../include/global_arrays.php:120
+#: ../include/global_arrays.php:121
 msgid "XML: Cannot locate type code."
 msgstr ""
 
-#: ../include/global_arrays.php:123
+#: ../include/global_arrays.php:124
 msgid "Username already exists."
 msgstr ""
 
-#: ../include/global_arrays.php:126
+#: ../include/global_arrays.php:127
 msgid "Username change not permitted for designated template or guest user."
 msgstr ""
 
-#: ../include/global_arrays.php:129
+#: ../include/global_arrays.php:130
 msgid "User delete not permitted for designated template or guest user."
 msgstr ""
 
-#: ../include/global_arrays.php:132
+#: ../include/global_arrays.php:133
 msgid "User delete not permitted for designated graph export user."
 msgstr ""
 
-#: ../include/global_arrays.php:135
+#: ../include/global_arrays.php:136
 msgid ""
 "Data Template Includes Deleted Data Source Profile.  Please resave the Data "
 "Template with an existing Data Source Profile."
 msgstr ""
 
-#: ../include/global_arrays.php:138
+#: ../include/global_arrays.php:139
 msgid ""
 "Graph Template Includes Deleted GPrint Prefix.  Please run Database Repair "
 "Script to Identify and/or Correct."
 msgstr ""
 
-#: ../include/global_arrays.php:141
+#: ../include/global_arrays.php:142
 msgid ""
 "Graph Template Includes Deleted CDEFs.  Please run Database Repair Script to "
 "Identify and/or Correct."
 msgstr ""
 
-#: ../include/global_arrays.php:144
+#: ../include/global_arrays.php:145
 msgid ""
 "Graph Template Includes Deleted Data Input Method.  Please run Database "
 "Repair Script to Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:147
+#: ../include/global_arrays.php:148
 msgid ""
 "Data Template Not Found during Export.  Please run Database Repair Script to "
 "Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:150
+#: ../include/global_arrays.php:151
 msgid ""
 "Device Template Not Found during Export.  Please run Database Repair Script "
 "to Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:153
+#: ../include/global_arrays.php:154
 msgid ""
 "Data Query Not Found during Export.  Please run Database Repair Script to "
 "Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:156
+#: ../include/global_arrays.php:157
 msgid ""
 "Graph Template Not Found during Export.  Please run Database Repair Script "
 "to Identify."
 msgstr ""
 
-#: ../include/global_arrays.php:159
+#: ../include/global_arrays.php:160
 msgid ""
 "Graph not found.  Either it has been deleted or your database needs repair."
 msgstr ""
 
-#: ../include/global_arrays.php:162
+#: ../include/global_arrays.php:163
 msgid "SNMPv3 Auth Passphrases must be 8 characters or greater."
 msgstr ""
 
-#: ../include/global_arrays.php:165
+#: ../include/global_arrays.php:166
 msgid ""
 "Some Graphs not Updated. Unable to Change Device for Data Query based Graphs."
 msgstr ""
 
-#: ../include/global_arrays.php:168
+#: ../include/global_arrays.php:169
 msgid "Unable to Change Device for Data Query based Graphs."
 msgstr ""
 
-#: ../include/global_arrays.php:171
+#: ../include/global_arrays.php:172
 msgid "Cacti Log purged successfully"
 msgstr ""
 
-#: ../include/global_arrays.php:174
+#: ../include/global_arrays.php:175
 msgid ""
 "Error: If you force a password change, you must also allow the user to "
 "change their password."
 msgstr ""
 
-#: ../include/global_arrays.php:177
+#: ../include/global_arrays.php:178
 msgid "Error: You are not allowed to change your password."
 msgstr ""
 
-#: ../include/global_arrays.php:180
+#: ../include/global_arrays.php:181
 msgid "Error: LDAP/AD based password change not supported."
 msgstr ""
 
-#: ../include/global_arrays.php:183
+#: ../include/global_arrays.php:184
 msgid "Error: Unable to clear log, no write permissions"
 msgstr ""
 
-#: ../include/global_arrays.php:186
+#: ../include/global_arrays.php:187
 msgid "Error: Unable to clear log, file does not exist"
 msgstr ""
 
-#: ../include/global_arrays.php:189
+#: ../include/global_arrays.php:190
 msgid "Invalid Timestamp. Select timestamp in the future."
 msgstr ""
 
-#: ../include/global_arrays.php:192
+#: ../include/global_arrays.php:193
 msgid "Data Collector(s) Synchronized for Offline Operation"
 msgstr ""
 
-#: ../include/global_arrays.php:195
+#: ../include/global_arrays.php:196
 msgid "Data Collector(s) Not found when attempting Synchronization"
 msgstr ""
 
-#: ../include/global_arrays.php:198
+#: ../include/global_arrays.php:199
 msgid "Unable to establish MySQL connection with remote Data Collector."
 msgstr ""
 
-#: ../include/global_arrays.php:201
+#: ../include/global_arrays.php:202
 msgid ""
 "Data Collector Synchronization must be initiated from the main Cacti server."
 msgstr ""
 
-#: ../include/global_arrays.php:204
+#: ../include/global_arrays.php:205
 msgid "Report Saved"
 msgstr ""
 
-#: ../include/global_arrays.php:207
+#: ../include/global_arrays.php:208
 msgid "Report Save Failed"
 msgstr ""
 
-#: ../include/global_arrays.php:210
+#: ../include/global_arrays.php:211
 msgid "Report Item Saved"
 msgstr ""
 
-#: ../include/global_arrays.php:213
+#: ../include/global_arrays.php:214
 msgid "Report Item Save Failed"
 msgstr ""
 
-#: ../include/global_arrays.php:305 ../include/global_arrays.php:618
+#: ../include/global_arrays.php:306 ../include/global_arrays.php:619
 msgid "Function"
 msgstr ""
 
-#: ../include/global_arrays.php:306 ../include/global_arrays.php:620
+#: ../include/global_arrays.php:307 ../include/global_arrays.php:621
 msgid "Special Data Source"
 msgstr ""
 
-#: ../include/global_arrays.php:307 ../include/global_arrays.php:622
+#: ../include/global_arrays.php:308 ../include/global_arrays.php:623
 msgid "Custom String"
 msgstr ""
 
-#: ../include/global_arrays.php:317 ../include/global_arrays.php:324
+#: ../include/global_arrays.php:318 ../include/global_arrays.php:325
 msgid "Script/Command"
 msgstr ""
 
-#: ../include/global_arrays.php:319 ../include/global_arrays.php:325
+#: ../include/global_arrays.php:320 ../include/global_arrays.php:326
 #: ../utilities.php:1607
 msgid "Script Server"
 msgstr ""
 
-#: ../include/global_arrays.php:331
+#: ../include/global_arrays.php:332
 msgid "Index Count"
 msgstr ""
 
-#: ../include/global_arrays.php:332
+#: ../include/global_arrays.php:333
 msgid "Verify All"
 msgstr ""
 
-#: ../include/global_arrays.php:336
+#: ../include/global_arrays.php:337
 msgid ""
 "All Re-Indexing will be manual or managed through scripts or Device "
 "Automation."
 msgstr ""
 
-#: ../include/global_arrays.php:337
+#: ../include/global_arrays.php:338
 msgid ""
 "When the Devices SNMP uptime goes backward, a Re-Index will be performed."
 msgstr ""
 
-#: ../include/global_arrays.php:338
+#: ../include/global_arrays.php:339
 msgid "When the Data Query index count changes, a Re-Index will be performed."
 msgstr ""
 
-#: ../include/global_arrays.php:339
+#: ../include/global_arrays.php:340
 msgid "Every polling cycle, a Re-Index will be performed.  Very expensive."
 msgstr ""
 
-#: ../include/global_arrays.php:343
+#: ../include/global_arrays.php:344
 msgid "SNMP Field Name (Dropdown)"
 msgstr ""
 
-#: ../include/global_arrays.php:344
+#: ../include/global_arrays.php:345
 msgid "SNMP Field Value (From User)"
 msgstr ""
 
-#: ../include/global_arrays.php:345
+#: ../include/global_arrays.php:346
 msgid "SNMP Output Type (Dropdown)"
 msgstr ""
 
-#: ../include/global_arrays.php:364 ../include/global_arrays.php:370
+#: ../include/global_arrays.php:365 ../include/global_arrays.php:371
 msgid "Normal"
 msgstr ""
 
-#: ../include/global_arrays.php:365
+#: ../include/global_arrays.php:366
 msgid "Light"
 msgstr ""
 
-#: ../include/global_arrays.php:366 ../include/global_arrays.php:371
+#: ../include/global_arrays.php:367 ../include/global_arrays.php:372
 msgid "Mono"
 msgstr ""
 
-#: ../include/global_arrays.php:375
+#: ../include/global_arrays.php:376
 msgid "North"
 msgstr ""
 
-#: ../include/global_arrays.php:376
+#: ../include/global_arrays.php:377
 msgid "South"
 msgstr ""
 
-#: ../include/global_arrays.php:377
+#: ../include/global_arrays.php:378
 msgid "West"
 msgstr ""
 
-#: ../include/global_arrays.php:378
+#: ../include/global_arrays.php:379
 msgid "East"
 msgstr ""
 
-#: ../include/global_arrays.php:383
+#: ../include/global_arrays.php:384
 msgid "Left"
 msgstr ""
 
-#: ../include/global_arrays.php:384
+#: ../include/global_arrays.php:385
 msgid "Right"
 msgstr ""
 
-#: ../include/global_arrays.php:385
+#: ../include/global_arrays.php:386
 msgid "Justified"
 msgstr ""
 
-#: ../include/global_arrays.php:386
+#: ../include/global_arrays.php:387
 msgid "Center"
 msgstr ""
 
-#: ../include/global_arrays.php:390
+#: ../include/global_arrays.php:391
 msgid "Top -> Down"
 msgstr ""
 
-#: ../include/global_arrays.php:391
+#: ../include/global_arrays.php:392
 msgid "Bottom -> Up"
 msgstr ""
 
-#: ../include/global_arrays.php:395 ../tree.php:1129
+#: ../include/global_arrays.php:396 ../tree.php:1129
 msgid "Numeric"
 msgstr ""
 
-#: ../include/global_arrays.php:396
+#: ../include/global_arrays.php:397
 msgid "Timestamp"
 msgstr ""
 
-#: ../include/global_arrays.php:397
+#: ../include/global_arrays.php:398
 msgid "Duration"
 msgstr ""
 
-#: ../include/global_arrays.php:429
+#: ../include/global_arrays.php:430
 msgid "Not In Use"
 msgstr ""
 
-#: ../include/global_arrays.php:430 ../include/global_arrays.php:431
-#: ../include/global_arrays.php:432 ../include/global_arrays.php:588
-#: ../include/global_arrays.php:589
+#: ../include/global_arrays.php:431 ../include/global_arrays.php:432
+#: ../include/global_arrays.php:433 ../include/global_arrays.php:589
+#: ../include/global_arrays.php:590
 #, php-format
 msgid "Version %d"
 msgstr ""
 
-#: ../include/global_arrays.php:436
+#: ../include/global_arrays.php:437
 msgid "MD5 (default)"
 msgstr ""
 
-#: ../include/global_arrays.php:437
+#: ../include/global_arrays.php:438
 msgid "SHA"
 msgstr ""
 
-#: ../include/global_arrays.php:441
+#: ../include/global_arrays.php:442
 msgid "[None]"
 msgstr ""
 
-#: ../include/global_arrays.php:442
+#: ../include/global_arrays.php:443
 msgid "DES (default)"
 msgstr ""
 
-#: ../include/global_arrays.php:443
+#: ../include/global_arrays.php:444
 msgid "AES"
 msgstr ""
 
-#: ../include/global_arrays.php:452
+#: ../include/global_arrays.php:453
 msgid "Logfile Only"
 msgstr ""
 
-#: ../include/global_arrays.php:453
+#: ../include/global_arrays.php:454
 msgid "Logfile and Syslog/Eventlog"
 msgstr ""
 
-#: ../include/global_arrays.php:454
+#: ../include/global_arrays.php:455
 msgid "Syslog/Eventlog Only"
 msgstr ""
 
-#: ../include/global_arrays.php:463
+#: ../include/global_arrays.php:464
 msgid "SNMP getNext"
 msgstr ""
 
-#: ../include/global_arrays.php:468
+#: ../include/global_arrays.php:469
 msgid "ICMP Ping"
 msgstr ""
 
-#: ../include/global_arrays.php:469
+#: ../include/global_arrays.php:470
 msgid "TCP Ping"
 msgstr ""
 
-#: ../include/global_arrays.php:470
+#: ../include/global_arrays.php:471
 msgid "UDP Ping"
 msgstr ""
 
-#: ../include/global_arrays.php:474
+#: ../include/global_arrays.php:475
 msgid "NONE - Syslog Only if Selected"
 msgstr ""
 
-#: ../include/global_arrays.php:475
+#: ../include/global_arrays.php:476
 msgid "LOW - Statistics and Errors"
 msgstr ""
 
-#: ../include/global_arrays.php:476
+#: ../include/global_arrays.php:477
 msgid "MEDIUM - Statistics, Errors and Results"
 msgstr ""
 
-#: ../include/global_arrays.php:477
+#: ../include/global_arrays.php:478
 msgid "HIGH - Statistics, Errors, Results and Major I/O Events"
 msgstr ""
 
-#: ../include/global_arrays.php:478
+#: ../include/global_arrays.php:479
 msgid "DEBUG - Statistics, Errors, Results, I/O and Program Flow"
 msgstr ""
 
-#: ../include/global_arrays.php:479
+#: ../include/global_arrays.php:480
 msgid "DEVEL - Developer DEBUG Level"
 msgstr ""
 
-#: ../include/global_arrays.php:488
+#: ../include/global_arrays.php:489
 msgid "Selected Poller Interval"
 msgstr ""
 
-#: ../include/global_arrays.php:503 ../include/global_arrays.php:504
-#: ../include/global_arrays.php:505 ../include/global_arrays.php:506
-#: ../include/global_arrays.php:537 ../include/global_arrays.php:538
-#: ../include/global_arrays.php:539 ../include/global_arrays.php:540
+#: ../include/global_arrays.php:504 ../include/global_arrays.php:505
+#: ../include/global_arrays.php:506 ../include/global_arrays.php:507
+#: ../include/global_arrays.php:538 ../include/global_arrays.php:539
+#: ../include/global_arrays.php:540 ../include/global_arrays.php:541
 #, php-format
 msgid "Every %d Seconds"
 msgstr ""
 
-#: ../include/global_arrays.php:507 ../include/global_arrays.php:541
-#: ../include/global_arrays.php:555
+#: ../include/global_arrays.php:508 ../include/global_arrays.php:542
+#: ../include/global_arrays.php:556
 msgid "Every Minute"
 msgstr ""
 
-#: ../include/global_arrays.php:508 ../include/global_arrays.php:509
-#: ../include/global_arrays.php:510 ../include/global_arrays.php:511
-#: ../include/global_arrays.php:542 ../include/global_arrays.php:556
+#: ../include/global_arrays.php:509 ../include/global_arrays.php:510
+#: ../include/global_arrays.php:511 ../include/global_arrays.php:512
+#: ../include/global_arrays.php:543 ../include/global_arrays.php:557
 #, php-format
 msgid "Every %d Minutes"
 msgstr ""
 
-#: ../include/global_arrays.php:512
+#: ../include/global_arrays.php:513
 msgid "Every Hour"
 msgstr ""
 
-#: ../include/global_arrays.php:513 ../include/global_arrays.php:514
+#: ../include/global_arrays.php:514 ../include/global_arrays.php:515
 #: ../include/global_arrays.php:1444 ../include/global_arrays.php:1445
 #: ../include/global_arrays.php:1446 ../include/global_arrays.php:1447
-#: ../include/global_arrays.php:1448 ../include/global_settings.php:1758
-#: ../include/global_settings.php:1759
+#: ../include/global_arrays.php:1448 ../include/global_settings.php:1765
+#: ../include/global_settings.php:1766
 #, php-format
 msgid "Every %d Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:533 ../include/global_settings.php:1098
+#: ../include/global_arrays.php:534 ../include/global_settings.php:1098
 msgid "1 Day"
 msgstr ""
 
-#: ../include/global_arrays.php:546
+#: ../include/global_arrays.php:547
 msgid "1 Thread (default)"
 msgstr ""
 
-#: ../include/global_arrays.php:571
+#: ../include/global_arrays.php:572
 msgid "Builtin Authentication"
 msgstr ""
 
-#: ../include/global_arrays.php:572
+#: ../include/global_arrays.php:573
 msgid "Web Basic Authentication"
 msgstr ""
 
-#: ../include/global_arrays.php:576
+#: ../include/global_arrays.php:577
 msgid "LDAP Authentication"
 msgstr ""
 
-#: ../include/global_arrays.php:577
+#: ../include/global_arrays.php:578
 msgid "Multiple LDAP/AD Domains"
 msgstr ""
 
-#: ../include/global_arrays.php:582
+#: ../include/global_arrays.php:583
 msgid "Active Directory"
 msgstr ""
 
-#: ../include/global_arrays.php:594 ../include/global_settings.php:1317
+#: ../include/global_arrays.php:595 ../include/global_settings.php:1324
 msgid "SSL"
 msgstr ""
 
-#: ../include/global_arrays.php:595 ../include/global_settings.php:1317
+#: ../include/global_arrays.php:596 ../include/global_settings.php:1324
 msgid "TLS"
 msgstr ""
 
-#: ../include/global_arrays.php:599
+#: ../include/global_arrays.php:600
 msgid "No Searching"
 msgstr ""
 
-#: ../include/global_arrays.php:600
+#: ../include/global_arrays.php:601
 msgid "Anonymous Searching"
 msgstr ""
 
-#: ../include/global_arrays.php:601
+#: ../include/global_arrays.php:602
 msgid "Specific Searching"
 msgstr ""
 
-#: ../include/global_arrays.php:614
+#: ../include/global_arrays.php:615
 msgid "Enabled (strict mode)"
 msgstr ""
 
-#: ../include/global_arrays.php:619 ../include/global_form.php:2101
+#: ../include/global_arrays.php:620 ../include/global_form.php:2101
 #: ../include/global_form.php:2143 ../lib/api_automation.php:1210
 #: ../lib/api_automation.php:1272
 msgid "Operator"
 msgstr ""
 
-#: ../include/global_arrays.php:621
+#: ../include/global_arrays.php:622
 msgid "Another CDEF"
 msgstr ""
 
-#: ../include/global_arrays.php:640
+#: ../include/global_arrays.php:641
 msgid "Inherit Parent Sorting"
 msgstr ""
 
-#: ../include/global_arrays.php:641
+#: ../include/global_arrays.php:642
 msgid "Manual Ordering (No Sorting)"
 msgstr ""
 
-#: ../include/global_arrays.php:642
+#: ../include/global_arrays.php:643
 msgid "Alphabetic Ordering"
 msgstr ""
 
-#: ../include/global_arrays.php:643
+#: ../include/global_arrays.php:644
 msgid "Natural Ordering"
 msgstr ""
 
-#: ../include/global_arrays.php:644
+#: ../include/global_arrays.php:645
 msgid "Numeric Ordering"
 msgstr ""
 
-#: ../include/global_arrays.php:648 ../lib/rrd.php:2612
+#: ../include/global_arrays.php:649 ../lib/rrd.php:2624
 msgid "Header"
 msgstr ""
 
-#: ../include/global_arrays.php:649 ../include/global_arrays.php:696
+#: ../include/global_arrays.php:650 ../include/global_arrays.php:697
 #: ../include/global_arrays.php:1269 ../include/global_arrays.php:1433
+#: ../lib/html_tree.php:351
 msgid "Graph"
 msgstr ""
 
-#: ../include/global_arrays.php:655 ../tree.php:1295
+#: ../include/global_arrays.php:656 ../tree.php:1295
 msgid "Data Query Index"
 msgstr ""
 
-#: ../include/global_arrays.php:659
+#: ../include/global_arrays.php:660
 msgid "Current Graph Item Data Source"
 msgstr ""
 
-#: ../include/global_arrays.php:660
+#: ../include/global_arrays.php:661
 msgid "Current Graph Item Polling Interval"
 msgstr ""
 
-#: ../include/global_arrays.php:661
+#: ../include/global_arrays.php:662
 msgid "All Data Sources (Do not Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:662
+#: ../include/global_arrays.php:663
 msgid "All Data Sources (Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:663
+#: ../include/global_arrays.php:664
 msgid "All Similar Data Sources (Do not Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:664
+#: ../include/global_arrays.php:665
 msgid "All Similar Data Sources (Do not Include Duplicates) Polling Interval"
 msgstr ""
 
-#: ../include/global_arrays.php:665
+#: ../include/global_arrays.php:666
 msgid "All Similar Data Sources (Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:666
+#: ../include/global_arrays.php:667
 msgid "Current Data Source Item: Minimum Value"
 msgstr ""
 
-#: ../include/global_arrays.php:667
+#: ../include/global_arrays.php:668
 msgid "Current Data Source Item: Maximum Value"
 msgstr ""
 
-#: ../include/global_arrays.php:668
+#: ../include/global_arrays.php:669
 msgid "Graph: Lower Limit"
 msgstr ""
 
-#: ../include/global_arrays.php:669
+#: ../include/global_arrays.php:670
 msgid "Graph: Upper Limit"
 msgstr ""
 
-#: ../include/global_arrays.php:670
+#: ../include/global_arrays.php:671
 msgid "Count of All Data Sources (Do not Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:671
+#: ../include/global_arrays.php:672
 msgid "Count of All Data Sources (Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:672
+#: ../include/global_arrays.php:673
 msgid "Count of All Similar Data Sources (Do not Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:673
+#: ../include/global_arrays.php:674
 msgid "Count of All Similar Data Sources (Include Duplicates)"
 msgstr ""
 
-#: ../include/global_arrays.php:679 ../lib/html_form_template.php:562
+#: ../include/global_arrays.php:680 ../lib/html_form_template.php:562
 #: ../lib/html_form_template.php:577
 msgid "New Graphs"
 msgstr ""
 
-#: ../include/global_arrays.php:681 ../include/global_arrays.php:733
-#: ../include/global_arrays.php:750
+#: ../include/global_arrays.php:682 ../include/global_arrays.php:734
+#: ../include/global_arrays.php:751
 msgid "Management"
 msgstr ""
 
-#: ../include/global_arrays.php:683 ../sites.php:378 ../sites.php:393
+#: ../include/global_arrays.php:684 ../sites.php:378 ../sites.php:393
 #: ../sites.php:472
 msgid "Sites"
 msgstr ""
 
-#: ../include/global_arrays.php:684 ../include/global_arrays.php:865
-#: ../tree.php:1476 ../tree.php:1491 ../tree.php:1549 ../user_admin.php:2909
-#: ../user_admin.php:2996 ../user_group_admin.php:1235
+#: ../include/global_arrays.php:685 ../include/global_arrays.php:866
+#: ../tree.php:1476 ../tree.php:1491 ../tree.php:1549 ../user_admin.php:1513
+#: ../user_admin.php:2926 ../user_admin.php:3013 ../user_group_admin.php:1235
 #: ../user_group_admin.php:2441
 msgid "Trees"
 msgstr ""
 
-#: ../include/global_arrays.php:687
+#: ../include/global_arrays.php:688
 msgid "Aggregates"
 msgstr ""
 
-#: ../include/global_arrays.php:689 ../include/global_arrays.php:736
-#: ../include/global_arrays.php:751
+#: ../include/global_arrays.php:690 ../include/global_arrays.php:737
+#: ../include/global_arrays.php:752
 msgid "Data Collection"
 msgstr ""
 
-#: ../include/global_arrays.php:690 ../include/global_arrays.php:737
+#: ../include/global_arrays.php:691 ../include/global_arrays.php:738
 #: ../pollers.php:508
 msgid "Data Collectors"
 msgstr ""
 
-#: ../include/global_arrays.php:698
+#: ../include/global_arrays.php:699
 msgid "Aggregate"
 msgstr ""
 
-#: ../include/global_arrays.php:701 ../include/global_arrays.php:753
+#: ../include/global_arrays.php:702 ../include/global_arrays.php:754
 #: ../include/global_settings.php:413
 msgid "Automation"
 msgstr ""
 
-#: ../include/global_arrays.php:703
+#: ../include/global_arrays.php:704
 msgid "Discovered Devices"
 msgstr ""
 
-#: ../include/global_arrays.php:704
+#: ../include/global_arrays.php:705
 msgid "Device Rules"
 msgstr ""
 
-#: ../include/global_arrays.php:709 ../include/global_arrays.php:754
+#: ../include/global_arrays.php:710 ../include/global_arrays.php:755
 #: ../lib/html_filter.php:178 ../lib/html_graph.php:255
 #: ../lib/html_tree.php:701
 msgid "Presets"
 msgstr ""
 
-#: ../include/global_arrays.php:710
+#: ../include/global_arrays.php:711
 msgid "Data Profiles"
 msgstr ""
 
-#: ../include/global_arrays.php:712 ../lib/functions.php:2311 ../vdef.php:651
+#: ../include/global_arrays.php:713 ../lib/functions.php:2328 ../vdef.php:651
 #: ../vdef.php:665 ../vdef.php:836
 msgid "VDEFs"
 msgstr ""
 
-#: ../include/global_arrays.php:716 ../include/global_arrays.php:755
+#: ../include/global_arrays.php:717 ../include/global_arrays.php:756
 msgid "Import/Export"
 msgstr ""
 
-#: ../include/global_arrays.php:717 ../lib/functions.php:2425
+#: ../include/global_arrays.php:718 ../lib/functions.php:2442
 #: ../templates_import.php:115
 msgid "Import Templates"
 msgstr ""
 
-#: ../include/global_arrays.php:718 ../lib/functions.php:2413
+#: ../include/global_arrays.php:719 ../lib/functions.php:2430
 #: ../templates_export.php:94
 msgid "Export Templates"
 msgstr ""
 
-#: ../include/global_arrays.php:720 ../include/global_arrays.php:739
-#: ../include/global_arrays.php:756 ../lib/plugins.php:763
+#: ../include/global_arrays.php:721 ../include/global_arrays.php:740
+#: ../include/global_arrays.php:757 ../lib/plugins.php:763
 msgid "Configuration"
 msgstr ""
 
-#: ../include/global_arrays.php:721 ../include/global_arrays.php:740
+#: ../include/global_arrays.php:722 ../include/global_arrays.php:741
 msgid "Settings"
 msgstr ""
 
-#: ../include/global_arrays.php:722 ../lib/functions.php:2359
-#: ../user_admin.php:2182 ../user_group_admin.php:667
+#: ../include/global_arrays.php:723 ../lib/functions.php:2376
+#: ../user_admin.php:2199 ../user_admin.php:2254 ../user_group_admin.php:667
 #: ../user_group_admin.php:2528
 msgid "Users"
 msgstr ""
 
-#: ../include/global_arrays.php:723 ../lib/functions.php:2389
+#: ../include/global_arrays.php:724 ../lib/functions.php:2406
 msgid "User Groups"
 msgstr ""
 
-#: ../include/global_arrays.php:724 ../lib/functions.php:2377
+#: ../include/global_arrays.php:725 ../lib/functions.php:2394
 #: ../user_domains.php:612 ../user_domains.php:705
 msgid "User Domains"
 msgstr ""
 
-#: ../include/global_arrays.php:726 ../include/global_arrays.php:742
-#: ../include/global_arrays.php:757 ../lib/functions.php:2239
+#: ../include/global_arrays.php:727 ../include/global_arrays.php:743
+#: ../include/global_arrays.php:758 ../lib/functions.php:2256
 msgid "Utilities"
 msgstr ""
 
-#: ../include/global_arrays.php:727 ../include/global_arrays.php:743
+#: ../include/global_arrays.php:728 ../include/global_arrays.php:744
 msgid "System Utilities"
 msgstr ""
 
-#: ../include/global_arrays.php:728 ../include/global_arrays.php:771
-#: ../include/global_arrays.php:854 ../links.php:90 ../links.php:301
+#: ../include/global_arrays.php:729 ../include/global_arrays.php:772
+#: ../include/global_arrays.php:855 ../links.php:90 ../links.php:301
 #: ../links.php:370 ../links.php:483
 msgid "External Links"
 msgstr ""
 
-#: ../include/global_arrays.php:780
+#: ../include/global_arrays.php:781
 msgid "All Lines"
 msgstr ""
 
-#: ../include/global_arrays.php:781 ../include/global_arrays.php:782
-#: ../include/global_arrays.php:783 ../include/global_arrays.php:784
-#: ../include/global_arrays.php:785 ../include/global_arrays.php:786
-#: ../include/global_arrays.php:787 ../include/global_arrays.php:788
-#: ../include/global_arrays.php:789 ../include/global_arrays.php:790
-#: ../include/global_arrays.php:791 ../include/global_arrays.php:792
+#: ../include/global_arrays.php:782 ../include/global_arrays.php:783
+#: ../include/global_arrays.php:784 ../include/global_arrays.php:785
+#: ../include/global_arrays.php:786 ../include/global_arrays.php:787
+#: ../include/global_arrays.php:788 ../include/global_arrays.php:789
+#: ../include/global_arrays.php:790 ../include/global_arrays.php:791
+#: ../include/global_arrays.php:792 ../include/global_arrays.php:793
 #, php-format
 msgid "%d Lines"
 msgstr ""
 
-#: ../include/global_arrays.php:847
+#: ../include/global_arrays.php:848
 msgid "Never"
 msgstr ""
 
-#: ../include/global_arrays.php:851
+#: ../include/global_arrays.php:852
 msgid "Console Access"
 msgstr ""
 
-#: ../include/global_arrays.php:853
+#: ../include/global_arrays.php:854
 msgid "Update Profile"
 msgstr ""
 
-#: ../include/global_arrays.php:856 ../user_admin.php:2161
+#: ../include/global_arrays.php:857 ../user_admin.php:2178
 msgid "User Management"
 msgstr ""
 
-#: ../include/global_arrays.php:857
+#: ../include/global_arrays.php:858
 msgid "Settings and Utilities"
 msgstr ""
 
-#: ../include/global_arrays.php:858
+#: ../include/global_arrays.php:859
 msgid "Automation Settings"
 msgstr ""
 
-#: ../include/global_arrays.php:863
+#: ../include/global_arrays.php:864
 msgid "Sites/Devices/Data Sources/Data Collectors"
 msgstr ""
 
-#: ../include/global_arrays.php:866
+#: ../include/global_arrays.php:867
 msgid "Remove Spikes from Graphs"
 msgstr ""
 
-#: ../include/global_arrays.php:869
+#: ../include/global_arrays.php:870
 msgid "Colors/GPrints/CDEFs/VDEFs"
 msgstr ""
 
-#: ../include/global_arrays.php:875
+#: ../include/global_arrays.php:876
 msgid "Export Data"
 msgstr ""
 
-#: ../include/global_arrays.php:876
+#: ../include/global_arrays.php:877
 msgid "Import Data"
 msgstr ""
 
-#: ../include/global_arrays.php:878 ../include/global_settings.php:665
+#: ../include/global_arrays.php:879 ../include/global_settings.php:665
 msgid "Log Management"
 msgstr ""
 
-#: ../include/global_arrays.php:879
+#: ../include/global_arrays.php:880
 msgid "Log Viewing"
 msgstr ""
 
-#: ../include/global_arrays.php:881
+#: ../include/global_arrays.php:882
 msgid "Reports Management"
 msgstr ""
 
-#: ../include/global_arrays.php:882
+#: ../include/global_arrays.php:883
 msgid "Reports Creation"
 msgstr ""
 
-#: ../include/global_arrays.php:980
+#: ../include/global_arrays.php:981
 msgid "CDEF"
 msgstr ""
 
-#: ../include/global_arrays.php:981
+#: ../include/global_arrays.php:982
 msgid "CDEF Item"
 msgstr ""
 
-#: ../include/global_arrays.php:982
+#: ../include/global_arrays.php:983
 msgid "GPRINT Preset"
 msgstr ""
 
-#: ../include/global_arrays.php:985
+#: ../include/global_arrays.php:986
 msgid "Data Input Field"
 msgstr ""
 
-#: ../include/global_arrays.php:986 ../include/global_form.php:394
+#: ../include/global_arrays.php:987 ../include/global_form.php:394
 #: ../include/global_form.php:1613
 msgid "Data Source Profile"
 msgstr ""
 
-#: ../include/global_arrays.php:987
+#: ../include/global_arrays.php:988
 msgid "Data Template Item"
 msgstr ""
 
-#: ../include/global_arrays.php:989
+#: ../include/global_arrays.php:990
 msgid "Graph Template Item"
 msgstr ""
 
-#: ../include/global_arrays.php:990
+#: ../include/global_arrays.php:991
 msgid "Graph Template Input"
 msgstr ""
 
-#: ../include/global_arrays.php:993
+#: ../include/global_arrays.php:994
 msgid "VDEF"
 msgstr ""
 
-#: ../include/global_arrays.php:994
+#: ../include/global_arrays.php:995
 msgid "VDEF Item"
 msgstr ""
 
-#: ../include/global_arrays.php:1038
+#: ../include/global_arrays.php:1039
 msgid "Last Half Hour"
 msgstr ""
 
-#: ../include/global_arrays.php:1039
+#: ../include/global_arrays.php:1040
 msgid "Last Hour"
 msgstr ""
 
-#: ../include/global_arrays.php:1040 ../include/global_arrays.php:1041
-#: ../include/global_arrays.php:1042 ../include/global_arrays.php:1043
+#: ../include/global_arrays.php:1041 ../include/global_arrays.php:1042
+#: ../include/global_arrays.php:1043 ../include/global_arrays.php:1044
 #, php-format
 msgid "Last %d Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1044
+#: ../include/global_arrays.php:1045
 msgid "Last Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1045 ../include/global_arrays.php:1046
-#: ../include/global_arrays.php:1047
+#: ../include/global_arrays.php:1046 ../include/global_arrays.php:1047
+#: ../include/global_arrays.php:1048
 #, php-format
 msgid "Last %d Days"
 msgstr ""
 
-#: ../include/global_arrays.php:1048
+#: ../include/global_arrays.php:1049
 msgid "Last Week"
 msgstr ""
 
-#: ../include/global_arrays.php:1049
+#: ../include/global_arrays.php:1050
 #, php-format
 msgid "Last %d Weeks"
 msgstr ""
 
-#: ../include/global_arrays.php:1050
+#: ../include/global_arrays.php:1051
 msgid "Last Month"
 msgstr ""
 
-#: ../include/global_arrays.php:1051 ../include/global_arrays.php:1052
-#: ../include/global_arrays.php:1053 ../include/global_arrays.php:1054
+#: ../include/global_arrays.php:1052 ../include/global_arrays.php:1053
+#: ../include/global_arrays.php:1054 ../include/global_arrays.php:1055
 #, php-format
 msgid "Last %d Months"
 msgstr ""
 
-#: ../include/global_arrays.php:1055
+#: ../include/global_arrays.php:1056
 msgid "Last Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1056
+#: ../include/global_arrays.php:1057
 #, php-format
 msgid "Last %d Years"
 msgstr ""
 
-#: ../include/global_arrays.php:1057
+#: ../include/global_arrays.php:1058
 msgid "Day Shift"
 msgstr ""
 
-#: ../include/global_arrays.php:1058
+#: ../include/global_arrays.php:1059
 msgid "This Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1059
+#: ../include/global_arrays.php:1060
 msgid "This Week"
 msgstr ""
 
-#: ../include/global_arrays.php:1060
+#: ../include/global_arrays.php:1061
 msgid "This Month"
 msgstr ""
 
-#: ../include/global_arrays.php:1061
+#: ../include/global_arrays.php:1062
 msgid "This Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1062
+#: ../include/global_arrays.php:1063
 msgid "Previous Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1063
+#: ../include/global_arrays.php:1064
 msgid "Previous Week"
 msgstr ""
 
-#: ../include/global_arrays.php:1064
+#: ../include/global_arrays.php:1065
 msgid "Previous Month"
 msgstr ""
 
-#: ../include/global_arrays.php:1065
+#: ../include/global_arrays.php:1066
 msgid "Previous Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1069
+#: ../include/global_arrays.php:1070
 #, php-format
 msgid "%d Min"
 msgstr ""
 
-#: ../include/global_arrays.php:1086 ../include/global_settings.php:1026
+#: ../include/global_arrays.php:1087 ../include/global_settings.php:1026
 #: ../rrdcleaner.php:493
 #, php-format
 msgid "%d Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1101
+#: ../include/global_arrays.php:1102
 msgid "Month Number, Day, Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1102
+#: ../include/global_arrays.php:1103
 msgid "Month Name, Day, Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1103
+#: ../include/global_arrays.php:1104
 msgid "Day, Month Number, Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1104
+#: ../include/global_arrays.php:1105
 msgid "Day, Month Name, Year"
 msgstr ""
 
-#: ../include/global_arrays.php:1105
+#: ../include/global_arrays.php:1106
 msgid "Year, Month Number, Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1106
+#: ../include/global_arrays.php:1107
 msgid "Year, Month Name, Day"
 msgstr ""
 
-#: ../include/global_arrays.php:1115
+#: ../include/global_arrays.php:1116
 msgid "After Boost"
 msgstr ""
 
-#: ../include/global_arrays.php:1125 ../include/global_arrays.php:1126
-#: ../include/global_arrays.php:1127 ../include/global_arrays.php:1128
-#: ../include/global_arrays.php:1129 ../include/global_arrays.php:1184
-#: ../include/global_arrays.php:1185 ../include/global_arrays.php:1186
-#: ../include/global_arrays.php:1187 ../include/global_arrays.php:1188
+#: ../include/global_arrays.php:1126 ../include/global_arrays.php:1127
+#: ../include/global_arrays.php:1128 ../include/global_arrays.php:1129
+#: ../include/global_arrays.php:1130 ../include/global_arrays.php:1185
+#: ../include/global_arrays.php:1186 ../include/global_arrays.php:1187
+#: ../include/global_arrays.php:1188 ../include/global_arrays.php:1189
 #, php-format
 msgid "%d MBytes"
 msgstr ""
 
-#: ../include/global_arrays.php:1130 ../include/global_arrays.php:1189
+#: ../include/global_arrays.php:1131 ../include/global_arrays.php:1190
 msgid "1 GByte"
 msgstr ""
 
-#: ../include/global_arrays.php:1131 ../include/global_arrays.php:1190
+#: ../include/global_arrays.php:1132 ../include/global_arrays.php:1191
 #, php-format
 msgid "%s GBytes"
 msgstr ""
 
-#: ../include/global_arrays.php:1132 ../include/global_arrays.php:1133
-#: ../include/global_arrays.php:1191 ../include/global_arrays.php:1192
+#: ../include/global_arrays.php:1133 ../include/global_arrays.php:1134
+#: ../include/global_arrays.php:1192 ../include/global_arrays.php:1193
 #, php-format
 msgid "%d GBytes"
 msgstr ""
 
-#: ../include/global_arrays.php:1146
+#: ../include/global_arrays.php:1147
 msgid "2,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1147
+#: ../include/global_arrays.php:1148
 msgid "5,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1148
+#: ../include/global_arrays.php:1149
 msgid "10,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1149
+#: ../include/global_arrays.php:1150
 msgid "15,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1150
+#: ../include/global_arrays.php:1151
 msgid "25,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1151
+#: ../include/global_arrays.php:1152
 msgid "50,000 Data Source Items (Default)"
 msgstr ""
 
-#: ../include/global_arrays.php:1152
+#: ../include/global_arrays.php:1153
 msgid "100,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1153
+#: ../include/global_arrays.php:1154
 msgid "200,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1154
+#: ../include/global_arrays.php:1155
 msgid "400,000 Data Source Items"
 msgstr ""
 
-#: ../include/global_arrays.php:1171
+#: ../include/global_arrays.php:1172
 msgid "2 Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1172
+#: ../include/global_arrays.php:1173
 msgid "4 Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1173
+#: ../include/global_arrays.php:1174
 msgid "6 Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1180
+#: ../include/global_arrays.php:1181
 #, php-format
 msgid "%s Hours"
 msgstr ""
 
-#: ../include/global_arrays.php:1199
+#: ../include/global_arrays.php:1200
 #, php-format
 msgid "%s Minutes"
 msgstr ""
 
-#: ../include/global_arrays.php:1219
+#: ../include/global_arrays.php:1220
 msgid "1 Megabyte"
 msgstr ""
 
-#: ../include/global_arrays.php:1220 ../include/global_arrays.php:1221
-#: ../include/global_arrays.php:1222 ../include/global_arrays.php:1223
-#: ../include/global_arrays.php:1224 ../include/global_arrays.php:1225
+#: ../include/global_arrays.php:1221 ../include/global_arrays.php:1222
+#: ../include/global_arrays.php:1223 ../include/global_arrays.php:1224
+#: ../include/global_arrays.php:1225 ../include/global_arrays.php:1226
 #, php-format
 msgid "%d Megabytes"
 msgstr ""
 
-#: ../include/global_arrays.php:1237
+#: ../include/global_arrays.php:1230
+msgid "Send Now"
+msgstr ""
+
+#: ../include/global_arrays.php:1238
 msgid "Take Ownership"
 msgstr ""
 
-#: ../include/global_arrays.php:1241
+#: ../include/global_arrays.php:1242
 msgid "Inline PNG Image"
 msgstr ""
 
@@ -7153,10 +7160,9 @@ msgid ""
 "as UNIX timestamps (number of seconds since January 1970)\n"
 "\t\t\tand expressed using strftime format (default is \"%Y-%m-%d %H:%M:%S"
 "\").  See also --units-length.  Finally \"duration\" where values\n"
-"\t\t\tare interpreted as duration in milliseconds.  Formatting follows the"
+"\t\t\tare interpreted as duration in milliseconds.  Formatting follows the "
 "rules of valstrfduration qualified PRINT/GPRINT."
 msgstr ""
-
 
 #: ../include/global_form.php:739
 msgid "Legend Options"
@@ -7240,7 +7246,7 @@ msgstr ""
 msgid "The opacity/alpha channel of the color."
 msgstr ""
 
-#: ../include/global_form.php:826 ../lib/rrd.php:2676
+#: ../include/global_form.php:826 ../lib/rrd.php:2688
 msgid "Consolidation Function"
 msgstr ""
 
@@ -7274,7 +7280,7 @@ msgid ""
 "'value' field."
 msgstr ""
 
-#: ../include/global_form.php:855 ../lib/rrd.php:2646 ../utilities.php:2338
+#: ../include/global_form.php:855 ../lib/rrd.php:2658 ../utilities.php:2338
 msgid "Value"
 msgstr ""
 
@@ -8065,8 +8071,8 @@ msgid "Enter a regular expression"
 msgstr ""
 
 #: ../include/global_settings.php:38 ../include/global_settings.php:836
-#: ../include/global_settings.php:940 ../include/global_settings.php:1558
-#: ../managers.php:39 ../user_admin.php:1904 ../user_group_admin.php:1642
+#: ../include/global_settings.php:940 ../include/global_settings.php:1565
+#: ../managers.php:39 ../user_admin.php:1921 ../user_group_admin.php:1642
 msgid "General"
 msgstr ""
 
@@ -8090,8 +8096,8 @@ msgstr ""
 msgid "Visual"
 msgstr ""
 
-#: ../include/global_settings.php:44 ../lib/functions.php:3779
-#: ../lib/functions.php:3784
+#: ../include/global_settings.php:44 ../lib/functions.php:3800
+#: ../lib/functions.php:3805
 msgid "Authentication"
 msgstr ""
 
@@ -8243,7 +8249,7 @@ msgid ""
 "etc if not specified."
 msgstr ""
 
-#: ../include/global_settings.php:174 ../lib/functions.php:2221
+#: ../include/global_settings.php:174 ../lib/functions.php:2238
 #: ../rrdcleaner.php:296
 msgid "RRD Cleaner"
 msgstr ""
@@ -8442,7 +8448,7 @@ msgid ""
 "another language."
 msgstr ""
 
-#: ../include/global_settings.php:342 ../include/global_settings.php:1812
+#: ../include/global_settings.php:342 ../include/global_settings.php:1819
 msgid "Date Display Format"
 msgstr ""
 
@@ -8450,7 +8456,7 @@ msgstr ""
 msgid "The System default date format to use in Cacti."
 msgstr ""
 
-#: ../include/global_settings.php:349 ../include/global_settings.php:1819
+#: ../include/global_settings.php:349 ../include/global_settings.php:1826
 msgid "Date Separator"
 msgstr ""
 
@@ -8696,11 +8702,11 @@ msgid "Theme Settings"
 msgstr ""
 
 #: ../include/global_settings.php:613 ../include/global_settings.php:764
-#: ../include/global_settings.php:1785
+#: ../include/global_settings.php:1792
 msgid "Theme"
 msgstr ""
 
-#: ../include/global_settings.php:614 ../include/global_settings.php:1786
+#: ../include/global_settings.php:614 ../include/global_settings.php:1793
 msgid "Please select one of the available Themes to skin your Cacti with."
 msgstr ""
 
@@ -8823,7 +8829,7 @@ msgid ""
 "mode."
 msgstr ""
 
-#: ../include/global_settings.php:731 ../lib/html_reports.php:398
+#: ../include/global_settings.php:731 ../lib/html_reports.php:365
 msgid "Graph Timespan"
 msgstr ""
 
@@ -8885,11 +8891,11 @@ msgstr ""
 msgid "Enter Valid Font Config Value"
 msgstr ""
 
-#: ../include/global_settings.php:774 ../include/global_settings.php:1970
+#: ../include/global_settings.php:774 ../include/global_settings.php:1977
 msgid "Title Font Size"
 msgstr ""
 
-#: ../include/global_settings.php:775 ../include/global_settings.php:1971
+#: ../include/global_settings.php:775 ../include/global_settings.php:1978
 msgid "The size of the font used for Graph Titles"
 msgstr ""
 
@@ -8903,11 +8909,11 @@ msgid ""
 "or valid Pango font-config value."
 msgstr ""
 
-#: ../include/global_settings.php:789 ../include/global_settings.php:1983
+#: ../include/global_settings.php:789 ../include/global_settings.php:1990
 msgid "Legend Font Size"
 msgstr ""
 
-#: ../include/global_settings.php:790 ../include/global_settings.php:1984
+#: ../include/global_settings.php:790 ../include/global_settings.php:1991
 msgid "The size of the font used for Graph Legend items"
 msgstr ""
 
@@ -8921,11 +8927,11 @@ msgid ""
 "or valid Pango font-config value."
 msgstr ""
 
-#: ../include/global_settings.php:804 ../include/global_settings.php:1996
+#: ../include/global_settings.php:804 ../include/global_settings.php:2003
 msgid "Axis Font Size"
 msgstr ""
 
-#: ../include/global_settings.php:805 ../include/global_settings.php:1997
+#: ../include/global_settings.php:805 ../include/global_settings.php:2004
 msgid "The size of the font used for Graph Axis"
 msgstr ""
 
@@ -8939,11 +8945,11 @@ msgid ""
 "file or valid Pango font-config value."
 msgstr ""
 
-#: ../include/global_settings.php:819 ../include/global_settings.php:2009
+#: ../include/global_settings.php:819 ../include/global_settings.php:2016
 msgid "Unit Font Size"
 msgstr ""
 
-#: ../include/global_settings.php:820 ../include/global_settings.php:2010
+#: ../include/global_settings.php:820 ../include/global_settings.php:2017
 msgid "The size of the font used for Graph Units"
 msgstr ""
 
@@ -9488,242 +9494,250 @@ msgstr ""
 msgid "PHP Mail() Function"
 msgstr ""
 
-#: ../include/global_settings.php:1247 ../lib/functions.php:3767
+#: ../include/global_settings.php:1247 ../lib/functions.php:3788
 msgid "SMTP"
 msgstr ""
 
-#: ../include/global_settings.php:1247 ../lib/functions.php:3762
+#: ../include/global_settings.php:1247 ../lib/functions.php:3783
 msgid "Sendmail"
 msgstr ""
 
-#: ../include/global_settings.php:1250 ../lib/html_reports.php:186
-msgid "From Email Address"
+#: ../include/global_settings.php:1250
+msgid "Ping Mail Server"
 msgstr ""
 
 #: ../include/global_settings.php:1251
+msgid "Ping the Mail Server before sending test Email?"
+msgstr ""
+
+#: ../include/global_settings.php:1257 ../lib/html_reports.php:186
+msgid "From Email Address"
+msgstr ""
+
+#: ../include/global_settings.php:1258
 msgid "This is the Email address that the Email will appear from."
 msgstr ""
 
-#: ../include/global_settings.php:1256 ../lib/html_reports.php:178
+#: ../include/global_settings.php:1263 ../lib/html_reports.php:178
 msgid "From Name"
 msgstr ""
 
-#: ../include/global_settings.php:1257
+#: ../include/global_settings.php:1264
 msgid "This is the actual name that the Email will appear from."
 msgstr ""
 
-#: ../include/global_settings.php:1262
+#: ../include/global_settings.php:1269
 msgid "Word Wrap"
 msgstr ""
 
-#: ../include/global_settings.php:1263
+#: ../include/global_settings.php:1270
 msgid ""
 "This is how many characters will be allowed before a line in the Email is "
 "automatically word wrapped. (0 = Disabled)"
 msgstr ""
 
-#: ../include/global_settings.php:1270
+#: ../include/global_settings.php:1277
 msgid "Sendmail Options"
 msgstr ""
 
-#: ../include/global_settings.php:1275 ../lib/functions.php:3762
+#: ../include/global_settings.php:1282 ../lib/functions.php:3783
 msgid "Sendmail Path"
 msgstr ""
 
-#: ../include/global_settings.php:1276
+#: ../include/global_settings.php:1283
 msgid ""
 "This is the path to sendmail on your server. (Only used if Sendmail is "
 "selected as the Mail Service)"
 msgstr ""
 
-#: ../include/global_settings.php:1282
+#: ../include/global_settings.php:1289
 msgid "SMTP Options"
 msgstr ""
 
-#: ../include/global_settings.php:1287
+#: ../include/global_settings.php:1294
 msgid "SMTP Hostname"
 msgstr ""
 
-#: ../include/global_settings.php:1288
+#: ../include/global_settings.php:1295
 msgid ""
 "This is the hostname/IP of the SMTP Server you will send the Email to. For "
 "failover, separate your hosts using a semi-colon."
 msgstr ""
 
-#: ../include/global_settings.php:1294
+#: ../include/global_settings.php:1301
 msgid "SMTP Port"
 msgstr ""
 
-#: ../include/global_settings.php:1295
+#: ../include/global_settings.php:1302
 msgid "The port on the SMTP Server to use."
 msgstr ""
 
-#: ../include/global_settings.php:1302
+#: ../include/global_settings.php:1309
 msgid "SMTP Username"
 msgstr ""
 
-#: ../include/global_settings.php:1303
+#: ../include/global_settings.php:1310
 msgid ""
 "The username to authenticate with when sending via SMTP. (Leave blank if you "
 "do not require authentication.)"
 msgstr ""
 
-#: ../include/global_settings.php:1308
+#: ../include/global_settings.php:1315
 msgid "SMTP Password"
 msgstr ""
 
-#: ../include/global_settings.php:1309
+#: ../include/global_settings.php:1316
 msgid ""
 "The password to authenticate with when sending via SMTP. (Leave blank if you "
 "do not require authentication.)"
 msgstr ""
 
-#: ../include/global_settings.php:1314
+#: ../include/global_settings.php:1321
 msgid "SMTP Security"
 msgstr ""
 
-#: ../include/global_settings.php:1315
+#: ../include/global_settings.php:1322
 msgid "The encryption method to use for the Email."
 msgstr ""
 
-#: ../include/global_settings.php:1321
+#: ../include/global_settings.php:1328
 msgid "SMTP Timeout"
 msgstr ""
 
-#: ../include/global_settings.php:1322
+#: ../include/global_settings.php:1329
 msgid "Please enter the SMTP timeout in seconds."
 msgstr ""
 
-#: ../include/global_settings.php:1329
+#: ../include/global_settings.php:1336
 msgid "Reporting Presets"
 msgstr ""
 
-#: ../include/global_settings.php:1334
+#: ../include/global_settings.php:1341
 msgid "Default Graph Image Format"
 msgstr ""
 
-#: ../include/global_settings.php:1335
+#: ../include/global_settings.php:1342
 msgid ""
 "When creating a new report, what image type should be used for the inline "
 "graphs."
 msgstr ""
 
-#: ../include/global_settings.php:1341
+#: ../include/global_settings.php:1348
 msgid "Maximum E-Mail Size"
 msgstr ""
 
-#: ../include/global_settings.php:1342
+#: ../include/global_settings.php:1349
 msgid "The maximum size of the E-Mail message including all attachements."
 msgstr ""
 
-#: ../include/global_settings.php:1348
+#: ../include/global_settings.php:1355
 msgid "Poller Logging Level for Cacti Reporting"
 msgstr ""
 
-#: ../include/global_settings.php:1349
+#: ../include/global_settings.php:1356
 msgid ""
 "What level of detail do you want sent to the log file. WARNING: Leaving in "
 "any other status than NONE or LOW can exhaust your disk space rapidly."
 msgstr ""
 
-#: ../include/global_settings.php:1355
+#: ../include/global_settings.php:1362
 msgid "Enable Lotus Notes (R) tweak"
 msgstr ""
 
-#: ../include/global_settings.php:1356
+#: ../include/global_settings.php:1363
 msgid "Enable code tweak for specific handling of Lotus Notes Mail Clients."
 msgstr ""
 
-#: ../include/global_settings.php:1361
+#: ../include/global_settings.php:1368
 msgid "DNS Options"
 msgstr ""
 
-#: ../include/global_settings.php:1366
+#: ../include/global_settings.php:1373
 msgid "Primary DNS IP Address"
 msgstr ""
 
-#: ../include/global_settings.php:1367
+#: ../include/global_settings.php:1374
 msgid "Enter the primary DNS IP Address to utilize for reverse lookups."
 msgstr ""
 
-#: ../include/global_settings.php:1373
+#: ../include/global_settings.php:1380
 msgid "Secondary DNS IP Address"
 msgstr ""
 
-#: ../include/global_settings.php:1374
+#: ../include/global_settings.php:1381
 msgid "Enter the secondary DNS IP Address to utilize for reverse lookups."
 msgstr ""
 
-#: ../include/global_settings.php:1380
+#: ../include/global_settings.php:1387
 msgid "DNS Timeout"
 msgstr ""
 
-#: ../include/global_settings.php:1381
+#: ../include/global_settings.php:1388
 msgid ""
 "Please enter the DNS timeout in milliseconds.  Cacti uses a PHP based DNS "
 "resolver."
 msgstr ""
 
-#: ../include/global_settings.php:1390
+#: ../include/global_settings.php:1397
 msgid "Data Sources Statistics"
 msgstr ""
 
-#: ../include/global_settings.php:1395
+#: ../include/global_settings.php:1402
 msgid "Enable Data Source Statistics Collection"
 msgstr ""
 
-#: ../include/global_settings.php:1396
+#: ../include/global_settings.php:1403
 msgid "Should Data Source Statistics be collected for this Cacti system?"
 msgstr ""
 
-#: ../include/global_settings.php:1401
+#: ../include/global_settings.php:1408
 msgid "Daily Update Frequency"
 msgstr ""
 
-#: ../include/global_settings.php:1402
+#: ../include/global_settings.php:1409
 msgid "How frequent should Daily Stats be updated?"
 msgstr ""
 
-#: ../include/global_settings.php:1408
+#: ../include/global_settings.php:1415
 msgid "Hourly Average Window"
 msgstr ""
 
-#: ../include/global_settings.php:1409
+#: ../include/global_settings.php:1416
 msgid ""
 "The number of consecutive hours that represent the hourly\n"
 "\t\t\taverage.  Keep in mind that a setting too high can result in very "
 "large memory tables"
 msgstr ""
 
-#: ../include/global_settings.php:1416
+#: ../include/global_settings.php:1423
 msgid "Maintenance Time"
 msgstr ""
 
-#: ../include/global_settings.php:1417
+#: ../include/global_settings.php:1424
 msgid ""
 "What time of day should Weekly, Monthly, and Yearly Data be updated?  Format "
 "is HH:MM [am/pm]"
 msgstr ""
 
-#: ../include/global_settings.php:1424
+#: ../include/global_settings.php:1431
 msgid "Memory Limit for Data Source Statistics Data Collector"
 msgstr ""
 
-#: ../include/global_settings.php:1425
+#: ../include/global_settings.php:1432
 msgid ""
 "The maximum amount of memory for the Cacti Poller and Data Source Statistics "
 "Poller"
 msgstr ""
 
-#: ../include/global_settings.php:1431
+#: ../include/global_settings.php:1438
 msgid "Debugging"
 msgstr ""
 
-#: ../include/global_settings.php:1436
+#: ../include/global_settings.php:1443
 msgid "Enable Single RRDtool Pipe"
 msgstr ""
 
-#: ../include/global_settings.php:1437
+#: ../include/global_settings.php:1444
 msgid ""
 "Using a single pipe will speed the RRDtool process by 10x.  However, RRDtool "
 "crashes\n"
@@ -9731,11 +9745,11 @@ msgid ""
 "RRDfile."
 msgstr ""
 
-#: ../include/global_settings.php:1443
+#: ../include/global_settings.php:1450
 msgid "Enable Partial Reference Data Retrieve"
 msgstr ""
 
-#: ../include/global_settings.php:1444
+#: ../include/global_settings.php:1451
 msgid ""
 "If using a large system, it may be beneficial for you to only gather data as "
 "needed\n"
@@ -9743,54 +9757,54 @@ msgid ""
 "Statistics will gather data this way."
 msgstr ""
 
-#: ../include/global_settings.php:1452
+#: ../include/global_settings.php:1459
 msgid "On-demand RRD Update Settings"
 msgstr ""
 
-#: ../include/global_settings.php:1457
+#: ../include/global_settings.php:1464
 msgid "Enable On-demand RRD Updating"
 msgstr ""
 
-#: ../include/global_settings.php:1458
+#: ../include/global_settings.php:1465
 msgid ""
 "Should Boost enable on demand RRD updating in Cacti?  If you disable, this "
 "change will not take effect until after the next polling cycle."
 msgstr ""
 
-#: ../include/global_settings.php:1463
+#: ../include/global_settings.php:1470
 msgid "System Level RRD Updater"
 msgstr ""
 
-#: ../include/global_settings.php:1464
+#: ../include/global_settings.php:1471
 msgid ""
 "Before RRD On-demand Update Can be Cleared, a poller run must always pass"
 msgstr ""
 
-#: ../include/global_settings.php:1469
+#: ../include/global_settings.php:1476
 msgid "How Often Should Boost Update All RRDs"
 msgstr ""
 
-#: ../include/global_settings.php:1470
+#: ../include/global_settings.php:1477
 msgid ""
 "When you enable boost, your RRD files are only updated when they are "
 "requested by a user, or when this time period elapses."
 msgstr ""
 
-#: ../include/global_settings.php:1477
+#: ../include/global_settings.php:1484
 msgid "Maximum Records"
 msgstr ""
 
-#: ../include/global_settings.php:1478
+#: ../include/global_settings.php:1485
 msgid ""
 "If the boost output table exceeds this size, in records, an update will take "
 "place."
 msgstr ""
 
-#: ../include/global_settings.php:1485
+#: ../include/global_settings.php:1492
 msgid "Maximum Data Source Items Per Pass"
 msgstr ""
 
-#: ../include/global_settings.php:1486
+#: ../include/global_settings.php:1493
 msgid ""
 "To optimize performance, the boost RRD updater needs to know how many Data "
 "Source Items\n"
@@ -9801,11 +9815,11 @@ msgid ""
 "\t\t\tnumber.  The default value is 50000."
 msgstr ""
 
-#: ../include/global_settings.php:1495
+#: ../include/global_settings.php:1502
 msgid "Maximum Argument Length"
 msgstr ""
 
-#: ../include/global_settings.php:1496
+#: ../include/global_settings.php:1503
 msgid ""
 "When boost sends update commands to RRDtool, it must not exceed the "
 "operating systems\n"
@@ -9815,155 +9829,155 @@ msgid ""
 "Linux 2.6.23++ unlimited"
 msgstr ""
 
-#: ../include/global_settings.php:1505
+#: ../include/global_settings.php:1512
 msgid "Memory Limit for Boost and Poller"
 msgstr ""
 
-#: ../include/global_settings.php:1506
+#: ../include/global_settings.php:1513
 msgid "The maximum amount of memory for the Cacti Poller and Boosts Poller"
 msgstr ""
 
-#: ../include/global_settings.php:1512
+#: ../include/global_settings.php:1519
 msgid "Maximum RRD Update Script Run Time"
 msgstr ""
 
-#: ../include/global_settings.php:1513
+#: ../include/global_settings.php:1520
 msgid ""
 "The maximum boot poller run time allowed prior to boost issuing warning\n"
 "\t\t\tmessages relative to possible hardware/software issues preventing "
 "proper updates."
 msgstr ""
 
-#: ../include/global_settings.php:1520
+#: ../include/global_settings.php:1527
 msgid "Enable direct population of poller_output_boost table"
 msgstr ""
 
-#: ../include/global_settings.php:1521
+#: ../include/global_settings.php:1528
 msgid ""
 "Enables direct insert of records into poller output boost with results in a "
 "25% time reduction in each poll cycle."
 msgstr ""
 
-#: ../include/global_settings.php:1526 ../utilities.php:2139
+#: ../include/global_settings.php:1533 ../utilities.php:2139
 msgid "Image Caching"
 msgstr ""
 
-#: ../include/global_settings.php:1531
+#: ../include/global_settings.php:1538
 msgid "Enable Image Caching"
 msgstr ""
 
-#: ../include/global_settings.php:1532
+#: ../include/global_settings.php:1539
 msgid "Should image caching be enabled?"
 msgstr ""
 
-#: ../include/global_settings.php:1537
+#: ../include/global_settings.php:1544
 msgid "Location for Image Files"
 msgstr ""
 
-#: ../include/global_settings.php:1538
+#: ../include/global_settings.php:1545
 msgid ""
 "Specify the location where Boost should place your image files.  These files "
 "will be automatically purged by the poller when they expire."
 msgstr ""
 
-#: ../include/global_settings.php:1544
+#: ../include/global_settings.php:1551
 msgid "Process Interlocking"
 msgstr ""
 
-#: ../include/global_settings.php:1549
+#: ../include/global_settings.php:1556
 msgid "Boost Debug Log"
 msgstr ""
 
-#: ../include/global_settings.php:1550
+#: ../include/global_settings.php:1557
 msgid ""
 "If this field is non-blank, Boost will log RRDupdate output from the boost"
 "\tpoller process."
 msgstr ""
 
-#: ../include/global_settings.php:1564
+#: ../include/global_settings.php:1571
 msgid ""
 "Choose if RRDs will be stored locally or being handled by an external "
 "RRDtool proxy server."
 msgstr ""
 
-#: ../include/global_settings.php:1567 ../include/global_settings.php:1575
+#: ../include/global_settings.php:1574 ../include/global_settings.php:1582
 msgid "RRDtool Proxy Server"
 msgstr ""
 
-#: ../include/global_settings.php:1570
+#: ../include/global_settings.php:1577
 msgid "Structured RRD Path (/host_id/local_data_id.rrd)"
 msgstr ""
 
-#: ../include/global_settings.php:1571
+#: ../include/global_settings.php:1578
 msgid "Use a separate subfolder for each hosts RRD files."
 msgstr ""
 
-#: ../include/global_settings.php:1580 ../include/global_settings.php:1612
+#: ../include/global_settings.php:1587 ../include/global_settings.php:1619
 msgid "Proxy Server"
 msgstr ""
 
-#: ../include/global_settings.php:1581
+#: ../include/global_settings.php:1588
 msgid "The DNS hostname or IP address of the RRDtool proxy server."
 msgstr ""
 
-#: ../include/global_settings.php:1586 ../include/global_settings.php:1618
+#: ../include/global_settings.php:1593 ../include/global_settings.php:1625
 msgid "Proxy Port Number"
 msgstr ""
 
-#: ../include/global_settings.php:1587
+#: ../include/global_settings.php:1594
 msgid "TCP port for encrypted communication."
 msgstr ""
 
-#: ../include/global_settings.php:1594 ../include/global_settings.php:1626
+#: ../include/global_settings.php:1601 ../include/global_settings.php:1633
 #: ../utilities.php:248
 msgid "RSA Fingerprint"
 msgstr ""
 
-#: ../include/global_settings.php:1595
+#: ../include/global_settings.php:1602
 msgid ""
 "The fingerprint of the current public RSA key the proxy is using. This is "
 "required to establish a trusted connection."
 msgstr ""
 
-#: ../include/global_settings.php:1602
+#: ../include/global_settings.php:1609
 msgid "RRDtool Proxy Server - Backup"
 msgstr ""
 
-#: ../include/global_settings.php:1607
+#: ../include/global_settings.php:1614
 msgid "Load Balancing"
 msgstr ""
 
-#: ../include/global_settings.php:1608
+#: ../include/global_settings.php:1615
 msgid ""
 "If both main and backup proxy are receivable this option allows to spread "
 "all requests against RRDtool."
 msgstr ""
 
-#: ../include/global_settings.php:1613
+#: ../include/global_settings.php:1620
 msgid ""
 "The DNS hostname or IP address of the RRDtool backup proxy server if proxy "
 "is running in MSR mode."
 msgstr ""
 
-#: ../include/global_settings.php:1619
+#: ../include/global_settings.php:1626
 msgid "TCP port for encrypted communication with the backup proxy."
 msgstr ""
 
-#: ../include/global_settings.php:1627
+#: ../include/global_settings.php:1634
 msgid ""
 "The fingerprint of the current public RSA key the backup proxy is using. "
 "This required to establish a trusted connection."
 msgstr ""
 
-#: ../include/global_settings.php:1636
+#: ../include/global_settings.php:1643
 msgid "Spike Kill Settings"
 msgstr ""
 
-#: ../include/global_settings.php:1641
+#: ../include/global_settings.php:1648
 msgid "Removal Method"
 msgstr ""
 
-#: ../include/global_settings.php:1642
+#: ../include/global_settings.php:1649
 msgid ""
 "There are two removal methods.  The first, Standard Deviation, will remove "
 "any\n"
@@ -9976,19 +9990,19 @@ msgid ""
 "\t\t\tto be excluded from the Variance Average calculation."
 msgstr ""
 
-#: ../include/global_settings.php:1649
+#: ../include/global_settings.php:1656
 msgid "Standard Deviation"
 msgstr ""
 
-#: ../include/global_settings.php:1649
+#: ../include/global_settings.php:1656
 msgid "Variance Based w/Outliers Removed"
 msgstr ""
 
-#: ../include/global_settings.php:1652 ../lib/html.php:1719
+#: ../include/global_settings.php:1659 ../lib/html.php:1719
 msgid "Replacement Method"
 msgstr ""
 
-#: ../include/global_settings.php:1653
+#: ../include/global_settings.php:1660
 msgid ""
 "There are three replacement methods.  The first method replaces the spike "
 "with the\n"
@@ -9997,23 +10011,23 @@ msgid ""
 "\t\t\tThe last replaces the spike with the last known good value found."
 msgstr ""
 
-#: ../include/global_settings.php:1658 ../lib/html.php:1720
+#: ../include/global_settings.php:1665 ../lib/html.php:1720
 msgid "Average"
 msgstr ""
 
-#: ../include/global_settings.php:1658 ../lib/html.php:1722
+#: ../include/global_settings.php:1665 ../lib/html.php:1722
 msgid "Last Known Good"
 msgstr ""
 
-#: ../include/global_settings.php:1658
+#: ../include/global_settings.php:1665
 msgid "NaN's"
 msgstr ""
 
-#: ../include/global_settings.php:1661
+#: ../include/global_settings.php:1668
 msgid "Number of Standard Deviations"
 msgstr ""
 
-#: ../include/global_settings.php:1662
+#: ../include/global_settings.php:1669
 msgid ""
 "Any value that is this many standard deviations above the average will be "
 "excluded.\n"
@@ -10022,20 +10036,20 @@ msgid ""
 "\t\t\tthan 5 Standard Deviations."
 msgstr ""
 
-#: ../include/global_settings.php:1668 ../include/global_settings.php:1669
-#: ../include/global_settings.php:1670 ../include/global_settings.php:1671
-#: ../include/global_settings.php:1672 ../include/global_settings.php:1673
-#: ../include/global_settings.php:1674 ../include/global_settings.php:1675
-#: ../include/global_settings.php:1676 ../include/global_settings.php:1677
+#: ../include/global_settings.php:1675 ../include/global_settings.php:1676
+#: ../include/global_settings.php:1677 ../include/global_settings.php:1678
+#: ../include/global_settings.php:1679 ../include/global_settings.php:1680
+#: ../include/global_settings.php:1681 ../include/global_settings.php:1682
+#: ../include/global_settings.php:1683 ../include/global_settings.php:1684
 #, php-format
 msgid "%d Standard Deviations"
 msgstr ""
 
-#: ../include/global_settings.php:1681 ../lib/html.php:1731
+#: ../include/global_settings.php:1688 ../lib/html.php:1731
 msgid "Variance Percentage"
 msgstr ""
 
-#: ../include/global_settings.php:1682
+#: ../include/global_settings.php:1689
 #, php-format
 msgid ""
 "This value represents the percentage above the adjusted sample average once "
@@ -10045,11 +10059,11 @@ msgid ""
 "\t\t\twould remove any sample above the quantity of 100 from the graph."
 msgstr ""
 
-#: ../include/global_settings.php:1703
+#: ../include/global_settings.php:1710
 msgid "Variance Number of Outliers"
 msgstr ""
 
-#: ../include/global_settings.php:1704
+#: ../include/global_settings.php:1711
 msgid ""
 "This value represents the number of high and low average samples will be "
 "removed from the\n"
@@ -10058,70 +10072,70 @@ msgid ""
 "\t\t\tand bottom 5 averages are removed."
 msgstr ""
 
-#: ../include/global_settings.php:1710 ../include/global_settings.php:1711
-#: ../include/global_settings.php:1712 ../include/global_settings.php:1713
-#: ../include/global_settings.php:1714 ../include/global_settings.php:1715
-#: ../include/global_settings.php:1716 ../include/global_settings.php:1717
+#: ../include/global_settings.php:1717 ../include/global_settings.php:1718
+#: ../include/global_settings.php:1719 ../include/global_settings.php:1720
+#: ../include/global_settings.php:1721 ../include/global_settings.php:1722
+#: ../include/global_settings.php:1723 ../include/global_settings.php:1724
 #, php-format
 msgid "%d High/Low Samples"
 msgstr ""
 
-#: ../include/global_settings.php:1721
+#: ../include/global_settings.php:1728
 msgid "Max Kills Per RRA"
 msgstr ""
 
-#: ../include/global_settings.php:1722
+#: ../include/global_settings.php:1729
 msgid ""
 "This value represents the maximum number of spikes to remove from a Graph "
 "RRA."
 msgstr ""
 
-#: ../include/global_settings.php:1726 ../include/global_settings.php:1727
-#: ../include/global_settings.php:1728 ../include/global_settings.php:1729
-#: ../include/global_settings.php:1730 ../include/global_settings.php:1731
-#: ../include/global_settings.php:1732 ../include/global_settings.php:1733
+#: ../include/global_settings.php:1733 ../include/global_settings.php:1734
+#: ../include/global_settings.php:1735 ../include/global_settings.php:1736
+#: ../include/global_settings.php:1737 ../include/global_settings.php:1738
+#: ../include/global_settings.php:1739 ../include/global_settings.php:1740
 #, php-format
 msgid "%d Samples"
 msgstr ""
 
-#: ../include/global_settings.php:1737
+#: ../include/global_settings.php:1744
 msgid "RRDfile Backup Directory"
 msgstr ""
 
-#: ../include/global_settings.php:1738
+#: ../include/global_settings.php:1745
 msgid ""
 "If this directory is not empty, then your original RRDfiles will be backed\n"
 "\t\t\tup to this location."
 msgstr ""
 
-#: ../include/global_settings.php:1746
+#: ../include/global_settings.php:1753
 msgid "Batch Spike Kill Settings"
 msgstr ""
 
-#: ../include/global_settings.php:1751
+#: ../include/global_settings.php:1758
 msgid "Removal Schedule"
 msgstr ""
 
-#: ../include/global_settings.php:1752
+#: ../include/global_settings.php:1759
 msgid ""
 "Do you wish to periodically remove spikes from your graphs?  If so, select "
 "the frequency\n"
 "\t\t\tbelow."
 msgstr ""
 
-#: ../include/global_settings.php:1760
+#: ../include/global_settings.php:1767
 msgid "Once a Day"
 msgstr ""
 
-#: ../include/global_settings.php:1761
+#: ../include/global_settings.php:1768
 msgid "Every Other Day"
 msgstr ""
 
-#: ../include/global_settings.php:1765
+#: ../include/global_settings.php:1772
 msgid "Base Time"
 msgstr ""
 
-#: ../include/global_settings.php:1766
+#: ../include/global_settings.php:1773
 msgid ""
 "The Base Time for Spike removal to occur.  For example, if you use '12:00am' "
 "and you choose\n"
@@ -10129,147 +10143,147 @@ msgid ""
 "every day."
 msgstr ""
 
-#: ../include/global_settings.php:1774
+#: ../include/global_settings.php:1781
 msgid "Graph Templates to Spike Kill"
 msgstr ""
 
-#: ../include/global_settings.php:1776
+#: ../include/global_settings.php:1783
 msgid ""
 "When performing batch spike removal, only the templates selected below will "
 "be acted on."
 msgstr ""
 
-#: ../include/global_settings.php:1792
+#: ../include/global_settings.php:1799
 msgid "Default View Mode"
 msgstr ""
 
-#: ../include/global_settings.php:1793
+#: ../include/global_settings.php:1800
 msgid ""
 "Which Graph mode you want displayed by default when you first visit the "
 "Graphs page?"
 msgstr ""
 
-#: ../include/global_settings.php:1799
+#: ../include/global_settings.php:1806
 msgid "User Language"
 msgstr ""
 
-#: ../include/global_settings.php:1800
+#: ../include/global_settings.php:1807
 msgid "Defines the preferred GUI language."
 msgstr ""
 
-#: ../include/global_settings.php:1806
+#: ../include/global_settings.php:1813
 msgid "Show Graph Title"
 msgstr ""
 
-#: ../include/global_settings.php:1807
+#: ../include/global_settings.php:1814
 msgid ""
 "Display the graph title on the page so that it may be searched using the "
 "browser."
 msgstr ""
 
-#: ../include/global_settings.php:1813
+#: ../include/global_settings.php:1820
 msgid "The date format to use in Cacti."
 msgstr ""
 
-#: ../include/global_settings.php:1820
+#: ../include/global_settings.php:1827
 msgid "The date separator to be used in Cacti."
 msgstr ""
 
-#: ../include/global_settings.php:1826
+#: ../include/global_settings.php:1833
 msgid "Page Refresh"
 msgstr ""
 
-#: ../include/global_settings.php:1827
+#: ../include/global_settings.php:1834
 msgid "The number of seconds between automatic page refreshes."
 msgstr ""
 
-#: ../include/global_settings.php:1833
+#: ../include/global_settings.php:1840
 msgid "Preview Graphs Per Page"
 msgstr ""
 
-#: ../include/global_settings.php:1834 ../include/global_settings.php:1949
+#: ../include/global_settings.php:1841 ../include/global_settings.php:1956
 msgid "The number of graphs to display on one page in preview mode."
 msgstr ""
 
-#: ../include/global_settings.php:1842
+#: ../include/global_settings.php:1849
 msgid "Default Time Range"
 msgstr ""
 
-#: ../include/global_settings.php:1843
+#: ../include/global_settings.php:1850
 msgid "The default RRA to use in rare occasions."
 msgstr ""
 
-#: ../include/global_settings.php:1849
+#: ../include/global_settings.php:1856
 msgid "Default Graph View Timespan"
 msgstr ""
 
-#: ../include/global_settings.php:1850
+#: ../include/global_settings.php:1857
 msgid "The default timespan you wish to be displayed when you display graphs"
 msgstr ""
 
-#: ../include/global_settings.php:1856
+#: ../include/global_settings.php:1863
 msgid "Default Graph View Timeshift"
 msgstr ""
 
-#: ../include/global_settings.php:1857
+#: ../include/global_settings.php:1864
 msgid "The default timeshift you wish to be displayed when you display graphs"
 msgstr ""
 
-#: ../include/global_settings.php:1863
+#: ../include/global_settings.php:1870
 msgid "Allow Graph to extend to Future"
 msgstr ""
 
-#: ../include/global_settings.php:1864
+#: ../include/global_settings.php:1871
 msgid "When displaying Graphs, allow Graph Dates to extend 'to future'"
 msgstr ""
 
-#: ../include/global_settings.php:1869
+#: ../include/global_settings.php:1876
 msgid "First Day of the Week"
 msgstr ""
 
-#: ../include/global_settings.php:1870
+#: ../include/global_settings.php:1877
 msgid "The first Day of the Week for weekly Graph Displays"
 msgstr ""
 
-#: ../include/global_settings.php:1876
+#: ../include/global_settings.php:1883
 msgid "Start of Daily Shift"
 msgstr ""
 
-#: ../include/global_settings.php:1877
+#: ../include/global_settings.php:1884
 msgid "Start Time of the Daily Shift."
 msgstr ""
 
-#: ../include/global_settings.php:1884
+#: ../include/global_settings.php:1891
 msgid "End of Daily Shift"
 msgstr ""
 
-#: ../include/global_settings.php:1885
+#: ../include/global_settings.php:1892
 msgid "End Time of the Daily Shift."
 msgstr ""
 
-#: ../include/global_settings.php:1894
+#: ../include/global_settings.php:1901
 msgid "Thumbnail Sections"
 msgstr ""
 
-#: ../include/global_settings.php:1895
+#: ../include/global_settings.php:1902
 msgid "Which portions of Cacti display Thumbnails by default."
 msgstr ""
 
-#: ../include/global_settings.php:1899 ../lib/functions.php:1863
+#: ../include/global_settings.php:1906 ../lib/functions.php:1880
 msgid "Preview Mode"
 msgstr ""
 
-#: ../include/global_settings.php:1909
+#: ../include/global_settings.php:1916
 msgid "Preview Thumbnail Columns"
 msgstr ""
 
-#: ../include/global_settings.php:1910
+#: ../include/global_settings.php:1917
 msgid ""
 "The number of columns to use when displaying Thumbnail graphs in Preview "
 "mode."
 msgstr ""
 
-#: ../include/global_settings.php:1913 ../include/global_settings.php:1920
+#: ../include/global_settings.php:1920 ../include/global_settings.php:1927
 #: ../lib/html_graph.php:231 ../lib/html_graph.php:232
 #: ../lib/html_graph.php:233 ../lib/html_graph.php:234
 #: ../lib/html_graph.php:235 ../lib/html_tree.php:677 ../lib/html_tree.php:678
@@ -10278,96 +10292,96 @@ msgstr ""
 msgid "%d Columns"
 msgstr ""
 
-#: ../include/global_settings.php:1913 ../include/global_settings.php:1920
+#: ../include/global_settings.php:1920 ../include/global_settings.php:1927
 msgid "1 Column"
 msgstr ""
 
-#: ../include/global_settings.php:1916
+#: ../include/global_settings.php:1923
 msgid "Tree View Thumbnail Columns"
 msgstr ""
 
-#: ../include/global_settings.php:1917
+#: ../include/global_settings.php:1924
 msgid ""
 "The number of columns to use when displaying Thumbnail graphs in Tree mode."
 msgstr ""
 
-#: ../include/global_settings.php:1923
+#: ../include/global_settings.php:1930
 msgid "Thumbnail Height"
 msgstr ""
 
-#: ../include/global_settings.php:1924
+#: ../include/global_settings.php:1931
 msgid "The height of Thumbnail graphs in pixels."
 msgstr ""
 
-#: ../include/global_settings.php:1931
+#: ../include/global_settings.php:1938
 msgid "Thumbnail Width"
 msgstr ""
 
-#: ../include/global_settings.php:1932
+#: ../include/global_settings.php:1939
 msgid "The width of Thumbnail graphs in pixels."
 msgstr ""
 
-#: ../include/global_settings.php:1941
+#: ../include/global_settings.php:1948
 msgid "Default Tree"
 msgstr ""
 
-#: ../include/global_settings.php:1942
+#: ../include/global_settings.php:1949
 msgid "The default graph tree to use when displaying graphs in tree mode."
 msgstr ""
 
-#: ../include/global_settings.php:1948
+#: ../include/global_settings.php:1955
 msgid "Graphs Per Page"
 msgstr ""
 
-#: ../include/global_settings.php:1955
+#: ../include/global_settings.php:1962
 msgid "Expand Devices"
 msgstr ""
 
-#: ../include/global_settings.php:1956
+#: ../include/global_settings.php:1963
 msgid ""
 "Choose whether to expand the Graph Templates and Data Queries used by a "
 "Device on Tree."
 msgstr ""
 
-#: ../include/global_settings.php:1963
+#: ../include/global_settings.php:1970
 msgid "Use Custom Fonts"
 msgstr ""
 
-#: ../include/global_settings.php:1964
+#: ../include/global_settings.php:1971
 msgid ""
 "Choose whether to use your own custom fonts and font sizes or utilize the "
 "system defaults."
 msgstr ""
 
-#: ../include/global_settings.php:1977
+#: ../include/global_settings.php:1984
 msgid "Title Font File"
 msgstr ""
 
-#: ../include/global_settings.php:1978
+#: ../include/global_settings.php:1985
 msgid "The font file to use for Graph Titles"
 msgstr ""
 
-#: ../include/global_settings.php:1990
+#: ../include/global_settings.php:1997
 msgid "Legend Font File"
 msgstr ""
 
-#: ../include/global_settings.php:1991
+#: ../include/global_settings.php:1998
 msgid "The font file to be used for Graph Legend items"
 msgstr ""
 
-#: ../include/global_settings.php:2003
+#: ../include/global_settings.php:2010
 msgid "Axis Font File"
 msgstr ""
 
-#: ../include/global_settings.php:2004
+#: ../include/global_settings.php:2011
 msgid "The font file to be used for Graph Axis items"
 msgstr ""
 
-#: ../include/global_settings.php:2016
+#: ../include/global_settings.php:2023
 msgid "Unit Font File"
 msgstr ""
 
-#: ../include/global_settings.php:2017
+#: ../include/global_settings.php:2024
 msgid "The font file to be used for Graph Unit items"
 msgstr ""
 
@@ -10548,8 +10562,8 @@ msgstr ""
 msgid "MySQL TimeZone Support"
 msgstr ""
 
-#: ../install/index.php:447 ../install/index.php:451 ../install/index.php:638
-#: ../install/index.php:646
+#: ../install/index.php:447 ../install/index.php:451 ../install/index.php:630
+#: ../install/index.php:638
 msgid "ERROR:"
 msgstr ""
 
@@ -10642,156 +10656,149 @@ msgstr ""
 msgid "Installation Type"
 msgstr ""
 
-#: ../install/index.php:562
-msgid "Please select the type of installation"
-msgstr ""
-
-#: ../install/index.php:564
-msgid "Note that when upgrading, you only will receive the Upgrade selection."
+#: ../install/index.php:565
+#, php-format
+msgid "Upgrade from <strong>%s</strong> to <strong>%s</strong>"
 msgstr ""
 
 #: ../install/index.php:566
-msgid "You have three Cacti installation options to choose from:"
-msgstr ""
-
-#: ../install/index.php:569
-msgid "Choose this for the Primary Cacti Web Site."
-msgstr ""
-
-#: ../install/index.php:569 ../install/index.php:583
-msgid "New Primary Server"
-msgstr ""
-
-#: ../install/index.php:570 ../install/index.php:584
-msgid "New Remote Poller"
-msgstr ""
-
-#: ../install/index.php:570
-msgid ""
-"Remote Pollers are used to access networks that are not readily accessible "
-"to the Primary Cacti Web Site."
-msgstr ""
-
-#: ../install/index.php:571 ../install/index.php:577
-msgid "Upgrade Previous Cacti"
-msgstr ""
-
-#: ../install/index.php:571
-msgid "Use this option to upgrade a previous release of Cacti"
-msgstr ""
-
-#: ../install/index.php:590
 msgid ""
 "WARNING - If you are upgrading from a previous version please close all "
 "Cacti browser sessions and clear cache before continuing"
 msgstr ""
 
-#: ../install/index.php:593
+#: ../install/index.php:569
+msgid "Please select the type of installation"
+msgstr ""
+
+#: ../install/index.php:571
+msgid "Installation options:"
+msgstr ""
+
+#: ../install/index.php:574
+msgid "Choose this for the Primary site."
+msgstr ""
+
+#: ../install/index.php:574 ../install/index.php:580
+msgid "New Primary Server"
+msgstr ""
+
+#: ../install/index.php:575 ../install/index.php:581
+msgid "New Remote Poller"
+msgstr ""
+
+#: ../install/index.php:575
+msgid ""
+"Remote Pollers are used to access networks that are not readily accessible "
+"to the Primary site."
+msgstr ""
+
+#: ../install/index.php:585
 msgid ""
 "The following information has been determined from Cacti's configuration "
 "file. If it is not correct, please edit \"include/config.php\" before "
 "continuing."
 msgstr ""
 
-#: ../install/index.php:597
+#: ../install/index.php:589
 msgid "Local Cacti database connection information"
 msgstr ""
 
-#: ../install/index.php:599 ../install/index.php:628
+#: ../install/index.php:591 ../install/index.php:620
 #, php-format
 msgid "Database: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:600 ../install/index.php:629
+#: ../install/index.php:592 ../install/index.php:621
 #, php-format
 msgid "Database User: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:601 ../install/index.php:630
+#: ../install/index.php:593 ../install/index.php:622
 #, php-format
 msgid "Database Hostname: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:602 ../install/index.php:631
+#: ../install/index.php:594 ../install/index.php:623
 #, php-format
 msgid "Port: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:603 ../install/index.php:632
+#: ../install/index.php:595 ../install/index.php:624
 #, php-format
 msgid "Server Operating System Type: <b>%s</b>"
 msgstr ""
 
-#: ../install/index.php:626 ../install/index.php:635
+#: ../install/index.php:618 ../install/index.php:627
 msgid "Remote Poller Cacti database connection information"
+msgstr ""
+
+#: ../install/index.php:630
+msgid ""
+"Your config.php file must be writable by\n"
+"\t\t\t\t\t\t\t\t\t\tthe web server during install in order to configure the "
+"Remote poller.  Once\n"
+"\t\t\t\t\t\t\t\t\t\tinstallation is complete, you must set this file to Read "
+"Only to prevent\n"
+"\t\t\t\t\t\t\t\t\t\tpossible security issues."
 msgstr ""
 
 #: ../install/index.php:638
 msgid ""
-"Your config.php file must be writable by \n"
-"\t\t\t\t\t\t\t\t\tthe web server during install in order to configure the "
-"Remote poller.  Once \n"
-"\t\t\t\t\t\t\t\t\tinstallation is complete, you must set this file to Read "
-"Only to prevent \n"
-"\t\t\t\t\t\t\t\t\tpossible security issues."
+"Your Remote Cacti Poller information has not\n"
+"\t\t\t\t\t\t\t\t\t\tbeen included in your config.php file.  Please review "
+"the config.php.dist, and\n"
+"\t\t\t\t\t\t\t\t\t\tset the variables: <i>$rdatabase_default, "
+"$rdatabase_username</i>, etc.\n"
+"\t\t\t\t\t\t\t\t\t\tThese variables must be set and point back to your "
+"Primary Cacti database server.\n"
+"\t\t\t\t\t\t\t\t\t\tCorrect this and try again."
 msgstr ""
 
-#: ../install/index.php:646
-msgid ""
-"Your Remote Cacti Poller information has not \n"
-"\t\t\t\t\t\t\t\t\tbeen included in your config.php file.  Please review the "
-"config.php.dist, and \n"
-"\t\t\t\t\t\t\t\t\tset the variables: <i>$rdatabase_default, "
-"$rdatabase_username</i>, etc.  \n"
-"\t\t\t\t\t\t\t\t\tThese variables must be set and point back to your Primary "
-"Cacti database server.\n"
-"\t\t\t\t\t\t\t\t\tCorrect this and try again."
-msgstr ""
-
-#: ../install/index.php:652
+#: ../install/index.php:644
 msgid "The variables that must be set include the following:"
 msgstr ""
 
-#: ../install/index.php:663
+#: ../install/index.php:655
 msgid "You must also set the $poller_id variable in the config.php."
 msgstr ""
 
-#: ../install/index.php:665
+#: ../install/index.php:657
 msgid ""
 "Once you have the variables set in the config.php file, you must also\n"
-"\t\t\t\t\t\t\t\t\tgrant the $rdatabase_username access to the Cacti "
+"\t\t\t\t\t\t\t\t\t\tgrant the $rdatabase_username access to the Cacti "
 "database.  Follow the same procedure you would with\n"
-"\t\t\t\t\t\t\t\t\tany other Cacti install.  You may then press the 'Test "
+"\t\t\t\t\t\t\t\t\t\tany other Cacti install.  You may then press the 'Test "
 "Connection' button.  If the test is\n"
-"\t\t\t\t\t\t\t\t\tsuccessful you will be able to proceed and complete the "
+"\t\t\t\t\t\t\t\t\t\tsuccessful you will be able to proceed and complete the "
 "install."
 msgstr ""
 
-#: ../install/index.php:689 ../install/index.php:705 ../lib/html.php:342
+#: ../install/index.php:682 ../install/index.php:698 ../lib/html.php:342
 msgid "Next"
 msgstr ""
 
-#: ../install/index.php:714
+#: ../install/index.php:707
 msgid "Upgrade"
 msgstr ""
 
-#: ../install/index.php:727
+#: ../install/index.php:720
 msgid "Remote Database: "
 msgstr ""
 
-#: ../install/index.php:738
+#: ../install/index.php:731
 msgid "Critical Binary Locations and Versions"
 msgstr ""
 
-#: ../install/index.php:740
+#: ../install/index.php:733
 msgid "Make sure all of these values are correct before continuing."
 msgstr ""
 
-#: ../install/index.php:798
+#: ../install/index.php:791
 msgid "Directory Permission Checks"
 msgstr ""
 
-#: ../install/index.php:800
+#: ../install/index.php:793
 msgid ""
 "Please ensure the directory permissions below are correct before "
 "proceeding.  During the install, these directories need to be owned by the "
@@ -10802,68 +10809,68 @@ msgid ""
 "be used from the command line after the install is complete."
 msgstr ""
 
-#: ../install/index.php:803
+#: ../install/index.php:796
 msgid ""
 "After the install is complete, you can make some of these directories read "
 "only to increase security."
 msgstr ""
 
-#: ../install/index.php:805
+#: ../install/index.php:798
 msgid ""
 "These directories will be required to stay read writable after the install "
 "so that the Cacti remote synchronization process can update them as the Main "
 "Cacti Web Site changes"
 msgstr ""
 
-#: ../install/index.php:836
+#: ../install/index.php:829
 msgid "Required Writable at Install Time Only"
 msgstr ""
 
-#: ../install/index.php:839 ../install/index.php:849 ../install/index.php:859
+#: ../install/index.php:832 ../install/index.php:842 ../install/index.php:852
 msgid "Writable"
 msgstr ""
 
-#: ../install/index.php:841 ../install/index.php:851 ../install/index.php:861
+#: ../install/index.php:834 ../install/index.php:844 ../install/index.php:854
 msgid "Not Writable"
 msgstr ""
 
-#: ../install/index.php:846 ../install/index.php:856
+#: ../install/index.php:839 ../install/index.php:849
 msgid "Required Writable after Install Complete"
 msgstr ""
 
-#: ../install/index.php:869
+#: ../install/index.php:862
 #, php-format
 msgid ""
 "Make sure your webserver has read and write access to the entire folder "
 "structure.<br> Example: chown -R apache.apache %s/resource/"
 msgstr ""
 
-#: ../install/index.php:870
+#: ../install/index.php:863
 msgid ""
 "For SELINUX-users make sure that you have the correct permissions or set "
 "'setenforce 0' temporarily."
 msgstr ""
 
-#: ../install/index.php:872
+#: ../install/index.php:865
 msgid "Check Permissions"
 msgstr ""
 
-#: ../install/index.php:874
+#: ../install/index.php:867
 msgid "All folders are writable"
 msgstr ""
 
-#: ../install/index.php:880
+#: ../install/index.php:873
 msgid ""
 "If you are installing packages, once the packages are installed, you should "
 "change the scripts directory back to read only as this presents some "
 "exposure to the web site."
 msgstr ""
 
-#: ../install/index.php:880 ../install/index.php:886 ../install/index.php:922
+#: ../install/index.php:873 ../install/index.php:879 ../install/index.php:915
 msgid "NOTE:"
 msgstr ""
 
-#: ../install/index.php:886
+#: ../install/index.php:879
 msgid ""
 "For remote pollers, it is critical that\n"
 "\t\t\t\t\t\t\t\tthe paths that you will be updating frequently, including "
@@ -10873,11 +10880,11 @@ msgid ""
 "\t\t\t\t\t\t\t\tupdate these paths from the main web server content."
 msgstr ""
 
-#: ../install/index.php:896
+#: ../install/index.php:889
 msgid "Template Setup"
 msgstr ""
 
-#: ../install/index.php:898
+#: ../install/index.php:891
 msgid ""
 "Please select the Device Templates that you wish to use after the Install.  "
 "If you Operating System is Windows, you need to ensure that you select the "
@@ -10885,7 +10892,7 @@ msgid ""
 "sure you select the 'Local Linux Machine' Device Template."
 msgstr ""
 
-#: ../install/index.php:900
+#: ../install/index.php:893
 msgid ""
 "Device Templates allow you to monitor and graph a vast assortment of data "
 "within Cacti.  After you select the desired Device Templates, press 'Finish' "
@@ -10893,45 +10900,41 @@ msgid ""
 "importation of the Device Templates can take a few minutes."
 msgstr ""
 
-#: ../install/index.php:906 ../plugins.php:378
+#: ../install/index.php:899 ../plugins.php:378
 msgid "Author"
 msgstr ""
 
-#: ../install/index.php:906
+#: ../install/index.php:899
 msgid "Homepage"
 msgstr ""
 
-#: ../install/index.php:924
+#: ../install/index.php:917
 msgid ""
 "Press 'Finish' to complete the installation process after selecting your "
 "Device Templates."
 msgstr ""
 
-#: ../install/index.php:928
+#: ../install/index.php:921
 msgid "Upgrade Results"
 msgstr ""
 
-#: ../install/index.php:930
-msgid "You Cacti database has been upgraded.  You can view the results below."
-msgstr ""
-
-#: ../install/index.php:938
+#: ../install/index.php:928
 msgid "[Fail]"
 msgstr ""
 
-#: ../install/index.php:939
+#: ../install/index.php:929
 msgid "[Success]"
 msgstr ""
 
-#: ../install/index.php:940
-msgid "[Not Ran]"
+#: ../install/index.php:930
+msgid "[Skipped]"
 msgstr ""
 
-#: ../install/index.php:965
-msgid "No SQL queries have been executed."
+#: ../install/index.php:934
+msgid "Database upgrade completed!"
 msgstr ""
 
-#: ../install/index.php:969
+#: ../install/index.php:955
 msgid ""
 "One or more of the SQL queries needed to upgraded your Cacti installation "
 "has failed. Please see below for more details. Your Cacti MySQL user must "
@@ -10940,53 +10943,57 @@ msgid ""
 "to ensure that you do not have a permissions problem."
 msgstr ""
 
-#: ../install/index.php:969 ../utilities.php:2010 ../utilities.php:2011
+#: ../install/index.php:955 ../utilities.php:2010 ../utilities.php:2011
 #: ../utilities.php:2014 ../utilities.php:2015
 msgid "WARNING:"
 msgstr ""
 
-#: ../install/index.php:976
+#: ../install/index.php:960
+msgid "No database action needed."
+msgstr ""
+
+#: ../install/index.php:965
 msgid "Important Upgrade Notice"
 msgstr ""
 
-#: ../install/index.php:977
+#: ../install/index.php:966
 msgid ""
 "Before you continue with the installation, you <strong>must</strong> update "
 "your <tt>/etc/crontab</tt> file to point to <tt>poller.php</tt> instead of "
 "<tt>cmd.php</tt>."
 msgstr ""
 
-#: ../install/index.php:978
+#: ../install/index.php:967
 msgid ""
 "See the sample crontab entry below with the change made in red. Your crontab "
 "line will look slightly different based upon your setup."
 msgstr ""
 
-#: ../install/index.php:980
+#: ../install/index.php:969
 msgid "Once you have made this change, please click Finish to continue."
 msgstr ""
 
-#: ../install/index.php:987
+#: ../install/index.php:976
 msgctxt "Dialog: previous"
 msgid "Previous"
 msgstr ""
 
-#: ../install/index.php:988
+#: ../install/index.php:977
 msgctxt "Dialog: complete"
 msgid "Finish"
 msgstr ""
 
-#: ../install/index.php:988
+#: ../install/index.php:977
 msgctxt "Dialog: go to the next page"
 msgid "Next"
 msgstr ""
 
-#: ../install/index.php:989
+#: ../install/index.php:978
 msgctxt "Dialog: test connection"
 msgid "Test Connection"
 msgstr ""
 
-#: ../install/index.php:989
+#: ../install/index.php:978
 msgid "Test remote database connection"
 msgstr ""
 
@@ -11012,11 +11019,11 @@ msgid ""
 "graphs."
 msgstr ""
 
-#: ../lib/api_aggregate.php:1210 ../lib/functions.php:1915
+#: ../lib/api_aggregate.php:1210 ../lib/functions.php:1932
 msgid "Graph Items"
 msgstr ""
 
-#: ../lib/api_aggregate.php:1210 ../lib/functions.php:2047
+#: ../lib/api_aggregate.php:1210 ../lib/functions.php:2064
 msgid "Graph Template Items"
 msgstr ""
 
@@ -11045,9 +11052,9 @@ msgid "Matching Devices"
 msgstr ""
 
 #: ../lib/api_automation.php:139 ../lib/api_automation.php:994
-#: ../lib/html_reports.php:309 ../lib/html_reports.php:1235
-#: ../lib/html_reports.php:1491 ../lib/html_reports.php:1502
-#: ../lib/rrd.php:2641 ../utilities.php:301 ../utilities.php:2338
+#: ../lib/html_reports.php:268 ../lib/html_reports.php:1211
+#: ../lib/html_reports.php:1481 ../lib/html_reports.php:1492
+#: ../lib/rrd.php:2653 ../utilities.php:301 ../utilities.php:2338
 msgid "Type"
 msgstr ""
 
@@ -11135,17 +11142,17 @@ msgstr ""
 msgid "No Tree Creation Criteria"
 msgstr ""
 
-#: ../lib/api_automation.php:1936
+#: ../lib/api_automation.php:1941
 #, php-format
 msgid "Rule Item [edit rule item for %s: %s]"
 msgstr ""
 
-#: ../lib/api_automation.php:1938
+#: ../lib/api_automation.php:1943
 #, php-format
 msgid "Rule Item [new rule item for %s: %s]"
 msgstr ""
 
-#: ../lib/api_automation.php:2653
+#: ../lib/api_automation.php:2634
 msgid "Added by Cacti Automation"
 msgstr ""
 
@@ -11202,8 +11209,8 @@ msgstr ""
 msgid "Contact:"
 msgstr ""
 
-#: ../lib/api_device.php:480 ../lib/functions.php:3792
-#: ../lib/functions.php:3794
+#: ../lib/api_device.php:480 ../lib/functions.php:3814
+#: ../lib/functions.php:3816 ../lib/functions.php:3820
 msgid "Ping Results"
 msgstr ""
 
@@ -11211,7 +11218,7 @@ msgstr ""
 msgid "No Ping or SNMP Availability Check in Use"
 msgstr ""
 
-#: ../lib/auth.php:310
+#: ../lib/auth.php:312
 msgid "Web Basic"
 msgstr ""
 
@@ -11277,285 +11284,289 @@ msgstr ""
 msgid "Oldest First"
 msgstr ""
 
-#: ../lib/functions.php:665
+#: ../lib/functions.php:676
 #, php-format
 msgid "Error %s is not readable"
 msgstr ""
 
-#: ../lib/functions.php:1801 ../lib/functions.php:1806
+#: ../lib/functions.php:1818 ../lib/functions.php:1823
 msgid "Logged in as"
 msgstr ""
 
-#: ../lib/functions.php:1801
+#: ../lib/functions.php:1818
 msgid "Login as Regular User"
 msgstr ""
 
-#: ../lib/functions.php:1801
+#: ../lib/functions.php:1818
 msgid "guest"
 msgstr ""
 
-#: ../lib/functions.php:1808
+#: ../lib/functions.php:1825
 msgid "Edit Profile"
 msgstr ""
 
-#: ../lib/functions.php:1810
+#: ../lib/functions.php:1827
 msgid "Logout"
 msgstr ""
 
-#: ../lib/functions.php:1827 ../lib/functions.php:1833
+#: ../lib/functions.php:1844 ../lib/functions.php:1850
 msgid "User Profile (Edit)"
 msgstr ""
 
-#: ../lib/functions.php:1845 ../lib/functions.php:1851
+#: ../lib/functions.php:1862 ../lib/functions.php:1868
 msgid "Tree Mode"
 msgstr ""
 
-#: ../lib/functions.php:1857
+#: ../lib/functions.php:1874
 msgid "List Mode"
 msgstr ""
 
-#: ../lib/functions.php:1879 ../lib/functions.php:1885
-#: ../lib/functions.php:2739 ../lib/html.php:1299 ../lib/html.php:1371
-#: ../links.php:344 ../user_admin.php:1636 ../user_group_admin.php:1374
+#: ../lib/functions.php:1896 ../lib/functions.php:1902
+#: ../lib/functions.php:2756 ../lib/html.php:1299 ../lib/html.php:1371
+#: ../links.php:344 ../user_admin.php:1653 ../user_group_admin.php:1374
 msgid "Console"
 msgstr ""
 
-#: ../lib/functions.php:1897 ../lib/functions.php:1939
-#: ../lib/functions.php:1957 ../lib/functions.php:2011
-#: ../lib/functions.php:2023 ../lib/functions.php:2035
-#: ../lib/functions.php:2071 ../lib/functions.php:2089
-#: ../lib/functions.php:2107 ../lib/functions.php:2125
-#: ../lib/functions.php:2143 ../lib/functions.php:2167
-#: ../lib/functions.php:2203 ../lib/functions.php:2323
-#: ../lib/functions.php:2347 ../lib/functions.php:2365
-#: ../lib/functions.php:2383 ../lib/functions.php:2395
-#: ../lib/functions.php:2497 ../lib/functions.php:2521
-#: ../lib/functions.php:2539 ../lib/functions.php:2557
-#: ../lib/functions.php:2575 ../lib/functions.php:2599
+#: ../lib/functions.php:1914 ../lib/functions.php:1956
+#: ../lib/functions.php:1974 ../lib/functions.php:2028
+#: ../lib/functions.php:2040 ../lib/functions.php:2052
+#: ../lib/functions.php:2088 ../lib/functions.php:2106
+#: ../lib/functions.php:2124 ../lib/functions.php:2142
+#: ../lib/functions.php:2160 ../lib/functions.php:2184
+#: ../lib/functions.php:2220 ../lib/functions.php:2340
+#: ../lib/functions.php:2364 ../lib/functions.php:2382
+#: ../lib/functions.php:2400 ../lib/functions.php:2412
+#: ../lib/functions.php:2514 ../lib/functions.php:2538
+#: ../lib/functions.php:2556 ../lib/functions.php:2574
+#: ../lib/functions.php:2592 ../lib/functions.php:2616
 msgid "(Edit)"
 msgstr ""
 
-#: ../lib/functions.php:1921
+#: ../lib/functions.php:1938
 msgid "Create New Graphs"
 msgstr ""
 
-#: ../lib/functions.php:1927
+#: ../lib/functions.php:1944
 msgid "Create Graphs from Data Query"
 msgstr ""
 
-#: ../lib/functions.php:1945 ../lib/functions.php:1963
-#: ../lib/functions.php:2059 ../lib/functions.php:2149
-#: ../lib/functions.php:2173 ../lib/functions.php:2329
+#: ../lib/functions.php:1962 ../lib/functions.php:1980
+#: ../lib/functions.php:2076 ../lib/functions.php:2166
+#: ../lib/functions.php:2190 ../lib/functions.php:2346
 msgid "(Remove)"
 msgstr ""
 
-#: ../lib/functions.php:1981 ../lib/functions.php:1987
-#: ../lib/functions.php:1993 ../lib/functions.php:1999
-#: ../lib/functions.php:2263
+#: ../lib/functions.php:1998 ../lib/functions.php:2004
+#: ../lib/functions.php:2010 ../lib/functions.php:2016
+#: ../lib/functions.php:2280
 msgid "View Cacti Log"
 msgstr ""
 
-#: ../lib/functions.php:2005
+#: ../lib/functions.php:2022
 msgid "Graph Trees"
 msgstr ""
 
-#: ../lib/functions.php:2137
+#: ../lib/functions.php:2154
 msgid "Round Robin Archives"
 msgstr ""
 
-#: ../lib/functions.php:2179
+#: ../lib/functions.php:2196
 msgid "Data Input Fields"
 msgstr ""
 
-#: ../lib/functions.php:2185 ../lib/functions.php:2215
+#: ../lib/functions.php:2202 ../lib/functions.php:2232
 msgid "(Remove Item)"
 msgstr ""
 
-#: ../lib/functions.php:2233
+#: ../lib/functions.php:2250
 msgid "List unused Files"
 msgstr ""
 
-#: ../lib/functions.php:2245 ../lib/functions.php:2257 ../utilities.php:1780
+#: ../lib/functions.php:2262 ../lib/functions.php:2274 ../utilities.php:1780
 msgid "View Poller Cache"
 msgstr ""
 
-#: ../lib/functions.php:2251 ../utilities.php:1784
+#: ../lib/functions.php:2268 ../utilities.php:1784
 msgid "View Data Query Cache"
 msgstr ""
 
-#: ../lib/functions.php:2269 ../utilities.php:1168
+#: ../lib/functions.php:2286 ../utilities.php:1168
 msgid "Clear Cacti Log"
 msgstr ""
 
-#: ../lib/functions.php:2275 ../utilities.php:1773
+#: ../lib/functions.php:2292 ../utilities.php:1773
 msgid "View User Log"
 msgstr ""
 
-#: ../lib/functions.php:2281
+#: ../lib/functions.php:2298
 msgid "Clear User Log"
 msgstr ""
 
-#: ../lib/functions.php:2287 ../utilities.php:1764
+#: ../lib/functions.php:2304 ../utilities.php:1764
 msgid "Technical Support"
 msgstr ""
 
-#: ../lib/functions.php:2293 ../utilities.php:1877
+#: ../lib/functions.php:2310 ../utilities.php:1877
 msgid "Boost Status"
 msgstr ""
 
-#: ../lib/functions.php:2299
+#: ../lib/functions.php:2316
 msgid "View SNMP Agent Cache"
 msgstr ""
 
-#: ../lib/functions.php:2305
+#: ../lib/functions.php:2322
 msgid "View SNMP Agent Notification Log"
 msgstr ""
 
-#: ../lib/functions.php:2335
+#: ../lib/functions.php:2352
 msgid "VDEF Items"
 msgstr ""
 
-#: ../lib/functions.php:2341
+#: ../lib/functions.php:2358
 msgid "View SNMP Notification Receivers"
 msgstr ""
 
-#: ../lib/functions.php:2353
+#: ../lib/functions.php:2370
 msgid "Cacti Settings"
 msgstr ""
 
-#: ../lib/functions.php:2371 ../lib/functions.php:2401
+#: ../lib/functions.php:2388 ../lib/functions.php:2418
 msgid "(Action)"
 msgstr ""
 
-#: ../lib/functions.php:2419
+#: ../lib/functions.php:2436
 msgid "Export Results"
 msgstr ""
 
-#: ../lib/functions.php:2431 ../lib/functions.php:2461 ../lib/html.php:1320
+#: ../lib/functions.php:2448 ../lib/functions.php:2478 ../lib/html.php:1320
 #: ../lib/html.php:1322 ../lib/html.php:1396
 msgid "Reporting"
 msgstr ""
 
-#: ../lib/functions.php:2437 ../lib/functions.php:2467
+#: ../lib/functions.php:2454 ../lib/functions.php:2484
 msgid "Report Add"
 msgstr ""
 
-#: ../lib/functions.php:2443 ../lib/functions.php:2473
+#: ../lib/functions.php:2460 ../lib/functions.php:2490
 msgid "Report Delete"
 msgstr ""
 
-#: ../lib/functions.php:2449 ../lib/functions.php:2479
+#: ../lib/functions.php:2466 ../lib/functions.php:2496
 msgid "Report Edit"
 msgstr ""
 
-#: ../lib/functions.php:2455 ../lib/functions.php:2485
+#: ../lib/functions.php:2472 ../lib/functions.php:2502
 msgid "Report Edit Item"
 msgstr ""
 
-#: ../lib/functions.php:2509
+#: ../lib/functions.php:2526
 msgid "Color Template Items"
 msgstr ""
 
-#: ../lib/functions.php:2551
+#: ../lib/functions.php:2568
 msgid "Aggregate Items"
 msgstr ""
 
-#: ../lib/functions.php:2587
+#: ../lib/functions.php:2604
 msgid "Graph Rule Items"
 msgstr ""
 
-#: ../lib/functions.php:2611
+#: ../lib/functions.php:2628
 msgid "Tree Rule Items"
 msgstr ""
 
-#: ../lib/functions.php:2696
+#: ../lib/functions.php:2713
 msgid "Leaf"
 msgstr ""
 
-#: ../lib/functions.php:2710
+#: ../lib/functions.php:2727
 msgid "Non Query Based"
 msgstr ""
 
-#: ../lib/functions.php:3414
+#: ../lib/functions.php:3435
 msgid ""
 "Mailer Error: No <b>TO</b> address set!!<br>If using the <i>Test Mail</i> "
 "link, please set the <b>Alert e-mail</b> setting."
 msgstr ""
 
-#: ../lib/functions.php:3726
+#: ../lib/functions.php:3747
 #, php-format
 msgid "Authentication failed: %s"
 msgstr ""
 
-#: ../lib/functions.php:3730
+#: ../lib/functions.php:3751
 #, php-format
 msgid "HELO failed: %s"
 msgstr ""
 
-#: ../lib/functions.php:3733
+#: ../lib/functions.php:3754
 #, php-format
 msgid "Connect failed: %s"
 msgstr ""
 
-#: ../lib/functions.php:3736
+#: ../lib/functions.php:3757
 msgid "SMTP error: "
 msgstr ""
 
-#: ../lib/functions.php:3749
+#: ../lib/functions.php:3770
 msgid ""
 "This is a test message generated from Cacti.  This message was sent to test "
 "the configuration of your Mail Settings."
 msgstr ""
 
-#: ../lib/functions.php:3750
+#: ../lib/functions.php:3771
 msgid "Your email settings are currently set as follows"
 msgstr ""
 
-#: ../lib/functions.php:3751
+#: ../lib/functions.php:3772
 msgid "Method"
 msgstr ""
 
-#: ../lib/functions.php:3753
+#: ../lib/functions.php:3774
 msgid "Checking Configuration...<br>"
 msgstr ""
 
-#: ../lib/functions.php:3760
+#: ../lib/functions.php:3781
 msgid "PHP's Mailer Class"
 msgstr ""
 
-#: ../lib/functions.php:3766
+#: ../lib/functions.php:3787
 msgid "Method: SMTP"
 msgstr ""
 
-#: ../lib/functions.php:3781
+#: ../lib/functions.php:3802
 msgid "Not Shown for Security Reasons"
 msgstr ""
 
-#: ../lib/functions.php:3782
+#: ../lib/functions.php:3803
 msgid "Security"
 msgstr ""
 
-#: ../lib/functions.php:3789
+#: ../lib/functions.php:3811
 msgid "Ping Results:"
 msgstr ""
 
-#: ../lib/functions.php:3802
+#: ../lib/functions.php:3820
+msgid "Bypassed"
+msgstr ""
+
+#: ../lib/functions.php:3828
 msgid "Creating Message Text..."
 msgstr ""
 
-#: ../lib/functions.php:3805
+#: ../lib/functions.php:3831
 msgid "Sending Message..."
 msgstr ""
 
-#: ../lib/functions.php:3809
+#: ../lib/functions.php:3835
 msgid "Cacti Test Message"
 msgstr ""
 
-#: ../lib/functions.php:3811
+#: ../lib/functions.php:3837
 msgid "Success!"
 msgstr ""
 
-#: ../lib/functions.php:3814
+#: ../lib/functions.php:3840
 msgid "Message Not Sent due to ping failure."
 msgstr ""
 
@@ -11758,8 +11769,8 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: ../lib/html_graph.php:282 ../lib/html_reports.php:1489
-#: ../lib/html_reports.php:1500 ../lib/html_tree.php:728
+#: ../lib/html_graph.php:282 ../lib/html_reports.php:1479
+#: ../lib/html_reports.php:1490 ../lib/html_tree.php:728
 msgid "From"
 msgstr ""
 
@@ -11767,8 +11778,8 @@ msgstr ""
 msgid "Start Date Selector"
 msgstr ""
 
-#: ../lib/html_graph.php:291 ../lib/html_reports.php:1490
-#: ../lib/html_reports.php:1501 ../lib/html_tree.php:737
+#: ../lib/html_graph.php:291 ../lib/html_reports.php:1480
+#: ../lib/html_reports.php:1491 ../lib/html_tree.php:737
 msgid "To"
 msgstr ""
 
@@ -11804,7 +11815,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: ../lib/html_reports.php:35 ../lib/html_reports.php:1484
+#: ../lib/html_reports.php:35 ../lib/html_reports.php:1474
 msgid "Report Name"
 msgstr ""
 
@@ -11995,256 +12006,268 @@ msgstr ""
 msgid "Select one of the given Types for the Image Attachments"
 msgstr ""
 
-#: ../lib/html_reports.php:312
+#: ../lib/html_reports.php:271
 msgid "Item Type to be added."
 msgstr ""
 
-#: ../lib/html_reports.php:317
+#: ../lib/html_reports.php:277
 msgid "Graph Tree"
 msgstr ""
 
-#: ../lib/html_reports.php:321
+#: ../lib/html_reports.php:281
 msgid "Select a Tree to use."
 msgstr ""
 
-#: ../lib/html_reports.php:326
+#: ../lib/html_reports.php:287
 msgid "Graph Tree Branch"
 msgstr ""
 
-#: ../lib/html_reports.php:330
+#: ../lib/html_reports.php:291
 msgid "Select a Tree Branch to use."
 msgstr ""
 
-#: ../lib/html_reports.php:345
+#: ../lib/html_reports.php:293
+msgid "Branch:"
+msgstr ""
+
+#: ../lib/html_reports.php:299 ../lib/html_tree.php:593
+msgid "Device:"
+msgstr ""
+
+#: ../lib/html_reports.php:309
 msgid "Cascade to Branches"
 msgstr ""
 
-#: ../lib/html_reports.php:348
+#: ../lib/html_reports.php:312
 msgid "Should all children branch Graphs be rendered?"
 msgstr ""
 
-#: ../lib/html_reports.php:351
+#: ../lib/html_reports.php:316
 msgid "Graph Name Regular Expression"
 msgstr ""
 
-#: ../lib/html_reports.php:354
+#: ../lib/html_reports.php:319
 msgid ""
 "A Perl compatible regular expression (REGEXP) used to select graphs to "
 "include from the tree."
 msgstr ""
 
-#: ../lib/html_reports.php:363
+#: ../lib/html_reports.php:329
 msgid "Select a Device Template to use."
 msgstr ""
 
-#: ../lib/html_reports.php:371
+#: ../lib/html_reports.php:338
 msgid "Select a Device to specify a Graph"
 msgstr ""
 
-#: ../lib/html_reports.php:380
+#: ../lib/html_reports.php:348
 msgid "Select a Graph Template for the host"
 msgstr ""
 
-#: ../lib/html_reports.php:389
+#: ../lib/html_reports.php:358
 msgid "The Graph to use for this report item."
 msgstr ""
 
-#: ../lib/html_reports.php:401
+#: ../lib/html_reports.php:368
 msgid "Graph End Time is always set to Cacti's schedule."
 msgstr ""
 
-#: ../lib/html_reports.php:402
+#: ../lib/html_reports.php:369
 msgid "Graph Start Time equals Graph End Time minus given timespan"
 msgstr ""
 
-#: ../lib/html_reports.php:406 ../lib/html_reports.php:1235
+#: ../lib/html_reports.php:374 ../lib/html_reports.php:1214
 msgid "Alignment"
 msgstr ""
 
-#: ../lib/html_reports.php:409
+#: ../lib/html_reports.php:377
 msgid "Alignment of the Item"
 msgstr ""
 
-#: ../lib/html_reports.php:413
+#: ../lib/html_reports.php:382
 msgid "Fixed Text"
 msgstr ""
 
-#: ../lib/html_reports.php:416
+#: ../lib/html_reports.php:385
 msgid "Enter descriptive Text"
 msgstr ""
 
-#: ../lib/html_reports.php:420 ../lib/html_reports.php:1235
+#: ../lib/html_reports.php:390 ../lib/html_reports.php:1215
 msgid "Font Size"
 msgstr ""
 
-#: ../lib/html_reports.php:424
+#: ../lib/html_reports.php:394
 msgid "Font Size of the Item"
 msgstr ""
 
-#: ../lib/html_reports.php:485
+#: ../lib/html_reports.php:457
 msgid "Date/Time moved to the same time Tomorrow"
 msgstr ""
 
-#: ../lib/html_reports.php:668
+#: ../lib/html_reports.php:640
 msgid "You must select at least one Report."
 msgstr ""
 
-#: ../lib/html_reports.php:676
+#: ../lib/html_reports.php:648
 msgid "Click 'Continue' to delete the following Report(s)."
 msgstr ""
 
-#: ../lib/html_reports.php:683
+#: ../lib/html_reports.php:655
 msgid "Click 'Continue' to take ownership of the following Report(s)."
 msgstr ""
 
-#: ../lib/html_reports.php:690
+#: ../lib/html_reports.php:662
 msgid ""
 "Click 'Continue' to duplicate the following Report(s).  You may optionally "
 "change the title for the new Reports"
 msgstr ""
 
-#: ../lib/html_reports.php:692
+#: ../lib/html_reports.php:664
 msgid "Name Format:"
 msgstr ""
 
-#: ../lib/html_reports.php:702
+#: ../lib/html_reports.php:674
 msgid "Click 'Continue' to enable the following Report(s)."
 msgstr ""
 
-#: ../lib/html_reports.php:704
+#: ../lib/html_reports.php:676
 msgid ""
 "Please be certain that those Report(s) have successfully been tested first!"
 msgstr ""
 
-#: ../lib/html_reports.php:710
+#: ../lib/html_reports.php:682
 msgid "Click 'Continue' to disable the following Reports."
 msgstr ""
 
-#: ../lib/html_reports.php:717
+#: ../lib/html_reports.php:689
 msgid "Click 'Continue' to send the following Report(s) now."
 msgstr ""
 
-#: ../lib/html_reports.php:763
+#: ../lib/html_reports.php:735
 #, php-format
 msgid "Unable to send Report '%d'.  Please set destination e-mail addresses"
 msgstr ""
 
-#: ../lib/html_reports.php:768
+#: ../lib/html_reports.php:740
 #, php-format
 msgid "Unable to send Report '%s'.  Please set an e-mail subject"
 msgstr ""
 
-#: ../lib/html_reports.php:773
+#: ../lib/html_reports.php:745
 #, php-format
 msgid "Unable to send Report '%s'.  Please set an e-mail From Name"
 msgstr ""
 
-#: ../lib/html_reports.php:778
+#: ../lib/html_reports.php:750
 #, php-format
 msgid "Unable to send Report '%s'.  Please set an e-mail from address"
 msgstr ""
 
-#: ../lib/html_reports.php:834
+#: ../lib/html_reports.php:806
 #, php-format
 msgid "Report Item [edit Report: %s]"
 msgstr ""
 
-#: ../lib/html_reports.php:836
+#: ../lib/html_reports.php:808
 #, php-format
 msgid "Report Item [new Report: %s]"
 msgstr ""
 
-#: ../lib/html_reports.php:1087 ../user_admin.php:1920
+#: ../lib/html_reports.php:1059 ../user_admin.php:1937
 #, php-format
 msgid "[edit: %s]"
 msgstr ""
 
-#: ../lib/html_reports.php:1088
+#: ../lib/html_reports.php:1060
 msgid "Events"
 msgstr ""
 
-#: ../lib/html_reports.php:1090 ../lib/import.php:1803 ../user_admin.php:1922
+#: ../lib/html_reports.php:1062 ../lib/import.php:1803 ../user_admin.php:1939
 msgid "[new]"
 msgstr ""
 
-#: ../lib/html_reports.php:1122
+#: ../lib/html_reports.php:1094
 msgid "Send Report"
 msgstr ""
 
-#: ../lib/html_reports.php:1200
+#: ../lib/html_reports.php:1172
 msgid "Scheduled Events"
 msgstr ""
 
-#: ../lib/html_reports.php:1211
+#: ../lib/html_reports.php:1183
 msgid "Report Preview"
 msgstr ""
 
-#: ../lib/html_reports.php:1235
+#: ../lib/html_reports.php:1212
 msgid "Item Details"
 msgstr ""
 
-#: ../lib/html_reports.php:1235
+#: ../lib/html_reports.php:1213
 msgid "Timespan"
 msgstr ""
 
-#: ../lib/html_reports.php:1270
+#: ../lib/html_reports.php:1252
 msgid "(All Branches)"
 msgstr ""
 
-#: ../lib/html_reports.php:1272
+#: ../lib/html_reports.php:1254
 msgid "(Current Branch)"
 msgstr ""
 
-#: ../lib/html_reports.php:1307
+#: ../lib/html_reports.php:1297
 msgid "No Report Items"
 msgstr ""
 
-#: ../lib/html_reports.php:1381
+#: ../lib/html_reports.php:1371
 msgid "Administrator Level"
 msgstr ""
 
-#: ../lib/html_reports.php:1381
+#: ../lib/html_reports.php:1371
 #, php-format
 msgid "Reports [%s]"
 msgstr ""
 
-#: ../lib/html_reports.php:1381
+#: ../lib/html_reports.php:1371
 msgid "User Level"
 msgstr ""
 
-#: ../lib/html_reports.php:1476
+#: ../lib/html_reports.php:1466
 msgid "Reports"
 msgstr ""
 
-#: ../lib/html_reports.php:1485 ../tree.php:1562
+#: ../lib/html_reports.php:1475 ../tree.php:1562
 msgid "Owner"
 msgstr ""
 
-#: ../lib/html_reports.php:1486 ../lib/html_reports.php:1497
+#: ../lib/html_reports.php:1476 ../lib/html_reports.php:1487
 msgid "Frequency"
 msgstr ""
 
-#: ../lib/html_reports.php:1487 ../lib/html_reports.php:1498
+#: ../lib/html_reports.php:1477 ../lib/html_reports.php:1488
 msgid "Last Run"
 msgstr ""
 
-#: ../lib/html_reports.php:1488 ../lib/html_reports.php:1499
+#: ../lib/html_reports.php:1478 ../lib/html_reports.php:1489
 msgid "Next Run"
 msgstr ""
 
-#: ../lib/html_reports.php:1496
+#: ../lib/html_reports.php:1486
 msgid "Report Title"
 msgstr ""
 
-#: ../lib/html_reports.php:1524
+#: ../lib/html_reports.php:1517
+msgid "Report Disabled - No Owner"
+msgstr ""
+
+#: ../lib/html_reports.php:1527
 msgid "Multiple"
 msgstr ""
 
-#: ../lib/html_reports.php:1525
+#: ../lib/html_reports.php:1528
 msgid "Invalid"
 msgstr ""
 
-#: ../lib/html_reports.php:1532
+#: ../lib/html_reports.php:1535
 msgid "No Reports Found"
 msgstr ""
 
@@ -12252,16 +12275,12 @@ msgstr ""
 msgid "Graph Template:"
 msgstr ""
 
-#: ../lib/html_tree.php:591 ../lib/reports.php:873
+#: ../lib/html_tree.php:591 ../lib/reports.php:886
 msgid "Tree:"
 msgstr ""
 
-#: ../lib/html_tree.php:592 ../lib/reports.php:878
+#: ../lib/html_tree.php:592 ../lib/reports.php:891
 msgid "Leaf:"
-msgstr ""
-
-#: ../lib/html_tree.php:593
-msgid "Device:"
 msgstr ""
 
 #: ../lib/html_tree.php:596
@@ -12473,60 +12492,60 @@ msgstr ""
 msgid "Unable to create LDAP connection object"
 msgstr ""
 
-#: ../lib/ping.php:118
+#: ../lib/ping.php:130
 msgid "ICMP Ping timed out"
 msgstr ""
 
-#: ../lib/ping.php:187 ../lib/ping.php:205
+#: ../lib/ping.php:199 ../lib/ping.php:217
 #, php-format
 msgid "ICMP Ping Success (%s ms)"
 msgstr ""
 
-#: ../lib/ping.php:192 ../lib/ping.php:210
+#: ../lib/ping.php:204 ../lib/ping.php:222
 msgid "ICMP ping Timed out"
 msgstr ""
 
-#: ../lib/ping.php:217 ../lib/ping.php:411 ../lib/ping.php:507
+#: ../lib/ping.php:229 ../lib/ping.php:431 ../lib/ping.php:536
 msgid "Destination address not specified"
 msgstr ""
 
-#: ../lib/ping.php:312 ../lib/ping.php:423
+#: ../lib/ping.php:326 ../lib/ping.php:446
 msgid "default"
 msgstr ""
 
-#: ../lib/ping.php:340
+#: ../lib/ping.php:356
 msgid "PHP version does not support IPv6"
 msgstr ""
 
-#: ../lib/ping.php:361
+#: ../lib/ping.php:378
 #, php-format
 msgid "UDP ping error: %s"
 msgstr ""
 
-#: ../lib/ping.php:394
+#: ../lib/ping.php:412
 #, php-format
 msgid "UDP Ping Success (%s ms)"
 msgstr ""
 
-#: ../lib/ping.php:451
+#: ../lib/ping.php:476
 msgid "PHP binary does not support IPv6"
 msgstr ""
 
-#: ../lib/ping.php:474
+#: ../lib/ping.php:500
 #, php-format
 msgid "TCP ping: socket_select() failed, reason: %s"
 msgstr ""
 
-#: ../lib/ping.php:488
+#: ../lib/ping.php:515
 #, php-format
 msgid "TCP Ping Success (%s ms)"
 msgstr ""
 
-#: ../lib/ping.php:497
+#: ../lib/ping.php:525
 msgid "TCP ping timed out"
 msgstr ""
 
-#: ../lib/ping.php:520
+#: ../lib/ping.php:552
 msgid "Ping not performed due to setting."
 msgstr ""
 
@@ -12543,221 +12562,221 @@ msgstr ""
 msgid "Plugin Management"
 msgstr ""
 
-#: ../lib/reports.php:883
+#: ../lib/reports.php:896
 msgid "Host:"
 msgstr ""
 
-#: ../lib/reports.php:888
+#: ../lib/reports.php:901
 msgid "Graph:"
 msgstr ""
 
-#: ../lib/reports.php:989
+#: ../lib/reports.php:1002
 msgid "(No Graph Template)"
 msgstr ""
 
-#: ../lib/reports.php:1408
+#: ../lib/reports.php:1421
 msgid "Add to Report"
 msgstr ""
 
-#: ../lib/reports.php:1426
+#: ../lib/reports.php:1439
 msgid ""
 "Choose the Report to associate these graphs with.  The defaults for "
 "alignment will be used for each graph in the list below."
 msgstr ""
 
-#: ../lib/reports.php:1428
+#: ../lib/reports.php:1441
 msgid "Report:"
 msgstr ""
 
-#: ../lib/reports.php:1435
+#: ../lib/reports.php:1448
 msgid "Graph Timespan:"
 msgstr ""
 
-#: ../lib/reports.php:1438
+#: ../lib/reports.php:1451
 msgid "Graph Alignment:"
 msgstr ""
 
-#: ../lib/reports.php:1520
+#: ../lib/reports.php:1533
 #, php-format
 msgid "Created Report Graph Item '<i>%s</i>'"
 msgstr ""
 
-#: ../lib/reports.php:1522
+#: ../lib/reports.php:1535
 #, php-format
 msgid "Failed Adding Report Graph Item '<i>%s</i>' Already Exists"
 msgstr ""
 
-#: ../lib/reports.php:1525
+#: ../lib/reports.php:1538
 #, php-format
 msgid "Skipped Report Graph Item '<i>%s</i>' Already Exists"
 msgstr ""
 
-#: ../lib/rrd.php:2402
+#: ../lib/rrd.php:2414
 #, php-format
 msgid "Required RRD step size is '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2440
+#: ../lib/rrd.php:2452
 #, php-format
 msgid "Type for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2445
+#: ../lib/rrd.php:2457
 #, php-format
 msgid "Heartbeat for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2453
+#: ../lib/rrd.php:2465
 #, php-format
 msgid "RRD minimum for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2477
+#: ../lib/rrd.php:2489
 #, php-format
 msgid "RRD maximum for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2487
+#: ../lib/rrd.php:2499
 #, php-format
 msgid "DS '%s' missing in RRDfile"
 msgstr ""
 
-#: ../lib/rrd.php:2496
+#: ../lib/rrd.php:2508
 #, php-format
 msgid "DS '%s' missing in Cacti definition"
 msgstr ""
 
-#: ../lib/rrd.php:2513 ../lib/rrd.php:2514
+#: ../lib/rrd.php:2525 ../lib/rrd.php:2526
 #, php-format
 msgid "Cacti RRA '%s' has same CF/steps (%s, %s) as '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2528 ../lib/rrd.php:2529
+#: ../lib/rrd.php:2540 ../lib/rrd.php:2541
 #, php-format
 msgid "File RRA '%s' has same CF/steps (%s, %s) as '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2560
+#: ../lib/rrd.php:2572
 #, php-format
 msgid "XFF for cacti RRA id '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2564
+#: ../lib/rrd.php:2576
 #, php-format
 msgid "Number of rows for Cacti RRA id '%s' should be '%s'"
 msgstr ""
 
-#: ../lib/rrd.php:2580
+#: ../lib/rrd.php:2592
 #, php-format
 msgid "RRA '%s' missing in RRDfile"
 msgstr ""
 
-#: ../lib/rrd.php:2589
+#: ../lib/rrd.php:2601
 #, php-format
 msgid "RRA '%s' missing in Cacti definition"
 msgstr ""
 
-#: ../lib/rrd.php:2608
+#: ../lib/rrd.php:2620
 msgid "RRD File Information"
 msgstr ""
 
-#: ../lib/rrd.php:2640
+#: ../lib/rrd.php:2652
 msgid "Data Source Items"
 msgstr ""
 
-#: ../lib/rrd.php:2642
+#: ../lib/rrd.php:2654
 msgid "Minimal Heartbeat"
 msgstr ""
 
-#: ../lib/rrd.php:2643
+#: ../lib/rrd.php:2655
 msgid "Min"
 msgstr ""
 
-#: ../lib/rrd.php:2644
+#: ../lib/rrd.php:2656
 msgid "Max"
 msgstr ""
 
-#: ../lib/rrd.php:2645
+#: ../lib/rrd.php:2657
 msgid "Last DS"
 msgstr ""
 
-#: ../lib/rrd.php:2647
+#: ../lib/rrd.php:2659
 msgid "Unknown Sec"
 msgstr ""
 
-#: ../lib/rrd.php:2675
+#: ../lib/rrd.php:2687
 msgid "Round Robin Archive"
 msgstr ""
 
-#: ../lib/rrd.php:2678
+#: ../lib/rrd.php:2690
 msgid "Cur Row"
 msgstr ""
 
-#: ../lib/rrd.php:2679
+#: ../lib/rrd.php:2691
 msgid "PDP per Row"
 msgstr ""
 
-#: ../lib/rrd.php:2680
+#: ../lib/rrd.php:2692
 msgid "X Files Factor"
 msgstr ""
 
-#: ../lib/rrd.php:2681
+#: ../lib/rrd.php:2693
 msgid "CDP Prep Value (0)"
 msgstr ""
 
-#: ../lib/rrd.php:2682
+#: ../lib/rrd.php:2694
 msgid "CDP Unknown Data points (0)"
 msgstr ""
 
-#: ../lib/rrd.php:2759
+#: ../lib/rrd.php:2771
 #, php-format
 msgid "rename %s to %s"
 msgstr ""
 
-#: ../lib/rrd.php:2809
+#: ../lib/rrd.php:2821
 msgid "Error while parsing the XML of rrdtool dump"
 msgstr ""
 
-#: ../lib/rrd.php:2841 ../lib/rrd.php:2896 ../lib/rrd.php:2952
+#: ../lib/rrd.php:2853 ../lib/rrd.php:2908 ../lib/rrd.php:2964
 #, php-format
 msgid "ERROR while writing XML file: %s"
 msgstr ""
 
-#: ../lib/rrd.php:2850
+#: ../lib/rrd.php:2862
 #, php-format
 msgid "Added Data Source(s) to RRDfile: %s"
 msgstr ""
 
-#: ../lib/rrd.php:2852 ../lib/rrd.php:2907
+#: ../lib/rrd.php:2864 ../lib/rrd.php:2919
 #, php-format
 msgid "ERROR: RRDfile %s not writeable"
 msgstr ""
 
-#: ../lib/rrd.php:2879 ../lib/rrd.php:2935
+#: ../lib/rrd.php:2891 ../lib/rrd.php:2947
 msgid "Error while parsing the XML of RRDtool dump"
 msgstr ""
 
-#: ../lib/rrd.php:2905
+#: ../lib/rrd.php:2917
 #, php-format
 msgid "Deleted RRA(s) from RRDfile: %s"
 msgstr ""
 
-#: ../lib/rrd.php:2961
+#: ../lib/rrd.php:2973
 #, php-format
 msgid "Deleted rra(s) from rrd file: %s"
 msgstr ""
 
-#: ../lib/rrd.php:2963
+#: ../lib/rrd.php:2975
 #, php-format
 msgid "ERROR: RRD file %s not writeable"
 msgstr ""
 
-#: ../lib/rrd.php:3168
+#: ../lib/rrd.php:3180
 #, php-format
 msgid "RRA (CF=%s, ROWS=%d, PDP_PER_ROW=%d, XFF=%1.2f) removed from RRD file\n"
 msgstr ""
 
-#: ../lib/rrd.php:3202
+#: ../lib/rrd.php:3214
 #, php-format
 msgid "RRA (CF=%s, ROWS=%d, PDP_PER_ROW=%d, XFF=%1.2f) adding to RRD file\n"
 msgstr ""
@@ -13029,16 +13048,16 @@ msgstr ""
 msgid "Reset filters"
 msgstr ""
 
-#: ../links.php:345 ../links.php:508 ../user_admin.php:1637
+#: ../links.php:345 ../links.php:508 ../user_admin.php:1654
 #: ../user_group_admin.php:1375
 msgid "Top Tab"
 msgstr ""
 
-#: ../links.php:346 ../user_admin.php:1638 ../user_group_admin.php:1376
+#: ../links.php:346 ../user_admin.php:1655 ../user_group_admin.php:1376
 msgid "Bottom Console"
 msgstr ""
 
-#: ../links.php:347 ../user_admin.php:1639 ../user_group_admin.php:1377
+#: ../links.php:347 ../user_admin.php:1656 ../user_group_admin.php:1377
 msgid "Top Console"
 msgstr ""
 
@@ -13169,7 +13188,7 @@ msgid "SNMP Notification Receivers"
 msgstr ""
 
 #: ../managers.php:156 ../managers.php:231 ../managers.php:539
-#: ../managers.php:791
+#: ../managers.php:793
 msgid "Receivers"
 msgstr ""
 
@@ -13211,73 +13230,73 @@ msgstr ""
 msgid "OID"
 msgstr ""
 
-#: ../managers.php:632
+#: ../managers.php:634
 msgid "No SNMP Notifications"
 msgstr ""
 
-#: ../managers.php:728 ../utilities.php:2516
+#: ../managers.php:730 ../utilities.php:2516
 msgid "Severity"
 msgstr ""
 
-#: ../managers.php:747 ../utilities.php:2559
+#: ../managers.php:749 ../utilities.php:2559
 msgid "Purge Notification Log"
 msgstr ""
 
-#: ../managers.php:795 ../utilities.php:2613
+#: ../managers.php:797 ../utilities.php:2613
 msgid "Notification"
 msgstr ""
 
-#: ../managers.php:795 ../utilities.php:2613
+#: ../managers.php:797 ../utilities.php:2613
 msgid "Time"
 msgstr ""
 
-#: ../managers.php:795 ../utilities.php:2613
+#: ../managers.php:797 ../utilities.php:2613
 msgid "Varbinds"
 msgstr ""
 
-#: ../managers.php:801
+#: ../managers.php:803
 msgid "Severity Level"
 msgstr ""
 
-#: ../managers.php:819 ../utilities.php:2635
+#: ../managers.php:821 ../utilities.php:2635
 msgid "No SNMP Notification Log Entries"
 msgstr ""
 
-#: ../managers.php:988
+#: ../managers.php:998
 msgid "Click 'Continue' to delete the following Notification Receiver"
 msgid_plural "Click 'Continue' to delete following Notification Receiver"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../managers.php:990
+#: ../managers.php:1000
 msgid "Click 'Continue' to enable the following Notification Receiver"
 msgid_plural "Click 'Continue' to enable following Notification Receiver"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../managers.php:992
+#: ../managers.php:1002
 msgid "Click 'Continue' to disable the following Notification Receiver"
 msgid_plural "Click 'Continue' to disable following Notification Receiver"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../managers.php:1049
+#: ../managers.php:1059
 msgid ""
 "Click 'Continue' to forward the following Notification Objects to this "
 "Notification Receiver."
 msgstr ""
 
-#: ../managers.php:1050
+#: ../managers.php:1060
 msgid ""
 "Click 'Continue' to disable forwarding the following Notification Objects to "
 "this Notification Receiver."
 msgstr ""
 
-#: ../managers.php:1059
+#: ../managers.php:1069
 msgid "Disable Notification Objects"
 msgstr ""
 
-#: ../managers.php:1061
+#: ../managers.php:1071
 msgid "You must select at least one notification object."
 msgstr ""
 
@@ -14184,7 +14203,7 @@ msgstr ""
 msgid "The name by which this Tree will be referred to as."
 msgstr ""
 
-#: ../tree.php:1558 ../user_admin.php:1504 ../user_group_admin.php:1243
+#: ../tree.php:1558 ../user_admin.php:1521 ../user_group_admin.php:1243
 msgid "Tree Name"
 msgstr ""
 
@@ -14357,8 +14376,8 @@ msgstr ""
 msgid "Default Graph Policy for this User"
 msgstr ""
 
-#: ../user_admin.php:1006 ../user_admin.php:1229 ../user_admin.php:1371
-#: ../user_admin.php:1504 ../user_group_admin.php:821
+#: ../user_admin.php:1006 ../user_admin.php:1242 ../user_admin.php:1384
+#: ../user_admin.php:1521 ../user_group_admin.php:821
 #: ../user_group_admin.php:966 ../user_group_admin.php:1109
 #: ../user_group_admin.php:1243
 msgid "Effective Policy"
@@ -14368,9 +14387,9 @@ msgstr ""
 msgid "No Matching Graphs Found"
 msgstr ""
 
-#: ../user_admin.php:1035 ../user_admin.php:1041 ../user_admin.php:1274
-#: ../user_admin.php:1280 ../user_admin.php:1413 ../user_admin.php:1419
-#: ../user_admin.php:1545 ../user_admin.php:1551 ../user_group_admin.php:862
+#: ../user_admin.php:1035 ../user_admin.php:1041 ../user_admin.php:1287
+#: ../user_admin.php:1293 ../user_admin.php:1426 ../user_admin.php:1432
+#: ../user_admin.php:1562 ../user_admin.php:1568 ../user_group_admin.php:862
 #: ../user_group_admin.php:868 ../user_group_admin.php:1010
 #: ../user_group_admin.php:1016 ../user_group_admin.php:1151
 #: ../user_group_admin.php:1157 ../user_group_admin.php:1283
@@ -14378,14 +14397,19 @@ msgstr ""
 msgid "Revoke Access"
 msgstr ""
 
-#: ../user_admin.php:1036 ../user_admin.php:1040 ../user_admin.php:1275
-#: ../user_admin.php:1279 ../user_admin.php:1414 ../user_admin.php:1418
-#: ../user_admin.php:1546 ../user_admin.php:1550 ../user_group_admin.php:62
+#: ../user_admin.php:1036 ../user_admin.php:1040 ../user_admin.php:1288
+#: ../user_admin.php:1292 ../user_admin.php:1427 ../user_admin.php:1431
+#: ../user_admin.php:1563 ../user_admin.php:1567 ../user_group_admin.php:62
 #: ../user_group_admin.php:863 ../user_group_admin.php:867
 #: ../user_group_admin.php:1011 ../user_group_admin.php:1015
 #: ../user_group_admin.php:1152 ../user_group_admin.php:1156
 #: ../user_group_admin.php:1284 ../user_group_admin.php:1288
 msgid "Grant Access"
+msgstr ""
+
+#: ../user_admin.php:1093 ../user_admin.php:2646 ../user_group_admin.php:1812
+#: ../user_group_admin.php:1872
+msgid "Groups"
 msgstr ""
 
 #: ../user_admin.php:1101 ../user_admin.php:1110
@@ -14400,14 +14424,14 @@ msgstr ""
 msgid "Non Member"
 msgstr ""
 
-#: ../user_admin.php:1112 ../user_admin.php:2282 ../user_admin.php:2283
-#: ../user_admin.php:2284 ../user_group_admin.php:1904
+#: ../user_admin.php:1112 ../user_admin.php:2299 ../user_admin.php:2300
+#: ../user_admin.php:2301 ../user_group_admin.php:1904
 #: ../user_group_admin.php:1905 ../user_group_admin.php:1906
 msgid "ALLOW"
 msgstr ""
 
-#: ../user_admin.php:1112 ../user_admin.php:2282 ../user_admin.php:2283
-#: ../user_admin.php:2284 ../user_group_admin.php:1904
+#: ../user_admin.php:1112 ../user_admin.php:2299 ../user_admin.php:2300
+#: ../user_admin.php:2301 ../user_group_admin.php:1904
 #: ../user_group_admin.php:1905 ../user_group_admin.php:1906
 msgid "DENY"
 msgstr ""
@@ -14432,8 +14456,8 @@ msgstr ""
 msgid "Default Device Policy for this User"
 msgstr ""
 
-#: ../user_admin.php:1240 ../user_admin.php:1248 ../user_admin.php:1382
-#: ../user_admin.php:1390 ../user_admin.php:1515 ../user_admin.php:1523
+#: ../user_admin.php:1253 ../user_admin.php:1261 ../user_admin.php:1395
+#: ../user_admin.php:1403 ../user_admin.php:1532 ../user_admin.php:1540
 #: ../user_group_admin.php:832 ../user_group_admin.php:840
 #: ../user_group_admin.php:977 ../user_group_admin.php:985
 #: ../user_group_admin.php:1120 ../user_group_admin.php:1128
@@ -14441,8 +14465,8 @@ msgstr ""
 msgid "Access Granted"
 msgstr ""
 
-#: ../user_admin.php:1242 ../user_admin.php:1246 ../user_admin.php:1384
-#: ../user_admin.php:1388 ../user_admin.php:1517 ../user_admin.php:1521
+#: ../user_admin.php:1255 ../user_admin.php:1259 ../user_admin.php:1397
+#: ../user_admin.php:1401 ../user_admin.php:1534 ../user_admin.php:1538
 #: ../user_group_admin.php:834 ../user_group_admin.php:838
 #: ../user_group_admin.php:979 ../user_group_admin.php:983
 #: ../user_group_admin.php:1122 ../user_group_admin.php:1126
@@ -14450,169 +14474,164 @@ msgstr ""
 msgid "Access Restricted"
 msgstr ""
 
-#: ../user_admin.php:1259 ../user_group_admin.php:996
+#: ../user_admin.php:1272 ../user_group_admin.php:996
 msgid "No Matching Devices Found"
 msgstr ""
 
-#: ../user_admin.php:1297 ../user_group_admin.php:1034
+#: ../user_admin.php:1310 ../user_group_admin.php:1034
 msgid "Default Graph Template Policy"
 msgstr ""
 
-#: ../user_admin.php:1302
+#: ../user_admin.php:1315
 msgid "Default Graph Template Policy for this User"
 msgstr ""
 
-#: ../user_admin.php:1371 ../user_group_admin.php:1109
+#: ../user_admin.php:1384 ../user_group_admin.php:1109
 msgid "Total Graphs"
 msgstr ""
 
-#: ../user_admin.php:1398 ../user_group_admin.php:1136
+#: ../user_admin.php:1411 ../user_group_admin.php:1136
 msgid "No Matching Graph Templates Found"
 msgstr ""
 
-#: ../user_admin.php:1436 ../user_group_admin.php:1175
+#: ../user_admin.php:1449 ../user_group_admin.php:1175
 msgid "Default Tree Policy"
 msgstr ""
 
-#: ../user_admin.php:1441
+#: ../user_admin.php:1454
 msgid "Default Tree Policy for this User"
 msgstr ""
 
-#: ../user_admin.php:1530 ../user_group_admin.php:1269
+#: ../user_admin.php:1547 ../user_group_admin.php:1269
 msgid "No Matching Trees Found"
 msgstr ""
 
-#: ../user_admin.php:1575 ../user_group_admin.php:1315
+#: ../user_admin.php:1592 ../user_group_admin.php:1315
 msgid "User Permissions"
 msgstr ""
 
-#: ../user_admin.php:1642 ../user_group_admin.php:1380
+#: ../user_admin.php:1659 ../user_group_admin.php:1380
 msgid "External Link Permissions"
 msgstr ""
 
-#: ../user_admin.php:1699 ../user_group_admin.php:1437
+#: ../user_admin.php:1716 ../user_group_admin.php:1437
 msgid "Plugin Permissions"
 msgstr ""
 
-#: ../user_admin.php:1755
+#: ../user_admin.php:1772
 msgid "Legacy 1.x Plugins"
 msgstr ""
 
-#: ../user_admin.php:1790 ../user_group_admin.php:1528
+#: ../user_admin.php:1807 ../user_group_admin.php:1528
 #, php-format
 msgid "User Settings %s"
 msgstr ""
 
-#: ../user_admin.php:1905 ../user_group_admin.php:1644
+#: ../user_admin.php:1922 ../user_group_admin.php:1644
 msgid "Permissions"
 msgstr ""
 
-#: ../user_admin.php:1906
+#: ../user_admin.php:1923
 msgid "Group Membership"
 msgstr ""
 
-#: ../user_admin.php:1907 ../user_group_admin.php:1645
+#: ../user_admin.php:1924 ../user_group_admin.php:1645
 msgid "Graph Perms"
 msgstr ""
 
-#: ../user_admin.php:1908 ../user_group_admin.php:1646
+#: ../user_admin.php:1925 ../user_group_admin.php:1646
 msgid "Device Perms"
 msgstr ""
 
-#: ../user_admin.php:1909 ../user_group_admin.php:1647
+#: ../user_admin.php:1926 ../user_group_admin.php:1647
 msgid "Template Perms"
 msgstr ""
 
-#: ../user_admin.php:1910 ../user_group_admin.php:1648
+#: ../user_admin.php:1927 ../user_group_admin.php:1648
 msgid "Tree Perms"
 msgstr ""
 
-#: ../user_admin.php:1952
+#: ../user_admin.php:1969
 #, php-format
 msgid "User Management %s"
 msgstr ""
 
-#: ../user_admin.php:1984
+#: ../user_admin.php:2001
 msgid "Password Too Short"
 msgstr ""
 
-#: ../user_admin.php:1989
+#: ../user_admin.php:2006
 msgid "Password Validation Passes"
 msgstr ""
 
-#: ../user_admin.php:2003
+#: ../user_admin.php:2020
 msgid "Passwords do Not Match"
 msgstr ""
 
-#: ../user_admin.php:2006
+#: ../user_admin.php:2023
 msgid "Passwords Match"
 msgstr ""
 
-#: ../user_admin.php:2250 ../user_group_admin.php:1884
+#: ../user_admin.php:2267 ../user_group_admin.php:1884
 msgid "Graph Policy"
 msgstr ""
 
-#: ../user_admin.php:2251 ../user_group_admin.php:1885
+#: ../user_admin.php:2268 ../user_group_admin.php:1885
 msgid "Device Policy"
 msgstr ""
 
-#: ../user_admin.php:2252 ../user_group_admin.php:1886
+#: ../user_admin.php:2269 ../user_group_admin.php:1886
 msgid "Template Policy"
 msgstr ""
 
-#: ../user_admin.php:2253
+#: ../user_admin.php:2270
 msgid "Last Login"
 msgstr ""
 
-#: ../user_admin.php:2274
+#: ../user_admin.php:2291
 msgid "Unavailable"
 msgstr ""
 
-#: ../user_admin.php:2290
+#: ../user_admin.php:2307
 msgid "No Users Found"
 msgstr ""
 
-#: ../user_admin.php:2505 ../user_group_admin.php:2124
+#: ../user_admin.php:2522 ../user_group_admin.php:2124
 #, php-format
 msgid "Graph Permissions %s"
 msgstr ""
 
-#: ../user_admin.php:2560 ../user_admin.php:2647
+#: ../user_admin.php:2577 ../user_admin.php:2664
 msgid "Show All"
 msgstr ""
 
-#: ../user_admin.php:2614
+#: ../user_admin.php:2631
 #, php-format
 msgid "Group Membership %s"
 msgstr ""
 
-#: ../user_admin.php:2629 ../user_group_admin.php:1812
-#: ../user_group_admin.php:1872
-msgid "Groups"
-msgstr ""
-
-#: ../user_admin.php:2702 ../user_group_admin.php:2234
+#: ../user_admin.php:2719 ../user_group_admin.php:2234
 #, php-format
 msgid "Devices Permission %s"
 msgstr ""
 
-#: ../user_admin.php:2753 ../user_admin.php:2840 ../user_admin.php:2927
+#: ../user_admin.php:2770 ../user_admin.php:2857 ../user_admin.php:2944
 #: ../user_group_admin.php:2179 ../user_group_admin.php:2285
 #: ../user_group_admin.php:2372 ../user_group_admin.php:2459
 msgid "Show Exceptions"
 msgstr ""
 
-#: ../user_admin.php:2807 ../user_group_admin.php:2339
+#: ../user_admin.php:2824 ../user_group_admin.php:2339
 #, php-format
 msgid "Template Permission %s"
 msgstr ""
 
-#: ../user_admin.php:2894 ../user_admin.php:2981 ../user_group_admin.php:2426
+#: ../user_admin.php:2911 ../user_admin.php:2998 ../user_group_admin.php:2426
 #, php-format
 msgid "Tree Permission %s"
 msgstr ""
 
-#: ../user_admin.php:3014
+#: ../user_admin.php:3031
 msgid "Show Exceptions<"
 msgstr ""
 

--- a/locales/po/cacti.pot
+++ b/locales/po/cacti.pot
@@ -7128,14 +7128,14 @@ msgstr ""
 msgid "Right Axis Formatter (--right-axis-formatter &lt;formatname&gt;)"
 msgstr ""
 
-#: ../include/global_form.php:722 ../include/global_form.php:733
+#: ../include/global_form.php:722
 msgid ""
 "When you setup the right axis labeling, apply a rule to the data format.  "
 "Supported formats include \"numeric\" where\n"
 "\t\t\tdata is treated as numeric, \"timestamp\" where values are interpreted "
 "as UNIX timestamps (number of seconds since January 1970)\n"
 "\t\t\tand expressed using strftime format (default is \"%Y-%m-%d %H:%M:%S"
-"\").  See also --units-length and --left-axis-format.  Finally\n"
+"\").  See also --units-length and --right-axis-format.  Finally\n"
 "\t\t\t\"duration\" where values are interpreted as duration in "
 "milliseconds.  Formatting follows the rules of valstrfduration qualified "
 "PRINT/GPRINT."
@@ -7144,6 +7144,19 @@ msgstr ""
 #: ../include/global_form.php:728
 msgid "Left Axis Formatter (--left-axis-formatter &lt;formatname&gt;)"
 msgstr ""
+
+#: ../include/global_form.php:733
+msgid ""
+"When you setup the left axis labeling, apply a rule to the data format.  "
+"Supported formats include \"numeric\" where\n"
+"\t\t\tdata is treated as numeric, \"timestamp\" where values are interpreted "
+"as UNIX timestamps (number of seconds since January 1970)\n"
+"\t\t\tand expressed using strftime format (default is \"%Y-%m-%d %H:%M:%S"
+"\").  See also --units-length.  Finally \"duration\" where values\n"
+"\t\t\tare interpreted as duration in milliseconds.  Formatting follows the"
+"rules of valstrfduration qualified PRINT/GPRINT."
+msgstr ""
+
 
 #: ../include/global_form.php:739
 msgid "Legend Options"


### PR DESCRIPTION
Some text corrections to the text displayed when changing or creating a graph template.
(Click on the 'Console' tab, then on 'Graph' within the 'Templates' section. Finally click on  a graph template name or the 'Add' link at the top-right.)
The changes relate to the X- and Y-axis options.
The '--left-axis-formatter' option refers to '--left-axis-format', but this option is not available on the form page (but it is available to the rrdgraph command). So the reference to it has been removed.
Because the '--left-axis-formatter' text is now different from that for the '--right-axis-formatter' option, a new entry had to be created for it in the 'include/global_form.php' file.