### PR TITLE
Fix for Issue #1260 - Missing TTF functions

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 
 1.1.34
 -issue#1258: cacti.sql does not appear to be up to date for all tables
+-issue#1260: Tabs should now display correctly in classic mode when TrueType is not available
 -issue#1261: Automatic logout should not fire when using Web Basic Authentication
 
 1.1.33

--- a/install/index.php
+++ b/install/index.php
@@ -553,6 +553,7 @@ $enabled = '1';
 						html_start_box('<strong> ' . __('Required PHP Modules') . '</strong>', '30', 0, '', '', false);
 						html_header( array( __('Name'), __('Required'), __('Installed') ) );
 
+						form_alternate_row('phpline',true);
 						form_selectable_cell(__('PHP Version'), '');
 						form_selectable_cell('5.2.0+', '');
 						form_selectable_cell((version_compare(PHP_VERSION, '5.2.0', '<') ? "<font color=red>" . PHP_VERSION . "</font>" : "<font color=green>" . PHP_VERSION . "</font>"), '');
@@ -616,6 +617,7 @@ $enabled = '1';
 							form_end_row();
 							if (!$e['installed']) $enabled = '0';
 						}
+
 						html_end_box(false);
 
 						print '<h3>' . __('Optional PHP Module Support') .'</h3>';
@@ -627,6 +629,9 @@ $enabled = '1';
 						);
 
 						$ext = verify_php_extensions($extensions);
+						$ext[] = array('name' => 'TrueType Text', 'installed' => function_exists('imagettftext'));
+						$ext[] = array('name' => 'TrueType Box', 'installed' => function_exists('imagettfbbox'));
+
 						html_start_box('<strong> ' . __('Optional Modules') . '</strong>', '30', 0, '', '', false);
 						html_header( array( __('Name'), __('Optional'), __('Installed') ) );
 						foreach ($ext as $id => $e) {
@@ -636,6 +641,7 @@ $enabled = '1';
 							form_selectable_cell(($e['installed'] ? '<font color=green>' . __('Yes') . '</font>' : '<font color=red>' . __('No') . '</font>'), '');
 							form_end_row();
 						}
+
 						html_end_box();
 
 						print '<br>' . __('These MySQL performance tuning settings will help your Cacti system perform better without issues for a longer time.') . '<br><br>';

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -4332,48 +4332,78 @@ function get_classic_tabimage($text, $down = false) {
 		imagecolortransparent($tab,$txcol);
 
 		$white = imagecolorallocate($tab, 255, 255, 255);
+		$ttf_functions = function_exists('imagettftext') && function_exists('imagettfbbox');
 
-		foreach ($possibles as $variation) {
-			$font     = $variation[0];
-			$fontsize = $variation[1];
+		if ($ttf_functions) {
+			foreach ($possibles as $variation) {
+				$font     = $variation[0];
+				$fontsize = $variation[1];
 
-			$lines = array();
+				$lines = array();
 
-			// if no wrapping is requested, or no wrapping is possible...
-			if((!$variation[2]) || ($variation[2] && strpos($text,' ') === false)) {
-				$bounds  = imagettfbbox($fontsize, 0, $font, $text);
-				$w       = $bounds[4] - $bounds[0];
-				$h       = $bounds[1] - $bounds[5];
-				$realx   = $x - $w/2 -1;
-				$lines[] = array($text, $font, $fontsize, $realx, $y);
-				$maxw    = $w;
-			} else {
-				$texts = explode("\n", wordwrap($text, $wrapsize), 2);
-				$line  = 1;
-				$maxw  = 0;
-				foreach ($texts as $txt) {
-					$bounds  = imagettfbbox($fontsize, 0, $font, $txt);
+				// if no wrapping is requested, or no wrapping is possible...
+				if((!$variation[2]) || ($variation[2] && strpos($text,' ') === false)) {
+					$bounds  = imagettfbbox($fontsize, 0, $font, $text);
 					$w       = $bounds[4] - $bounds[0];
 					$h       = $bounds[1] - $bounds[5];
 					$realx   = $x - $w/2 -1;
-					$realy   = $y - $h * $line + 3;
-					$lines[] = array($txt, $font, $fontsize, $realx, $realy);
-					if ($maxw < $w) {
-						$maxw = $w;
-					}
+					$lines[] = array($text, $font, $fontsize, $realx, $y);
+					$maxw    = $w;
+				} else {
+					$texts = explode("\n", wordwrap($text, $wrapsize), 2);
+					$line  = 1;
+					$maxw  = 0;
+					foreach ($texts as $txt) {
+						$bounds  = imagettfbbox($fontsize, 0, $font, $txt);
+						$w       = $bounds[4] - $bounds[0];
+						$h       = $bounds[1] - $bounds[5];
+						$realx   = $x - $w/2 -1;
+						$realy   = $y - $h * $line + 3;
+						$lines[] = array($txt, $font, $fontsize, $realx, $realy);
+						if ($maxw < $w) {
+							$maxw = $w;
+						}
 
-					$line--;
+						$line--;
+					}				
+				}
+
+				if($maxw<$wlimit) break;
+			}
+		} else {
+			while ($text > '') {
+				for ($fontid = 5; $fontid>0; $fontid--) {
+					$fontw = imagefontwidth($fontid);
+					$fonth = imagefontheight($fontid);
+					$realx = ($w - ($fontw * strlen($text)))/2;
+					$realy = ($h - $fonth - 5);
+
+					// Since we can't use FreeType, lets use a fixed location
+					$lines = array();
+					$lines[] = array($text, $fontid, 0, $realx, $realy);
+
+					if ($realx > 10 && $realy > 0) break;
+				}
+
+				if ($fontid == 0) {
+					$spacer = strrpos($text,' ');
+					if ($spacer === FALSE) {
+						$spacer = strlen($text) - 1;
+					}
+					$text = substr($text,0,$spacer);						
+//					$lines[] = array(substr($text,0,$maxtext).'.'.$w.'.'.$maxtext.'.'.$fontw, $fontid, 0, $realx, $realy);
+				} else {
+					break;
 				}
 			}
-
-			if($maxw<$wlimit) break;
 		}
 
+
 		foreach ($lines as $line) {
-			if (function_exists('imagettftext')) {
+			if ($ttf_functions) {
 				imagettftext($tab, $line[2], 0, $line[3], $line[4], $white, $line[1], $line[0]);
 			}else{
-				imagestring($tab, $line[2], $line[3], $line[4], $string, $white);
+				imagestring($tab, $line[1], $line[3], $line[4], $line[0], $white);
 			}
 		}
 


### PR DESCRIPTION
This change corrects an issue where TTF is not enabled even though GD has been enabled as described in #1260.  The code will now also list the state of TTF functionality during installation under the optional modules.

Testing can be done by modifying the either of the two function_exists() calls to an invalid function name.  If TTF is not available, the code will attempt to place the text within the Classic tab image.  It will reduce the font size, and failing that look for any available spaces, then trim back to this.  If all spaces have been used, it will start reducing characters one at a time to find a fit against any of the system fonts.