### PR TITLE
Fix for issue #1162 - Missing error messages

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#1155: Non-secure mail setting not functional due to changes in phpmailer
 -issue#1157: Resolve issue with branch permission api
 -issue#1158: Change CLOG to use regex replacement so line details are not mangled
+-issue#1162: Error messages are not display when editing a user
 -issue: basename function undefined during upgrade to 1.0.x
 -issue: Storage API and translations required for Change password function
 -issue: ALTER IGNORE still throws an error when attempting to drop the primary key

--- a/user_admin.php
+++ b/user_admin.php
@@ -52,6 +52,9 @@ if (isset_request_var('update_policy')) {
 		break;
 	case 'user_edit':
 		top_header();
+		if (is_error_message() && get_nfilter_request_var('header')) {
+			display_output_messages();
+		}
 		user_edit();
 		bottom_footer();
 


### PR DESCRIPTION
Error messages are not display when editing a user