### PR TITLE
Fix for issue #1339: first graph not displaying properly in graph view

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 1.1.36
 -issue#1334: Console->Users->(Edit) Permissions checkmark descriptions missing
 -issue#1336: Fix issue with $config not being defined
+-issue#1339: Fix issue with first graph not displaying properly in graph view
 -issue: Fixed some language string inconsistencies
 -feature: Updated Dutch translations
 

--- a/include/layout.js
+++ b/include/layout.js
@@ -2235,7 +2235,6 @@ function redrawGraph(graph_id) {
 }
 
 function initializeGraphs() {
-	$.ajaxQ.abortAll();
 	$('a[id$="_mrtg"]').unbind('click').click(function(event) {
 		event.preventDefault();
 		event.stopPropagation();


### PR DESCRIPTION
This patch corrects issues where the first graph is not always displayed in graph view when switching between tabs as identified in #1339.

I'm not sure if this may have other implications and why the ajaxQ.abortAll() is being used both outside the click and inside the click. Inside, is more understandable to cancel any ongoing ajax requests which may conflict with the graph update so this has been left in.