### PR TITLE
Issue #1217 Allow drill down to non-system data_input's from data_template

### DIFF
--- a/data_input.php
+++ b/data_input.php
@@ -426,6 +426,11 @@ function data_edit() {
 	/* ==================================================== */
 
 	if (!isempty_request_var('id')) {
+		$data_id = get_nonsystem_data_input(get_request_var('id'));
+		if ($data_id == 0 || $data_id == NULL) {
+			header('Location: data_input.php');
+			return;
+		}
 		$data_input = db_fetch_row_prepared('SELECT * FROM data_input WHERE id = ?', array(get_request_var('id')));
 		$header_label = __('Data Input Methods [edit: %s]', html_escape($data_input['name']));
 	} else {

--- a/data_templates.php
+++ b/data_templates.php
@@ -485,7 +485,7 @@ function template_rrd_add() {
 }
 
 function template_edit() {
-	global $struct_data_source, $struct_data_source_item, $data_source_types, $fields_data_template_template_edit, $fields_host_edit;
+	global $struct_data_source, $struct_data_source_item, $data_source_types, $fields_data_template_template_edit, $fields_host_edit, $hash_system_data_inputs;
 
 	/* ================= input validation ================= */
 	get_filter_request_var('id');
@@ -497,6 +497,32 @@ function template_edit() {
 		$template = db_fetch_row_prepared('SELECT * FROM data_template WHERE id = ?', array(get_request_var('id')));
 
 		$header_label = __('Data Templates [edit: %s]', html_escape($template['name']));
+
+		?>
+		<table style='width:100%'>
+			<tr>
+				<td class='textInfo left' style='vertical-align:top;'>
+					<?php print html_escape($template['name']);?>
+				</td>
+				<td class='textInfo right' style='vertical-align:top;'>
+					<?php
+						$data_input_id = 0;
+						if (!empty($template_data['data_input_id'])) {
+							$data_input_id = get_nonsystem_data_input($template_data['data_input_id']);
+							if (!isset($data_input_id) || $data_input_id == NULL) {
+								$data_input_id = 0;
+							}
+						}
+
+						if ($data_input_id > 0) {
+							?><span class='linkMarker'>*</span><a class='hyperLink' href='<?php print htmlspecialchars('data_input.php?action=edit&id=' . $data_input_id);?>'><?php print __('Edit Data Input Method.');?></a><br><?php
+						}
+					?>
+				</td>
+			</tr>
+		</table>
+		<br>
+		<?php
 	} else {
 		$header_label = __('Data Templates [new]');
 	}

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -18,6 +18,7 @@ Cacti CHANGELOG
 -issue#1212: Cacti breadcrumbs don't handle External links correctly
 -issue#1213: PHPMailer trying TLS despite SMTPSecure setting
 -issue#1215: Make installation pages format better and display version
+-issue#1217: Allow drill down to non-system data_input's from data_template
 -issue: Named colors fail to import on install or upgrade
 -issue: Drag and Drop issues on multiple pages could corrupt sequencing
 -feature: Enhance filter to permit more glyphs for table headers

--- a/include/global_arrays.php
+++ b/include/global_arrays.php
@@ -1083,6 +1083,14 @@ $hash_type_names = array(
 	'vdef_item'            => __('VDEF Item')
 );
 
+$hash_system_data_inputs = array(
+	'3eb92bb845b9660a7445cf9740726522', // Get SNMP Data
+	'bf566c869ac6443b0c75d1c32b5a350e', // Get SNMP Data (Indexed)
+	'80e9e4c4191a5da189ae26d0e237f015', // Get Script Data (Indexed)
+	'332111d8b54ac8ce939af87a7eac0c06'  // Get Script Server Data (Indexed)
+);
+
+
 $host_struc = array(
 	'host_template_id',
 	'description',

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5004,3 +5004,12 @@ function cacti_gethostbyname($hostname, $type = '') {
 
 	return $hostname;
 }
+
+function get_nonsystem_data_input($data_input_id) {
+	global $hash_system_data_inputs;
+	$diid = db_fetch_cell_prepared('SELECT id FROM data_input
+					WHERE hash NOT IN ("' . implode('","', $hash_system_data_inputs) . '")
+					AND id = ?',
+					array($data_input_id));
+	return $diid;
+}


### PR DESCRIPTION
issue#1217 - Allow drill down to non-system data_input's from data_template.  This adds a new global array of system hashes for data inputs that should be excluded.  Any call to data_input with an id parameter whose hash matches one of these system hashes will redirect back to the main data input listing