### PR TITLE
fix LDAP search success log line

### DIFF
--- a/lib/ldap.php
+++ b/lib/ldap.php
@@ -494,7 +494,7 @@ class Ldap {
 						$output['dn'] = $ldap_entries['0']['dn'];
 						$output['error_num'] = '0';
 						$output['error_text'] = __('User found');
-						cacti_log("LDAP_SEARCH: User found, DN '%s'" . $output['dn'], false, 'AUTH');
+						cacti_log('LDAP_SEARCH: ' . $output['error_text'] . ', DN \'' . $output['dn'] . '\'', false, 'AUTH');
 					} elseif ($ldap_entries['count'] > 1) {
 						/* more than 1 result */
 						$output['dn'] = '';


### PR DESCRIPTION
Cacti 1.1.23 log output on successful LDAP search
```
AUTH LDAP_SEARCH: User found, DN '%s'cn=Kevin,ou=test,dc=domain,dc=com
```

log output with this change
```
AUTH LDAP_SEARCH: User found, DN 'cn=Kevin,ou=test,dc=domain,dc=com'
```