### PR TITLE
issue: Allow dynamic setting of from name when emailing

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -17,6 +17,7 @@ Cacti CHANGELOG
 -issue#1362: DSStats Avg/Peak function broken due to change in RRDtool processing
 -issue#1365: Plugin Management - Reject invalid folder names
 -issue#1366: Improve error/info message display
+-issue: Allow dynamic setting of from name when emailing
 -issue: Fixed some language string inconsistencies
 -issue: Update filter layout of Data Query Cache to match Poller Cache
 -issue: Remove spurious php code from checkbox area in user admin

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3594,10 +3594,16 @@ function general_header() {
 }
 
 function send_mail($to, $from, $subject, $body, $attachments = '', $headers = '', $html = false) {
+	$fromname = '';
+	if (is_array($from)) {
+		$fromname = $from[1];
+		$from     = $from[0];
+	}
+
 	if ($from == '') {
 		$from     = read_config_option('settings_from_email');
 		$fromname = read_config_option('settings_from_name');
-	} else {
+	} elseif ($fromname = '') {
 		$full_name = db_fetch_cell_prepared('SELECT full_name
 			FROM user_auth
 			WHERE email_address = ?',


### PR DESCRIPTION
Currently the mail expects only a single string meaning you can not predefine the name/email.  One place that does this currently is routerconfig, so now enable the passing of an array.