### PR TITLE
Further fix for "From" in emails not working properly

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -7,6 +7,7 @@ Cacti CHANGELOG
 -issue#1421: Fix issue when SQL had all bad modes, missing variable warning was generated
 -issue#1426: Fix issue where remote poller was not using unique filenames when attempting to verify files
 -issue#1432: Delete confirmation does not disappear
+-issue#1371: Further fix for #1371 due to incorrect sign usage
 -issue: Output message timer not clearing properly on page refresh
 -feature: Updated Chinese Simplified translations
 -feature: Updated Dutch translations
@@ -39,7 +40,7 @@ Cacti CHANGELOG
 -issue#1390: Plugin uninstall should prompt user before removal
 -issue#1396: Prevent installation/uninstallation of a plugin if dependency is present
 -issue#1397: Distinguish between plugin tabs and core tabs in settings
--issue: Allow dynamic setting of from name when emailing
+-issue#1371: Allow dynamic setting of from name when emailing
 -issue: Data Query Cache filter layout more consistent
 -issue: Minor plugin permissions format change
 -issue: Implementation of error handling causes errors creating New Graphs

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3598,7 +3598,7 @@ function send_mail($to, $from, $subject, $body, $attachments = '', $headers = ''
 	if ($from == '') {
 		$from     = read_config_option('settings_from_email');
 		$fromname = read_config_option('settings_from_name');
-	} elseif ($fromname = '') {
+	} elseif ($fromname == '') {
 		$full_name = db_fetch_cell_prepared('SELECT full_name
 			FROM user_auth
 			WHERE email_address = ?',
@@ -3611,8 +3611,7 @@ function send_mail($to, $from, $subject, $body, $attachments = '', $headers = ''
 		}
 	}
 
-	$from = array($from, $fromname);
-
+	$from = array(0 => $from, 1 => $fromname);
 	return mailer($from, $to, '', '', '', $subject, $body, '', $attachments, $headers, $html);
 }
 


### PR DESCRIPTION
This fixes the issue where the from name is always wiped out and the default cacti from name is used instead.