### PR TITLE
issue #1421: When SQL had all bad modes, missing variable warning was generated

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.1.37
+-issue#1421: Fix issue when SQL had all bad modes, missing variable warning was generated
 -issue: fixed typo's
 -feature: Updated Chinese Simplified translations
 -feature: Updated Dutch translations

--- a/lib/database.php
+++ b/lib/database.php
@@ -83,7 +83,7 @@ function db_connect_real($device, $user, $pass, $db_name, $db_type = 'mysql', $p
 
 			// Get rid of bad modes
 			$modes = explode(',', db_fetch_cell('SELECT @@sql_mode'));
-			$new_modes = array()
+			$new_modes = array();
 
 			foreach($modes as $mode) {
 				if (array_search($mode, $bad_modes) === false) {

--- a/lib/database.php
+++ b/lib/database.php
@@ -83,6 +83,7 @@ function db_connect_real($device, $user, $pass, $db_name, $db_type = 'mysql', $p
 
 			// Get rid of bad modes
 			$modes = explode(',', db_fetch_cell('SELECT @@sql_mode'));
+			$new_modes = array()
 
 			foreach($modes as $mode) {
 				if (array_search($mode, $bad_modes) === false) {


### PR DESCRIPTION
If all the SQL modes set by default are modes that Cacti does not want to use, an undefined variable error occurs within database.php.  The fix for #1421 is to prime the new_modes array before the loop so it exists.  If it is blank, it will be expanded as blank which is the correct setting for the current session.

