### PR TITLE
Updated add_graphs.php to better handle regex

### DIFF
--- a/cli/add_graphs.php
+++ b/cli/add_graphs.php
@@ -578,7 +578,7 @@ if (sizeof($parms)) {
 				if (sizeof($dsGraph['snmpValue'])) {
 					$req .= ' AND field_value = ' . db_qstr($dsGraph['snmpValue'][$index_snmp_filter]). ')';
 				} else {
-					$req .= ' AND field_value LIKE "%' . addslashes($dsGraph['snmpValueRegex'][$index_snmp_filter]) . '%")';
+					$req .= ' AND field_value REGEXP "' . addslashes($dsGraph['snmpValueRegex'][$index_snmp_filter]) . '")';
 				}
 
 				$index_snmp_filter++;


### PR DESCRIPTION
The option `--snmp-value-regex` doesn't seem to actually handle valid regex expressions, but rather simple text patterns using the `LIKE` MySQL operator and wildcards. This can be  confusing to an end-user given the name. It's also very limiting. This code swaps out `LIKE` and the wildcards with `REGEXP` to better handle regex.