### PR TITLE
Issue #1286: Correct CHUNKED_ENCODING error 

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,5 +1,8 @@
 Cacti CHANGELOG
 
+1.1.35
+-issue#1286: Correct CHUNKED_ENCODING error when retrieving graph with some browsers
+
 1.1.34
 -issue#1040: Correct sizeof() issues with get_data_query_array() and get_graph_group() results
 -issue#1195: Convert Cacti's use of $.get(), $.getJSON, and $.post() to $.ajax() in order to trap and handle errors

--- a/graph_json.php
+++ b/graph_json.php
@@ -218,9 +218,9 @@ if ($output !== false && $output != '') {
 
 	ob_start();
 
-    $graph_data_array['get_error'] = true;
+	$graph_data_array['get_error'] = true;
 
-    rrdtool_function_graph(get_request_var('local_graph_id'), $rra_id, $graph_data_array);
+	rrdtool_function_graph(get_request_var('local_graph_id'), $rra_id, $graph_data_array);
 
 	$error = ob_get_contents();
 
@@ -260,5 +260,8 @@ if ($output !== false && $output != '') {
 }
 
 header('Content-Type: application/json');
-print json_encode($oarray);
+$json = json_encode($oarray);
+header('Content-Length: '.strlen($json));
+echo $json;
+
 

--- a/graph_json.php
+++ b/graph_json.php
@@ -261,7 +261,7 @@ if ($output !== false && $output != '') {
 
 header('Content-Type: application/json');
 $json = json_encode($oarray);
-header('Content-Length: '.strlen($json));
-echo $json;
+header('Content-Length: ' . strlen($json));
+print $json;
 
 


### PR DESCRIPTION
When calling graph_json.php to retrieve a graph, some browsers generate a CHUNKED_ENCODING error.  

To prevent this, the http header `Content-Length` is now set to the length of the JSON string that is produced by PHP.  This removes the http header `Encoding-Type: Chunked` from being automatically generated due to the output buffer of the server being less than the data output by PHP.