### PR TITLE
Ensure the last poller run includes the mibs option if required.

### DIFF
--- a/poller.php
+++ b/poller.php
@@ -487,7 +487,7 @@ while ($poller_runs_completed < $poller_runs) {
 		if ($host_count > 1) {
 			$last_host = $item['id'];
 
-			exec_background($command_string, "$extra_args --poller=$poller_id --first=$first_host --last=$last_host");
+			exec_background($command_string, "$extra_args --poller=$poller_id --first=$first_host --last=$last_host" . ($mibs ? ' --mibs':''));
 			usleep(100000);
 
 			$started_processes++;


### PR DESCRIPTION
Using cacti 1.1.26 we noticed that one polled device never had its uptime updated. SNMP was returning the correct uptime, but cacti was not displaying it in the 'console->management->devices' page.
We traced this to poller.php, and by using some log statements were able to see that the final call to cmd.php (in our case) did not include the '--mibs' option. Hence the devices system info, including the uptime, were never updated in the database.
This commit adds the mibs option into the called command line.