### PR TITLE
Correct issue where filtering no longer filters after #1419

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -779,11 +779,12 @@ function determine_display_log_entry($message_type, $line, $filter) {
 
 	/* match any lines that match the search string */
 	if ($display === true && $filter != '') {
-		if (strpos(strtolower($line), $filter)) {
+		if (stripos($line, $filter) !== false) {
 			return $line;
 		} elseif (validate_is_regex($filter) && preg_match('/' . $filter . '/i', $line)) {
 			return $line;
 		}
+		return false;
 	}
 
 	return $display;


### PR DESCRIPTION
This corrects and issue where the filtering was not working after the fix for #1419.  It also replaces the extra call to strtolower() in favour of using stripos and corrects the check of the return value of stripos.