### PR TITLE
Add backticks to mysql column names using reserved words.

### DIFF
--- a/install/upgrades/1_0_0.php
+++ b/install/upgrades/1_0_0.php
@@ -1440,8 +1440,8 @@ function upgrade_to_1_0_0() {
 
 				foreach($rras as $r) {
 					db_install_execute("INSERT INTO data_source_profiles_rra
-						(data_source_profile_id, name, steps, rows)
-						SELECT '$id' AS data_source_profile_id, name, steps, rows FROM rra WHERE id=" . $r);
+						(`data_source_profile_id`, `name`, `steps`, `rows`)
+						SELECT '$id' AS `data_source_profile_id`, `name`, `steps`, `rows` FROM `rra` WHERE `id`=" . $r);
 
 					db_install_execute("REPLACE INTO data_source_profiles_cf
 						(data_source_profile_id, consolidation_function_id)


### PR DESCRIPTION
Ran into an issue today while attempting to upgrade from ```0.8.8g``` to the latest version.  The issue I kept having was that the database upgrade was failing.  After taking a closer look I found that the upgrade script was not properly escaping the word ```rows``` in it's queries.  I have a feeling the word ```rows``` is reserved only on specific brands and/or versions (ex: MySQL vs MariaDB). My system is ```CentOS 7``` with ```MariaDB 10.2``` coming directly from MariaDB yum repo, and ```PHP 5.4.16```.