### PR TITLE
Resolving issue #1802

### DIFF
--- a/include/global_constants.php
+++ b/include/global_constants.php
@@ -300,11 +300,6 @@ define('REPORTS_TREE_NONE', 0);
 define('REPORTS_TIMESPAN_DEFAULT', GT_LAST_DAY);
 
 define('REPORTS_EXTENSION_GD', 'gd');
-if (function_exists('read_config_option')) {
-	define('REPORTS_DEBUG', read_config_option('reports_log_verbosity'), true);
-} else {
-	define('REPORTS_DEBUG', 1, true);
-}
 
 define('REPORTS_OUTPUT_STDOUT', 1);
 define('REPORTS_OUTPUT_EMAIL',  2);

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -266,6 +266,15 @@ function utime_add($timestamp, $yr=0, $mon=0, $day=0, $hr=0, $min=0, $sec=0) {
  @param bool $output 	- whether to output the log line to the browser using pring() or not
  @param string $environ - tell's from where the script was called from */
 function reports_log($string, $output = false, $environ='REPORTS', $level=POLLER_VERBOSITY_NONE) {
+	# Define REPORTS_DEBUG if not already set
+	if (!defined('REPORTS_DEBUG')) {
+		if (function_exists('read_config_option')) {
+			define('REPORTS_DEBUG', read_config_option('reports_log_verbosity'), true);
+		} else {
+			define('REPORTS_DEBUG', 1, true);
+		}
+	}
+
 	# if current verbosity >= level of current message, print it
 	if (strstr($string, 'STATS')) {
 		cacti_log($string, $output, 'SYSTEM');


### PR DESCRIPTION
This patch should correct some functionality issues within `read_config_option()` so that settings are not incorrectly primed if the database is not opened yet as noted in #1802