### PR TITLE
Add debug ability to test email

### DIFF
--- a/cli/test_email.php
+++ b/cli/test_email.php
@@ -1,5 +1,35 @@
+#!/usr/bin/php -q
 <?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2018 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+/* do NOT run this script through a web browser */
+if (!isset($_SERVER['argv'][0]) || isset($_SERVER['REQUEST_METHOD'])  || isset($_SERVER['REMOTE_ADDR'])) {
+	die('<br><strong>This script is only meant to run at the command line.</strong>');
+}
+
 $no_http_headers = true;
+
 include('../include/global.php');
 
 global $config;
@@ -11,9 +41,12 @@ $message .= '<b>Method</b>: ';
 print 'Checking Configuration...';
 
 $ping_results = true;
+
 $how = read_config_option('settings_how');
-if ($how < 0 || $how > 2)
+if ($how < 0 || $how > 2) {
 	$how = 0;
+}
+
 if ($how == 0) {
 	$mail = 'PHP\'s Mailer Class';
 } else if ($how == 1) {

--- a/cli/test_email.php
+++ b/cli/test_email.php
@@ -1,0 +1,88 @@
+<?php
+$no_http_headers = true;
+include('../include/global.php');
+
+global $config;
+
+$message =  'This is a test message generated from Cacti.  This message was sent to test the configuration of your Mail Settings<br><br>';
+$message .= 'Your email settings are currently set as follows<br><br>';
+$message .= '<b>Method</b>: ';
+
+print 'Checking Configuration...';
+
+$ping_results = true;
+$how = read_config_option('settings_how');
+if ($how < 0 || $how > 2)
+	$how = 0;
+if ($how == 0) {
+	$mail = 'PHP\'s Mailer Class';
+} else if ($how == 1) {
+	$mail = 'Sendmail<br><b>Sendmail Path</b>: ';
+	$sendmail = read_config_option('settings_sendmail_path');
+	$mail .= $sendmail;
+} else if ($how == 2) {
+	print 'Method: SMTP';
+	$mail = 'SMTP<br>';
+	$smtp_host = read_config_option('settings_smtp_host');
+	$smtp_port = read_config_option('settings_smtp_port');
+	$smtp_username = read_config_option('settings_smtp_username');
+	$smtp_password = read_config_option('settings_smtp_password');
+	$smtp_secure   = read_config_option('settings_smtp_secure');
+	$smtp_timeout  = read_config_option('settings_smtp_timeout');
+
+	$mail .= "<b>Device</b>: $smtp_host<br>";
+	$mail .= "<b>Port</b>: $smtp_port<br>";
+
+	if ($smtp_username != '' && $smtp_password != '') {
+		$mail .= '<b>Authentication</b>: true<br>';
+		$mail .= "<b>Username</b>: $smtp_username<br>";
+		$mail .= '<b>Password</b>: (Not Shown for Security Reasons)<br>';
+		$mail .= "<b>Security</b>: $smtp_secure<br>";
+	} else {
+		$mail .= '<b>Authentication</b>: false<br>';
+	}
+
+	if (read_config_option('settings_ping_mail') == 0) {
+		$ping_results = ping_mail_server($smtp_host, $smtp_port, $smtp_username, $smtp_password, $smtp_timeout, $smtp_secure);
+
+		print "\nPing Results: " . ($ping_results == 1 ? 'Success':$ping_results);
+
+		if ($ping_results != 1) {
+			$mail .= '<b>Ping Results</b>: ' . $ping_results . '<br>';
+		} else {
+			$mail .= '<b>Ping Results</b>: Success<br>';
+		}
+	} else {
+		$ping_results = 1;
+		$mail .= '<b>Ping Results</b>: Bypassed<br>';
+		print "\nPing Results: Bypassed";
+	}
+}
+$message .= $mail;
+$message .= '<br>';
+
+$errors = '';
+if ($ping_results == 1) {
+	print "\nSending Message...";
+
+	$global_alert_address = read_config_option('settings_test_email');
+
+	$errors = send_test($global_alert_address, '', 'Cacti Test Message', $message, '', '', true);
+	if ($errors == '') {
+		$errors = 'Success!';
+	}
+} else {
+	$errors = 'Message Not Sent due to ping failure.';
+}
+print "\nResult: $errors\n";
+
+function send_test($to, $from, $subject, $body, $attachments = '', $headers = '', $html = false) {
+	global $config;
+
+	$cc = '';
+	$bcc = '';
+	$replyto = '';
+	$body_text = '';
+
+	return mailer($from, $to, '', '', '', $subject, $body, '', $attachments, $headers, $html, 3);
+}

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -1335,18 +1335,25 @@ $settings = array(
 			'friendly_name' => __('Emailing Options'),
 			'method' => 'spacer',
 			),
-		'settings_test_email' => array(
-			'friendly_name' => __('Test Email'),
-			'description' => __('This is a Email account used for sending a test message to ensure everything is working properly.'),
-			'method' => 'textbox',
-			'max_length' => 255,
-			),
 		'settings_how' => array(
 			'friendly_name' => __('Mail Services'),
 			'description' => __('Which mail service to use in order to send mail'),
 			'method' => 'drop_array',
 			'default' => __('PHP Mail() Function'),
 			'array' => array( __('PHP Mail() Function'), __('Sendmail'), __('SMTP') ),
+			),
+		'settings_test_email' => array(
+			'friendly_name' => __('Test Email'),
+			'description' => __('This is a Email account used for sending a test message to ensure everything is working properly.'),
+			'method' => 'textbox',
+			'max_length' => 255,
+			),
+		'settings_test_debug' => array(
+			'friendly_name' => __('Test Debug Level'),
+			'description' => __('The level of debug to apply (currently only applies to SMTP).'),
+			'method' => 'drop_array',
+			'array' => array( '0' => __('None'), '1' => __('Client'), '2' => __('Client And Server'), '3' => __('Connection'), '4' => __('Low Level') ),
+			'default' => 'none'
 			),
 		'settings_ping_mail' => array(
 			'friendly_name' => __('Ping Mail Server'),

--- a/settings.php
+++ b/settings.php
@@ -200,8 +200,23 @@ case 'save':
 
 	break;
 case 'send_test':
+	if (isset_request_var('email')) {
+		db_execute_prepared('REPLACE INTO settings
+			(name, value)
+			VALUES ("settings_test_email", ?)',
+			array(get_nfilter_request_var('email')));
+	}
+
+	if (isset_request_var('level')) {
+		db_execute_prepared('REPLACE INTO settings
+			(name, value)
+			VALUES ("settings_test_debug", ?)',
+			array(get_nfilter_request_var('level')));
+	}
+
 	email_test();
 	break;
+
 default:
 	top_header();
 
@@ -453,7 +468,9 @@ default:
 			});
 
 			$('#emailtest').click(function() {
-				$.get('settings.php?action=send_test')
+				email = $('#settings_test_email').val();
+				level = $('#settings_test_debug').val();
+				$.get('settings.php?action=send_test&email='+email+'&level='+level)
 					.done(function(data) {
 						$('body').append('<div id="testmail" title="<?php print __esc('Test Email Results');?>"></div>');
 						$('#testmail').html(data);
@@ -571,6 +588,7 @@ default:
 				$('#row_settings_smtp_password').hide();
 				$('#row_settings_smtp_secure').hide();
 				$('#row_settings_smtp_timeout').hide();
+				$('#row_settings_test_debug').hide();
 				break;
 			case '1':
 				if (smtpPath != '') {
@@ -586,6 +604,7 @@ default:
 				$('#row_settings_smtp_password').hide();
 				$('#row_settings_smtp_secure').hide();
 				$('#row_settings_smtp_timeout').hide();
+				$('#row_settings_test_debug').hide();
 				break;
 			case '2':
 				$('#settings_sendmail_path').val('');
@@ -598,6 +617,7 @@ default:
 				$('#row_settings_smtp_password').show();
 				$('#row_settings_smtp_secure').show();
 				$('#row_settings_smtp_timeout').show();
+				$('#row_settings_test_debug').show();
 				break;
 			}
 		}


### PR DESCRIPTION
This adds the ability to get debug information from SMTP connections when sending a test email.  Also, sending a test email will automatically save the email address and level to the settings table.

Also included is a command line tool to send a test email.