### PR TITLE
Feature #1597: Ensure synchronised files have same attributes as originals

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -39,6 +39,7 @@ Cacti CHANGELOG
 -feature#1580: Support Drag & Drop for Report Items
 -feature#1581: Allow Mass Adding of Graphs to Reports
 -feature#1584: Allow theme selection when installing
+-feature#1597: Ensure synchronised files have same attributes as originals
 -feature: Make Graph and Data Source suggested naming more efficient
 -feature: Make tree editing responive
 -feature: Add support for DDERIVE and DCOUNTER to Cacti

--- a/install/upgrades/1_2_0.php
+++ b/install/upgrades/1_2_0.php
@@ -49,4 +49,9 @@ function upgrade_to_1_2_0() {
 		db_install_execute("ALTER TABLE poller
 			ADD COLUMN `timezone` varchar(40) DEFAULT '' AFTER `status`");
 	}
+
+	if (!db_column_exists('poller_resource_cache', 'attributes')) {
+		db_install_execute("ALTER TABLE poller_resource_cache
+			ADD COLUMN `attributes` INT unsigned DEFAULT '0'");
+	}
 }


### PR DESCRIPTION
As per  #1597 this feature update ensures that remote files have the same attributes as the local files.   This only updates the attributes not the owners and reports a warning if an attribute can not be updated.  

Note, this is unlike to work on Windows systems as the fileperms function should return a 0 since there are not unix-like permissions set.  If a zero value is detected in the attributes column, no update of permissions is attempted.