### PR TITLE
Feature #1676 - Allow duplicate sysnames during network discovery

### DIFF
--- a/automation_networks.php
+++ b/automation_networks.php
@@ -171,6 +171,7 @@ function api_networks_save($post) {
 		$save['enabled']            = (isset($post['enabled']) ? 'on':'');
 		$save['enable_netbios']     = (isset($post['enable_netbios']) ? 'on':'');
 		$save['add_to_cacti']       = (isset($post['add_to_cacti']) ? 'on':'');
+		$save['same_sysname']       = (isset($post['same_sysname']) ? 'on':'');
 		$save['rerun_data_queries'] = (isset($post['rerun_data_queries']) ? 'on':'');
 
 		/* discovery connectivity settings */
@@ -536,6 +537,12 @@ function network_edit() {
 		'friendly_name' => __('Automatically Add to Cacti'),
 		'description' => __('For any newly discovered Devices that are reachable using SNMP and who match a Device Rule, add them to Cacti.'),
 		'value' => '|arg1:add_to_cacti|'
+		),
+	'same_sysname' => array(
+		'method' => 'checkbox',
+		'friendly_name' => __('Allow same sysName on different hosts'),
+		'description' => __('When discovering devices, allow duplicate sysnames to be added on different hosts'),
+		'value' => '|arg1:same_sysname|'
 		),
 	'rerun_data_queries' => array(
 		'method' => 'checkbox',

--- a/cacti.sql
+++ b/cacti.sql
@@ -294,6 +294,7 @@ CREATE TABLE `automation_networks` (
   `snmp_id` int(10) unsigned DEFAULT NULL,
   `enable_netbios` char(2) DEFAULT '',
   `add_to_cacti` char(2) DEFAULT '',
+  `same_sysname` char(2) DEFAULT '',
   `total_ips` int(10) unsigned DEFAULT '0',
   `up_hosts` int(10) unsigned NOT NULL DEFAULT '0',
   `snmp_hosts` int(10) unsigned NOT NULL DEFAULT '0',

--- a/cacti.sql
+++ b/cacti.sql
@@ -325,7 +325,7 @@ CREATE TABLE `automation_networks` (
 -- Dumping data for table `automation_networks`
 --
 
-INSERT INTO `automation_networks` VALUES (1,1,1,'Test Network','192.168.1.0/24','','',1,'on','',254,14,8,2,22,400,1,2,10,1200,'2015-05-17 16:15','0000-00-00 00:00:00',2,'4','1,2,6','1,2,3,4,6,7,11,12,14,15,17,19,26,32','','',40.178689002991,'2015-05-19 02:23:22','','on');
+INSERT INTO `automation_networks` VALUES (1,1,1,'Test Network','192.168.1.0/24','','',1,'on','','',254,14,8,2,22,400,1,2,10,1200,'2015-05-17 16:15','0000-00-00 00:00:00',2,'4','1,2,6','1,2,3,4,6,7,11,12,14,15,17,19,26,32','','',40.178689002991,'2015-05-19 02:23:22','','on');
 
 --
 -- Table structure for table `automation_processes`

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -40,6 +40,7 @@ Cacti CHANGELOG
 -issue#1655: Correct Cacti to handle new MySQL 8.0 reserved word `system`
 -issue#1658: Devices drop down should be filtered by Site
 -issue#1660: Reports based upon Tree don't maintain graph order
+-issue#1676: Allow automation discovery to add the same sysname on different hosts
 -issue: Move Graph removal function to Graph API
 -issue: Fix issue with display_custom_error_message() causing problem with system error message handling
 -issue: Graph List View was not fully responsive

--- a/install/upgrades/1_2_0.php
+++ b/install/upgrades/1_2_0.php
@@ -62,7 +62,7 @@ function upgrade_to_1_2_0() {
 
 	if (!db_column_exists('automation_networks', 'same_sysname')) {
 		db_install_execute("ALTER TABLE automation_networks
-			ADD COLUMN `same_sysname` char(2) DEFAULT ''");
+			ADD COLUMN `same_sysname` char(2) DEFAULT '' AFTER `add_to_cacti`");
 	}
 
 	db_install_execute('UPDATE graph_templates_graph SET t_title="" WHERE t_title IS NULL or t_title="0"');

--- a/install/upgrades/1_2_0.php
+++ b/install/upgrades/1_2_0.php
@@ -60,5 +60,10 @@ function upgrade_to_1_2_0() {
 			ADD COLUMN `refresh` int unsigned default NULL");
 	}
 
+	if (!db_column_exists('automation_networks', 'same_sysname')) {
+		db_install_execute("ALTER TABLE automation_networks
+			ADD COLUMN `dupe_sysname` char(2) DEFAULT ''");
+	}
+
 	db_install_execute('UPDATE graph_templates_graph SET t_title="" WHERE t_title IS NULL or t_title="0"');
 }

--- a/install/upgrades/1_2_0.php
+++ b/install/upgrades/1_2_0.php
@@ -62,7 +62,7 @@ function upgrade_to_1_2_0() {
 
 	if (!db_column_exists('automation_networks', 'same_sysname')) {
 		db_install_execute("ALTER TABLE automation_networks
-			ADD COLUMN `dupe_sysname` char(2) DEFAULT ''");
+			ADD COLUMN `same_sysname` char(2) DEFAULT ''");
 	}
 
 	db_install_execute('UPDATE graph_templates_graph SET t_title="" WHERE t_title IS NULL or t_title="0"');

--- a/poller_automation.php
+++ b/poller_automation.php
@@ -579,8 +579,8 @@ function discoverDevices($network_id, $thread) {
 							if ($snmp_sysName != '') {
 								$isCactiSysName = db_fetch_cell_prepared('SELECT COUNT(*)
 									FROM host
-									AND ip == ?
-									WHERE snmp_sysName = ?',
+									WHERE snmp_sysName = ?
+									AND ip == ?',
 									array($snmp_sysName, $device['ip_address']));
 
 								if ($isCactiSysName) {

--- a/poller_automation.php
+++ b/poller_automation.php
@@ -579,8 +579,9 @@ function discoverDevices($network_id, $thread) {
 							if ($snmp_sysName != '') {
 								$isCactiSysName = db_fetch_cell_prepared('SELECT COUNT(*)
 									FROM host
+									AND ip == ?
 									WHERE snmp_sysName = ?',
-									array($snmp_sysName));
+									array($snmp_sysName, $device['ip_address']));
 
 								if ($isCactiSysName) {
 									automation_debug(", Skipping sysName '" . $snmp_sysName . "' already in Cacti!\n");
@@ -588,18 +589,20 @@ function discoverDevices($network_id, $thread) {
 									continue;
 								}
 
-								$isDuplicateSysName = db_fetch_cell_prepared('SELECT COUNT(*)
-									FROM automation_devices
-									WHERE network_id = ?
-									AND sysName != ""
-									AND ip != ?
-									AND sysName = ?',
-									array($device['ip_address'], $network_id, $snmp_sysName));
+								if ($network['same_sysname'] == '') {
+									$isDuplicateSysName = db_fetch_cell_prepared('SELECT COUNT(*)
+										FROM automation_devices
+										WHERE network_id = ?
+										AND sysName != ""
+										AND ip != ?
+										AND sysName = ?',
+										array($device['ip_address'], $network_id, $snmp_sysName));
 
-								if ($isDuplicateSysName) {
-									automation_debug(", Skipping sysName '" . $snmp_sysName . "' already Discovered!\n");
-									markIPDone($device['ip_address'], $network_id);
-									continue;
+									if ($isDuplicateSysName) {
+										automation_debug(", Skipping sysName '" . $snmp_sysName . "' already Discovered!\n");
+										markIPDone($device['ip_address'], $network_id);
+										continue;
+									}
 								}
 
 								$stats['snmp']++;


### PR DESCRIPTION
Feature #1676 adds functionality to enable duplicate sysnames to be added to the system on multiple hosts.  An option will be visible in the settings of the Network being discovered to enable this functionality which is disabled by default to maintain the current level of functionality