### PR TITLE
Support FreeBSD 11 ping error for IPv6 hosts

### DIFF
--- a/scripts/ping.pl
+++ b/scripts/ping.pl
@@ -21,12 +21,12 @@ $ENV{LANG}='en_US.UTF-8';
 
 # old linux version use 'icmp_seq'
 # newer use 'icmp_req' instead
-open(PROCESS, "ping -c 1 $host 2>&1 | grep -E '(icmp_[s|r]eq.*time|unknown host|Unknown host|not supported|Name or service not known)' 2>/dev/null |");
+open(PROCESS, "ping -c 1 $host 2>&1 | grep -E '(icmp_[s|r]eq.*time|unknown host|Unknown host|not supported|Name or service not known|No address associated with name)' 2>/dev/null |");
 $ping = <PROCESS>;
 close(PROCESS);
 chomp($ping);
 
-if (($ping =~ 'unknown host') || ($ping =~ 'Unknown host') || ($ping =~ 'not supported') || ($ping =~ 'Name or service not known')) {
+if (($ping =~ 'unknown host') || ($ping =~ 'Unknown host') || ($ping =~ 'not supported') || ($ping =~ 'Name or service not known') || ($ping =~ 'No address associated with name')) {
 	if ((-f '/bin/ping6') || (-f '/sbin/ping6')) {
 		open(PROCESS, "ping6 -c 1 $host 2>&1 | grep 'icmp_[s|r]eq.*time' 2>/dev/null |");
 		$ping = <PROCESS>;


### PR DESCRIPTION
FreeBSD 11 returns "No address associated with name" when ping is passed a hostname with only an AAAA record. Adding this to the list of error messages will force fallback to ping6.