### PR TITLE
Issue #1447: Cli audit_database.php not detecting database name

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -7,6 +7,7 @@ Cacti CHANGELOG
 -issue#1421: Fix issue when SQL had all bad modes, missing variable warning was generated
 -issue#1426: Fix issue where remote poller was not using unique filenames when attempting to verify files
 -issue#1432: Delete confirmation does not disappear
+-issue#1447: Cli audit_database.php not detecting database name, and failed to create audit tables when run fresh
 -issue: Output message timer not clearing properly on page refresh
 -feature: Updated Chinese Simplified translations
 -feature: Updated Dutch translations


### PR DESCRIPTION
Issue #1447: Cli audit_database.php not detecting database name, and failed to create audit tables when run from fresh due to invalid indxees.

MySQL was complaining about the key not all being NOT NULL for a PRIMARY key as opposed to being UNIQUE