### PR TITLE
feature #1400: User settings should have checkbox to enable overriding of default settings

### DIFF
--- a/auth_profile.php
+++ b/auth_profile.php
@@ -95,7 +95,7 @@ function form_save() {
 
 	// Save the users graph settings if they have permission
 	if (is_view_allowed('graph_settings') == true) {
-		save_user_settings();
+		save_user_settings($_SESSION['sess_user_id']);
 	}
 
 	if (sizeof($errors) == 0) {

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -31,6 +31,7 @@ Cacti CHANGELOG
 -feature#1142: Add Site dropdown to the Graphs and Data Source pages
 -feature#1395: Ensure messages have each new line keep the same prefix in cacti_log()
 -feature#1399: Allow 'requires' to include version against a plugin
+-feature#1400: User settings should have checkbox to enable overriding of global settings
 -feature#1422: Automatically select the next unused data input field when clicking add on data input method
 -feature#1505: Allow Device Edit from Graphs page
 -feature#1527: Update Fontawesome from 4.7 to 5.0.10

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -1866,6 +1866,7 @@ $settings = array(
 $settings_user = array(
 	'general' => array(
 		'selected_theme' => array(
+			'user' => true,
 			'friendly_name' => __('Theme'),
 			'description' => __('Please select one of the available Themes to skin your Cacti with.'),
 			'method' => 'drop_array',
@@ -1873,32 +1874,37 @@ $settings_user = array(
 			'array' => $themes
 			),
 		'default_view_mode' => array(
+			'user' => true,
 			'friendly_name' => __('Default View Mode'),
 			'description' => __('Which Graph mode you want displayed by default when you first visit the Graphs page?'),
 			'method' => 'drop_array',
 			'array' => $graph_views,
 			'default' => '1'
 			),
-        'user_language' => array(
-            'friendly_name' => __('User Language'),
-            'description' => __('Defines the preferred GUI language.'),
-            'method' => 'drop_array',
-            'default' => get_new_user_default_language(),
-            'array' => get_installed_locales()
-            ),
+		'user_language' => array(
+			'user' => true,
+			'friendly_name' => __('User Language'),
+			'description' => __('Defines the preferred GUI language.'),
+			'method' => 'drop_array',
+			'default' => get_new_user_default_language(),
+			'array' => get_installed_locales()
+		),
 		'show_graph_title' => array(
+			'user' => true,
 			'friendly_name' => __('Show Graph Title'),
 			'description' => __('Display the graph title on the page so that it may be searched using the browser.'),
 			'method' => 'checkbox',
 			'default' => ''
 			),
 		'hide_disabled' => array(
+			'user' => true,
 			'friendly_name' => __('Hide Disabled'),
 			'description' => __('Hide Disabled Devices and Graphs from Disabled Devices.'),
 			'method' => 'checkbox',
 			'default' => 'on'
 			),
 		'default_date_format' => array(
+			'user' => true,
 			'friendly_name' => __('Date Display Format'),
 			'description' => __('The date format to use in Cacti.'),
 			'method' => 'drop_array',
@@ -1906,6 +1912,7 @@ $settings_user = array(
 			'default' => GD_Y_MO_D
 			),
 		'default_datechar' => array(
+			'user' => true,
 			'friendly_name' => __('Date Separator'),
 			'description' => __('The date separator to be used in Cacti.'),
 			'method' => 'drop_array',
@@ -1913,6 +1920,7 @@ $settings_user = array(
 			'default' => GDC_SLASH
 			),
 		'page_refresh' => array(
+			'user' => true,
 			'friendly_name' => __('Page Refresh'),
 			'description' => __('The number of seconds between automatic page refreshes.'),
 			'method' => 'drop_array',
@@ -1920,6 +1928,7 @@ $settings_user = array(
 			'array' => array( '15' => __('%d Seconds', 15), '20' => __('%d Seconds', 20), '30' => __('%d Seconds', 30), '60' => __('1 Minute'), '300' => __('%d Minutes', 5) )
 			),
 		'preview_graphs_per_page' => array(
+			'user' => true,
 			'friendly_name' => __('Preview Graphs Per Page'),
 			'description' => __('The number of graphs to display on one page in preview mode.'),
 			'method' => 'drop_array',
@@ -1929,6 +1938,7 @@ $settings_user = array(
 		),
 	'timespan' => array(
 		'default_rra_id' => array(
+			'user' => true,
 			'friendly_name' => __('Default Time Range'),
 			'description' => __('The default RRA to use in rare occasions.'),
 			'method' => 'drop_sql',
@@ -1936,6 +1946,7 @@ $settings_user = array(
 			'default' => '1'
 			),
 		'default_timespan' => array(
+			'user' => true,
 			'friendly_name' => __('Default Graph View Timespan'),
 			'description' => __('The default timespan you wish to be displayed when you display graphs'),
 			'method' => 'drop_array',
@@ -1943,6 +1954,7 @@ $settings_user = array(
 			'default' => GT_LAST_DAY
 			),
 		'default_timeshift' => array(
+			'user' => true,
 			'friendly_name' => __('Default Graph View Timeshift'),
 			'description' => __('The default timeshift you wish to be displayed when you display graphs'),
 			'method' => 'drop_array',
@@ -1950,12 +1962,14 @@ $settings_user = array(
 			'default' => GTS_1_DAY
 			),
 		'allow_graph_dates_in_future' => array(
+			'user' => true,
 			'friendly_name' => __('Allow Graph to extend to Future'),
 			'description' => __('When displaying Graphs, allow Graph Dates to extend \'to future\''),
 			'method' => 'checkbox',
 			'default' => 'on'
-		),
+			),
 		'first_weekdayid' => array(
+			'user' => true,
 			'friendly_name' => __('First Day of the Week'),
 			'description' => __('The first Day of the Week for weekly Graph Displays'),
 			'method' => 'drop_array',
@@ -1963,6 +1977,7 @@ $settings_user = array(
 			'default' => WD_MONDAY
 			),
 		'day_shift_start' => array(
+			'user' => true,
 			'friendly_name' => __('Start of Daily Shift'),
 			'description' => __('Start Time of the Daily Shift.'),
 			'method' => 'textbox',
@@ -1971,6 +1986,7 @@ $settings_user = array(
 			'size' => '7'
 			),
 		'day_shift_end' => array(
+			'user' => true,
 			'friendly_name' => __('End of Daily Shift'),
 			'description' => __('End Time of the Daily Shift.'),
 			'method' => 'textbox',
@@ -1981,6 +1997,7 @@ $settings_user = array(
 		),
 	'thumbnail' => array(
 		'thumbnail_sections' => array(
+			'user' => true,
 			'friendly_name' => __('Thumbnail Sections'),
 			'description' => __('Which portions of Cacti display Thumbnails by default.'),
 			'method' => 'checkbox_group',
@@ -1996,6 +2013,7 @@ $settings_user = array(
 				)
 			),
 		'num_columns' => array(
+			'user' => true,
 			'friendly_name' => __('Preview Thumbnail Columns'),
 			'description' => __('The number of columns to use when displaying Thumbnail graphs in Preview mode.'),
 			'method' => 'drop_array',
@@ -2003,6 +2021,7 @@ $settings_user = array(
 			'array' => array('1' => __('1 Column'),'2' => __('%d Columns', 2), '3' => __('%d Columns', 3), '4' => __('%d Columns', 4), '5' => __('%d Columns', 5), '6' => __('%d Columns', 6) )
 			),
 		'num_columns_tree' => array(
+			'user' => true,
 			'friendly_name' => __('Tree View Thumbnail Columns'),
 			'description' => __('The number of columns to use when displaying Thumbnail graphs in Tree mode.'),
 			'method' => 'drop_array',
@@ -2010,6 +2029,7 @@ $settings_user = array(
 			'array' => array('1' => __('1 Column'),'2' => __('%d Columns', 2), '3' => __('%d Columns', 3), '4' => __('%d Columns', 4), '5' => __('%d Columns', 5), '6' => __('%d Columns', 6) )
 			),
 		'default_height' => array(
+			'user' => true,
 			'friendly_name' => __('Thumbnail Height'),
 			'description' => __('The height of Thumbnail graphs in pixels.'),
 			'method' => 'textbox',
@@ -2018,6 +2038,7 @@ $settings_user = array(
 			'size' => '7'
 			),
 		'default_width' => array(
+			'user' => true,
 			'friendly_name' => __('Thumbnail Width'),
 			'description' => __('The width of Thumbnail graphs in pixels.'),
 			'method' => 'textbox',
@@ -2028,6 +2049,7 @@ $settings_user = array(
 		),
 	'tree' => array(
 		'default_tree_id' => array(
+			'user' => true,
 			'friendly_name' => __('Default Tree'),
 			'description' => __('The default graph tree to use when displaying graphs in tree mode.'),
 			'method' => 'drop_sql',
@@ -2035,6 +2057,7 @@ $settings_user = array(
 			'default' => '0'
 			),
 		'treeview_graphs_per_page' => array(
+			'user' => true,
 			'friendly_name' => __('Graphs Per Page'),
 			'description' => __('The number of graphs to display on one page in preview mode.'),
 			'method' => 'drop_array',
@@ -2042,6 +2065,7 @@ $settings_user = array(
 			'array' => $graphs_per_page
 			),
 		'expand_hosts' => array(
+			'user' => true,
 			'friendly_name' => __('Expand Devices'),
 			'description' => __('Choose whether to expand the Graph Templates and Data Queries used by a Device on Tree.'),
 			'method' => 'checkbox',
@@ -2050,6 +2074,7 @@ $settings_user = array(
 		),
 	'fonts' => array(
 		'custom_fonts' => array(
+			'user' => true,
 			'friendly_name' => __('Use Custom Fonts'),
 			'description' => __('Choose whether to use your own custom fonts and font sizes or utilize the system defaults.'),
 			'method' => 'checkbox',
@@ -2057,6 +2082,7 @@ $settings_user = array(
 			'default' => ''
 			),
 		'title_size' => array(
+			'user' => true,
 			'friendly_name' => __('Title Font Size'),
 			'description' => __('The size of the font used for Graph Titles'),
 			'method' => 'textbox',
@@ -2064,12 +2090,14 @@ $settings_user = array(
 			'max_length' => '10'
 			),
 		'title_font' => array(
+			'user' => true,
 			'friendly_name' => __('Title Font File'),
 			'description' => __('The font file to use for Graph Titles'),
 			'method' => 'font',
 			'max_length' => '100'
 			),
 		'legend_size' => array(
+			'user' => true,
 			'friendly_name' => __('Legend Font Size'),
 			'description' => __('The size of the font used for Graph Legend items'),
 			'method' => 'textbox',
@@ -2077,12 +2105,14 @@ $settings_user = array(
 			'max_length' => '10'
 			),
 		'legend_font' => array(
+			'user' => true,
 			'friendly_name' => __('Legend Font File'),
 			'description' => __('The font file to be used for Graph Legend items'),
 			'method' => 'font',
 			'max_length' => '100'
 			),
 		'axis_size' => array(
+			'user' => true,
 			'friendly_name' => __('Axis Font Size'),
 			'description' => __('The size of the font used for Graph Axis'),
 			'method' => 'textbox',
@@ -2090,12 +2120,14 @@ $settings_user = array(
 			'max_length' => '10'
 			),
 		'axis_font' => array(
+			'user' => true,
 			'friendly_name' => __('Axis Font File'),
 			'description' => __('The font file to be used for Graph Axis items'),
 			'method' => 'font',
 			'max_length' => '100'
 			),
 		'unit_size' => array(
+			'user' => true,
 			'friendly_name' => __('Unit Font Size'),
 			'description' => __('The size of the font used for Graph Units'),
 			'method' => 'textbox',
@@ -2103,6 +2135,7 @@ $settings_user = array(
 			'max_length' => '10'
 			),
 		'unit_font' => array(
+			'user' => true,
 			'friendly_name' => __('Unit Font File'),
 			'description' => __('The font file to be used for Graph Unit items'),
 			'method' => 'font',
@@ -2113,6 +2146,7 @@ $settings_user = array(
 
 if (is_realm_allowed(25)) {
 	$settings_user['general']['realtime_mode'] = array(
+		'user' => true,
 		'friendly_name' => __('Realtime View Mode'),
 		'description' => __('How do you wish to view Realtime Graphs?'),
 		'method' => 'drop_array',

--- a/include/layout.js
+++ b/include/layout.js
@@ -317,6 +317,12 @@ $.tablesorter.addParser({
 	});
 })(jQuery);
 
+function checkOptionalEnabled(item, e) {
+	isOptionalEnabled = item.is(':checked');
+	siblings = item.closest('div').siblings('.formColumnLeft, .formColumnRight');
+	siblings.find('*').prop('disabled', !isOptionalEnabled);
+}
+
 // helper function which selects row range when shift key is pressed during click
 function updateCheckboxes(checkboxes, clicked_element) {
 	var prev_checkbox = $(clicked_element).closest('tr').siblings().find('[data-prev-check]:checkbox');
@@ -379,6 +385,14 @@ function applySelectorVisibilityAndActions() {
 
 			$(this).closest('tr').toggleClass('selected');
 		}
+	});
+
+	$('input[id^="user_optional_"]').each(function(data) {
+		optional = $(this);
+		optional.unbind('click').click(function(e) {
+			checkOptionalEnabled($(this), e);
+		});
+		checkOptionalEnabled($(this), null);
 	});
 
 	var lines = $('tr[id^="line"].selectable');

--- a/include/layout.js
+++ b/include/layout.js
@@ -320,7 +320,12 @@ $.tablesorter.addParser({
 function checkOptionalEnabled(item, e) {
 	isOptionalEnabled = item.is(':checked');
 	siblings = item.closest('div').siblings('.formColumnLeft, .formColumnRight');
-	siblings.find('*').prop('disabled', !isOptionalEnabled);
+	elements = siblings.find('*.formFieldName, *.ui-widget, *.formCheckbox, *.checkboxLabel, *:input');
+	if (isOptionalEnabled) {
+		elements.removeClass('ui-state-disabled').prop('disabled', false);
+	} else {
+		elements.addClass('ui-state-disabled').prop('disabled', true);
+	}
 }
 
 // helper function which selects row range when shift key is pressed during click
@@ -385,14 +390,6 @@ function applySelectorVisibilityAndActions() {
 
 			$(this).closest('tr').toggleClass('selected');
 		}
-	});
-
-	$('input[id^="user_optional_"]').each(function(data) {
-		optional = $(this);
-		optional.unbind('click').click(function(e) {
-			checkOptionalEnabled($(this), e);
-		});
-		checkOptionalEnabled($(this), null);
 	});
 
 	var lines = $('tr[id^="line"].selectable');
@@ -678,6 +675,14 @@ function applySkin() {
 
 	$.when.apply(this, showPage).done(function() {
 		responsiveUI('force');
+	});
+
+	$('input[id^="user_optional_"]').each(function(data) {
+		optional = $(this);
+		optional.unbind('click').click(function(e) {
+			checkOptionalEnabled($(this), e);
+		});
+		checkOptionalEnabled($(this), null);
 	});
 
 	displayMessages();

--- a/include/themes/classic/main.css
+++ b/include/themes/classic/main.css
@@ -1183,18 +1183,24 @@ legend {
 	text-align: left;
 }
 
+.formColumnOptional {
+	float: left;
+	display: table-column;
+	width: 5%;
+}
+
 .formColumnLeft {
 	float: left;
 	display: table-column;
 	padding-left: 4px;
-	width: 40%;
+	width: 45%;
 	text-align: left;
 }
 
 .formColumnRight {
 	float: left;
 	display: table-column;
-	width: 58%;
+	width: 45%;
 	text-align: left;
 }
 
@@ -1292,7 +1298,7 @@ legend {
 	.formColumnLeft {
 		float: left;
 		display: table-row;
-		width: 100%;
+		width: 90%;
 		text-align: left;
 	}
 

--- a/include/themes/dark/main.css
+++ b/include/themes/dark/main.css
@@ -1297,17 +1297,23 @@ legend {
 	text-align: left;
 }
 
+.formColumnOptional {
+	float: left;
+	display: table-column;
+	width: 5%;
+}
+
 .formColumnLeft {
 	float: left;
 	display: table-column;
-	width: 50%;
+	width: 45%;
 	text-align: left;
 }
 
 .formColumnRight {
 	float: left;
 	display: table-column;
-	width: 50%;
+	width: 45%;
 	text-align: left;
 }
 
@@ -1402,7 +1408,7 @@ legend {
 	.formColumnLeft {
 		float: left;
 		display: table-row;
-		width: 100%;
+		width: 90%;
 		text-align: left;
 	}
 

--- a/include/themes/modern/main.css
+++ b/include/themes/modern/main.css
@@ -1337,10 +1337,16 @@ legend {
 	text-align: left;
 }
 
+.formColumnOptional {
+	float: left;
+	display: table-column;
+	width: 5%;
+}
+
 .formColumnLeft {
 	float: left;
 	display: table-column;
-	width: 49%;
+	width: 44%;
 	text-align: left;
 	padding-left: 3px;
 }
@@ -1348,7 +1354,7 @@ legend {
 .formColumnRight {
 	float: left;
 	display: table-column;
-	width: 50%;
+	width: 45%;
 	text-align: left;
 }
 
@@ -1457,7 +1463,7 @@ legend {
 	.formColumnLeft {
 		float: left;
 		display: table-row;
-		width: 100%;
+		width: 90%;
 		text-align: left;
 	}
 

--- a/include/themes/paper-plane/main.css
+++ b/include/themes/paper-plane/main.css
@@ -1260,10 +1260,16 @@ table.cactiTable {
 	display: table-column;
 }
 
+.formColumnOptional {
+	float: left;
+	display: table-column;
+	width: 5%;
+}
+
 .formColumnLeft {
 	float: left;
 	display: table-column;
-	width: 50%;
+	width: 45%;
 	text-align: left;
 	color: #000;
 }
@@ -1271,7 +1277,7 @@ table.cactiTable {
 .formColumnRight {
 	float: left;
 	display: table-column;
-	width: 50%;
+	width: 45%;
 	text-align: left;
 	color: #000;
 }
@@ -1343,7 +1349,7 @@ table.cactiTable {
 	.formColumnLeft {
 		float: left;
 		display: table-row;
-		width: 100%;
+		width: 90%;
 	}
 
 	.formColumnRight {

--- a/include/themes/paw/main.css
+++ b/include/themes/paw/main.css
@@ -1124,17 +1124,23 @@ legend {
 	text-align: left;
 }
 
+.formColumnOptional {
+	float: left;
+	display: table-column;
+	width: 5%;
+}
+
 .formColumnLeft {
 	float: left;
 	display: table-column;
-	width: 50%;
+	width: 45%;
 	text-align: left;
 }
 
 .formColumnRight {
 	float: left;
 	display: table-column;
-	width: 50%;
+	width: 45%;
 	text-align: left;
 }
 
@@ -1229,7 +1235,7 @@ legend {
 	.formColumnLeft {
 		float: left;
 		display: table-row;
-		width: 100%;
+		width: 90%;
 		color: #000000;
 		text-align: left;
 	}

--- a/include/themes/sunrise/main.css
+++ b/include/themes/sunrise/main.css
@@ -1295,17 +1295,23 @@ table.cactiTable {
 	display: table-column;
 }
 
+.formColumnOptional {
+	float: left;
+	display: table-column;
+	width: 5%;
+}
+
 .formColumnLeft {
 	float: left;
 	display: table-column;
-	width: 50%;
+	width: 45%;
 	text-align: left;
 }
 
 .formColumnRight {
 	float: left;
 	display: table-column;
-	width: 50%;
+	width: 45%;
 	text-align: left;
 }
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -100,14 +100,14 @@ function read_graph_config_option($config_name, $force = false) {
 	return read_user_setting($config_name, false, $force);
 }
 
-/* sAVE_user_setting - sets/updates aLL user settings
+/* save_user_setting - sets/updates aLL user settings
    @arg $config_name - the name of the configuration setting as specified $settings array
    @arg $value       - the values to be saved
    @arg $user        - the user id, otherwise the session user
    @returns          - void */
 function save_user_settings($user = -1) {
 	global $settings_user;
-	if ($user == -1) {
+	if ($user == -1 || empty($user)) {
 		$user = $_SESSION['sess_user_id'];
 	}
 
@@ -116,7 +116,7 @@ function save_user_settings($user = -1) {
 			if (!empty($field_array['user'])) {
 				if (!isset_request_var('user_optional_' . $field_name) ||
 				    get_nfilter_request_var('user_optional_' . $field_name) != 'on') {
-					clear_user_setting($field_name);
+					clear_user_setting($field_name, $user);
 					continue;
 				}
 			}
@@ -206,13 +206,13 @@ function user_setting_exists($config_name, $user_id) {
    @arg $config_name - the name of the configuration setting as specified $settings_user array
      in 'include/global_settings.php'
    @arg $user_id - the id of the user to remove the configuration value for */
-function clear_user_setting($config_name, $user_id) {
+function clear_user_setting($config_name, $user = -1) {
 	global $settings_user;
 
-	db_execute_prepared('DELETE FROM settings_user WHERE name = ? AND user_id = ?', array($config_name, $user_id));
-
-	unset($_SESSION['sess_user_config_array']);
-	unset($settings_user[$config_name]['value']);
+	if ($user == -1) {
+		$user = $_SESSION['sess_user_id'];
+	}
+	db_execute_prepared('DELETE FROM settings_user WHERE name = ? AND user_id = ?', array($config_name, $user));
 }
 
 /* read_default_user_setting - finds the default value of a user configuration setting

--- a/lib/html_form.php
+++ b/lib/html_form.php
@@ -75,6 +75,21 @@ function draw_edit_form($array) {
 					}
 				}
 
+				print "<div class='formColumnOptional'>";
+				if (isset($field_array['user'])) {
+					form_checkbox('user_optional_' . $field_name,
+						empty($field_array['user_set']) ? '' : 'on',
+						'',
+						'',
+						'',
+						'',
+						'',
+						'');
+				} else {
+					print '&nbsp;';
+				}
+				print "</div>";
+
 				// Make a form cell
 				print "<div class='formColumnLeft'>";
 

--- a/user_admin.php
+++ b/user_admin.php
@@ -610,23 +610,6 @@ function form_save() {
 		raise_message(1);
 	} elseif (isset_request_var('save_component_graph_settings')) {
 		save_user_settings();
-		foreach ($settings_user as $tab_short_name => $tab_fields) {
-			foreach ($tab_fields as $field_name => $field_array) {
-				if ((isset($field_array['items'])) && (is_array($field_array['items']))) {
-					foreach ($field_array['items'] as $sub_field_name => $sub_field_array) {
-						db_execute_prepared('REPLACE INTO settings_user
-							(user_id, name, value)
-							VALUES (?, ?, ?)',
-							array((!empty($user_id) ? $user_id : get_filter_request_var('id')), $sub_field_name, get_nfilter_request_var($sub_field_name, '')));
-					}
-				} else {
-					db_execute_prepared('REPLACE INTO settings_user
-						(user_id, name, value)
-						VALUES (?, ?, ?)',
-						array((!empty($user_id) ? $user_id : get_filter_request_var('id')), $field_name, get_nfilter_request_var($field_name)));
-				}
-			}
-		}
 
 		/* reset local settings cache so the user sees the new settings */
 		kill_session_var('sess_user_config_array');

--- a/user_admin.php
+++ b/user_admin.php
@@ -609,6 +609,7 @@ function form_save() {
 
 		raise_message(1);
 	} elseif (isset_request_var('save_component_graph_settings')) {
+		save_user_settings();
 		foreach ($settings_user as $tab_short_name => $tab_fields) {
 			foreach ($tab_fields as $field_name => $field_array) {
 				if ((isset($field_array['items'])) && (is_array($field_array['items']))) {


### PR DESCRIPTION
This pull request introduces a tick box for enabling of user settings overrides.  This is work in progress, but I believe that most functionality has been achieved.  

The only step that should probably be added is the removal of any user settings that match default values but I'm a little unsure which defaults to refer to.  That should probably be part of the 1_2_0.php upgrade file.

Known issues:
- When disabling the setting inputs, they don't seem to become enabled again even though I'm setting disabled to false.
- Text prompts do not seem to dim despite being disabled so some CSS stlying may need to be applied on top of the disabled attribute.