### PR TITLE
Patch for issue #1338: Allow automation to be run in debug mode from GUI 

### DIFF
--- a/automation_networks.php
+++ b/automation_networks.php
@@ -359,16 +359,6 @@ function form_actions() {
 				<div class='itemlist'><ul>$networks_list</ul></div>
 				<p><input type='checkbox' id='discover_debug' name='discover_debug' value='1'>
 				<label id='discover_debug_label' for='discover_debug'>Run discover in debug mode</label></p>
-
-				<script type='javascript'>
-				$('#discover_debug_label').click(function() {
-					if($('#discover_debug').attr('checked')) {
-						$('#discover_debug').attr('checked', false);
-					} else {
-						$('#discover_debug').attr('checked', true);
-					}
-				});
-				</script>
 			</td>
 		</tr>\n";
 	} elseif (get_nfilter_request_var('drp_action') == '5') { /* cancel discovery now */

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -290,10 +290,7 @@ function form_actions() {
 					api_networks_disable($item);
 				}
 			} elseif (get_nfilter_request_var('drp_action') == '4') { /* run now */
-				$discover_debug = false;
-				if (isset_request_var('discover_debug')) {
-					$discover_debug = true;
-				}
+				$discover_debug = isset_request_var('discover_debug');
 
 				foreach($selected_items as $item) {
 					api_networks_discover($item, $discover_debug);

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -105,7 +105,7 @@ function api_networks_cancel($network_id){
 		array($network_id));
 }
 
-function api_networks_discover($network_id) {
+function api_networks_discover($network_id, $discover_debug) {
 	global $config;
 
 	$enabled   = db_fetch_cell_prepared('SELECT enabled
@@ -131,8 +131,10 @@ function api_networks_discover($network_id) {
 	if ($enabled == 'on') {
 		if (!$running) {
 			if ($config['poller_id'] == $poller_id) {
-				exec_background(read_config_option('path_php_binary'), '-q ' . read_config_option('path_webroot') . "/poller_automation.php --network=$network_id --force");
+				$args_debug = ($discover_debug) ? ' --debug' : '';
+				exec_background(read_config_option('path_php_binary'), '-q ' . read_config_option('path_webroot') . "/poller_automation.php --network=$network_id --force" . $args_debug);
 			} else {
+				$args_debug = ($discover_debug) ? '&debug=true' : '';
 				$hostname = db_fetch_cell_prepared('SELECT hostname
 					FROM poller
 					WHERE id = ?',
@@ -140,7 +142,7 @@ function api_networks_discover($network_id) {
 
 				$fgc_contextoption = get_default_contextoption(5);
 				$fgc_context       = stream_context_create($fgc_contextoption);
-				$response          = @file_get_contents(get_url_type() .'://' . $hostname . $config['url_path'] . 'remote_agent.php?action=discover&network=' . $network_id, false, $fgc_context);
+				$response          = @file_get_contents(get_url_type() .'://' . $hostname . $config['url_path'] . 'remote_agent.php?action=discover&network=' . $network_id . $args_debug, false, $fgc_context);
 			}
 		} else {
 			$_SESSION['automation_message'] = "Can Not Restart Discovery for Discovery in Progress for Network '$name'";
@@ -288,8 +290,13 @@ function form_actions() {
 					api_networks_disable($item);
 				}
 			} elseif (get_nfilter_request_var('drp_action') == '4') { /* run now */
+				$discover_debug = false;
+				if (isset_request_var('discover_debug')) {
+					$discover_debug = true;
+				}
+
 				foreach($selected_items as $item) {
-					api_networks_discover($item);
+					api_networks_discover($item, $discover_debug);
 				}
 			} elseif (get_nfilter_request_var('drp_action') == '5') { /* cancel */
 				foreach($selected_items as $item) {
@@ -353,6 +360,18 @@ function form_actions() {
 			<td class='textArea'>
 				<p>" . __('Click \'Continue\' to discover the following Network(s).') . "</p>
 				<div class='itemlist'><ul>$networks_list</ul></div>
+				<p><input type='checkbox' id='discover_debug' name='discover_debug' value='1'>
+				<label id='discover_debug_label' for='discover_debug'>Run discover in debug mode</label></p>
+
+				<script type='javascript'>
+				$('#discover_debug_label').click(function() {
+					if($('#discover_debug').attr('checked')) {
+						$('#discover_debug').attr('checked', false);
+					} else {
+						$('#discover_debug').attr('checked', true);
+					}
+				});
+				</script>
 			</td>
 		</tr>\n";
 	} elseif (get_nfilter_request_var('drp_action') == '5') { /* cancel discovery now */

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -5,6 +5,7 @@ Cacti CHANGELOG
 -issue#1331: Maintenance time should occur at midnight, not random time in day
 -issue#1334: Console->Users->(Edit) Permissions checkmark descriptions missing
 -issue#1336: Fix issue with $config not being defined
+-issue#1338: Allow automation to be run in debug mode from GUI
 -issue#1339: First graph of second page does not render
 -issue#1340: Unable to open Time Graph View in new tab
 -issue#1348: Toggle context menu of Zoom


### PR DESCRIPTION
This patch allows automation discovery to be run in debug mode from the GUI as per #1338.  Since it was only a minor change and I already had the automation knowledge in my head, figured it would be simple to add.  Debug mode also works with remote_agent.php since that already checks for the presence of "debug" and passes that onto the command line.