### PR TITLE
Issue #1617: Editing a data query results in missing $header variable

### DIFF
--- a/data_queries.php
+++ b/data_queries.php
@@ -213,6 +213,12 @@ function form_save() {
 		get_filter_request_var('graph_template_id');
 		/* ==================================================== */
 
+		if (isset_request_var('header') && get_nfilter_request_var('header') == 'false') {
+			$header = '&header=false';
+		} else {
+			$header = '';
+		}
+
 		if  (isempty_request_var('svg_text')) {
 			raise_message(39);
 			header('Location: data_queries.php?header=false&action=item_edit' . $header . '&id=' . get_request_var('id') . '&snmp_query_id=' . get_request_var('snmp_query_id'));
@@ -249,6 +255,12 @@ function form_save() {
 		get_filter_request_var('snmp_query_id');
 		get_filter_request_var('graph_template_id');
 		/* ==================================================== */
+
+		if (isset_request_var('header') && get_nfilter_request_var('header') == 'false') {
+			$header = '&header=false';
+		} else {
+			$header = '';
+		}
 
 		if  (isempty_request_var('svds_text')) {
 			raise_message(39);

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -24,6 +24,7 @@ Cacti CHANGELOG
 -issue#1574: User templates are not correctly being applied
 -issue#1602: PHP ERROR: Call to undefined function api_data_source_cache_crc_update()
 -issue#1609: Remote pollers update 'stats_poller' on main poller
+-issue#1617: Editing a data query results in missing $header variable
 -issue: Move Graph removal function to Graph API
 -issue: Fix issue with display_custom_error_message() causing problem with system error message handling
 -issue: Graph List View was not fully responsive


### PR DESCRIPTION
Resolves an issue when editing a data query can result in $header variable not found warnings.