### PR TITLE
Issue #1723 - die() messages should include \n for better logging

### DIFF
--- a/aggregate_items.php
+++ b/aggregate_items.php
@@ -298,7 +298,7 @@ function item_edit() {
 		$page_name  = 'aggregate_templates.php';
 	}else {
 		/* TODO redirect somewhere and show an error message, rather than die */
-		die();
+		die("We should have redirected somewhere but we ended up here instead\n");
 	}
 
 	if (!isempty_request_var('id')) {

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -54,6 +54,7 @@ Cacti CHANGELOG
 -issue#1716: New Installation incorrectly reports log unwritable bug
 -issue#1718: auth_changepassword generates no such file warning
 -issue#1721: Console Side Bar not correct on first login
+-issue#1723: die() messages should include \n for better logging
 -issue: Move Graph removal function to Graph API
 -issue: Fix issue with display_custom_error_message() causing problem with system error message handling
 -issue: Graph List View was not fully responsive

--- a/include/global.php
+++ b/include/global.php
@@ -75,7 +75,7 @@ if (file_exists(dirname(__FILE__) . '/config.php')) {
 }
 
 if (isset($config['cacti_version'])) {
-	die('Invalid include/config.php file detected.');
+	die("Invalid include/config.php file detected.\n");
 	exit;
 }
 
@@ -204,7 +204,7 @@ include_once($config['include_path'] . '/global_constants.php');
 
 /* check cacti log is available */
 if (!is_resource_writable(cacti_log_file())) {
-	die('System log file is not available for writing, please enable write access');
+	die("System log file is not available for writing, please enable write access\n");
 }
 
 $filename = get_current_page();

--- a/include/global_languages.php
+++ b/include/global_languages.php
@@ -153,12 +153,12 @@ $l10n = array();
 foreach ($cacti_textdomains as $domain => $paths) {
 	$input = new FileReader($cacti_textdomains[$domain]['path2catalogue']);
 	if ($input == false) {
-		die('Unable to read file: ' . $cacti_textdomains[$domain]['path2catalogue']);
+		die('Unable to read file: ' . $cacti_textdomains[$domain]['path2catalogue'] . "\n");
 	}
 
 	$l10n[$domain] = new gettext_reader($input);
 	if ($l10n[$domain] == false) {
-		die('Invalid language file: ' . $cacti_textdomains[$domain]['path2catalogue']);
+		die('Invalid language file: ' . $cacti_textdomains[$domain]['path2catalogue'] . "\n");
 	}
 }
 unset($input);

--- a/install/background.php
+++ b/install/background.php
@@ -49,7 +49,7 @@ $params = $_SERVER['argv'];
 array_shift($params);
 
 if (sizeof($params) == 0) {
-	die('no parameters passed');
+	die("no parameters passed\n");
 }
 
 $backgroundTime = read_config_option('install_started', true);

--- a/lib/aggregate.php
+++ b/lib/aggregate.php
@@ -296,7 +296,7 @@ function aggregate_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
 		cacti_debug_backtrace('AGGREGATE', true);
 
 		if (isset($GLOBALS['error_fatal'])) {
-			if($GLOBALS['error_fatal'] & $errno) die('fatal');
+			if($GLOBALS['error_fatal'] & $errno) die("Fatal error $errno\n");
 		}
 	}
 

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -1501,7 +1501,7 @@ function reports_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
 		cacti_debug_backtrace('REPORTS', true);
 
 		if (isset($GLOBALS['error_fatal'])) {
-			if($GLOBALS['error_fatal'] & $errno) die('fatal');
+			if($GLOBALS['error_fatal'] & $errno) die("Fatal error $errno\n");
 		}
 	}
 


### PR DESCRIPTION
This corrects issue #1723 where die() messages appear in log files without a new line character causing logs to appear corrupted.