### PR TITLE
Fix issue #1119 - ss_host_cpu.php pulling back too much data

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.1.29
+-issue#1119: Reduced amount of data feteched for CPU usage to just the data used
 -issue#1111: Fixed PHP NOTICE when using LDAP authenication
 -issue: New Graph pagenation and filter reset
 

--- a/scripts/ss_host_cpu.php
+++ b/scripts/ss_host_cpu.php
@@ -51,8 +51,8 @@ function ss_host_cpu($hostname, $host_id, $snmp_auth, $cmd, $arg1 = '', $arg2 = 
 	}
 
 	$oids = array(
-		'index' => '.1.3.6.1.2.1.25.3.3.1',
-		'usage' => '.1.3.6.1.2.1.25.3.3.1'
+		'index' => '.1.3.6.1.2.1.25.3.3.1.2',
+		'usage' => '.1.3.6.1.2.1.25.3.3.1.2'
 		);
 
 	if (($cmd == 'index')) {
@@ -126,7 +126,7 @@ function ss_host_cpu($hostname, $host_id, $snmp_auth, $cmd, $arg1 = '', $arg2 = 
 }
 
 function ss_host_cpu_get_cpu_usage($hostname, $snmp_community, $snmp_version, $snmp_auth_username, $snmp_auth_password, $snmp_auth_protocol, $snmp_priv_passphrase, $snmp_priv_protocol, $snmp_context, $snmp_port, $snmp_timeout, $ping_retries, $max_oids) {
-	$arr = ss_host_cpu_reindex(cacti_snmp_walk($hostname, $snmp_community, '.1.3.6.1.2.1.25.3.3.1', $snmp_version, $snmp_auth_username, $snmp_auth_password, $snmp_auth_protocol, $snmp_priv_passphrase, $snmp_priv_protocol, $snmp_context, $snmp_port, $snmp_timeout, $ping_retries, $max_oids, SNMP_POLLER));
+	$arr = ss_host_cpu_reindex(cacti_snmp_walk($hostname, $snmp_community, '.1.3.6.1.2.1.25.3.3.1.2', $snmp_version, $snmp_auth_username, $snmp_auth_password, $snmp_auth_protocol, $snmp_priv_passphrase, $snmp_priv_protocol, $snmp_context, $snmp_port, $snmp_timeout, $ping_retries, $max_oids, SNMP_POLLER));
 	$return_arr = array();
 
 	$j = 0;
@@ -142,7 +142,7 @@ function ss_host_cpu_get_cpu_usage($hostname, $snmp_community, $snmp_version, $s
 }
 
 function ss_host_cpu_get_indexes($hostname, $snmp_community, $snmp_version, $snmp_auth_username, $snmp_auth_password, $snmp_auth_protocol, $snmp_priv_passphrase, $snmp_priv_protocol, $snmp_context, $snmp_port, $snmp_timeout, $ping_retries, $max_oids) {
-	$arr = ss_host_cpu_reindex(cacti_snmp_walk($hostname, $snmp_community, '.1.3.6.1.2.1.25.3.3.1', $snmp_version, $snmp_auth_username, $snmp_auth_password, $snmp_auth_protocol, $snmp_priv_passphrase, $snmp_priv_protocol, $snmp_context, $snmp_port, $snmp_timeout, $ping_retries, $max_oids, SNMP_POLLER));
+	$arr = ss_host_cpu_reindex(cacti_snmp_walk($hostname, $snmp_community, '.1.3.6.1.2.1.25.3.3.1.2', $snmp_version, $snmp_auth_username, $snmp_auth_password, $snmp_auth_protocol, $snmp_priv_passphrase, $snmp_priv_protocol, $snmp_context, $snmp_port, $snmp_timeout, $ping_retries, $max_oids, SNMP_POLLER));
 	$return_arr = array();
 
 	$j = 0;


### PR DESCRIPTION
The script is pulling back everything from the hrProcessorTable rather than just the processor usage. There appears to be a field named 'hrProcessorFrwID' being defined in the database which is actually the index field not the firmware ID