### PR TITLE
Feature #1806 - Control of low level debug

### DIFF
--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -100,6 +100,7 @@ Cacti CHANGELOG
 -feature#1731: Warn a user if they are going off page and there are unsaved changes
 -feature#1734: Visual enhancements to RRD error message when file not found
 -feature#1763: Automatic refresh for Time Graph View - Enhancement
+-feature#1806: Control low level debug routines via config.php
 -feature: New Install/Upgrade user permission to limit access to being able to upgrade
 -feature: Make Graph and Data Source suggested naming more efficient
 -feature: Make tree editing responive

--- a/include/config.php.dist
+++ b/include/config.php.dist
@@ -98,3 +98,33 @@ $cacti_db_session = false;
 
 //$input_whitelist = '/usr/local/etc/cacti/input_whitelist.json';
 
+/*
+ * The following are optional variables for debugging low level system
+ * functions that are generally only used by Cacti Developers to help
+ * identify potential issues in commonly used functions
+ *
+ * To use them, uncomment and the equivalent field will be set in the
+ * $config variable allowing for instant on but still allowing the
+ * ability to fine turn and turn them off.
+ */
+
+/*
+ * Debug the read_config_option program flow
+ */
+# define('DEBUG_READ_CONFIG_OPTION', true);
+
+/*
+ * Automatically suppress the DEBUG_READ_CONFIG_OPTION
+ */
+# define('DEBUG_READ_CONFIG_OPTION_DB_OPEN', true);
+
+/*
+ * Always write the SQL command to the cacti log file
+ */
+# define('DEBUG_SQL_CMD', true);
+
+/*
+ * Debug the flow of calls to the db_xxx functions that
+ * are defined in lib/database.php
+ */
+# define('DEBUG_SQL_FLOW', true);

--- a/include/global.php
+++ b/include/global.php
@@ -132,6 +132,12 @@ $config['cacti_server_os'] = (strstr(PHP_OS, 'WIN')) ? 'win32' : 'unix';
 /* built-in snmp support */
 $config['php_snmp_support'] = function_exists('snmpget');
 
+/* Set various debug fields */
+$config['DEBUG_READ_CONFIG_OPTION']         = defined('DEBUG_READ_CONFIG_OPTION');
+$config['DEBUG_READ_CONFIG_OPTION_DB_OPEN'] = defined('DEBUG_READ_CONFIG_OPTION_DB_OPEN');
+$config['DEBUG_SQL_CMD']                    = defined('DEBUG_SQL_CMD');
+$config['DEBUG_SQL_FLOW']                   = defined('DEBUG_SQL_FLOW');
+
 /* Set the poller_id */
 if (isset($poller_id)) {
 	$config['poller_id'] = $poller_id;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -392,9 +392,8 @@ function read_config_option($config_name, $force = false) {
 		$config_array = $config['config_options_array'];
 	}
 
-	if (defined('DEBUG_READ_OPTIONS') && !defined('DEBUG_READ_OPTIONS_DB_OPEN')) {
-		$prefix = '<[' . getmypid() . ']> -- ';
-		file_put_contents(sys_get_temp_dir() . '/read.log', $prefix . cacti_debug_backtrace($config_name, false, false) . "\n", FILE_APPEND);
+	if (!empty($config['DEBUG_READ_CONFIG_OPTION'])) {
+		file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() . cacti_debug_backtrace($config_name, false, false) . "\n", FILE_APPEND);
 	}
 
 	// Do we have a value already stored in the array, or
@@ -405,9 +404,8 @@ function read_config_option($config_name, $force = false) {
 		// unless we can actually read the DB
 		$value = read_default_config_option($config_name);
 
-		if (defined('DEBUG_READ_OPTIONS')) {
-			$prefix = '<[' . getmypid() . ']> -- ';
-			file_put_contents(sys_get_temp_dir() . '/read.log', $prefix .
+		if (!empty($config['DEBUG_READ_CONFIG_OPTION'])) {
+			file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() .
 				" $config_name: " .
 				' dh: ' . isset($database_hostname) .
 				' dp: ' . isset($database_port) .
@@ -416,8 +414,7 @@ function read_config_option($config_name, $force = false) {
 				"\n", FILE_APPEND);
 
 			if (isset($database_hostname) && isset($database_port) && isset($database_default)) {
-				$prefix = '<[' . getmypid() . ']> -- ';
-				file_put_contents(sys_get_temp_dir() . '/read.log', $prefix .
+				file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() .
 					" $config_name: [$database_hostname:$database_port:$database_default]\n", FILE_APPEND);
 			}
 		}
@@ -5142,7 +5139,7 @@ function repair_system_data_input_methods($step = 'import') {
 	}
 }
 
-if ($config['cacti_server_os'] == 'win32' && !function_exists('posix_kill')) {
+if (isset($config['cacti_server_os']) && $config['cacti_server_os'] == 'win32' && !function_exists('posix_kill')) {
 	function posix_kill($pid, $signal = SIGTERM) {
 		$wmi   = new COM("winmgmts:{impersonationLevel=impersonate}!\\\\.\\root\\cimv2");
 		$procs = $wmi->ExecQuery("SELECT ProcessId FROM Win32_Process WHERE ProcessId='" . $pid . "'");
@@ -5497,4 +5494,11 @@ function get_running_user() {
 
 		return (empty($tmp_user) ? 'apache' : $tmp_user);
 	}
+}
+
+function get_debug_prefix() {
+	$dateTime = new DateTime('NOW');
+	$dateTime = $dateTime->format('Y-m-d H:i:s.u');
+
+	return sprintf('<[ %s | %7d ]> -- ', $dateTime, getmypid());
 }


### PR DESCRIPTION
This patch adds functionality to control the debugging of low level routines via defines within the config.php file.  In order to allow flexibility, if these are defined, variables within the $config array are primed as true, otherwise false.

These elements within the $config array are defined in uppercase to highlight the difference between these are other ordinary configuration options.

Should a function or program need to enable debugging of these various options, simply setting the value to true in the $config array will enable logging from that point.  Inversely, setting it to false will stop logging from that point.

The only option that is of limited use is DEBUG_READ_CONFIG_OPTION_DB_OPEN that will only work up to the database being open.  Setting this to true after the database has already been opened will not automatic turn off the companion option DEBUG_READ_CONFIG_OPTION since the db_connect_real() will
not be called again.

The list of options and their functionality are:

- **DEBUG_READ_CONFIG_OPTION**
   *record use of read_config_option() to cacti-option.log in the system temporary folder*

- **DEBUG_READ_CONFIG_OPTION_DB_OPEN**
   *Once the database has been successfully opened, disable DEBUG_READ_CONFIG_OPTION*

- **DEBUG_SQL_CMD**
   *Always write a copy of the SQL being requested to the cacti-sql.log file in the system temporary folder*

- **DEBUG_SQL_FLOW**
   *Write flow of db_xxx calls to the cacti-sql.log in the system temporary folder.*

The system temporary folder is normally set to one of the following:

System | Mode | Temp Location
---: | :---: | :--
Linux | CLI | /tmp/
Linux | WEB | Apache/Ngix's temporary folder
Windows | CLI | %TEMP%
Windows | WEB | Temp folder of web user or %WINDIR%\TEMP
