### PR TITLE
Fix for issue #1202 and #629

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -10,6 +10,7 @@ Cacti CHANGELOG
 -issue#1189: Allow ability to sort tree list by name asc/desc
 -issue#1190: When Enabling, Disabling, Uninstalling plugin, you should page refresh
 -issue#1191: Tree sequences were not set or checked
+-issue#1202: Fix backspace functionality on filter input boxes
 -issue: Named colors were not importing on install/upgrade
 -feature: Enhance Cacti filter API to permit more glyphs for table headers
 -feature: Add a page refresh dropdown to the Automation Networks page

--- a/include/layout.js
+++ b/include/layout.js
@@ -1328,7 +1328,7 @@ function ajaxAnchors() {
 		handlePopState();
 	});
 
-	$('#filter, #rfilter').keyup(function(event) {
+	$('#filter, #rfilter').keydown(function(event) {
 		if (event.keyCode == 8 && $(this).val() == '') {
 			handlePopState();
 		}


### PR DESCRIPTION
issue #1202 and #629: Fixes backspace functionality on filter input boxes

Note, this does NOT add backspace functionality to other stanard input boxes