### PR TITLE
Avoid 414 URI Too Long when using refresh on graph_view.php

### DIFF
--- a/include/global_session.php
+++ b/include/global_session.php
@@ -65,11 +65,11 @@ if (isset($_SESSION['refresh'])) {
 	unset($_SESSION['refresh']);
 } elseif (isset($refresh) && is_array($refresh)) {
 	$myrefresh['seconds'] = $refresh['seconds'];
-	$myrefresh['page']    = sanitize_uri($refresh['page'] . (strpos($refresh['page'], 'header=false') == -1 ? ((strpos($refresh['page'], '?') ? '&':'?') . 'header=false') : ''));
+	$myrefresh['page']    = sanitize_uri(appendHeaderSuppression($refresh['page'] . (strpos($refresh['page'], '?') ? '&':'?') . 'header=false'));
 	$refreshIsLogout      = 'false';
 } elseif (isset($refresh)) {
 	$myrefresh['seconds'] = $refresh;
-	$myrefresh['page']    = sanitize_uri($_SERVER['REQUEST_URI'] . (strpos($_SERVER['REQUEST_URI'], 'header=false') == -1 ? ((strpos($_SERVER['REQUEST_URI'], '?') ? '&':'?') . 'header=false') : ''));
+	$myrefresh['page']    = sanitize_uri(appendHeaderSuppression($_SERVER['REQUEST_URI'] . (strpos($_SERVER['REQUEST_URI'], '?') ? '&':'?') . 'header=false'));
 	$refreshIsLogout      = 'false';
 } elseif (read_config_option('auth_cache_enabled') == 'on' && isset($_COOKIE['cacti_remembers'])) {
 	$myrefresh['seconds'] = 99999999;

--- a/include/global_session.php
+++ b/include/global_session.php
@@ -65,11 +65,11 @@ if (isset($_SESSION['refresh'])) {
 	unset($_SESSION['refresh']);
 } elseif (isset($refresh) && is_array($refresh)) {
 	$myrefresh['seconds'] = $refresh['seconds'];
-	$myrefresh['page']    = sanitize_uri($refresh['page'] . (strpos($refresh['page'], '?') ? '&':'?') . 'header=false');
+	$myrefresh['page']    = sanitize_uri($refresh['page'] . (strpos($refresh['page'], 'header=false') == -1 ? ((strpos($refresh['page'], '?') ? '&':'?') . 'header=false') : ''));
 	$refreshIsLogout      = 'false';
 } elseif (isset($refresh)) {
 	$myrefresh['seconds'] = $refresh;
-	$myrefresh['page']    = sanitize_uri($_SERVER['REQUEST_URI'] . (strpos($_SERVER['REQUEST_URI'], '?') ? '&':'?') . 'header=false');
+	$myrefresh['page']    = sanitize_uri($_SERVER['REQUEST_URI'] . (strpos($_SERVER['REQUEST_URI'], 'header=false') == -1 ? ((strpos($_SERVER['REQUEST_URI'], '?') ? '&':'?') . 'header=false') : ''));
 	$refreshIsLogout      = 'false';
 } elseif (read_config_option('auth_cache_enabled') == 'on' && isset($_COOKIE['cacti_remembers'])) {
 	$myrefresh['seconds'] = 99999999;


### PR DESCRIPTION
I ran into an issue where refresh on graph_view.php would start to stack header=false in the uri.  Within 8 hours it would hit the 414 error and stop refreshing.  Since these were monitors up on the wall it was a pain to manually reset them all the time.

Here is the fix to stop it from happening, hope it helps others and saves them the frustration.