### PR TITLE
Issue #1464: Further issues with DSSTATS storage location

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -3,6 +3,7 @@ Cacti CHANGELOG
 1.1.37
 -issue#1371: Further fix for #1371 due to incorrect sign usage
 -issue#1405: When Data Query columns are wide, they cause rendering issues
+-issue#1414: DSSTATS reports incorrectly that a data source does not exist
 -issue#1419: CLog: preg_match can blow up log file
 -issue#1420: Debian test suite reports issues 
 -issue#1421: Fix issue when SQL had all bad modes, missing variable warning was generated
@@ -15,6 +16,7 @@ Cacti CHANGELOG
 -issue#1457: Path-Based Cross-Site Scripting (XSS) issues
 -issue#1458: Error in logs when creating new graphs
 -issue#1459: Automation filter not applied correctly
+-issue#1464: Further issues with DSSTATS storage location
 -issue: Output message timer not clearing properly on page refresh
 -issue: Incorrect default found path of spine
 -feature: Updated Chinese Simplified translations

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -1,4 +1,4 @@
-<?php
+s<?php
 /*
  +-------------------------------------------------------------------------+
  | Copyright (C) 2004-2018 The Cacti Group                                 |
@@ -52,7 +52,7 @@ function dsstats_get_and_store_ds_avgpeak_values($interval) {
 	$rrdfiles = get_rrdfile_names();
 	$stats    = array();
 
-	$use_proxy = (read_config_option('storage_location') != '' ? true:false);
+	$use_proxy = (read_config_option('storage_location') ? true:false);
 
 	/* open a pipe to rrdtool for writing and reading */
 	if ($use_proxy) {
@@ -156,7 +156,7 @@ function dsstats_write_buffer(&$stats_array, $interval) {
 function dsstats_obtain_data_source_avgpeak_values($rrdfile, $interval, $rrdtool_pipe) {
 	global $config;
 
-	$use_proxy = (read_config_option('storage_location') != '' ? true:false);
+	$use_proxy = (read_config_option('storage_location') ? true:false);
 
 	if ($use_proxy) {
 		$file_exists = rrdtool_execute("file_exists $rrdfile", true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'DSSTATS');


### PR DESCRIPTION
This fix also incorporates the #1414 fix that was applied to the
feature branch already.  Therefore, there may be a conflict when
develop is reapplied to the feature branch but needs to be applied
here for 1.1.37 release.

Issue #1414: DSSTATS reports incorrectly that a data source does not exist