### PR TITLE
When changing graph templates, set the template filter to any for the return page.

### DIFF
--- a/graphs.php
+++ b/graphs.php
@@ -719,7 +719,11 @@ function form_actions() {
 			api_plugin_hook_function('graphs_action_bottom', array(get_request_var('drp_action'), $selected_items));
 		}
 
-		header('Location: graphs.php?header=false');
+		if (get_request_var('drp_action') == '2') { // change graph template
+			header('Location: graphs.php?header=false&template_id=-1');
+		} else {
+			header('Location: graphs.php?header=false');
+		}
 		exit;
 	}
 


### PR DESCRIPTION
When a graph template is changed, the user is returned to the previous page but with no graphs being shown at all (which is correct since the template filter is still set for the previous graph template and that has now changed).
This commit just sets the template filter to -1 (meaning any template) when returning. So the list of relevant graph names are now shown.
