### PR TITLE
Update .gitignore to ignore plugins and custom themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,17 @@ log/**
 rra/**
 # Ignore Cacti cache files (comment out to commit new directory)
 cache/**
+# Ignore Cacti plugin foldres
+plugins/**
+# Ignore Custom Cacti theme folders
+# Do not ignore standard Cacti theme folders
+include/themes/*
+!include/themes/classic
+!include/themes/dark
+!include/themes/modern
+!include/themes/paper-plane
+!include/themes/paw
+!include/themes/sunrise
+# Ignore 
+scripts/**
+


### PR DESCRIPTION
Updated .gitignore to ignore system areas that are common updated by the user
- plugins/
- include/themes/
- scripts/

This does not affect files that have already been added or the standard package themes that are distributed.  Any changes in the theme folders which cacti distributes are shown including new files.

For plugins/scripts, new files are not automatically listed any more, but can be manually added if required.

This change prevents a number of files showing up when I'm testing a lot of add-ons but checking changes to the base system.