### PR TITLE
Issue #1674 - Threads and Processes values not migrated to Poller table during upgrade

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -40,6 +40,7 @@ Cacti CHANGELOG
 -issue#1655: Correct Cacti to handle new MySQL 8.0 reserved word `system`
 -issue#1658: Devices drop down should be filtered by Site
 -issue#1660: Reports based upon Tree don't maintain graph order
+-issue#1674: Threads and Processes values not migrated to Poller table during upgrade
 -issue: Move Graph removal function to Graph API
 -issue: Fix issue with display_custom_error_message() causing problem with system error message handling
 -issue: Graph List View was not fully responsive

--- a/install/upgrades/1_2_0.php
+++ b/install/upgrades/1_2_0.php
@@ -37,6 +37,21 @@ function upgrade_to_1_2_0() {
 			ADD COLUMN total_polls INT unsigned DEFAULT '0' AFTER avg_time,
 			ADD COLUMN processes INT unsigned DEFAULT '1' AFTER total_polls,
 			ADD COLUMN threads INT unsigned DEFAULT '1' AFTER processes");
+
+		// Take the value from the settings table and translate to
+		// the new Data Collector table settings
+
+		// Ensure value falls in line with what we expect for processes
+		$max_processes = read_config_option('concurrent_processes');
+		if ($max_processes < 1) $max_processes = 1;
+		if ($max_processes > 10) $max_processes = 10;
+
+		// Ensure value falls in line with what we expect for threads
+		$max_threads = read_config_option('max_threads');
+		if ($max_threads < 1) $max_threads = 1;
+		if ($max_threads > 100) $max_threads = 100;
+
+		db_install_execute("UPDATE TABLE poller SET processes = $max_processes, threads = $max_threads");
 	}
 
 	if (!db_column_exists('host', 'location')) {


### PR DESCRIPTION
When upgrading to v1.2.0 a new set of fields are added to the Poller table to allow customisation of the number of processes/threads per poller.  That helps to vary the amount used if any given poller has more or less power than another.

However, the system-wide defaults should be migrated against each poller present in the poller table during the upgrade, otherwise both values default back to 1 which seriously increases the time to poll (especially if you have a super high timeout value) as noted in issue #1674