### PR TITLE
Feature: Allow searching of SNMP Index in View Data Query Cache

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -3,6 +3,7 @@ Cacti CHANGELOG
 -issue#1334: Console->Users->(Edit) Permissions checkmark descriptions missing
 -issue#1336: Fix issue with $config not being defined
 -issue: Fixed some language string inconsistencies
+-feature: Allow searching of SNMP Index in View Data Query Cache
 -feature: Updated Dutch translations
 
 1.1.36

--- a/utilities.php
+++ b/utilities.php
@@ -1365,8 +1365,8 @@ function utilities_view_snmp_cache() {
 						<input id='filter' type='text' size='25' value='<?php print html_escape_request_var('filter');?>'>
 					</td>
 					<td>
+						<input id='with_index' type='checkbox' onChange='applyFilter()' title='<?php print __esc('Allow the search term to include the index column');?>' <?php if (get_request_var('with_index') == 1) { print ' checked '; }?>>
 						<label for='with_index'><?php print __('Include Index') ?></label>
-						<input id='with_index' type='checkbox' onChange='applyFilter()' <?php if (get_request_var('with_index') == 1) { print ' checked '; }?>>
 					</td>
 					<?php print html_host_filter(get_request_var('host_id'));?>
 					<td>

--- a/utilities.php
+++ b/utilities.php
@@ -1274,6 +1274,10 @@ function utilities_view_snmp_cache() {
 			'default' => '',
 			'options' => array('options' => 'sanitize_search_string')
 			),
+		'with_index' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'default' => '0'
+			),
 		'host_id' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
@@ -1312,6 +1316,11 @@ function utilities_view_snmp_cache() {
 	function applyFilter() {
 		strURL  = urlPath+'utilities.php?host_id=' + $('#host_id').val();
 		strURL += '&snmp_query_id=' + $('#snmp_query_id').val();
+		if ($('#with_index').is(':checked')) {
+			strURL += '&with_index=1';
+		} else {
+			strURL += '&with_index=0';
+		}
 		strURL += '&filter=' + $('#filter').val();
 		strURL += '&rows=' + $('#rows').val();
 		strURL += '&action=view_snmp_cache';
@@ -1354,6 +1363,10 @@ function utilities_view_snmp_cache() {
 					</td>
 					<td>
 						<input id='filter' type='text' size='25' value='<?php print html_escape_request_var('filter');?>'>
+					</td>
+					<td>
+						<label for='with_index'><?php print __('Include Index') ?></label>
+						<input id='with_index' type='checkbox' onChange='applyFilter()' <?php if (get_request_var('with_index') == 1) { print ' checked '; }?>>
 					</td>
 					<?php print html_host_filter(get_request_var('host_id'));?>
 					<td>
@@ -1444,7 +1457,11 @@ function utilities_view_snmp_cache() {
 			OR sq.name LIKE '%" . get_request_var('filter') . "%'
 			OR hsc.field_name LIKE '%" . get_request_var('filter') . "%'
 			OR hsc.field_value LIKE '%" . get_request_var('filter') . "%'
-			OR hsc.oid LIKE '%" . get_request_var('filter') . "%')";
+			OR hsc.oid LIKE '%" . get_request_var('filter') . "%'";
+		if (get_request_var('with_index') == 1) {
+			$sql_where .= " OR hsc.snmp_index LIKE '%" . get_request_var('filter') . "%'";
+		}
+		$sql_where .= ")";
 	}
 
 	$total_rows = db_fetch_cell("SELECT COUNT(*)


### PR DESCRIPTION
This pull request allows the searching of SNMP Index in View Data Query Cache.  By default the search does not include the index (as per current functionality).  When ticked, includes the SNMP index in the search.

If there are no MIBs for the OID being searched against, this will likely result in the same rows being listed when the checkbox is ticked and unticked.  However, if an MIB is present then the name is displayed instead of the OID.  As a result of this, any row not showing the index value in the columns other than index will only present only when the checkbox is ticked.