### PR TITLE
Fix issue 1106 - Graph Filters: template filter have empty value

### DIFF
--- a/graph_view.php
+++ b/graph_view.php
@@ -533,20 +533,22 @@ case 'list':
 							if (sizeof($graph_templates)) {
 								$selected    = explode(',', get_request_var('graph_template_id'));
 								foreach ($graph_templates as $gt) {
-									$found = db_fetch_cell_prepared('SELECT id
-										FROM graph_local
-										WHERE graph_template_id = ? LIMIT 1',
-										array($gt['id']));
+									if ($gt['id'] != 0) {
+										$found = db_fetch_cell_prepared('SELECT id
+											FROM graph_local
+											WHERE graph_template_id = ? LIMIT 1',
+											array($gt['id']));
 
-									if ($found) {
-										print "<option value='" . $gt['id'] . "'";
-										if (sizeof($selected)) {
-											if (in_array($gt['id'], $selected)) {
-												print ' selected';
+										if ($found) {
+											print "<option value='" . $gt['id'] . "'";
+											if (sizeof($selected)) {
+												if (in_array($gt['id'], $selected)) {
+													print ' selected';
+												}
 											}
+											print '>';
+											print $gt['name'] . "</option>\n";
 										}
-										print '>';
-										print $gt['name'] . "</option>\n";
 									}
 								}
 							}


### PR DESCRIPTION
he filter uses index 0 as "All Graphs and Templates" but then searches graph_local for matches against graph_template_id. However, if index 0 is passed as a variable, it is also used in the search. Now when I looked at my database, the following entry existed:

```
select * from graph_local where graph_template_id = 0;
+------+-------------------+---------+---------------+---------------------+------------+
| id   | graph_template_id | host_id | snmp_query_id | snmp_query_graph_id | snmp_index |
+------+-------------------+---------+---------------+---------------------+------------+
| 1837 |                 0 |       0 |             0 |                   0 |            |
+------+-------------------+---------+---------------+---------------------+------------+

```
Therefore, it displays an index, but can't get a name for the template since there is no template with ID 0.

```
select * from graph_templates where id = 0;
Empty set (0.00 sec)
```

Added code to check for a zero value and only search the databsae if a value is present.