### PR TITLE
allow to send single part plain text mails

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3731,12 +3731,10 @@ function mailer($from, $to, $cc, $bcc, $replyto, $subject, $body, $body_text = '
 		$text['text']  = strip_tags($body);
 		$mail->isHTML(false);
 		$mail->Body    = $text['text'];
-		$mail->AltBody = $text['text'];
 	} elseif ($html == false) {
 		$text['text']  = strip_tags($body);
 		$mail->isHTML(false);
 		$mail->Body    = $text['text'];
-		$mail->AltBody = $text['text'];
 	} else {
 		$text['html']  = $body . '<br>';
 		$text['text']  = strip_tags(str_replace('<br>', "\n", $body));


### PR DESCRIPTION
Using Body and altBody phpmailer properties makes sending single part plain text mails impossible, so I propose to not use altBody for text-only posts.