### PR TITLE
Fix issue #1426 where remote poller was not using unique filenames

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 
 1.1.37
 -issue#1421: Fix issue when SQL had all bad modes, missing variable warning was generated
+-issue#1426: Fix issue where remote poller was not using unique filenames when attempting to verify files
 -issue: fixed typo's
 -feature: Updated Chinese Simplified translations
 -feature: Updated Dutch translations

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -882,7 +882,7 @@ function resource_cache_out($type, $path) {
 										}
 									}
 
-									//unlink($tmpfile);
+									unlink($tmpfile);
 								} else {
 									cacti_log("ERROR: Unable to write file '" . $tmpfile . "' for PHP Syntax verification", false, 'POLLER');
 								}

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -875,7 +875,7 @@ function resource_cache_out($type, $path) {
 										}
 									} else {
 										cacti_log("ERROR: PHP Source File '" . $mypath . "' from Cache has an error whilst checking syntax ($exit) whilst executing: $php_path -l $tmpfile", false, 'POLLER');
-										cacti_log("ERROR: PHP Source File '" . $mypath . "': " . str_replace("\n"," ",str_replace("\n"," ", $output)), false, 'POLLER');
+										cacti_log("ERROR: PHP Source File '" . $mypath . "': " . str_replace("\n"," ",str_replace("\t"," ", $output)), false, 'POLLER');
 									}
 
 									unlink($tmpfile);

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -874,9 +874,8 @@ function resource_cache_out($type, $path) {
 											cacti_log("ERROR: Cache in cannot write to '" . $mypath . "', purge this location");
 										}
 									} else {
-										cacti_log("ERROR: PHP Source File '" . $mypath . "' from Cache has an error whilst checking syntax ($exit)!", false, 'POLLER');
-										cacti_log("ERROR: PHP Source File '" . $mypath . "' tried to execute: $php_path -l $tmpfile", false, 'POLLER');
-										cacti_log("ERROR: PHP Source File '" . $mypath . "': " . str_repalce("\n"," ",str_replace("\n"," ", $output)), false, 'POLLER');
+										cacti_log("ERROR: PHP Source File '" . $mypath . "' from Cache has an error whilst checking syntax ($exit) whilst executing: $php_path -l $tmpfile", false, 'POLLER');
+										cacti_log("ERROR: PHP Source File '" . $mypath . "': " . str_replace("\n"," ",str_replace("\n"," ", $output)), false, 'POLLER');
 									}
 
 									unlink($tmpfile);

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -876,10 +876,7 @@ function resource_cache_out($type, $path) {
 									} else {
 										cacti_log("ERROR: PHP Source File '" . $mypath . "' from Cache has an error whilst checking syntax ($exit)!", false, 'POLLER');
 										cacti_log("ERROR: PHP Source File '" . $mypath . "' tried to execute: $php_path -l $tmpfile", false, 'POLLER');
-										$lines = explode("\n",$output);
-										foreach ($lines as $line) {
-											cacti_log("ERROR: PHP Source File '" . $mypath . "': $line!", false, 'POLLER');
-										}
+										cacti_log("ERROR: PHP Source File '" . $mypath . "': " . str_repalce("\n"," ",str_replace("\n"," ", $output)), false, 'POLLER');
 									}
 
 									unlink($tmpfile);

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -860,15 +860,10 @@ function resource_cache_out($type, $path) {
 
 						/* if the file type is PHP check syntax */
 						if ($extension == 'php') {
-							if ($config['cacti_server_os'] == 'win32') {
-								$tmpfile = '%TEMP%' . DIRECTORY_SEPARATOR . 'cachecheck.php';
-								$tmpdir  = '%TEMP%';
-							} else {
-								$tmpfile = '/tmp/cachecheck.php';
-								$tmpdir  = '/tmp';
-							}
+							$tmpdir = sys_get_temp_dir();
+							$tmpfile = tempnam($tmpdir,'ccp').'.php';
 
-							if ((is_writeable($tmpdir) && !file_exists($tmpfile)) || (file_exists($tmpfile) && !is_writable($tmpfile))) {
+							if ((is_writeable($tmpdir) && !file_exists($tmpfile)) || (file_exists($tmpfile) && is_writable($tmpfile))) {
 								if (file_put_contents($tmpfile, $contents) !== false) {
 									$output = system($php_path . ' -l ' . $tmpfile, $exit);
 									if ($exit == 0) {
@@ -879,10 +874,15 @@ function resource_cache_out($type, $path) {
 											cacti_log("ERROR: Cache in cannot write to '" . $mypath . "', purge this location");
 										}
 									} else {
-										cacti_log("ERROR: PHP Source File '" . $mypath . "' from Cache has a Syntax error!", false, 'POLLER');
+										cacti_log("ERROR: PHP Source File '" . $mypath . "' from Cache has an error whilst checking syntax ($exit)!", false, 'POLLER');
+										cacti_log("ERROR: PHP Source File '" . $mypath . "' tried to execute: $php_path -l $tmpfile", false, 'POLLER');
+										$lines = explode("\n",$output);
+										foreach ($lines as $line) {
+											cacti_log("ERROR: PHP Source File '" . $mypath . "': $line!", false, 'POLLER');
+										}
 									}
 
-									unlink($tmpfile);
+									//unlink($tmpfile);
 								} else {
 									cacti_log("ERROR: Unable to write file '" . $tmpfile . "' for PHP Syntax verification", false, 'POLLER');
 								}


### PR DESCRIPTION
Fix for issue #1426 where remote poller was not using unique filenames when attempting to verify files