### PR TITLE
Fix open database when in home directory there is file or directory named localhost

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -62,7 +62,7 @@ function db_connect_real($device, $user, $pass, $db_name, $db_type = 'mysql', $p
 
 	while ($i <= $retries) {
 		try {
-			if (file_exists($device)) {
+			if (filetype($device) == 'socket') {
 				$cnn_id = new PDO("$db_type:unix_socket=$device;dbname=$db_name;charset=utf8", $user, $pass, $flags);
 			} else {
 				$cnn_id = new PDO("$db_type:host=$device;port=$port;dbname=$db_name;charset=utf8", $user, $pass, $flags);


### PR DESCRIPTION
Only use socket when It really is a socket, because the PHP user's home maybe is a file or directory named localhost.
It's only a filename not a socket from command line.
