### PR TITLE
Fix for Issue #1220 - Missing Header Tabs in Paw/Paper Plane

### DIFF
--- a/include/themes/paper-plane/main.css
+++ b/include/themes/paper-plane/main.css
@@ -1810,7 +1810,7 @@ div#gtabs {
 }
 
 .maintabs nav {
-	display: none;
+	display: block;
 }
 
 .maintabs li {

--- a/include/themes/paw/main.css
+++ b/include/themes/paw/main.css
@@ -1642,7 +1642,7 @@ div#gtabs {
 }
 
 .maintabs nav {
-	display: none;
+	display: block;
 }
 
 .maintabs li {


### PR DESCRIPTION
issue-#1220 Paw and Paper Plane themes are missing header tabs in latest release (1.1.31).  This fixes the issue but may cause other layout issues.