### PR TITLE
Further fix for #1451 to prevent empty files being left behind

### DIFF
--- a/lib/poller.php
+++ b/lib/poller.php
@@ -861,7 +861,7 @@ function resource_cache_out($type, $path) {
 						/* if the file type is PHP check syntax */
 						if ($extension == 'php') {
 							$tmpdir = sys_get_temp_dir();
-							$tmpfile = tempnam($tmpdir,'ccp').'.php';
+							$tmpfile = tempnam($tmpdir,'ccp');
 
 							if ((is_writeable($tmpdir) && !file_exists($tmpfile)) || (file_exists($tmpfile) && is_writable($tmpfile))) {
 								if (file_put_contents($tmpfile, $contents) !== false) {


### PR DESCRIPTION
Further fix for #1451 to prevent empty files being left behind due to adding .php to the filename after calling `tempnam()`

`tempnam()` will always create the file it returns, so this needed either removing, but it seemed easier just to use that filename for the syntax check since PHP will happily syntax change a PHP file with any name.