### PR TITLE
Fix issue #1166 - Incorrect default language

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -6,6 +6,7 @@ Cacti CHANGELOG
 -issue#1158: Change CLOG to use regex replacement so line details are not mangled
 -issue#1161: Graph View regex's are not preserved during automatic page refresh
 -issue#1162: Error messages are not display when editing a user
+-issue#1166: Default language was not correctly set when editing a user
 -issue: basename function undefined during upgrade to 1.0.x
 -issue: Storage API and translations required for Change password function
 -issue: ALTER IGNORE still throws an error when attempting to drop the primary key

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -1820,7 +1820,7 @@ $settings_user = array(
             'friendly_name' => __('User Language'),
             'description' => __('Defines the preferred GUI language.'),
             'method' => 'drop_array',
-            'default' => 'us',
+            'default' => 'en',
             'array' => get_installed_locales()
             ),
 		'show_graph_title' => array(


### PR DESCRIPTION
When editing a user, default language became first in the list rather than English