### PR TITLE
Incorrect default found path of spine

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -8,6 +8,7 @@ Cacti CHANGELOG
 -issue#1426: Fix issue where remote poller was not using unique filenames when attempting to verify files
 -issue#1432: Delete confirmation does not disappear
 -issue: Output message timer not clearing properly on page refresh
+-issue: Incorrect default found path of spine
 -feature: Updated Chinese Simplified translations
 -feature: Updated Dutch translations
 -feature: Make LDAP errors consistent across functions

--- a/install/functions.php
+++ b/install/functions.php
@@ -412,7 +412,7 @@ function install_file_paths () {
 		if (config_value_exists('path_spine')) {
 			$input['path_spine']['default'] = read_config_option('path_spine');
 		}else if (!empty($which_spine)) {
-			$input['path_spine']['default'] = $which_spine . '/spine';
+			$input['path_spine']['default'] = $which_spine;
 		} else {
 			$input['path_spine']['default'] = '/usr/local/spine/bin/spine';
 		}


### PR DESCRIPTION
When installating Cacti for the first time, with spine installed, the found path is (in my case) "/usr/local/spine/bin/spine/spine" instead of "/usr/local/spine/bin/spine".