### PR TITLE
Fixes for issues #1084, #1106 and #1116

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # Ignore Cacti config
 include/config.php
 # Ignore Cacti log files
-log/cacti.log
+log/**
 # Ignore Cacti rrd files
 rra/**
 # Ignore Cacti cache files (comment out to commit new directory)

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,9 @@
 Cacti CHANGELOG
 
 1.1.29
+-issue#1084: Fix issue with Graph Tree Branch not properly populating when editing report item
+-issue#1106: Fix issue with Template Filters having empty row
+-issue#1116: Fix issue with filters not allowing "None" or "All" when editing report item
 -issue: New Graph pagenation and filter reset
 
 1.1.28

--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -230,17 +230,23 @@ if (isset_request_var('item_id')) {
 }
 
 /* get the hosts sql first */
-$hosts = array();
-if (isset_request_var('host_template_id') && get_filter_request_var('host_template_id') > 0) {
-	$hosts = array_rekey(
-		get_allowed_devices('h.host_template_id =' . get_request_var('host_template_id')),
-		'id', 'description'
-	);
+$hosts = null;
+if (isset_request_var('host_template_id')) {
+	if (get_filter_request_var('host_template_id') > 0) {
+		$hosts = array_rekey(
+			get_allowed_devices('h.host_template_id =' . get_request_var('host_template_id')),
+			'id', 'description'
+		);
+	}
 } elseif (sizeof($report_item) && $report_item['host_template_id'] > 0) {
 	$hosts = array_rekey(
 		get_allowed_devices('h.host_template_id =' . $report_item['host_template_id']),
 		'id', 'description'
 	);
+}
+
+if ($hosts == null) {
+	$hosts = array_rekey(get_allowed_devices(),'id','description');
 }
 
 $graph_templates = array();
@@ -258,20 +264,26 @@ if (isset_request_var('host_id') && get_filter_request_var('host_id') > 0) {
 
 $sql_where = '';
 $graphs    = array();
-if (isset_request_var('host_template_id') && get_filter_request_var('host_template_id') > 0) {
-	$sql_where = 'h.host_template_id=' . get_request_var('host_template_id');
+if (isset_request_var('host_template_id')) {
+	if (get_filter_request_var('host_template_id') > 0) {
+		$sql_where = 'h.host_template_id=' . get_request_var('host_template_id');
+	}
 } elseif (sizeof($report_item) && $report_item['host_template_id'] > 0) {
 	$sql_where = 'h.host_template_id=' . $report_item['host_template_id'];
 }
 
-if (isset_request_var('host_id') && get_filter_request_var('host_id') > 0) {
-	$sql_where .= ($sql_where != '' ? ' AND ':'') . 'gl.host_id=' . get_request_var('host_id');
+if (isset_request_var('host_id')) {
+	if (get_filter_request_var('host_id') > 0) {
+		$sql_where .= ($sql_where != '' ? ' AND ':'') . 'gl.host_id=' . get_request_var('host_id');
+	}
 } elseif (sizeof($report_item) && $report_item['host_id'] > 0) {
 	$sql_where .= ($sql_where != '' ? ' AND ':'') . 'gl.host_id=' . $report_item['host_id'];
 }
 
-if (isset_request_var('graph_template_id') && get_filter_request_var('graph_template_id') > 0) {
-	$sql_where .= ($sql_where != '' ? ' AND ':'') . 'gl.graph_template_id=' . get_request_var('graph_template_id');
+if (isset_request_var('graph_template_id')) {
+	if (get_filter_request_var('graph_template_id') > 0) {
+		$sql_where .= ($sql_where != '' ? ' AND ':'') . 'gl.graph_template_id=' . get_request_var('graph_template_id');
+	}
 } elseif (sizeof($report_item) && $report_item['graph_template_id'] > 0) {
 	$sql_where .= ($sql_where != '' ? ' AND ':'') . 'gl.graph_template_id=' . $report_item['graph_template_id'];
 }
@@ -291,6 +303,20 @@ if ($sql_where != '') {
 
 $trees = array_rekey(
 	get_allowed_trees(),
+	'id', 'name'
+);
+
+$sql_where = '';
+if (isset_request_var('tree_id')) {
+	if (get_filter_request_var('tree_id') > 0) {
+		$sql_where .= ($sql_where != '' ? ' AND ':'') . 'gt.id=' . get_request_var('tree_id');
+	}
+} elseif (sizeof($report_item) && $report_item['tree_id'] > 0) {
+	$sql_where .= ($sql_where != '' ? ' AND ':'') . 'gt.id=' . $report_item['tree_id'];
+}
+
+$branches = array_rekey(
+	get_allowed_branches($sql_where),
 	'id', 'name'
 );
 
@@ -316,11 +342,14 @@ $fields_reports_item_edit = array(
 	),
 	'branch_id' => array(
 		'friendly_name' => __('Graph Tree Branch'),
-		'method' => 'drop_sql',
+		'method' => 'drop_array',
 		'default' => REPORTS_TREE_NONE,
 		'none_value' => __('All'),
 		'description' => __('Select a Tree Branch to use.'),
 		'value' => '|arg1:branch_id|',
+		'on_change' => 'applyChange(document.reports_item_edit)',
+		'array' => $branches
+/*
 		'sql' => "(SELECT id, CONCAT('" . __('Branch:') . " ', title) AS name
 			FROM graph_tree_items
 			WHERE graph_tree_id=|arg1:tree_id| AND host_id=0 AND local_graph_id=0
@@ -335,6 +364,7 @@ $fields_reports_item_edit = array(
 			AND host.id IN(" . implode(',', array_keys(array_rekey(get_allowed_devices(), 'id', 'description'))) . ")
 			GROUP BY name)
 			ORDER BY name"
+*/
 	),
 	'tree_cascade' => array(
 		'friendly_name' => __('Cascade to Branches'),
@@ -786,6 +816,10 @@ function reports_send($id) {
 			generate_report($report, true);
 		}
 	}
+	if ($reports_item['tree_id'] == 0) {
+		$reports_item['branch_id'] = 0;
+	}
+
 }
 
 function reports_item_movedown() {
@@ -832,46 +866,21 @@ function reports_item_edit() {
 		$reports_item['host_id']   = REPORTS_HOST_NONE;
 	}
 
-	# if a different host_template_id was selected, use it
-	if (isset_request_var('item_id')) {
+	// if a different item_type was selected, use it
+	if (isset_request_var('item_type')) {
 		if (get_filter_request_var('item_type') > 0) {
 			$reports_item['item_type'] = get_request_var('item_type');
 		}
 	}
 
-	if (isset_request_var('tree_id')) {
-		if (get_filter_request_var('tree_id') > 0) {
-			$reports_item['tree_id'] = get_request_var('tree_id');
-		}else if (!isset($reports_item['tree_id'])) {
-			$reports_item['tree_id'] = 0;
-		}
-	} else {
-		$fields_reports_item_edit['branch_id']['sql'] =
-			"SELECT '0' AS id, '" . __('None') . "' AS name";
-	}
+	$reports_item = set_reports_item_var($reports_item, 'host_id');
+	$reports_item = set_reports_item_var($reports_item, 'branch_id');
+	$reports_item = set_reports_item_var($reports_item, 'tree_id');
+	$reports_item = set_reports_item_var($reports_item, 'host_template_id');
+	$reports_item = set_reports_item_var($reports_item, 'graph_template_id');
 
-	if (isset_request_var('host_template_id')) {
-		if (get_filter_request_var('host_template_id') > 0) {
-			$reports_item['host_template_id'] = get_request_var('host_template_id');
-		}else if (!isset($reports_item['host_template_id'])) {
-			$reports_item['host_template_id'] = 0;
-		}
-	}
-
-	# if a different host_id was selected, use it
-	if (isset_request_var('host_id')) {
-		if (get_filter_request_var('host_id') > 0) {
-			$reports_item['host_id'] = get_request_var('host_id');
-		}
-	}
-
-	# if a different graph_template_id was selected, use it
-	if (isset_request_var('graph_template_id')) {
-		if (get_filter_request_var('graph_template_id') > 0) {
-			$reports_item['graph_template_id'] = get_request_var('graph_template_id');
-		}else if (!isset($reports_item['graph_template_id'])) {
-			$reports_item['graph_template_id'] = 0;
-		}
+	if ($reports_item['tree_id'] == 0) {
+		$reports_item['branch_id'] = 0;
 	}
 
 	load_current_session_value('host_template_id', 'sess_reports_edit_host_template_id', 0);
@@ -1618,4 +1627,18 @@ function reports_html_account_exists($user_id) {
 
 function reports_html_report_disable($report_id) {
 	db_execute_prepared('UPDATE reports SET enabled="" WHERE id = ?', array($report_id));
+}
+
+function set_reports_item_var($reports_item, $var_id) {
+	// if a different host_id was selected, use it
+	if (isset_request_var($var_id) && get_filter_request_var($var_id) >= 0) {
+		$reports_item[$var_id] = get_request_var($var_id);
+	}
+
+	// Check that we have set a host_id, if not, default to 0
+	if (!isset($reports_item[$var_id])) {
+		$reports_item[$var_id] = 0;
+	}
+
+	return $reports_item;
 }


### PR DESCRIPTION
Fixes for issues 1106 (Graph filters), 1084 (Tree Branch population) and 1116 (Device Template won't set to none).

### Issue #1084 - reports_admin.php - Graph Tree Branch not properly populating 
Because the tree and branches section were not using the same logic as the other code.  Added a new function get_allowed_branches() to auth.php which limits the available branches based off the get_allowed_trees() function.  

This new function is now assigned into $branches to be used instead of the SQL statement that was being used.

_The SQL may need to be double checked that I have applied it correctly._

### Issue #1106 - Graph Filters: template filter have empty value.
A blank entry was selectable in the Graph Template list because an aggregate graph existed which sets graph_template_id to 0 in graph_local.  This is a further fix on #1114 so there could be other areas were Graph Templates need to be checked.

### Issue #1116 - reports_admin.php - Unable to set Device Template to none if device selected
The filter variable on the URL was being ignored if not a positive value.  As such that means selected None or All in the lists resulted in 0 being passed and ignored.  The code then reverted back to the report_item array.

This has now been corrected to allow a zero value and use it.  If the filter variable is present, sets the report_items object on the index of the same name to the URL value. Introduced a new set_reports_items_var function to handle this replicated code.

### Other fixes
Corrected issue where item_id and item_type where being mixed up together. Assumed this should be item_type as item_id was already done earlier.  

Updated .gitignore to ignore all log files not just the cacti.log as there are now multiple dated files and potentially other plugin logs too