### PR TITLE
Ensure the rewrite_index field is handled and checked correctly.

### DIFF
--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -730,6 +730,8 @@ function query_snmp_host($host_id, $snmp_query_id) {
 
 			debug_log_insert_section_end('data_query');
 		}
+
+		$fields_processed[] = $field_name;
 	}
 
 	$session->close();
@@ -832,15 +834,17 @@ function data_query_rewrite_indexes(&$errmsg, $host_id, $snmp_query_id, $rewrite
 	foreach($oid_items as $item){
 		$matches = array();
 		if (preg_match('/^\|query_([^|]+)\|$/', $item, $matches)){
-			$iv = db_qstr($matches[1]);
+			$iv = $matches[1];
 			if (is_array($fields_processed) && !in_array($iv, $fields_processed)){
 				$errmsg[] = "rewrite_index='$rewrite_index': '$iv' is not processed yet, could not use it as index source";
 					continue;
 			}
+
 			if (!isset($chain_indexes[$iv])) {
 				$hash =  "$host_id@$snmp_query_id@$iv";
 				if (!isset($data_query_rewrite_indexes_cache[$hash])) {
 					$data_query_rewrite_indexes_cache[$hash] = array();
+					$iv = db_qstr($iv);
 
 					$field_values = db_fetch_assoc_prepared("SELECT snmp_index, field_value
 						FROM host_snmp_cache


### PR DESCRIPTION
The use of 'rewrite_index' in SNMP query XML files was not handled correctly and always failed. This commit ensures that the rewrite_index field is now recognised (by setting it in the 'fields_processed' array). Also the call to 'db_qstr' was adding quotes to the field name, so preventing it from ever matching the filed name used in the XML file. This call has been moved further down since it really relates to the database SELECT call.