### PR TITLE
Fix for issue #1732

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -56,6 +56,7 @@ Cacti CHANGELOG
 -issue#1721: Console Side Bar not correct on first login
 -issue#1723: die() messages should include PHP_EOF for better logging
 -issue#1726: Poor page performance editing a Graphs Graph Items
+-issue#1732: Correct utf8 table conversion script name
 -issue: Move Graph removal function to Graph API
 -issue: Fix issue with display_custom_error_message() causing problem with system error message handling
 -issue: Graph List View was not fully responsive

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -1603,7 +1603,7 @@ class Installer implements JsonSerializable {
 			if ($show_warning) {
 				$output .= Installer::sectionTitleError(__('WARNING'));
 				$output .= Installer::sectionNormal(__('One or more tables are too large to convert during the installation.  You should use the cli/convert_tables.php script to perform the conversion.'));
-				$output .= Installer::sectionCode(read_config_option('path_php_binary') . ' -q ' . $config['base_path'] . 'cli/convert_database.php -u -i');
+				$output .= Installer::sectionCode(read_config_option('path_php_binary') . ' -q ' . $config['base_path'] . 'cli/convert_tables.php -u -i');
 			}
 
 			ob_end_clean();


### PR DESCRIPTION
This corrects the display asking the user to run `cli/convert_database.php` to `cli/convert_tables.php` which is the correct script name (#1732)