### PR TITLE
Add db_prepare_statement to enable prepared statements in plugins

### DIFF
--- a/lib/poller.php
+++ b/lib/poller.php
@@ -1060,16 +1060,22 @@ function replicate_out_table($conn, &$data, $table, $remote_poller_id) {
 			$rowcnt++;
 
 			if ($rowcnt > 1000) {
-				db_execute($prefix . $sql, true, $conn);
-				$rows_done += db_affected_rows($conn);
+				$query = db_prepare_statement($prefix . $sql, true, $conn);
+				db_execute($query, true, $conn);
+				$rows_done += $query->rowCount();
+				$query->closeCursor();
+				unset($query);
 				$sql = '';
 				$rowcnt = 0;
 			}
 		}
 
 		if ($rowcnt > 0) {
-			db_execute($prefix . $sql, true, $conn);
-			$rows_done += db_affected_rows($conn);
+                        $query = db_prepare_statement($prefix . $sql, true, $conn);
+			db_execute($query, true, $conn);
+                        $rows_done += $query->rowCount();
+                        $query->closeCursor();
+                        unset($query);
 		}
 
 		cacti_log('NOTE: Table ' . $table . ' Replicated to Remote Poller ' . $remote_poller_id . ' With ' . $rows_done . ' Rows Updated');

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -195,13 +195,16 @@ if ($run) {
 		WHERE id= ?', array($poller_id), true, $remote_db_cnn_id);
 
 	while (true) {
-		$time_records  = db_fetch_assoc('SELECT time, count(*) AS entries 
-			FROM poller_output_boost 
-			GROUP BY time', true, $local_db_cnn_id);
+                $query = db_prepare_statement('SELECT time, count(*) AS entries
+			FROM poller_output_boost
+                        GROUP BY time', true, $local_db_cnn_id);
+		$time_records  = db_fetch_assoc($query, true, $local_db_cnn_id);
 
 		debug('There are ' . sizeof($time_records) . ' in the recovery database');
 
-		$total_records = db_affected_rows();
+                $total_records = $query->rowCount();
+                $query->closeCursor();
+                unset($query);
 		$found         = 0;
 
 		if (!sizeof($time_records)) {


### PR DESCRIPTION
This patch add support for prepared statements and remove the 'global' affected_row counter. 

The db_prepare_statement function returns an new prepared PDOStatement when given an SQL string and when given an PDOStatement it returns the same PDOStatement. 
All the db_prepared_ functions are updated to use this function.

This way you can prepare a SQL statement and get an handle to that statement and use that in the following db_ function calls. This way an prepared statement can be reused or the affected rowCount can be retrieved.

For example:

	$query = db_prepare_statement($prefix . $sql, true, $conn);
	db_execute($query, true, $conn);
	$rows_done += $query->rowCount();
	unset($query);

Best regards,

Arjan