### PR TITLE
Further changes for #1323 to disable form data until checked

### DIFF
--- a/include/layout.js
+++ b/include/layout.js
@@ -2973,3 +2973,12 @@ function checkSNMPPassphraseConfirm(type) {
 	}
 }
 
+function toggleCheckBoxInput(e) {
+	var formDataName = e.id;
+	var formData = $('#'+formDataName+'_formdata');
+	if (formData.hasClass('ui-state-disabled')) {
+		formData.removeClass('ui-state-disabled');
+	} else {
+		formData.addClass('ui-state-disabled');
+	}
+}

--- a/include/main.css
+++ b/include/main.css
@@ -777,3 +777,7 @@ div.calendar { position: relative; }
 @media print {
 	.noprint { display:none }
 }
+
+.formData.ui-state-disabled {
+	pointer-events: none;
+}

--- a/include/themes/classic/main.css
+++ b/include/themes/classic/main.css
@@ -1902,3 +1902,8 @@ tr#realtime td:first-child {
 .graphWrapper {
 	position: relative;
 }
+
+.formData.ui-state-disabled {
+	pointer-events: none;
+}
+

--- a/include/themes/dark/main.css
+++ b/include/themes/dark/main.css
@@ -2152,3 +2152,8 @@ tr#realtime td:first-child {
 .graphWrapper {
 	position: relative;
 }
+
+.formData.ui-state-disabled {
+	pointer-events: none;
+}
+

--- a/include/themes/modern/main.css
+++ b/include/themes/modern/main.css
@@ -2247,3 +2247,13 @@ tr#realtime td:first-child {
 .note a:hover {
 	text-decoration: underline;
 }
+
+.formData.ui-state-disabled {
+	pointer-events: none;
+}
+
+
+.formData.ui-state-disabled {
+	pointer-events: none;
+}
+

--- a/include/themes/paper-plane/main.css
+++ b/include/themes/paper-plane/main.css
@@ -2205,3 +2205,8 @@ tr#realtime td:first-child {
 	overflow-y: scroll;
 	overflow-x: hidden;
 }
+
+.formData.ui-state-disabled {
+	pointer-events: none;
+}
+

--- a/include/themes/paw/main.css
+++ b/include/themes/paw/main.css
@@ -2015,3 +2015,8 @@ tr#realtime td:first-child {
 	overflow-y: scroll;
 	overflow-x: hidden;
 }
+
+.formData.ui-state-disabled {
+	pointer-events: none;
+}
+

--- a/include/themes/sunrise/main.css
+++ b/include/themes/sunrise/main.css
@@ -2320,3 +2320,9 @@ tr#realtime td:first-child {
 	overflow-y: auto;
 	overflow-x: hidden;
 }
+
+
+.formData.ui-state-disabled {
+	pointer-events: none;
+}
+

--- a/lib/html_form.php
+++ b/lib/html_form.php
@@ -81,6 +81,10 @@ function draw_edit_form($array) {
 				print "<div class='formFieldName'>";
 
 				if (isset($field_array['sub_checkbox'])) {
+					if (!isset($field_array['sub_checkbox']['on_change'])) {
+						$field_array['sub_checkbox']['on_change'] = "toggleCheckBoxInput(this);";
+						$has_checkbox = $field_array['sub_checkbox']['name'];
+					}
 					form_checkbox($field_array['sub_checkbox']['name'],
 						$field_array['sub_checkbox']['value'],
 						'',
@@ -107,7 +111,10 @@ function draw_edit_form($array) {
 				print '</div>';
 
 				// New form column for content
-				print '<div class="formColumnRight"><div class="formData">';
+				if (isset($has_checkbox)) {
+					$has_checkbox = ' ui-state-disabled" id="'.$has_checkbox.'_formdata"';
+				}
+				print '<div class="formColumnRight"><div class="formData'.$has_checkbox.'">';
 
 				draw_edit_control($field_name, $field_array);
 
@@ -1245,4 +1252,5 @@ function form_end($ajax = true) {
 		<?php
 	}
 }
+
 


### PR DESCRIPTION
This provides extra functionality on top of the changes already made for #1323 to prevent being able to click on form data items until the checkbox is actually checked.  This manages this by using the smallest possible change of adding the ui-state-disabled class to the formData DIV and making a combo class selection of formData+ui-state-disabled prevent any pointer-events from working.

Haven't tested it in all browsers, but works well in Chrome.