### PR TITLE
Fix for issue #1331: Maintenance time should occur at midnight

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,5 +1,8 @@
 Cacti CHANGELOG
 
+1.1.36
+-issue#1331: Maintenance time should occur at midnight, not random time in day
+
 1.1.35
 -issue#114: *all_max_peak* percentile calculations incorrect
 -issue#430: Pressing Back often fails to work as expected

--- a/poller_maintenance.php
+++ b/poller_maintenance.php
@@ -166,7 +166,8 @@ if (read_config_option('logrotate_enabled') == 'on') {
 	$date_last = (new DateTime())->setTimestamp($last)->setTime(0,0,59)->modify('-1 minute');
 
 	// Make sure we clone the last date, or we end up modifying the same object!
-	$date_next = (clone $date_last)->modify('+'.$frequency.'day');
+	$date_next = clone $date_last;
+	$date_next->modify('+'.$frequency.'day');
 
 	if ($date_next < $date_now) {
 		logrotate_rotatenow();

--- a/poller_maintenance.php
+++ b/poller_maintenance.php
@@ -163,7 +163,7 @@ if (read_config_option('logrotate_enabled') == 'on') {
 	$date_last = (new DateTime())->setTimestamp($last)->setTime(0,0,59)->modify('-1minute');
 	$date_next = $date_last->modify('+'.$frequency.'day');
 
-	if ($date_next <= $date_now) {
+	if ($date_next < $date_now) {
 		logrotate_rotatenow();
 	}
 }

--- a/poller_maintenance.php
+++ b/poller_maintenance.php
@@ -150,12 +150,20 @@ if (read_config_option('logrotate_enabled') == 'on') {
 	if (empty($frequency)) {
 		$frequency = 1;
 	}
+
 	$last = read_config_option('logrotate_lastrun');
 	$now  = time();
 
 	if (empty($last)) {
-		set_config_option('logrotate_lastrun', time());
-	} elseif (($last + ($frequency * 86400)) < $now) {
+		$last = time();
+		set_config_option('logrotate_lastrun', $time);
+	}
+
+	$date_now = (new DateTime())->setTimestamp($now);
+	$date_last = (new DateTime())->setTimestamp($last)->setTime(0,0,59)->modify('-1minute');
+	$date_next = $date_last->modify('+'.$frequency.'day');
+
+	if ($date_next <= $date_now) {
 		logrotate_rotatenow();
 	}
 }
@@ -204,8 +212,9 @@ function logrotate_rotatenow () {
 		$log = $config['base_path'] . '/log/cacti.log';
 	}
 
-	set_config_option('logrotate_lastrun', time());
-
+	$run_time = time();
+	set_config_option('logrotate_lastrun', $run_time);
+	$date_log = new DateTime($run_time)->modify('-1day');
 	clearstatcache();
 
 	if (is_writable(dirname($log) . '/') && is_writable($log)) {
@@ -214,10 +223,10 @@ function logrotate_rotatenow () {
 		$group = filegroup($log);
 
 		if ($owner !== false) {
-			$ext = date('Ymd');
+			$ext = $date_log->format('Ymd');
 
 			if (file_exists($log . '-' . $ext)) {
-				$ext = date('YmdHis');
+				$ext = $date_log->format('YmdHis');
 			}
 
 			if (rename($log, $log . '-' . $ext)) {


### PR DESCRIPTION
As noted in issue #1331 rotation of logs occurs at a random time during the day resulting in confusion between which log should be referenced.  This fix should address that but is currently in testing.  I published the PR already should anyone else wish to try out this fix and report any issues.

As my rotation is set to a day, I will have to wait a couple of days to see if the issue has resolved itself.

The fix works by taking the last run time, setting the time-part to 59 seconds past midnight and then deducting 1 minute.  This leads to a time of 23:59:59 on the previous day which is compared against the current time and if less, triggers the maintenance.

eg, 
```
Time now.: 2018-02-12 11:14:26.000000
Time ran: 2018-02-11 11:45:04.000000
Time last: 2018-02-10 23:59:59.000000
Time next: 2018-02-11 23:59:59.000000 +1 days
Log Rotate is due
```

Since we aren't working in microseconds with the datetime objects, this will always cause the log to rotate at 00:00:00 of the next day.