### PR TITLE
Fix documentation links in install page for commit f717283

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -431,7 +431,7 @@ $enabled = '1';
 						print '<h2>' . __('License Agreement') . '</h2>';
 
 						print '<p>' . __('Thanks for taking the time to download and install Cacti, the complete graphing solution for your network. Before you can start making cool graphs, there are a few pieces of data that Cacti needs to know.') . '</p>';
-						print '<p>' . __('Make sure you have read and followed the required steps needed to install Cacti before continuing. Install information can be found for <a href="%1$s">Unix</a> and <a href="%2$s">Win32</a>-based operating systems.', '../docs/html/install_unix.html', '../docs/html/install_windows.html') . '</p>';
+						print '<p>' . __('Make sure you have read and followed the required steps needed to install Cacti before continuing. Install information can be found for <a href="%1$s">Unix</a> and <a href="%2$s">Win32</a>-based operating systems.', '../docs/html/install-unix.html', '../docs/html/install-windows.html') . '</p>';
 						print '<p>' . __('Also, if this is an upgrade, be sure to reading the <a href="%s">Upgrade</a> information file.', '../docs/html/upgrade.html') . '</p>';
 						print '<p>' . __('Cacti is licensed under the GNU General Public License, you must agree to its provisions before continuing:') . "</p>";
 					?>


### PR DESCRIPTION
The links in the install web page don't work due to the changes of commit f717283.

This update fixes that.