### PR TITLE
Two data source custom data fixes for themes

### DIFF
--- a/include/themes/paper-plane/main.css
+++ b/include/themes/paper-plane/main.css
@@ -1214,12 +1214,14 @@ table.cactiTable {
 	float: left;
 	display: table-column;
 	width: 50%;
+	text-align: left;
 }
 
 .formColumnRight {
 	float: left;
 	display: table-column;
 	width: 50%;
+	text-align: left;
 }
 
 .formData {

--- a/lib/html_form_template.php
+++ b/lib/html_form_template.php
@@ -519,7 +519,7 @@ function draw_nontemplated_fields_custom_data($data_template_data_id, $field_nam
 
 				print "<div class='formRow'>\n";
 
-				print "<div class='formColumnLeft'>" . $field['name'] . "</div>\n";
+				print "<div class='formColumnLeft'><div class='formFieldName'>" . $field['name'] . "</div></div>\n";
 				print "<div class='formColumnRight'>";
 
 				draw_custom_data_row($form_field_name, $field['id'], $data['id'], $old_value);


### PR DESCRIPTION
Two fixes when selecting a data source from 'Data Sources' in the Management area:

1) With the 'Modern' theme, the custom data field names were not being shown (only the values appeared);
2) With the 'Paper-plane' theme the custom data field names and values were indented to the right.