### PR TITLE
Change font name from Ariel to Arial

### DIFF
--- a/include/themes/classic/rrdtheme.php
+++ b/include/themes/classic/rrdtheme.php
@@ -11,15 +11,15 @@
 #$rrdcolors['frame']  = '2C4D43';
 
 # RRDtool graph fonts in RRDtool 1.2+
-#$rrdfonts['title']['font']     = 'Ariel';
+#$rrdfonts['title']['font']     = 'Arial';
 #$rrdfonts['title']['size']     = '11';
-#$rrdfonts['axis']['font']      = 'Ariel';
+#$rrdfonts['axis']['font']      = 'Arial';
 #$rrdfonts['axis']['size']      = '8';
 #$rrdfonts['legend']['font']    = 'Courier';
 #$rrdfonts['legend']['size']    = '8';
-#$rrdfonts['unit']['font']      = 'Ariel';
+#$rrdfonts['unit']['font']      = 'Arial';
 #$rrdfonts['unit']['size']      = '8';
-#$rrdfonts['watermark']['font'] = 'Ariel';
+#$rrdfonts['watermark']['font'] = 'Arial';
 #$rrdfonts['watermark']['size'] = '6';
 
 # Only supported in RRDtool 1.4+

--- a/include/themes/dark/rrdtheme.php
+++ b/include/themes/dark/rrdtheme.php
@@ -11,15 +11,15 @@ $rrdcolors['arrow']  = '2C4D43';
 $rrdcolors['frame']  = '060606';
 
 # RRDtool graph fonts in RRDtool 1.2+
-$rrdfonts['title']['font']     = 'Ariel';
+$rrdfonts['title']['font']     = 'Arial';
 $rrdfonts['title']['size']     = '11';
-$rrdfonts['axis']['font']      = 'Ariel';
+$rrdfonts['axis']['font']      = 'Arial';
 $rrdfonts['axis']['size']      = '8';
 $rrdfonts['legend']['font']    = 'Courier';
 $rrdfonts['legend']['size']    = '8';
-$rrdfonts['unit']['font']      = 'Ariel';
+$rrdfonts['unit']['font']      = 'Arial';
 $rrdfonts['unit']['size']      = '8';
-$rrdfonts['watermark']['font'] = 'Ariel';
+$rrdfonts['watermark']['font'] = 'Arial';
 $rrdfonts['watermark']['size'] = '6';
 
 # Only supported in RRDtool 1.4+

--- a/include/themes/modern/rrdtheme.php
+++ b/include/themes/modern/rrdtheme.php
@@ -11,15 +11,15 @@ $rrdcolors['arrow']  = '2C4D43';
 $rrdcolors['frame']  = '2C4D43';
 
 # RRDtool graph fonts in RRDtool 1.2+
-$rrdfonts['title']['font']     = 'Ariel';
+$rrdfonts['title']['font']     = 'Arial';
 $rrdfonts['title']['size']     = '11';
-$rrdfonts['axis']['font']      = 'Ariel';
+$rrdfonts['axis']['font']      = 'Arial';
 $rrdfonts['axis']['size']      = '8';
 $rrdfonts['legend']['font']    = 'Courier';
 $rrdfonts['legend']['size']    = '8';
-$rrdfonts['unit']['font']      = 'Ariel';
+$rrdfonts['unit']['font']      = 'Arial';
 $rrdfonts['unit']['size']      = '8';
-$rrdfonts['watermark']['font'] = 'Ariel';
+$rrdfonts['watermark']['font'] = 'Arial';
 $rrdfonts['watermark']['size'] = '6';
 
 # Only supported in RRDtool 1.4+

--- a/include/themes/paper-plane/rrdtheme.php
+++ b/include/themes/paper-plane/rrdtheme.php
@@ -11,15 +11,15 @@ $rrdcolors['arrow']  = '2C4D43';
 $rrdcolors['frame']  = '060606';
 
 # RRDtool graph fonts in RRDtool 1.2+
-$rrdfonts['title']['font']     = 'Ariel';
+$rrdfonts['title']['font']     = 'Arial';
 $rrdfonts['title']['size']     = '11';
-$rrdfonts['axis']['font']      = 'Ariel';
+$rrdfonts['axis']['font']      = 'Arial';
 $rrdfonts['axis']['size']      = '8';
 $rrdfonts['legend']['font']    = 'Courier';
 $rrdfonts['legend']['size']    = '8';
-$rrdfonts['unit']['font']      = 'Ariel';
+$rrdfonts['unit']['font']      = 'Arial';
 $rrdfonts['unit']['size']      = '8';
-$rrdfonts['watermark']['font'] = 'Ariel';
+$rrdfonts['watermark']['font'] = 'Arial';
 $rrdfonts['watermark']['size'] = '6';
 
 # Only supported in RRDtool 1.4+

--- a/include/themes/paw/rrdtheme.php
+++ b/include/themes/paw/rrdtheme.php
@@ -11,15 +11,15 @@ $rrdcolors['arrow']  = '2C4D43';
 $rrdcolors['frame']  = '2C4D43';
 
 # RRDtool graph fonts in RRDtool 1.2+
-$rrdfonts['title']['font']     = 'Ariel';
+$rrdfonts['title']['font']     = 'Arial';
 $rrdfonts['title']['size']     = '11';
-$rrdfonts['axis']['font']      = 'Ariel';
+$rrdfonts['axis']['font']      = 'Arial';
 $rrdfonts['axis']['size']      = '8';
 $rrdfonts['legend']['font']    = 'Courier';
 $rrdfonts['legend']['size']    = '8';
-$rrdfonts['unit']['font']      = 'Ariel';
+$rrdfonts['unit']['font']      = 'Arial';
 $rrdfonts['unit']['size']      = '8';
-$rrdfonts['watermark']['font'] = 'Ariel';
+$rrdfonts['watermark']['font'] = 'Arial';
 $rrdfonts['watermark']['size'] = '6';
 
 # Only supported in RRDtool 1.4+

--- a/include/themes/sunrise/rrdtheme.php
+++ b/include/themes/sunrise/rrdtheme.php
@@ -11,15 +11,15 @@ $rrdcolors['arrow']  = '2C4D43';
 $rrdcolors['frame']  = '060606';
 
 # RRDtool graph fonts in RRDtool 1.2+
-$rrdfonts['title']['font']     = 'Ariel';
+$rrdfonts['title']['font']     = 'Arial';
 $rrdfonts['title']['size']     = '11';
-$rrdfonts['axis']['font']      = 'Ariel';
+$rrdfonts['axis']['font']      = 'Arial';
 $rrdfonts['axis']['size']      = '8';
 $rrdfonts['legend']['font']    = 'Courier';
 $rrdfonts['legend']['size']    = '8';
-$rrdfonts['unit']['font']      = 'Ariel';
+$rrdfonts['unit']['font']      = 'Arial';
 $rrdfonts['unit']['size']      = '8';
-$rrdfonts['watermark']['font'] = 'Ariel';
+$rrdfonts['watermark']['font'] = 'Arial';
 $rrdfonts['watermark']['size'] = '6';
 
 # Only supported in RRDtool 1.4+


### PR DESCRIPTION
- The font name was changed from Ariel to Arial in:
  include/themes/classic/rrdtheme.php
  include/themes/dark/rrdtheme.php
  include/themes/modern/rrdtheme.php
  include/themes/paw/rrdtheme.php
  include/themes/sunrise/rrdtheme.php
  include/themes/paper-plane/rrdtheme.php