### PR TITLE
Fixed an inconsistent reference to the template

### DIFF
--- a/automation_templates.php
+++ b/automation_templates.php
@@ -313,7 +313,7 @@ function template_edit() {
 		'sysDescr' => array(
 			'method' => 'textbox',
 			'friendly_name' => __('System Description Match'),
-			'description' => __('This is a unique string that will be matched to a devices sysDescr string to pair it to this Discovery Template.  Any Perl regular expression can be used in addition to any SQL Where expression.'),
+			'description' => __('This is a unique string that will be matched to a devices sysDescr string to pair it to this Automation Template.  Any Perl regular expression can be used in addition to any SQL Where expression.'),
 			'value' => '|arg1:sysDescr|',
 			'max_length' => '255',
 			),


### PR DESCRIPTION
Minor fix: One of the descriptions refers to the template as a "Discovery Template", while the other inputs in the same form refer to the template as an "Automation Template".