### PR TITLE
Fix for issue #1293: Correctly identify if command 'snmpbulkwalk' is available

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -10,6 +10,7 @@ Cacti CHANGELOG
 -issue#1268: Regex filters will now correctly filter
 -issue#1274: Host CPU script checks value prescence to prevent unnecessary errors
 -issue#1275: Fix issues with authPriv not supplying username/password
+-issue#1293: Correctly identify if command 'snmpbulkwalk' is available
 -issue: When a checkbox table has no rows, the checkbox is resizable
 
 1.1.33

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -856,7 +856,7 @@ function snmp_get_method($type = 'walk', $version = 1, $context = '', $engineid 
 		return SNMP_METHOD_BINARY;
 	} elseif ($version == 3 && $engineid != '') {
 		return SNMP_METHOD_BINARY;
-	} elseif ($type == 'walk' && file_exists('path_snmpbulkwalk')) {
+	} elseif ($type == 'walk' && file_exists(read_config_option('path_snmpbulkwalk'))) {
 		return SNMP_METHOD_BINARY;
 	} elseif (function_exists('snmpget') && $version == 1) {
 		return SNMP_METHOD_PHP;


### PR DESCRIPTION
This corrects a problem with the `snmp_get_method` as described in issue #1293.  This does not fix the issue of increasing OID checks if you are using the PHP methods.