### PR TITLE
Change graph template fixes

### DIFF
--- a/graph_templates.php
+++ b/graph_templates.php
@@ -348,7 +348,7 @@ function form_actions() {
 		} elseif (get_request_var('drp_action') == '4') { // retemplate
 			print "<tr>
 				<td class='textArea'>
-					<p>" . __('Click \'Continue\' to Synchronize your Graphs the following Graph Template(s). This function is important if you have Graphs that exist with multiple versions of a Graph Template and wish to make them all common in appearance.') . "</p>
+					<p>" . __('Click \'Continue\' to Synchronize your Graphs with the following Graph Template(s). This function is important if you have Graphs that exist with multiple versions of a Graph Template and wish to make them all common in appearance.') . "</p>
 					<div class='itemlist'><ul>$graph_list</ul></div>
 				</td>
 			</tr>\n";

--- a/lib/import.php
+++ b/lib/import.php
@@ -537,7 +537,6 @@ function xml_to_graph_template($hash, &$xml_array, &$hash_cache, $hash_version, 
 
 		if ($remove_orphans) {
 			retemplate_graphs($graph_template_id);
-			
 		}
 	}
 


### PR DESCRIPTION
When changing the graph template for an existing graph, not all the compatible templates were being shown. (We have added a few Interface in/out templates based on the standard 'In/Out Bits (64-bit Counters)', but only modified the y-axis. So they should be compatible.) The SQL used to get the dropdown list of templates now handles cases were more than one entry may be present.
The template id selected is actually stored in 2 tables. Only one table was being updated, and this meant that the previous template name was still being shown on the Console->Management->Graphs page. Updating the second table when the template changes, corrected this.
In some cases the legend ends up being composed of both legends from the old and new graph templates. This was because the table holding the legend items was modified, and then a later check was run against the template and the table to see if any entries should be removed. However, the number of items in the table (graph) was not recalculated, so no legend items were removed. (This also explains why running the 'change graph template' again or 'sync graphs', then corrected the graph. Because the newly calculated number of legend items from the table did not now match the template. So items were removed on the second run.)

There are still one or two problems. One is that the page you are returned to after changing the template shows no graph names (because the template name has changed). Clicking on the filter 'Go' button resolves this, but it would be nice if the code did it for you. Not sure how to do this.
I'll take a look at some more next week.