### PR TITLE
Feature #1034: Ensure tables are UTF8

### DIFF
--- a/install/functions.php
+++ b/install/functions.php
@@ -226,6 +226,35 @@ function install_setup_get_templates() {
 	return $info;
 }
 
+function install_setup_get_tables() {
+	/* ensure all tables are utf8 enabled */
+	$db_tables = db_fetch_assoc("SHOW TABLES");
+	$t = array();
+	foreach ($db_tables as $tables) {
+		foreach ($tables as $table) {
+			$table_status = db_fetch_row("SHOW TABLE STATUS LIKE '$table'");
+			$collation = '';
+			$engine = '';
+			$rows = 0;
+
+			if ($table_status !== false) {
+				$collation = ($table_status['Collation'] != 'utf8mb4_unicode_ci') ? $table_status['Collation'] : '';
+				$engine    = ($table_status['Engine']    == 'MyISAM')             ? $table_status['Engine']    : '';
+				$rows      = $table_status['Rows'];
+			}
+
+			if ($table_status === false || $collation != '' || $engine != '') {
+				$t[$table]['Name'] = $table;
+				$t[$table]['Collation'] = $collation;
+				$t[$table]['Engine'] = $engine;
+				$t[$table]['Rows'] = $rows;
+			}
+		}
+	}
+
+	return $t;
+}
+
 function to_array ($data) {
 	if (is_object($data)) {
 		$data = get_object_vars($data);

--- a/install/install.js
+++ b/install/install.js
@@ -16,7 +16,8 @@ const STEP_BINARY_LOCATIONS = 4;
 const STEP_PERMISSION_CHECK = 5;
 const STEP_DEFAULT_PROFILE = 6;
 const STEP_TEMPLATE_INSTALL = 7;
-const STEP_INSTALL_CONFIRM = 8;
+const STEP_CHECK_TABLES = 8;
+const STEP_INSTALL_CONFIRM = 9;
 const STEP_INSTALL_OLDVERSION = 11;
 const STEP_INSTALL = 97;
 const STEP_COMPLETE = 98;
@@ -234,6 +235,29 @@ function processStepTemplateInstall(StepData) {
 
 }
 
+function processStepCheckTables(StepData) {
+	var tables = StepData.Tables;
+	if (tables.all) {
+		element = $('#selectall');
+		if (element != null && element.length > 0) {
+			element.click();
+		}
+	} else {
+		for (var propName in tables) {
+			if (tables.hasOwnProperty(propName)) {
+				propValue = tables[propName];
+				if (propValue) {
+					element = $('#' + propName);
+					if (element != null && element.length > 0) {
+						element.prop('checked', true);
+					}
+				}
+			}
+		}
+	}
+
+}
+
 function processStepInstallConfirm(StepData) {
 	if ($('#confirm').length) {
 		$('#confirm').click(function() {
@@ -329,6 +353,7 @@ function prepareInstallData(installStep) {
 		else if (step == STEP_BINARY_LOCATIONS) prepareStepBinaryLocations(newData);
 		else if (step == STEP_DEFAULT_PROFILE) prepareStepDefaultProfile(newData);
 		else if (step == STEP_TEMPLATE_INSTALL) prepareStepTemplateInstall(newData);
+		else if (step == STEP_CHECK_TABLES) prepareStepCheckTables(newData);
 
 		newData.Step = installStep;
 	}
@@ -379,6 +404,15 @@ function prepareStepDefaultProfile(installData) {
 		installData.Profile = element[0].value;
 	}
 }
+
+function prepareStepCheckTables(installData) {
+	tables = {}
+	$('input[name^="chk_"]').each(function(index,element) {
+		tables[element.id] =$(element).is(':checked');
+	});
+	installData.Tables = tables;
+}
+
 function prepareStepTemplateInstall(installData) {
 	templates = {}
 	$('input[name^="chk_"]').each(function(index,element) {
@@ -447,6 +481,8 @@ function performStep(installStep) {
 				processStepDefaultProfile(data.StepData);
 			} else if (data.Step == STEP_TEMPLATE_INSTALL) {
 				processStepTemplateInstall(data.StepData);
+			} else if (data.Step == STEP_CHECK_TABLES) {
+				processStepCheckTables(data.StepData);
 			} else if (data.Step == STEP_INSTALL_CONFIRM) {
 				processStepInstallConfirm(data.StepData);
 			} else if (data.Step == STEP_INSTALL) {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5112,6 +5112,14 @@ function get_cacti_version() {
 }
 
 /**
+ * get_cacti_cli_version() {
+ */
+function get_cacti_cli_version() {
+	$version = get_cacti_version();
+	return ($version == 'new_install') ? CACTI_VERSION : $version;
+}
+
+/**
  * cacti_version_compare - Compare Cacti version numbers
  */
 function cacti_version_compare($version1, $version2, $operator = '>') {

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -351,7 +351,8 @@ class Installer implements JsonSerializable {
 		foreach ($known_tables as $known) {
 			$table = $known['Name'];
 			$key = $known['Name'];
-			$isSelected = !empty($hasTables) && (!empty(read_config_option('install_table_' . $key)));
+			$option = read_config_option('install_table_' . $key);
+			$isSelected = !empty($hasTables) && (!empty($option));
 			$selected['chk_table_' . $key] = $isSelected;
 			if ($isSelected) {
 				$select_count++;


### PR DESCRIPTION
This adds UTF8 and InnoDB conversion to the installer so that admins can see the status of the database at install time.  Especially useful for upgrades were the collation/engine may not be optimal.