### PR TITLE
Added Code So That "Sync to Device Template" Will Remove Unused Graph Templates Not Associated with a Device's Assigned Device Template

### DIFF
--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -319,6 +319,7 @@ function api_device_save($id, $host_template_id, $description, $hostname, $snmp_
 function api_device_update_host_template($host_id, $host_template_id) {
 	db_execute_prepared('UPDATE host SET host_template_id = ? WHERE id = ?', array($host_template_id, $host_id));
 
+	/* add all snmp queries assigned to the device template */
 	$snmp_queries = db_fetch_assoc_prepared('SELECT snmp_query_id
 		FROM host_template_snmp_query
 		WHERE host_template_id = ?', array($host_template_id));
@@ -335,6 +336,7 @@ function api_device_update_host_template($host_id, $host_template_id) {
 		}
 	}
 
+	/* add all graph templates assigned to the device template */
 	$graph_templates = db_fetch_assoc_prepared('SELECT graph_template_id
 		FROM host_template_graph
 		WHERE host_template_id = ?', array($host_template_id));
@@ -352,6 +354,36 @@ function api_device_update_host_template($host_id, $host_template_id) {
 				array('host_id' => $host_id, 'graph_template_id' => $graph_template['graph_template_id']));
 		}
 	}
+
+	/* remove unused graph templates not assigned to the device template */
+	$unused_graph_templates = db_fetch_assoc_prepared('
+	SELECT result.id, result.name, graph_local.id AS graph_local_id
+	    FROM (
+		    SELECT DISTINCT gt.id, gt.name
+		    FROM graph_templates AS gt
+		    INNER JOIN host_graph AS hg
+		    ON gt.id = hg.graph_template_id
+		    WHERE hg.host_id = ?
+	    ) AS result
+	    LEFT JOIN graph_local
+	    ON graph_local.graph_template_id = result.id
+	    AND graph_local.host_id = ?
+	    HAVING graph_local_id IS NULL
+	    ORDER BY result.name',
+	    array($host_id, $host_id)
+	);
+
+	if (sizeof($unused_graph_templates)) {
+		foreach ($unused_graph_templates as $unused_graph_template) {
+			db_execute_prepared('
+				DELETE
+				FROM host_graph
+				WHERE host_id = ?
+				AND graph_template_id = ?',
+				array($host_id, $unused_graph_template['id']));
+		}
+	}
+
 }
 
 /* api_device_template_sync_template - updates the device template mapping for all devices mapped to a template


### PR DESCRIPTION
When a user clicks "Sync to Device Template", if the device is currently missing any SNMP queries or graph templates associated with its assigned device template, they're added to the device's list of associated queries and/or templates automatically to reconcile this difference. This PR introduces additional code that removes **unused graph templates** that are not associated with a device's assigned device template. The intention is to help keep the device's list of associated SNMP queries and graphs more in sync with the device template, but still retain any associations that are actively being used.