### PR TITLE
Fix for Issue #1454: When using oid_regexp_parse, filter indexes to hose that match

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -5,6 +5,7 @@ Cacti CHANGELOG
 -feature#973: Obtain users email and full name from ldap 
 -feature#1347: Update automation logging to work better
 -feature#1142: Add Site dropdown to the Graphs and Data Source pages
+-issue#1454: When using oid_regexp_parse, filter indexes to those that match
 -feature#1422: Automatically select the next unused data input field when clicking add on data input method
 -feature#1399: Allow 'requires' to include version against a plugin
 -issue#1072: CVE-2009-4112 with regard to exploiting Data Input methods

--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -469,9 +469,19 @@ function query_snmp_host($host_id, $snmp_query_id) {
 	if (isset($snmp_queries['oid_index_parse'])) {
 		$index_parse_regexp = '/' . str_replace('OID/REGEXP:', '', $snmp_queries['oid_index_parse']) . '/';
 
+		$parsed_indexes = array();
 		foreach ($snmp_indexes as $oid => $value) {
-			$snmp_indexes[$oid] = preg_replace($index_parse_regexp, "\\1", $oid);
-			query_debug_timer_offset('data_query', __('index_parse at OID: \'%s\' results: \'%s\'', $oid , $snmp_indexes[$oid]));
+			if (preg_match($index_parse_regexp, $oid)) {
+				$parsed_indexes[$oid] = preg_replace($index_parse_regexp, "\\1", $oid);
+			}
+		}
+
+		$snmp_indexes = $parsed_indexes;
+		query_debug_timer_offset('data_query', __('Filtering list of indexes @ \'%s\' Index Count: %s', $snmp_queries['oid_index'] , sizeof($snmp_indexes)));
+
+		/* show list of indices found */
+		foreach ($snmp_indexes as $oid => $value) {
+			query_debug_timer_offset('data_query', __('Filtered Index found at OID: \'%s\' value: \'%s\'', $oid , $value));
 		}
 	}
 


### PR DESCRIPTION
When using oid_regexp_parse all indexes are returned, some with their OID's correctly replaced.  If an index does not match, it's index is kept as an OID.  This is now corrected to filter indexes to just those that match.