### PR TITLE
Update api_device.php

### DIFF
--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -183,7 +183,7 @@ function api_device_save($id, $host_template_id, $description, $hostname, $snmp_
 	}
 
 	$save['id']                   = form_input_validate($id, 'id', '^[0-9]+$', false, 3);
-	$save['host_template_id']     = form_input_validate($host_template_id, 'host_template_id', '^[0-9]+$', false, 3);
+	$save['host_template_id']     = form_input_validate($host_template_id, 'host_template_id', '^[0-9]+$', true, 3);
 
 	$save['poller_id']            = form_input_validate($poller_id, 'poller_id', '^[0-9]+$', true, 3);
 	$save['site_id']              = form_input_validate($site_id, 'site_id', '^[0-9]+$', true, 3);


### PR DESCRIPTION
The only two documented fields required for the _add_devices.php_ script are `description` and `ip`, however, `form_input_validate` is passed an argument indicating it should receive a non-null value for the optional `host_template_id` field. This results in an "ERROR: Failed to add this device" error message when adding a host via the command line .