### PR TITLE
Fix for Issue #1257 - Boost logging corrected

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.1.34
+-issue#1257: Boost no longer ignores logging levels when updating single local data id's
 -issue#1258: cacti.sql does not appear to be up to date for all tables
 -issue#1261: Automatic logout should not fire when using Web Basic Authentication
 

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -691,10 +691,10 @@ function boost_process_poller_output($local_data_id = '', $rrdtool_pipe = '') {
 	}
 
 	if ($single_local_data_id) {
-		$log_verbosity = read_config_option('log_verbosity');
+		$log_verbosity = POLLER_VERBOSITY_DEBUG;
 
 		if ($debug) {
-			$log_verbosity = POLLER_VERBOSITY_DEBUG;
+			$log_verbosity = POLLER_VERBOSITY_LOW;
 		}
 
 		cacti_log("NOTE: Updating Local Data ID:'$local_data_id', Total of '" . sizeof($results) . "' Updates to Process", false, 'BOOST', $log_verbosity);


### PR DESCRIPTION
When deciding on a logging level boost was incorrectly reading the configuration option resulting in always logging as per #1257