### PR TITLE
Fix typo of 'locale' in global_languages.php during #1166

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 
 1.1.32
 -issue#969: Undefined index: color_id / task_item when viewing graphs
+-issue#1166: Fix typo of 'locale' in global_languages.php
 -issue#1222: Graphs with large number of items causes RRDTool to error
 -issue#1230: PHP Fatal error: Call to undefined function get_max_tree_sequence()
 -issue#1238: SNMP functions fail to handle "Invalid object identifier" error

--- a/include/global_languages.php
+++ b/include/global_languages.php
@@ -76,7 +76,7 @@ if (isset($_REQUEST['language']) && isset($lang2locale[$_REQUEST['language']])) 
 		$accepted = (isset($lang2locale[$accepted])) ? $accepted : str_replace(strstr($accepted, '-'), '', $accepted);
 
 		if (isset($lang2locale[$accepted])) {
-			$cacti_local_set = true;
+			$cacti_locale_set = true;
 			$cacti_locale = $accepted;
 			$cacti_country = $lang2locale[$accepted]['country'];
 		}
@@ -89,7 +89,7 @@ if (isset($_REQUEST['language']) && isset($lang2locale[$_REQUEST['language']])) 
 		}
 
 		if (isset($lang2locale[$accepted])) {
-			$cacti_local_set = true;
+			$cacti_locale_set = true;
 			$cacti_locale = $accepted;
 			$cacti_country = $lang2locale[$accepted]['country'];
 		}


### PR DESCRIPTION
Whilst creating a test language page, I noticed I introduced a typo in the "cacti_locale_set" variable.  This fix corrects that issue and corrects the language detection.