### PR TITLE
Resolving issue #1689

### DIFF
--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -879,7 +879,7 @@ function graph_edit() {
 
 		form_hidden_box('save_component_graph','1','');
 		form_hidden_box('save_component_input','1','');
-		form_hidden_box('rrdtool_version', read_config_option('rrdtool_version'), '');
+		form_hidden_box('rrdtool_version', get_rrdtool_version(), '');
 		form_save_button($referer, 'return', 'id');
 
 		echo '</div>';
@@ -907,7 +907,7 @@ function graph_edit() {
 		function dynamic() {
 			if ($('#scale_log_units')) {
 				$('#scale_log_units').prop('disabled', true);
-				if (($('#rrdtool_version').val() != 'rrd-1.0.x') &&
+				if (($('#rrdtool_version').val() != '1.0.0') &&
 					($('#auto_scale_log').is(':checked'))) {
 					$('#scale_log_units').prop('disabled', true);
 				}
@@ -917,7 +917,7 @@ function graph_edit() {
 		function changeScaleLog() {
 			if ($('#scale_log_units')) {
 				$('#scale_log_units').prop('disabled', true);
-				if (($('#rrdtool_version').val() != 'rrd-1.0.x') &&
+				if (($('#rrdtool_version').val() != '1.0.0') &&
 					($('#auto_scale_log').is(':checked'))) {
 					$('#scale_log_units').prop('disabled', false);
 				}

--- a/aggregate_items.php
+++ b/aggregate_items.php
@@ -381,7 +381,7 @@ function item_edit() {
 	form_hidden_box('_graph_type_id', (isset($template_item) ? $template_item['graph_type_id'] : '0'), '');
 	form_hidden_box('save_component_item', '1', '');
 	form_hidden_box('invisible_alpha', $form_array['alpha']['value'], 'FF');
-	form_hidden_box('rrdtool_version', read_config_option('rrdtool_version'), '');
+	form_hidden_box('rrdtool_version', get_rrdtool_version(), '');
 	form_hidden_box('aggregate_graph_id', get_request_var('aggregate_graph_id'), '0');
 	form_hidden_box('aggregate_template_id', get_request_var('aggregate_template_id'), '0');
 

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -49,6 +49,7 @@ Cacti CHANGELOG
 -issue#1674: Threads and Processes values not migrated to Poller table during upgrade
 -issue#1676: Allow automation discovery to add the same sysname on different hosts
 -issue#1682: Slow Select Statement lib/api_automation.php
+-issue#1689: Technical Support's RRDTool version should show detected RRD version
 -issue#1690: Report a warning if the default collation is not utf8mb4_unicode_ci
 -issue#1700: Mail sent without auth causes errors to appear in logs
 -issue#1710: RRDtool create command causes first update to fail

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -535,7 +535,7 @@ function template_edit() {
 		)
 	);
 
-	form_hidden_box('rrdtool_version', read_config_option('rrdtool_version'), '');
+	form_hidden_box('rrdtool_version', get_rrdtool_version(), '');
 
 	html_end_box(true, true);
 

--- a/graph_templates_items.php
+++ b/graph_templates_items.php
@@ -465,7 +465,7 @@ function item_edit() {
 	form_hidden_box('_task_item_id', (isset($template_item) ? $template_item['task_item_id'] : '0'), '');
 	form_hidden_box('save_component_item', '1', '');
 	form_hidden_box('invisible_alpha', $form_array['alpha']['value'], 'FF');
-	form_hidden_box('rrdtool_version', read_config_option('rrdtool_version'), '');
+	form_hidden_box('rrdtool_version', get_rrdtool_version(), '');
 
 	form_save_button('graph_templates.php?action=template_edit&id=' . get_request_var('graph_template_id'));
 

--- a/graphs.php
+++ b/graphs.php
@@ -1557,7 +1557,7 @@ function graph_edit() {
 		form_hidden_box('save_component_graph_new','1','');
 	}
 
-	form_hidden_box('rrdtool_version', read_config_option('rrdtool_version'), '');
+	form_hidden_box('rrdtool_version', get_rrdtool_version(), '');
 
 	form_save_button('graphs.php');
 

--- a/graphs_items.php
+++ b/graphs_items.php
@@ -499,7 +499,7 @@ function item_edit() {
 	form_hidden_box('_graph_type_id', (!empty($template_item) ? $template_item['graph_type_id'] : '0'), '');
 	form_hidden_box('save_component_item', '1', '');
 	form_hidden_box('invisible_alpha', $form_array['alpha']['value'], 'FF');
-	form_hidden_box('rrdtool_version', read_config_option('rrdtool_version'), '');
+	form_hidden_box('rrdtool_version', get_rrdtool_version(), '');
 
 	html_end_box(true, true);
 

--- a/include/global_arrays.php
+++ b/include/global_arrays.php
@@ -471,7 +471,7 @@ $data_source_types = array(
 	5 => 'COMPUTE'
 );
 
-if (get_rrdtool_version() >= 1.5) {
+if (cacti_version_compare(get_rrdtool_version(), '1.5', '>=')) {
 	$data_source_types[6] = 'DCOUNTER';
 	$data_source_types[7] = 'DDERIVE';
 }
@@ -756,11 +756,12 @@ $ldap_modes = array(
 );
 
 $rrdtool_versions = array(
-	'rrd-1.3.x' => 'RRDtool 1.3.x',
-	'rrd-1.4.x' => 'RRDtool 1.4.x',
-	'rrd-1.5.x' => 'RRDtool 1.5.x',
-	'rrd-1.6.x' => 'RRDtool 1.6.x',
-	'rrd-1.7.x' => 'RRDtool 1.7.x'
+	'1.3.0' => 'RRDtool 1.3+',
+	'1.4.0' => 'RRDtool 1.4+',
+	'1.5.0' => 'RRDtool 1.5+',
+	'1.6.0' => 'RRDtool 1.6+',
+	'1.7.0' => 'RRDtool 1.7+',
+	'1.8.0' => 'RRDtool 1.8+'
 );
 
 $i18n_modes = array(

--- a/include/global_constants.php
+++ b/include/global_constants.php
@@ -47,11 +47,6 @@ define('RRDTOOL_OUTPUT_STDERR', 2);
 define('RRDTOOL_OUTPUT_GRAPH_DATA', 3);
 define('RRDTOOL_OUTPUT_BOOLEAN', 4);
 
-define('RRD_VERSION_1_3', 'rrd-1.3.x');
-define('RRD_VERSION_1_4', 'rrd-1.4.x');
-define('RRD_VERSION_1_5', 'rrd-1.5.x');
-define('RRD_VERSION_1_6', 'rrd-1.6.x');
-
 define('RRD_FONT_RENDER_NORMAL',  'normal');
 define('RRD_FONT_RENDER_LIGHT',   'light');
 define('RRD_FONT_RENDER_MONO',    'mono');

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -380,7 +380,7 @@ $settings = array(
 			'friendly_name' => __('RRDtool Version'),
 			'description' => __('The version of RRDtool that you have installed.'),
 			'method' => 'drop_array',
-			'default' => 'rrd-1.4.x',
+			'default' => '1.4.0',
 			'array' => $rrdtool_versions,
 			),
 		'graph_auth_method' => array(

--- a/install/functions.php
+++ b/install/functions.php
@@ -393,16 +393,13 @@ function install_file_paths () {
 		exec("\"" . $input['path_rrdtool']['default'] . "\"", $out_array);
 
 		if (sizeof($out_array) > 0) {
-			if (preg_match('/^RRDtool 1\.7/', $out_array[0])) {
-				$input['rrdtool_version']['default'] = 'rrd-1.7.x';
-			}else if (preg_match('/^RRDtool 1\.6/', $out_array[0])) {
-				$input['rrdtool_version']['default'] = 'rrd-1.6.x';
-			}else if (preg_match('/^RRDtool 1\.5/', $out_array[0])) {
-				$input['rrdtool_version']['default'] = 'rrd-1.5.x';
-			}else if (preg_match('/^RRDtool 1\.4\./', $out_array[0])) {
-				$input['rrdtool_version']['default'] = 'rrd-1.4.x';
-			}else if (preg_match('/^RRDtool 1\.3\./', $out_array[0])) {
-				$input['rrdtool_version']['default'] = 'rrd-1.3.x';
+			if (preg_match('/^RRDtool ([0-9.]+) /', $out_array[0], $m)) {
+				global $rrdtool_versions;
+				foreach ($rrdtool_versions as $rrdtool_version => $rrdtool_version_text) {
+					if (cacti_version_compare($rrdtool_version, $m[1], '<=')) {
+						$input['rrdtool_version']['default'] = $rrdtool_version;
+					}
+				}
 			}
 		}
 	}

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -1265,7 +1265,7 @@ function boost_rrdtool_function_update($local_data_id, $rrd_path, $rrd_update_te
 		$valid_entry = boost_rrdtool_function_create($local_data_id, $initial_time, false, $rrdtool_pipe);
 	}
 
-	if (get_rrdtool_version() >= 1.5) {
+	if (cacti_version_compare(get_rrdtool_version(),'1.5','>=')) {
 		$update_options='--skip-past-updates';
 	} else {
 		$update_options='';

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5306,7 +5306,14 @@ function get_nonsystem_data_input($data_input_id) {
 }
 
 function get_rrdtool_version() {
-	return str_replace('rrd-', '', str_replace('.x', '', read_config_option('rrdtool_version')));
+	return str_replace('rrd-', '', str_replace('.x', '.0', read_config_option('rrdtool_version')));
+}
+
+function get_installed_rrdtool_version() {
+	$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool') . ' -v 2>&1'));
+	if (preg_match('/^RRDtool ([0-9.]+)$/', $shell, $matches)) {
+		return $matches[1];
+	}
 }
 
 function get_md5_hash($path) {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5306,7 +5306,7 @@ function get_nonsystem_data_input($data_input_id) {
 }
 
 function get_rrdtool_version() {
-	return str_replace('rrd-', '', str_replace('.x', '.0', read_config_option('rrdtool_version')));
+	return str_replace('rrd-', '', str_replace('.x', '.0', read_config_option('rrdtool_version', true)));
 }
 
 function get_installed_rrdtool_version() {

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -195,7 +195,7 @@ class Installer implements JsonSerializable {
 
 		set_config_option('selected_theme', $this->theme);
 
-		$this->rrdVersion = read_config_option('rrdtool_version', true);
+		$this->rrdVersion = get_rrdtool_version();
 
 		$mode = read_config_option('install_mode', true);
 		if ($mode === false || $mode === null) {

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -689,7 +689,7 @@ function rrdtool_function_update($update_cache_array, $rrdtool_pipe = '') {
 					$rrd_update_values .= $value;
 				}
 
-				if (get_rrdtool_version() >= 1.5) {
+				if (cacti_version_compare(get_rrdtool_version(),'1.5','>=')) {
 					$update_options='--skip-past-updates';
 				} else {
 					$update_options='';
@@ -1069,28 +1069,28 @@ function rrd_function_process_graph_options($graph_start, $graph_end, &$graph, &
 			}
 			break;
 		case "legend_position":
-			if ($version != RRD_VERSION_1_3) {
+			if (cacti_version_compare($version, '1.4', '>=') {
 				if (!empty($value)) {
 					$graph_opts .= "--legend-position " . cacti_escapeshellarg($value) . RRD_NL;
 				}
 			}
 			break;
 		case "legend_direction":
-			if ($version != RRD_VERSION_1_3) {
+			if (cacti_version_compare($version, '1.4', '>=') {
 				if (!empty($value)) {
 					$graph_opts .= "--legend-direction " . cacti_escapeshellarg($value) . RRD_NL;
 				}
 			}
 			break;
 		case 'left_axis_formatter':
-			if ($version != RRD_VERSION_1_3) {
+			if (cacti_version_compare($version, '1.4', '>=') {
 				if (!empty($value)) {
 					$graph_opts .= "--left-axis-formatter " . cacti_escapeshellarg($value) . RRD_NL;
 				}
 			}
 			break;
 		case 'right_axis_formatter':
-			if ($version != RRD_VERSION_1_3) {
+			if (cacti_version_compare($version, '1.4', '>=') {
 				if (!empty($value)) {
 					$graph_opts .= "--right-axis-formatter " . cacti_escapeshellarg($value) . RRD_NL;
 				}
@@ -2695,10 +2695,10 @@ function rrdtool_info2html($info_array, $diff=array()) {
 	}
 
 	$loop = array(
-		'filename' 		=> $info_array['filename'],
-		'rrd_version'	=> $info_array['rrd_version'],
-		'step' 			=> $info_array['step'],
-		'last_update'	=> $info_array['last_update']);
+		'filename'    => $info_array['filename'],
+		'rrd_version' => $info_array['rrd_version'],
+		'step'        => $info_array['step'],
+		'last_update' => $info_array['last_update']);
 
 	foreach ($loop as $key => $value) {
 		form_alternate_row($key, true);

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1069,28 +1069,28 @@ function rrd_function_process_graph_options($graph_start, $graph_end, &$graph, &
 			}
 			break;
 		case "legend_position":
-			if (cacti_version_compare($version, '1.4', '>=') {
+			if (cacti_version_compare($version, '1.4', '>=')) {
 				if (!empty($value)) {
 					$graph_opts .= "--legend-position " . cacti_escapeshellarg($value) . RRD_NL;
 				}
 			}
 			break;
 		case "legend_direction":
-			if (cacti_version_compare($version, '1.4', '>=') {
+			if (cacti_version_compare($version, '1.4', '>=')) {
 				if (!empty($value)) {
 					$graph_opts .= "--legend-direction " . cacti_escapeshellarg($value) . RRD_NL;
 				}
 			}
 			break;
 		case 'left_axis_formatter':
-			if (cacti_version_compare($version, '1.4', '>=') {
+			if (cacti_version_compare($version, '1.4', '>=')) {
 				if (!empty($value)) {
 					$graph_opts .= "--left-axis-formatter " . cacti_escapeshellarg($value) . RRD_NL;
 				}
 			}
 			break;
 		case 'right_axis_formatter':
-			if (cacti_version_compare($version, '1.4', '>=') {
+			if (cacti_version_compare($version, '1.4', '>=')) {
 				if (!empty($value)) {
 					$graph_opts .= "--right-axis-formatter " . cacti_escapeshellarg($value) . RRD_NL;
 				}

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -859,7 +859,7 @@ function rrd_function_process_graph_options($graph_start, $graph_end, &$graph, &
 	$scale               = '';
 	$rigid               = '';
 	$unit_value          = '';
-	$version             = read_config_option('rrdtool_version');
+	$version             = get_rrdtool_version();
 	$unit_exponent_value = '';
 
 	if ($graph['auto_scale'] == 'on') {
@@ -2278,7 +2278,7 @@ function rrdtool_function_theme_font_options(&$graph_data_array) {
 	}
 
 	if (file_exists($rrdtheme) && is_readable($rrdtheme)) {
-		$rrdversion = str_replace('rrd-', '', str_replace('.x', '', read_config_option('rrdtool_version')));
+		$rrdversion = get_rrdtool_version();
 		include($rrdtheme);
 
 		if (isset($rrdcolors)) {
@@ -2287,7 +2287,7 @@ function rrdtool_function_theme_font_options(&$graph_data_array) {
 			}
 		}
 
-		if (isset($rrdborder) && $rrdversion >= 1.4) {
+		if (isset($rrdborder) && cacti_version_compare($rrdversion,'1.4','>=')) {
 			$graph_opts .= "--border $rrdborder " ;
 		}
 
@@ -2309,7 +2309,7 @@ function rrdtool_function_theme_font_options(&$graph_data_array) {
 	$graph_opts .= rrdtool_function_set_font('unit', '', $themefonts);
 
 	/* watermark fonts */
-	if (isset($rrdversion) && $rrdversion > 1.3) {
+	if (isset($rrdversion) && cacti_version_compare($rrdversion,'1.3','>')) {
 		$graph_opts .= rrdtool_function_set_font('watermark', '', $themefonts);
 	}
 

--- a/lib/snmpagent.php
+++ b/lib/snmpagent.php
@@ -68,7 +68,7 @@ function snmpagent_global_settings_update(){
 	$mc = new MibCache();
 	$mc->object('cactiApplVersion')->set( snmpagent_read('cactiApplVersion') );
 	$mc->object('cactiApplSnmpVersion')->set( snmpagent_read('cactiApplSnmpVersion') );
-	$mc->object('cactiApplRrdtoolVersion')->set( read_config_option('rrdtool_version', true) );
+	$mc->object('cactiApplRrdtoolVersion')->set( get_rrdtool_version() );
 	$mc->object('cactiApplPollerEnabled')->set( (read_config_option('poller_enabled', true) == 'on') ? 1 : 2 );
 	$mc->object('cactiApplPollerType')->set( read_config_option('poller_type', true) );
 	$mc->object('cactiApplPollerInterval')->set( read_config_option('poller_interval', true) );

--- a/utilities.php
+++ b/utilities.php
@@ -181,7 +181,7 @@ function utilities_view_tech($php_info = '') {
 
 	/* Check RRDtool issues */
 	$rrdtool_errors = array();
-	if (cacti_version_compare($rrdtool_version, read_config_option('rrdtool_version'), '<')) {
+	if (cacti_version_compare($rrdtool_version, get_rrdtool_version(), '<')) {
 		$rrdtool_errors[] = "<span class='deviceDown'>" . __('ERROR: Installed RRDtool version does not exceed configured version.<br>Please visit the %s and select the correct RRDtool Utility Version.', "<a href='" . html_escape('settings.php?tab=general') . "'>" . __('Configuration Settings') . '</a>') . "</span>";
 	}
 
@@ -272,7 +272,7 @@ function utilities_view_tech($php_info = '') {
 
 		form_alternate_row();
 		print '<td>' . __('RRDtool Version') . ' ' . __('Configured') . "</td>\n";
-		print '<td>' . read_config_option('rrdtool_version') . "+</td>\n";
+		print '<td>' . get_rrdtool_version() . "+</td>\n";
 		form_end_row();
 
 		form_alternate_row();

--- a/utilities.php
+++ b/utilities.php
@@ -164,8 +164,10 @@ function utilities_view_tech($php_info = '') {
 		$out_array = array();
 		exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
 		if (sizeof($out_array) > 0) {
-			if (preg_match('/^RRDtool ([1-9]\.[0-9])/', $out_array[0], $m)) {
-				$rrdtool_version = 'rrd-'. $m[1] .'.x';
+			if (preg_match('/^RRDtool ([0-9.]+)/', $out_array[0], $m)) {
+				preg_match('/^([0-9]+\.[0-9]+)\./', $m[1], $m2);
+				$rrdtool_release = $m[1];
+				$rrdtool_version = $m2[1];
 			}
 		}
 	}
@@ -178,13 +180,14 @@ function utilities_view_tech($php_info = '') {
 	}
 
 	/* Check RRDtool issues */
-	$rrdtool_error = '';
-	if ($rrdtool_version != read_config_option('rrdtool_version')) {
-		$rrdtool_error .= "<br><span class='deviceDown'>" . __('ERROR: Installed RRDtool version does not match configured version.<br>Please visit the %s and select the correct RRDtool Utility Version.', "<a href='" . html_escape('settings.php?tab=general') . "'>" . __('Configuration Settings') . '</a>') . "</span><br>";
+	$rrdtool_errors = array();
+	if (cacti_version_compare($rrdtool_version, read_config_option('rrdtool_version'), '<')) {
+		$rrdtool_errors[] = "<span class='deviceDown'>" . __('ERROR: Installed RRDtool version does not exceed configured version.<br>Please visit the %s and select the correct RRDtool Utility Version.', "<a href='" . html_escape('settings.php?tab=general') . "'>" . __('Configuration Settings') . '</a>') . "</span>";
 	}
+
 	$graph_gif_count = db_fetch_cell('SELECT COUNT(*) FROM graph_templates_graph WHERE image_format_id = 2');
 	if ($graph_gif_count > 0) {
-		$rrdtool_error .= "<br><span class='deviceDown'>" . __('ERROR: RRDtool 1.2.x+ does not support the GIF images format, but %d" graph(s) and/or templates have GIF set as the image format.', $graph_gif_count) . '</span><br>';
+		$rrdtool_errors[] = "<span class='deviceDown'>" . __('ERROR: RRDtool 1.2.x+ does not support the GIF images format, but %d" graph(s) and/or templates have GIF set as the image format.', $graph_gif_count) . '</span>';
 	}
 
 	/* Get spine version */
@@ -268,9 +271,27 @@ function utilities_view_tech($php_info = '') {
 		form_end_row();
 
 		form_alternate_row();
-		print '<td>' . __('RRDtool Version') . "</td>\n";
-		print '<td>' . $rrdtool_versions[$rrdtool_version] . ' ' . $rrdtool_error . "</td>\n";
+		print '<td>' . __('RRDtool Version') . ' ' . __('Configured') . "</td>\n";
+		print '<td>' . read_config_option('rrdtool_version') . "+</td>\n";
 		form_end_row();
+
+		form_alternate_row();
+		print '<td>' . __('RRDtool Version') . ' ' . __('Found') . "</td>\n";
+		print '<td>' . $rrdtool_release . "</td>\n";
+		form_end_row();
+
+		if (!empty($rrdtool_errors)) {
+			form_alternate_row();
+			print "<td>&nbsp;</td>\n";
+			$br = '';
+			print "<td>";
+			foreach ($rrdtool_errors as $rrdtool_error) {
+				print $br . $rrdtool_error;
+				$br = '<br/>';
+			}
+			print "</td>\n";
+			form_end_row();
+		}
 
 		form_alternate_row();
 		print '<td>' . __('Devices') . "</td>\n";


### PR DESCRIPTION
As noted in issue #1689 (Technical Support's RRDTool version should show detected RRD version) the version of the RRDTool is never actually displayed. The code has now been updated to properly handle versioning and displays both the configured and installed versions.

The setting for rrdtool_version has been updated to a proper minimum version number so that the cacti_version_compare() function may be effectively used. This means that the constant values of RRDTOOL_VERSION_1_3 through RRDTOOL_VERSION_1_7 have now been removed from the system.
