### PR TITLE
Fix for Issue #1537: Numeric validation not ignoring blank elements

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -16,6 +16,7 @@ Cacti CHANGELOG
 -issue#1510: New Graphs Undefined Variable $graph_template_name
 -issue#1515: Special characters not rendered properly in settings
 -issue#1530: Inconsistent behaviour handling blank Field Name/Value when editing data query suggested values
+-issue#1537: Numeric validation not ignoring blank elements
 -issue: Move Graph removal function to Graph API
 -issue: Fix issue with display_custom_error_message() causing problem with system error message handling
 -issue: Graph List View was not fully responsive

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -635,7 +635,7 @@ function validate_store_request_vars($filters, $sess_prefix = '') {
 					}
 				} elseif ($options['filter'] == FILTER_VALIDATE_IS_NUMERIC_LIST) {
 					$valid = true;
-					$values = explode(',', $_REQUEST[$variable]);
+					$values = preg_split('/,/', $_REQUEST[$variable], NULL, PREG_SPLIT_NO_EMPTY);
 					foreach($values AS $number) {
 						if (!is_numeric($number)) {
 							$valid = false;

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -414,7 +414,7 @@ function get_filter_request_var($name, $filter = FILTER_VALIDATE_INT, $options =
 				}
 			} elseif ($filter == FILTER_VALIDATE_IS_NUMERIC_LIST) {
 				$valid = true;
-				$values = explode(',', $_REQUEST[$name]);
+				$values = preg_split('/,/', $_REQUEST[$name], NULL, PREG_SPLIT_NO_EMPTY);
 				foreach($values AS $number) {
 					if (!is_numeric($number)) {
 						$valid = false;


### PR DESCRIPTION
This patch provides a fix for Issue #1537 where the aggregate graphs are appending extra commas to the graph_add variable.  Because of this the numeric validation was generating an error as it was not ignoring blank elements.
