### PR TITLE
Resolving issues #1791 and #1794

### DIFF
--- a/cacti.sql
+++ b/cacti.sql
@@ -1245,6 +1245,29 @@ CREATE TABLE data_local (
 --
 
 --
+-- Table structure for table `data_debug`
+--
+
+CREATE TABLE `data_debug` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `started` int(11) NOT NULL default '0',
+  `done` int(11) NOT NULL default '0',
+  `user` int(11) NOT NULL default '0',
+  `datasource` int(11) NOT NULL default '0',
+  `info` text NOT NULL default '',
+  `issue` text NOT NULL NULL default '',
+  PRIMARY KEY (`id`),
+  KEY `user` (`user`),
+  KEY `done` (`done`),
+  KEY `datasource` (`datasource`),
+  KEY `started` (`started`)
+) ENGINE=InnoDB COMMENT='Datasource Debugger Information';
+
+--
+-- Dumping data for table `data_debug`
+--
+
+--
 -- Table structure for table `data_source_profiles`
 --
 

--- a/include/global_arrays.php
+++ b/include/global_arrays.php
@@ -1685,11 +1685,6 @@ $i18n_weekdays_short = array(
 	'Sat'	=> __x('A textual representation of a day, three letters', 'Sat')
 );
 
-define('DB_STATUS_ERROR'  , 0);
-define('DB_STATUS_WARNING', 1);
-define('DB_STATUS_SUCCESS', 2);
-define('DB_STATUS_SKIPPED', 3);
-
 $database_statuses = array(
 	0 => __('[Fail]'),
 	1 => __('[Warning]'),

--- a/include/global_constants.php
+++ b/include/global_constants.php
@@ -416,6 +416,11 @@ define('EINPROGRESS',     115);
 define('EREMOTEIO',       121);
 define('ECANCELED',       125);
 
+define('DB_STATUS_ERROR'  , 0);
+define('DB_STATUS_WARNING', 1);
+define('DB_STATUS_SUCCESS', 2);
+define('DB_STATUS_SKIPPED', 3);
+
 if (!defined('PASSWORD_DEFAULT')) {
 	define('PASSWORD_DEFAULT', 1);
 }


### PR DESCRIPTION
Resolves the issue in #1791 where the new data_debug table was not present in the installation cacti.sql file.