### PR TITLE
Removed Incorrect php-format mark on cacti.pot

### DIFF
--- a/locales/po/cacti.pot
+++ b/locales/po/cacti.pot
@@ -10054,7 +10054,6 @@ msgid "Variance Percentage"
 msgstr ""
 
 #: ../include/global_settings.php:1689
-#, php-format
 msgid ""
 "This value represents the percentage above the adjusted sample average once "
 "outliers\n"


### PR DESCRIPTION
As I understand it shouldn't be php-format.
It doesn't care about the space between "100% o" and taking this as %o

http://php.net/manual/en/function.sprintf.php