### PR TITLE
Feature #1677 - Default Tree node sorting to be inherited

### DIFF
--- a/cacti.sql
+++ b/cacti.sql
@@ -1790,7 +1790,7 @@ CREATE TABLE graph_tree_items (
   host_id mediumint(8) unsigned NOT NULL DEFAULT '0',
   site_id int unsigned DEFAULT '0',
   host_grouping_type tinyint(3) unsigned NOT NULL DEFAULT '1',
-  sort_children_type tinyint(3) unsigned NOT NULL DEFAULT '1',
+  sort_children_type tinyint(3) unsigned NOT NULL DEFAULT '0',
   graph_regex varchar(60) DEFAULT '',
   host_regex varchar(60) DEFAULT '',
   PRIMARY KEY (`id`),

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -62,6 +62,7 @@ Cacti CHANGELOG
 -feature#1597: Ensure synchronised files have same attributes as originals
 -feature#1593: Allow External links to auto refresh
 -feature#1610: Script STDERR logging
+-feature#1677: Default Tree nodes sorting to be inherited
 -feature: Make Graph and Data Source suggested naming more efficient
 -feature: Make tree editing responive
 -feature: Add support for DDERIVE and DCOUNTER to Cacti

--- a/install/upgrades/1_2_0.php
+++ b/install/upgrades/1_2_0.php
@@ -61,6 +61,8 @@ function upgrade_to_1_2_0() {
 	}
 
 	db_install_execute("ALTER TABLE graph_tree_items
-			MODIFY COLUMN sort_children_type tinyint(3) unsigned NOT NULL DEFAULT '0'");
-	db_install_execute('UPDATE graph_templates_graph SET t_title="" WHERE t_title IS NULL or t_title="0"');
+		MODIFY COLUMN sort_children_type tinyint(3) unsigned NOT NULL DEFAULT '0'");
+	
+	db_install_execute('UPDATE graph_templates_graph 
+		SET t_title="" WHERE t_title IS NULL or t_title="0"');
 }

--- a/install/upgrades/1_2_0.php
+++ b/install/upgrades/1_2_0.php
@@ -60,5 +60,7 @@ function upgrade_to_1_2_0() {
 			ADD COLUMN `refresh` int unsigned default NULL");
 	}
 
+	db_install_execute("ALTER TABLE graph_tree_items
+			MODIFY COLUMN sort_children_type tinyint(3) unsigned NOT NULL DEFAULT '0'");
 	db_install_execute('UPDATE graph_templates_graph SET t_title="" WHERE t_title IS NULL or t_title="0"');
 }

--- a/lib/api_tree.php
+++ b/lib/api_tree.php
@@ -151,7 +151,7 @@ function api_tree_copy_node($tree_id, $node_id, $new_parent, $new_position) {
 	$save['host_id']            = $data['host'];
 	$save['site_id']            = $data['site'];
 	$save['host_grouping_type'] = 1;
-	$save['sort_children_type'] = 1;
+	$save['sort_children_type'] = TREE_ORDERING_INHERIT;
 	$save['title']              = $title;
 
 	$id = sql_save($save, 'graph_tree_items');
@@ -237,7 +237,7 @@ function api_tree_create_node($tree_id, $node_id, $position, $title = '') {
 	$save['host_id']            = 0;
 	$save['site_id']            = 0;
 	$save['host_grouping_type'] = 1;
-	$save['sort_children_type'] = 1;
+	$save['sort_children_type'] = TREE_ORDERING_INHERIT;
 	$save['title']              = $title;
 
 	$id = sql_save($save, 'graph_tree_items');


### PR DESCRIPTION
This feature (#1677) changes the default sorting option to be 'Inherited' when creating new nodes (including root ones) whilst editing a tree. This does not update existing ones to be inherited.

Note: if a DB has already been updated to 1.2, either downgrade and upgrade again or modify the `sort_children_type` default on the `graph_tree_items` table to be 0 rather than 1.  Failure to do so will result in manual sorting still being applied do to SQL/PHP assuming that a zero means no value!