### PR TITLE
Feature #1627 - Allow setting SNMP options during install

### DIFF
--- a/automation_snmp.php
+++ b/automation_snmp.php
@@ -409,143 +409,15 @@ function automation_snmp_item_edit() {
 	/* this is snmp we are talking about here */
 	unset($snmp_versions[0]);
 
-	$fields_automation_snmp_item = array(
-	'snmp_version' => array(
-		'method' => 'drop_array',
-		'friendly_name' => __('SNMP Version'),
-		'description' => __('Choose the SNMP version for this host.'),
-		'on_change' => 'setSNMP()',
-		'value' => '|arg1:snmp_version|',
-		'default' => read_config_option('snmp_version'),
-		'array' => $snmp_versions
-		),
-	'snmp_community' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Community String'),
-		'description' => __('Fill in the SNMP read community for this device.'),
-		'value' => '|arg1:snmp_community|',
-		'default' => read_config_option('snmp_community'),
-		'max_length' => '100',
-		'size' => '20'
-		),
-	'snmp_security_level' => array(
-		'method' => 'drop_array',
-		'friendly_name' => __('SNMP Security Level'),
-		'description' => __('SNMP v3 Security Level to user for querying the device.'),
-		'on_change' => 'setSNMP()',
-		'value' => '|arg1:snmp_security_level|',
-		'form_id' => '|arg1:id|',
-		'default' => read_config_option('snmp_security_level'),
-		'array' => $snmp_security_levels
-		),
-	'snmp_username' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Username (v3)'),
-		'description' => __('SNMP v3 username for this device.'),
-		'value' => '|arg1:snmp_username|',
-		'default' => read_config_option('snmp_username'),
-		'max_length' => '50',
-		'size' => '15'
-		),
-	'snmp_auth_protocol' => array(
-		'method' => 'drop_array',
-		'friendly_name' => __('SNMP Auth Protocol (v3)'),
-		'description' => __('Choose the SNMPv3 Authorization Protocol.'),
-		'on_change' => 'setSNMP()',
-		'value' => '|arg1:snmp_auth_protocol|',
-		'default' => read_config_option('snmp_auth_protocol'),
-		'array' => $snmp_auth_protocols,
-		),
-	'snmp_password' => array(
-		'method' => 'textbox_password',
-		'friendly_name' => __('SNMP Password (v3)'),
-		'description' => __('SNMP v3 password for this device.'),
-		'value' => '|arg1:snmp_password|',
-		'default' => read_config_option('snmp_password'),
-		'max_length' => '50',
-		'size' => '15'
-		),
-	'snmp_priv_protocol' => array(
-		'method' => 'drop_array',
-		'friendly_name' => __('SNMP Privacy Protocol (v3)'),
-		'description' => __('Choose the SNMPv3 Privacy Protocol.'),
-		'on_change' => 'setSNMP()',
-		'value' => '|arg1:snmp_priv_protocol|',
-		'default' => read_config_option('snmp_priv_protocol'),
-		'array' => $snmp_priv_protocols,
-		),
-	'snmp_priv_passphrase' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Privacy Passphrase (v3)'),
-		'description' => __('Choose the SNMPv3 Privacy Passphrase.'),
-		'value' => '|arg1:snmp_priv_passphrase|',
-		'default' => read_config_option('snmp_priv_passphrase'),
-		'max_length' => '200',
-		'size' => '40'
-		),
-	'snmp_context' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Context'),
-		'description' => __('Enter the SNMP Context to use for this device.'),
-		'value' => '|arg1:snmp_context|',
-		'default' => '',
-		'max_length' => '64',
-		'size' => '25'
-		),
-	'snmp_engine_id' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Engine ID (v3)'),
-		'description' => __('Enter the SNMP v3 Engine Id to use for this device. Leave this field empty to use the SNMP Engine ID being defined per SNMPv3 Notification receiver.'),
-		'value' => '|arg1:snmp_engine_id|',
-		'default' => '',
-		'max_length' => '64',
-		'size' => '40'
-		),
-	'snmp_port' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Port'),
-		'description' => __('The UDP/TCP Port to poll the SNMP agent on.'),
-		'value' => '|arg1:snmp_port|',
-		'max_length' => '8',
-		'default' => read_config_option('snmp_port'),
-		'size' => '10'
-		),
-	'snmp_timeout' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Timeout'),
-		'description' => __('The maximum number of milliseconds Cacti will wait for an SNMP response (does not work with php-snmp support).'),
-		'value' => '|arg1:snmp_timeout|',
-		'max_length' => '8',
-		'default' => read_config_option('snmp_timeout'),
-		'size' => '10'
-		),
-	'snmp_retries' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Retries'),
-		'description' => __('The maximum number of attempts to reach a device via an SNMP readstring prior to giving up.'),
-		'value' => '|arg1:snmp_retries|',
-		'max_length' => '8',
-		'default' => read_config_option('snmp_retries'),
-		'size' => '10'
-		),
-	'max_oids' => array(
-		'method' => 'textbox',
-		'friendly_name' => __("Maximum OID's Per Get Request"),
-		'description' => __('Specified the number of OIDs that can be obtained in a single SNMP Get request.'),
-		'value' => '|arg1:max_oids|',
-		'max_length' => '8',
-		'default' => read_config_option('max_get_size'),
-		'size' => '15'
-		),
-	);
+	global $fields_snmp_item_with_retry;
 
-    /* file: mactrack_snmp.php, action: item_edit */
-	$fields_automation_snmp_item_edit = $fields_automation_snmp_item + array(
-	'sequence' => array(
-		'method' => 'view',
-		'friendly_name' => __('Sequence'),
-		'description' => __('Sequence of Item.'),
-		'value' => '|arg1:sequence|'),
+	/* file: mactrack_snmp.php, action: item_edit */
+	$fields_automation_snmp_item_edit = $fields_snmp_item_with_retry + array(
+		'sequence' => array(
+			'method' => 'view',
+			'friendly_name' => __('Sequence'),
+			'description' => __('Sequence of Item.'),
+			'value' => '|arg1:sequence|'),
 	);
 
 	draw_edit_form(array(

--- a/include/global_form.php
+++ b/include/global_form.php
@@ -28,6 +28,141 @@ if (!defined('VALID_HOST_FIELDS')) {
 }
 $valid_host_fields = VALID_HOST_FIELDS;
 
+$fields_snmp_item = array(
+	'snmp_version' => array(
+		'method' => 'drop_array',
+		'friendly_name' => __('SNMP Version'),
+		'description' => __('Choose the SNMP version for this host.'),
+		'on_change' => 'setSNMP()',
+		'value' => '|arg1:snmp_version|',
+		'default' => read_config_option('snmp_version'),
+		'array' => $snmp_versions
+		),
+	'snmp_community' => array(
+		'method' => 'textbox',
+		'friendly_name' => __('SNMP Community String'),
+		'description' => __('Fill in the SNMP read community for this device.'),
+		'value' => '|arg1:snmp_community|',
+		'default' => read_config_option('snmp_community'),
+		'max_length' => '100',
+		'size' => '20'
+		),
+	'snmp_security_level' => array(
+		'method' => 'drop_array',
+		'friendly_name' => __('SNMP Security Level'),
+		'description' => __('SNMP v3 Security Level to user for querying the device.'),
+		'on_change' => 'setSNMP()',
+		'value' => '|arg1:snmp_security_level|',
+		'form_id' => '|arg1:id|',
+		'default' => read_config_option('snmp_security_level'),
+		'array' => $snmp_security_levels
+		),
+	'snmp_username' => array(
+		'method' => 'textbox',
+		'friendly_name' => __('SNMP Username (v3)'),
+		'description' => __('SNMP v3 username for this device.'),
+		'value' => '|arg1:snmp_username|',
+		'default' => read_config_option('snmp_username'),
+		'max_length' => '50',
+		'size' => '20'
+		),
+	'snmp_auth_protocol' => array(
+		'method' => 'drop_array',
+		'friendly_name' => __('SNMP Auth Protocol (v3)'),
+		'description' => __('Choose the SNMPv3 Authorization Protocol.'),
+		'on_change' => 'setSNMP()',
+		'value' => '|arg1:snmp_auth_protocol|',
+		'default' => read_config_option('snmp_auth_protocol'),
+		'array' => $snmp_auth_protocols,
+		),
+	'snmp_password' => array(
+		'method' => 'textbox_password',
+		'friendly_name' => __('SNMP Password (v3)'),
+		'description' => __('SNMP v3 password for this device.'),
+		'value' => '|arg1:snmp_password|',
+		'default' => read_config_option('snmp_password'),
+		'max_length' => '50',
+		'size' => '20'
+		),
+	'snmp_priv_protocol' => array(
+		'method' => 'drop_array',
+		'friendly_name' => __('SNMP Privacy Protocol (v3)'),
+		'description' => __('Choose the SNMPv3 Privacy Protocol.'),
+		'on_change' => 'setSNMP()',
+		'value' => '|arg1:snmp_priv_protocol|',
+		'default' => read_config_option('snmp_priv_protocol'),
+		'array' => $snmp_priv_protocols,
+		),
+	'snmp_priv_passphrase' => array(
+		'method' => 'textbox_password',
+		'friendly_name' => __('SNMP Privacy Passphrase (v3)'),
+		'description' => __('Choose the SNMPv3 Privacy Passphrase.'),
+		'value' => '|arg1:snmp_priv_passphrase|',
+		'default' => read_config_option('snmp_priv_passphrase'),
+		'max_length' => '200',
+		'size' => '40'
+		),
+	'snmp_context' => array(
+		'method' => 'textbox',
+		'friendly_name' => __('SNMP Context (v3)'),
+		'description' => __('Enter the SNMP Context to use for this device.'),
+		'value' => '|arg1:snmp_context|',
+		'default' => '',
+		'max_length' => '64',
+		'size' => '40'
+		),
+	'snmp_engine_id' => array(
+		'method' => 'textbox',
+		'friendly_name' => __('SNMP Engine ID (v3)'),
+		'description' => __('Enter the SNMP v3 Engine Id to use for this device. Leave this field empty to use the SNMP Engine ID being defined per SNMPv3 Notification receiver.'),
+		'value' => '|arg1:snmp_engine_id|',
+		'default' => '',
+		'max_length' => '64',
+		'size' => '40'
+		),
+	'snmp_port' => array(
+		'method' => 'textbox',
+		'friendly_name' => __('SNMP Port'),
+		'description' => __('Enter the UDP port number to use for SNMP (default is 161).'),
+		'value' => '|arg1:snmp_port|',
+		'max_length' => '5',
+		'default' => read_config_option('snmp_port'),
+		'size' => '12'
+		),
+	'snmp_timeout' => array(
+		'method' => 'textbox',
+		'friendly_name' => __('SNMP Timeout'),
+		'description' => __('The maximum number of milliseconds Cacti will wait for an SNMP response (does not work with php-snmp support).'),
+		'value' => '|arg1:snmp_timeout|',
+		'max_length' => '8',
+		'default' => read_config_option('snmp_timeout'),
+		'size' => '12'
+		),
+	);
+$fields_snmp_item_with_oids = $fields_snmp_item + array(
+	'max_oids' => array(
+		'method' => 'textbox',
+		'friendly_name' => __("Maximum OID's Per Get Request"),
+		'description' => __('Specified the number of OIDs that can be obtained in a single SNMP Get request.'),
+		'value' => '|arg1:max_oids|',
+		'max_length' => '8',
+		'default' => read_config_option('max_get_size'),
+		'size' => '12'
+		),
+	);
+
+$fields_snmp_item_with_retry = $fields_snmp_item_with_oids + array(
+	'snmp_retries' => array(
+		'method' => 'textbox',
+		'friendly_name' => __('SNMP Retries'),
+		'description' => __('The maximum number of attempts to reach a device via an SNMP readstring prior to giving up.'),
+		'value' => '|arg1:snmp_retries|',
+		'max_length' => '8',
+		'default' => read_config_option('snmp_retries'),
+		'size' => '12'
+		),
+	);
+
 /* file: profiles.php, action: edit */
 $fields_profile_edit = array(
 	'name' => array(
@@ -1060,125 +1195,7 @@ $fields_host_edit = array(
 		'method' => 'spacer',
 		'friendly_name' => __('SNMP Options'),
 		),
-	'snmp_version' => array(
-		'method' => 'drop_array',
-		'friendly_name' => __('SNMP Version'),
-		'description' => __('Choose the SNMP version for this device.'),
-		'on_change' => 'changeHostForm()',
-		'value' => '|arg1:snmp_version|',
-		'default' => read_config_option('snmp_version'),
-		'array' => $snmp_versions,
-		),
-	'snmp_community' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Community'),
-		'description' => __('SNMP read community for this device.'),
-		'value' => '|arg1:snmp_community|',
-		'form_id' => '|arg1:id|',
-		'default' => read_config_option('snmp_community'),
-		'max_length' => '100',
-		'size' => '20'
-		),
-	'snmp_security_level' => array(
-		'method' => 'drop_array',
-		'friendly_name' => __('SNMP Security Level'),
-		'description' => __('SNMP v3 Security Level to user for querying the device.'),
-		'on_change' => 'setSNMP()',
-		'value' => '|arg1:snmp_security_level|',
-		'form_id' => '|arg1:id|',
-		'default' => read_config_option('snmp_security_level'),
-		'array' => $snmp_security_levels
-		),
-	'snmp_username' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Username (v3)'),
-		'description' => __('SNMP v3 username for this device.'),
-		'value' => '|arg1:snmp_username|',
-		'default' => read_config_option('snmp_username'),
-		'max_length' => '50',
-		'size' => '20'
-		),
-	'snmp_auth_protocol' => array(
-		'method' => 'drop_array',
-		'friendly_name' => __('SNMP Auth Protocol (v3)'),
-		'description' => __('Choose the SNMPv3 authentication protocol.'),
-		'on_change' => 'setSNMP()',
-		'value' => '|arg1:snmp_auth_protocol|',
-		'default' => read_config_option('snmp_auth_protocol'),
-		'array' => $snmp_auth_protocols,
-		),
-	'snmp_password' => array(
-		'method' => 'textbox_password',
-		'friendly_name' => __('SNMP Password (v3)'),
-		'description' => __('SNMP v3 authentication pass phrase for this device.'),
-		'value' => '|arg1:snmp_password|',
-		'default' => read_config_option('snmp_password'),
-		'max_length' => '50',
-		'size' => '20'
-		),
-	'snmp_priv_protocol' => array(
-		'method' => 'drop_array',
-		'friendly_name' => __('SNMP Privacy Protocol (v3)'),
-		'description' => __('Choose the SNMPv3 privacy protocol.'),
-		'on_change' => 'setSNMP()',
-		'value' => '|arg1:snmp_priv_protocol|',
-		'default' => read_config_option('snmp_priv_protocol'),
-		'array' => $snmp_priv_protocols,
-		),
-	'snmp_priv_passphrase' => array(
-		'method' => 'textbox_password',
-		'friendly_name' => __('SNMP Privacy Passphrase (v3)'),
-		'description' => __('Choose the SNMPv3 privacy passphrase.'),
-		'value' => '|arg1:snmp_priv_passphrase|',
-		'default' => read_config_option('snmp_priv_passphrase'),
-		'max_length' => '200',
-		'size' => '40'
-		),
-	'snmp_context' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Context (v3)'),
-		'description' => __('Enter the SNMP v3 context to use for this device.'),
-		'value' => '|arg1:snmp_context|',
-		'default' => '',
-		'max_length' => '64',
-		'size' => '40'
-		),
-	'snmp_engine_id' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Engine ID (v3)'),
-		'description' => __('Enter the SNMP v3 Engine Id to use for this device. Leave this field empty to use the SNMP Engine ID being defined per SNMPv3 Notification receiver.'),
-		'value' => '|arg1:snmp_engine_id|',
-		'default' => '',
-		'max_length' => '64',
-		'size' => '40'
-		),
-	'snmp_port' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Port'),
-		'description' => __('Enter the UDP port number to use for SNMP (default is 161).'),
-		'value' => '|arg1:snmp_port|',
-		'max_length' => '5',
-		'default' => read_config_option('snmp_port'),
-		'size' => '12'
-		),
-	'snmp_timeout' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('SNMP Timeout'),
-		'description' => __('The maximum number of milliseconds Cacti will wait for an SNMP response (does not work with php-snmp support).'),
-		'value' => '|arg1:snmp_timeout|',
-		'max_length' => '8',
-		'default' => read_config_option('snmp_timeout'),
-		'size' => '12'
-		),
-	'max_oids' => array(
-		'method' => 'textbox',
-		'friendly_name' => __('Maximum OIDs Per Get Request'),
-		'description' => __('Specified the number of OIDs that can be obtained in a single SNMP Get request.'),
-		'value' => '|arg1:max_oids|',
-		'max_length' => '8',
-		'default' => read_config_option('max_get_size'),
-		'size' => '12'
-		),
+	) + $fields_snmp_item_with_oids + array(
 	'host_avail_head' => array(
 		'method' => 'spacer',
 		'friendly_name' => __('Availability/Reachability Options'),
@@ -1672,106 +1689,7 @@ $fields_template_import = array(
 			'friendly_name' => __('SNMP Options'),
 			'collapsible' => 'true'
 			),
-		'snmp_version' => array(
-			'method' => 'drop_array',
-			'friendly_name' => __('SNMP Version'),
-			'description' => __('Choose the SNMP version for this device.'),
-			'on_change' => 'setSNMP()',
-			'value' => '|arg1:snmp_version|',
-			'default' => '1',
-			'array' => array('1'=>'Version 1', '2'=>'Version 2', '3' => 'Version 3'),
-			),
-		'snmp_community' => array(
-			'method' => 'textbox',
-			'friendly_name' => __('SNMP Community'),
-			'description' => __('SNMP read community for this device.'),
-			'value' => '|arg1:snmp_community|',
-			'form_id' => '|arg1:id|',
-			'default' => read_config_option('snmp_community'),
-			'max_length' => '100',
-			'size' => '20'
-			),
-		'snmp_security_level' => array(
-			'method' => 'drop_array',
-			'friendly_name' => __('SNMP Security Level'),
-			'description' => __('SNMP v3 Security Level to user for querying the device.'),
-			'on_change' => 'setSNMP()',
-			'value' => '|arg1:snmp_security_level|',
-			'form_id' => '|arg1:id|',
-			'default' => read_config_option('snmp_security_level'),
-			'array' => $snmp_security_levels
-			),
-		'snmp_username' => array(
-			'method' => 'textbox',
-			'friendly_name' => __('SNMP Username (v3)'),
-			'description' => __('SNMP v3 username for this device.'),
-			'value' => '|arg1:snmp_username|',
-			'default' => read_config_option('snmp_username'),
-			'max_length' => '50',
-			'size' => '20'
-			),
-		'snmp_auth_protocol' => array(
-			'method' => 'drop_array',
-			'friendly_name' => __('SNMP Auth Protocol (v3)'),
-			'description' => __('Choose the SNMPv3 Authorization Protocol.<br>Note: SHA authentication support is only available if you have OpenSSL installed.'),
-			'on_change' => 'setSNMP()',
-			'value' => '|arg1:snmp_auth_protocol|',
-			'default' => read_config_option('snmp_auth_protocol'),
-			'array' => $snmp_auth_protocols,
-			),
-		'snmp_password' => array(
-			'method' => 'textbox_password',
-			'friendly_name' => __('SNMP Auth Password (v3)'),
-			'description' => __('SNMP v3 user password for this device.'),
-			'value' => '|arg1:snmp_password|',
-			'default' => read_config_option('snmp_password'),
-			'max_length' => '50',
-			'size' => '20'
-			),
-		'snmp_priv_protocol' => array(
-			'method' => 'drop_array',
-			'friendly_name' => __('SNMP Privacy Protocol (v3)'),
-			'description' => __('Choose the SNMPv3 Privacy Protocol.<br>Note: DES/AES encryption support is only available if you have OpenSSL installed.'),
-			'on_change' => 'setSNMP()',
-			'value' => '|arg1:snmp_priv_protocol|',
-			'default' => read_config_option('snmp_priv_protocol'),
-			'array' => $snmp_priv_protocols,
-			),
-		'snmp_priv_passphrase' => array(
-			'method' => 'textbox_password',
-			'friendly_name' => __('SNMP Privacy Password (v3)'),
-			'description' => __('Choose the SNMPv3 Privacy Passphrase.'),
-			'value' => '|arg1:snmp_priv_passphrase|',
-			'default' => read_config_option('snmp_priv_passphrase'),
-			'max_length' => '200',
-			'size' => '40'
-			),
-		'snmp_engine_id' => array(
-			'friendly_name' => __('SNMP Engine ID'),
-			'description' => __('Defines the unique SNMP Engine ID to identify this peer. Following format will be recommended:<br>FlexibleLength+Enterprise(8000) + IANA-Cacti(5d75) + MAC-Following(03) + YOUR-MAC-ADDRESS(e.g.:D89D67287B00).<br>Per default the locally administrated MAC 02-FF-FF-FF-FF-FF will be used.'),
-			'value' => '|arg1:snmp_engine_id|',
-			'method' => 'textbox',
-			'max_length' => 64,
-			'default' => '80005d750302FFFFFFFFFF',
-			),
-		'snmp_port' => array(
-			'method' => 'textbox',
-			'friendly_name' => __('SNMP Port'),
-			'description' => __('The UDP port to be used for SNMP traps. Typically, 162.'),
-			'value' => '|arg1:snmp_port|',
-			'max_length' => '5',
-			'default' => '162',
-			'size' => '7'
-			),
-		'snmp_timeout' => array(
-			'method' => 'textbox',
-			'friendly_name' => __('SNMP Timeout'),
-			'description' => __('The maximum number of milliseconds Cacti will wait for an SNMP response (does not work with php-snmp support).'),
-			'value' => '|arg1:snmp_timeout|',
-			'max_length' => '8',
-			'default' => read_config_option('snmp_timeout'),
-			'size' => '7'
-			),
+		) + $fields_snmp_item + array(
 		'snmp_message_type' => array(
 			'friendly_name' => __('SNMP Message Type'),
 			'description' => __('SNMP traps are always unacknowledged. To send out acknowledged SNMP notifications, formally called "INFORMS", SNMPv2 or above will be required.'),

--- a/include/global_form.php
+++ b/include/global_form.php
@@ -28,6 +28,7 @@ if (!defined('VALID_HOST_FIELDS')) {
 }
 $valid_host_fields = VALID_HOST_FIELDS;
 
+/* If you update this, check that you have updated the installer */
 $fields_snmp_item = array(
 	'snmp_version' => array(
 		'method' => 'drop_array',

--- a/install/install.js
+++ b/install/install.js
@@ -29,7 +29,7 @@ const DB_STATUS_SUCCESS = 2;
 const DB_STATUS_SKIPPED = 3;
 
 const FIELDS_WELCOME = {
-	accept:                { type: 'checked',  name: 'Eula'               },
+	accept:                { type: 'checkbox',  name: 'Eula'              },
 	theme:                 { type: 'dropdown', name: 'Theme'              },
 	language:              { type: 'dropdown', name: 'Language'           },
 }
@@ -50,8 +50,9 @@ const FIELDS_BINARY_LOCATIONS = {
 const FIELDS_PROFILE = {
 	default_profile:       { type: 'dropdown', name: 'Profile'            },
 	cron_interval:         { type: 'textbox',  name: 'CronInterval'       },
-	automation_mode:       { type: 'dropdown', name: 'AutomationMode'     },
+	automation_mode:       { type: 'checkbox', name: 'AutomationMode'     },
 	automation_range:      { type: 'textbox',  name: 'AutomationRange'    },
+	automation_override:   { type: 'checkbox', name: 'AutomationOverride' },
 }
 
 const FIELDS_SNMP = {
@@ -72,11 +73,19 @@ const FIELDS_SNMP = {
 };
 
 const FIELDS_CHECK_TABLES = {
-	tables:                { type: 'checked'                              },
+	tables:                { type: 'checkbox'                             },
 }
 
 const FIELDS_TEMPLATES = {
-	templates:             { type: 'checked'                              },
+	templates:             { type: 'checkbox'                             },
+}
+
+function setSNMPOverride() {
+	element = $('#automation_override');
+	if (element != null && element.length > 0) {
+		enabled = ($(element[0]).is(':checked'));
+		toggleSection('#automation_snmp_options', enabled);
+	}
 }
 
 function setButtonData(buttonName, buttonData) {
@@ -115,12 +124,12 @@ function setFieldData(fields, fieldData) {
 
 		var field = fields[fieldId];
 
-		if (field.type == "checked") {
+		if (field.type == "checkbox") {
 			for (var propName in fieldData) {
 				if (fieldData.hasOwnProperty(propName)) {
 					propValue = fieldData[propName];
 					if (propValue !== undefined) {
-						element = $('#' + fieldId);
+						element = $('#' + propName);
 						if (element != null && element.length > 0) {
 							element.prop('checked', propValue != 0);
 						}
@@ -152,7 +161,7 @@ function getFieldData(fields, fieldData) {
 
 		var field = fields[fieldId];
 
-		if (field.type == 'checked') {
+		if (field.type == 'checkbox') {
 			if (field.name) {
 				fieldData[field.name] = $("#" + fieldId).is(':checked');
 			} else {
@@ -207,6 +216,27 @@ function toggleHeader(key, initial = null) {
 	}
 }
 
+function toggleSection(key, initial = null) {
+	if (key != null) {
+		header = $(key);
+		if (header != null && header.length > 0) {
+
+			if (initial == null) {
+				initial = !header.visible;
+			}
+
+			firstSibling = header.next();
+			if (!initial) {
+				firstSibling.hide();
+				header.hide();
+			} else {
+				header.show();
+				firstSibling.show();
+			}
+		}
+	}
+}
+
 function disableButton(buttonName) {
 	button = $('#button'+buttonName);
 	if (button != null) {
@@ -249,7 +279,7 @@ function collapseHeadings(headingStates) {
 
 function hideHeadings(headingStates) {
 	for (var key in headingStates) {
-v		// skip loop if the property is from prototype
+		// skip loop if the property is from prototype
 		if (!headingStates.hasOwnProperty(key)) {
 			continue;
 		}
@@ -387,6 +417,14 @@ function processStepProfileAndAutomation(StepData) {
 	setSNMP();
 	applySkin();
 
+	element = $('#automation_override');
+	if (element != null && element.length > 0) {
+		element.change(function() {
+			setSNMPOverride();
+		});
+	}
+
+	setSNMPOverride();
 }
 
 function processStepTemplateInstall(StepData) {

--- a/install/install.js
+++ b/install/install.js
@@ -239,6 +239,7 @@ function processStepBinaryLocations(StepData) {
 }
 
 function processStepProfileAndAutomation(StepData) {
+	setSNMP();
 }
 
 function processStepTemplateInstall(StepData) {

--- a/install/install.js
+++ b/install/install.js
@@ -28,6 +28,57 @@ const DB_STATUS_WARNING = 1;
 const DB_STATUS_SUCCESS = 2;
 const DB_STATUS_SKIPPED = 3;
 
+const FIELDS_WELCOME = {
+	accept:                { type: 'checked',  name: 'Eula'               },
+	theme:                 { type: 'dropdown', name: 'Theme'              },
+	language:              { type: 'dropdown', name: 'Language'           },
+}
+
+const FIELDS_INSTALL_TYPE = {
+	install_type:          { type: 'dropdown', name: 'Mode'               },
+}
+
+const FIELDS_BINARY_OPTIONS = {
+	selected_theme:        { type: 'dropdown', name: 'Theme'              },
+	rrdtool_version:       { type: 'dropdown', name: 'RRDVer'             },
+}
+
+const FIELDS_BINARY_LOCATIONS = {
+	paths:                 { type: 'textbox',  prefix: 'path_'            },
+}
+
+const FIELDS_PROFILE = {
+	default_profile:       { type: 'dropdown', name: 'Profile'            },
+	cron_interval:         { type: 'textbox',  name: 'CronInterval'       },
+	automation_mode:       { type: 'dropdown', name: 'AutomationMode'     },
+	automation_range:      { type: 'textbox',  name: 'AutomationRange'    },
+}
+
+const FIELDS_SNMP = {
+	snmp_version:          { type: 'dropdown', name: 'SnmpVersion'        },
+	snmp_community:        { type: 'textbox',  name: 'SnmpCommunity'      },
+	snmp_security_level:   { type: 'dropdown', name: 'SnmpSecurityLevel'  },
+	snmp_username:         { type: 'textbox',  name: 'SnmpUsername'       },
+	snmp_auth_protocol:    { type: 'dropdown', name: 'SnmpAuthProtocol'   },
+	snmp_password:         { type: 'textbox',  name: 'SnmpPassword'       },
+	snmp_priv_protocol:    { type: 'dropdown', name: 'SnmpPrivProtocol'   },
+	snmp_priv_passphrase:  { type: 'textbox',  name: 'SnmpPrivPassphrase' },
+	snmp_context:          { type: 'textbox',  name: 'SnmpContext'        },
+	snmp_engine_id:        { type: 'textbox',  name: 'SnmpEngineId'       },
+	snmp_port:             { type: 'textbox',  name: 'SnmpPort'           },
+	snmp_timeout:          { type: 'textbox',  name: 'SnmpTimeout'        },
+	max_oids:              { type: 'textbox',  name: 'SnmpMaxOids'        },
+	snmp_retries:          { type: 'textbox',  name: 'SnmpRetries'        },
+};
+
+const FIELDS_CHECK_TABLES = {
+	tables:                { type: 'checked'                              },
+}
+
+const FIELDS_TEMPLATES = {
+	templates:             { type: 'checked'                              },
+}
+
 function setButtonData(buttonName, buttonData) {
 	button = $('#button'+buttonName);
 	if (button != null) {
@@ -50,6 +101,91 @@ function setButtonData(buttonName, buttonData) {
 		}
 
 	}
+}
+
+function setFieldData(fields, fieldData) {
+	if (fieldData === null) {
+		return;
+	}
+
+	for (var fieldId in fields) {
+		if (!fields.hasOwnProperty(fieldId)) {
+			continue;
+		}
+
+		var field = fields[fieldId];
+
+		if (field.type == "checked") {
+			for (var propName in fieldData) {
+				if (fieldData.hasOwnProperty(propName)) {
+					propValue = fieldData[propName];
+					if (propValue !== undefined) {
+						element = $('#' + fieldId);
+						if (element != null && element.length > 0) {
+							element.prop('checked', propValue != 0);
+						}
+					}
+				}
+			}
+		} else if (fieldData[field.name]) {
+			element = $("#" + fieldId);
+			if (element != null && element.length > 0) {
+				if (field.type == 'textbox') {
+					element[0].value = fieldData[field.name];
+				} else if (field.type == 'dropdown' ) {
+					element[0].value = fieldData[field.name];
+				}
+			}
+		}
+	};
+}
+
+function getFieldData(fields, fieldData) {
+	if (fieldData === null) {
+		return;
+	}
+
+	for (var fieldId in fields) {
+		if (!fields.hasOwnProperty(fieldId)) {
+			continue;
+		}
+
+		var field = fields[fieldId];
+
+		if (field.type == 'checked') {
+			if (field.name) {
+				fieldData[field.name] = $("#" + fieldId).is(':checked');
+			} else {
+				prefix="chk_";
+				if (field.prefix) {
+					prefix = field.prefix;
+				}
+
+				$('input[name^="' + prefix + '"]').each(function(index,element) {
+					fieldData[element.id] =$(element).is(':checked');
+				});
+			}
+		} else {
+			if (field.prefix) {
+				$('input[name^="' + field.prefix + '"]').each(function(index, element) {
+					fieldData[element.id] = element.value;
+				});
+			} else {
+				element = $('#' + fieldId);
+				if (element != null && element.length > 0) {
+					if (field.type == 'textbox') {
+						fieldData[field.name] = element[0].value;
+					} else if (field.type == 'dropdown') {
+						fieldData[field.name] = element[0].value;
+					}
+				}
+			}
+		}
+	};
+}
+
+function getDefaultInstallData() {
+	return { Step: STEP_WELCOME, Eula: 0 };
 }
 
 function toggleHeader(key, initial = null) {
@@ -113,7 +249,7 @@ function collapseHeadings(headingStates) {
 
 function hideHeadings(headingStates) {
 	for (var key in headingStates) {
-		// skip loop if the property is from prototype
+v		// skip loop if the property is from prototype
 		if (!headingStates.hasOwnProperty(key)) {
 			continue;
 		}
@@ -135,9 +271,11 @@ function hideHeadings(headingStates) {
 }
 
 function processStepWelcome(StepData) {
-	if (StepData.Eula == 1) {
-		$('#accept').prop('checked',true);
-	}
+	setFieldData(FIELDS_WELCOME, StepData);
+
+//	if (StepData.Eula == 1) {
+//		$('#accept').prop('checked',true);
+//	}
 
 	if (StepData.Theme != 'classic') {
 		$('select#theme').selectmenu({
@@ -216,6 +354,9 @@ function processStepPermissionCheck(StepData) {
 }
 
 function processStepBinaryLocations(StepData) {
+	setFieldData(FIELDS_BINARY_OPTIONS, StepData);
+	setFieldData(FIELDS_BINARY_LOCATIONS, StepData);
+
 	var errors = StepData.Errors;
 	$(function () {
             var focusedElement;
@@ -226,6 +367,7 @@ function processStepBinaryLocations(StepData) {
             });
         });
 
+	/* Focus on first error */
 	for (var propName in errors) {
 		if (errors.hasOwnProperty(propName)) {
 			propValue = errors[propName];
@@ -239,7 +381,12 @@ function processStepBinaryLocations(StepData) {
 }
 
 function processStepProfileAndAutomation(StepData) {
+	setFieldData(FIELDS_PROFILE, StepData);
+	setFieldData(FIELDS_SNMP, StepData);
+
 	setSNMP();
+	applySkin();
+
 }
 
 function processStepTemplateInstall(StepData) {
@@ -250,17 +397,7 @@ function processStepTemplateInstall(StepData) {
 			element.click();
 		}
 	} else {
-		for (var propName in templates) {
-			if (templates.hasOwnProperty(propName)) {
-				propValue = templates[propName];
-				if (propValue) {
-					element = $('#' + propName);
-					if (element != null && element.length > 0) {
-						element.prop('checked', true);
-					}
-				}
-			}
-		}
+		setFieldData(FIELDS_TEMPLATES, StepData.Templates);
 	}
 
 }
@@ -273,17 +410,7 @@ function processStepCheckTables(StepData) {
 			element.click();
 		}
 	} else {
-		for (var propName in tables) {
-			if (tables.hasOwnProperty(propName)) {
-				propValue = tables[propName];
-				if (propValue) {
-					element = $('#' + propName);
-					if (element != null && element.length > 0) {
-						element.prop('checked', true);
-					}
-				}
-			}
-		}
+		setFieldData(FIELDS_CHECK_TABLES, StepData.Tables);
 	}
 
 }
@@ -343,22 +470,6 @@ function progress(timeleft, timetotal, $element, fnComplete, fnStatus) {
 	}, 1000);
 }
 
-function progress_old(timeleft, timetotal, $element, fnComplete, fnStatus) {
-	setProgressBar(timeleft, timetotal, $element, 100, fnStatus);
-	if (timeleft < timetotal - 0.1) {
-		setTimeout(function() {
-			//progress(timeleft + 0.5, timetotal, $element, fnComplete, fnStatus);
-			fnComplete();
-		}, 100);
-	} else if (fnComplete != null) {
-		fnComplete();
-	}
-}
-
-function getDefaultInstallData() {
-	return { Step: STEP_WELCOME, Eula: 0 };
-}
-
 function prepareInstallData(installStep) {
 	installData = $('#installData').data('installData');
 	if (typeof installData == 'undefined' || installData == null) {
@@ -392,78 +503,37 @@ function prepareInstallData(installStep) {
 }
 
 function prepareStepWelcome(installData) {
-	element = $('#accept');
-	if (element != null && element.length > 0) {
-		installData.Eula = element.is(':checked');
-	}
-
-	element = $('#theme');
-	if (element != null && element.length > 0) {
-		installData.Theme = element.val();
-	}
+	getFieldData(FIELDS_WELCOME, installData);
 }
 
 function prepareStepInstallType(installData) {
-	element = $('#install_type');
-	if (element != null && element.length > 0) {
-		installData.Mode = element[0].value;
-	}
+	getFieldData(FIELDS_INSTALL_TYPE, installData);
 }
 
 function prepareStepBinaryLocations(installData) {
-	paths = {}
-	$('input[name^="path_"]').each(function(index,element) {
-		paths[element.id] = element.value;
-	});
+	installData.Paths = {};
 
-	installData.Paths = paths;
-	element = $('#selected_theme');
-	if (element != null && element.length > 0) {
-		installData.Theme = element[0].value;
-	}
-
-	element = $('#rrdtool_version');
-	if (element != null && element.length > 0) {
-		installData.RRDVer = element[0].value;
-	}
+	getFieldData(FIELDS_BINARY_OPTIONS, installData);
+	getFieldData(FIELDS_BINARY_LOCATIONS, installData.Paths);
 }
 
 function prepareStepProfileAndAutomation(installData) {
-	element = $('#default_profile');
-	if (element != null && element.length > 0) {
-		installData.Profile = element[0].value;
-	}
+	installData.SnmpOptions = {};
 
-	element = $('#cron_interval');
-	if (element != null && element.length > 0) {
-		installData.CronInterval = element[0].value;
-	}
-
-	element = $('#automation_mode');
-	if (element != null && element.length > 0) {
-		installData.AutomationMode = element[0].value;
-	}
-
-	element = $('#automation_range');
-	if (element != null && element.length > 0) {
-		installData.AutomationRange = element[0].value;
-	}
+	getFieldData(FIELDS_PROFILE, installData);
+	getFieldData(FIELDS_SNMP, installData.SnmpOptions);
 }
 
 function prepareStepCheckTables(installData) {
-	tables = {}
-	$('input[name^="chk_"]').each(function(index,element) {
-		tables[element.id] =$(element).is(':checked');
-	});
-	installData.Tables = tables;
+	installData.Tables = {}
+
+	getFieldData(FIELDS_CHECK_TABLES, installData.Tables);
 }
 
 function prepareStepTemplateInstall(installData) {
-	templates = {}
-	$('input[name^="chk_"]').each(function(index,element) {
-		templates[element.id] =$(element).is(':checked');
-	});
-	installData.Templates = templates;
+	installData.Templates = {}
+
+	getFieldData(FIELDS_TEMPLATES, installData.Templates);
 }
 
 function setAddressBar(data, replace) {

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -146,7 +146,6 @@ class Installer implements JsonSerializable {
 		$this->errors          = array();
 		$this->theme           = (isset($_SESSION['install_theme']) ? $_SESSION['install_theme']:read_config_option('selected_theme', true));
 		$this->profile         = read_config_option('install_profile', true);
-
 		$this->automationMode  = read_config_option('install_automation_mode', true);
 		$this->cronInterval    = read_config_option('cron_interval', true);
 
@@ -1553,9 +1552,8 @@ class Installer implements JsonSerializable {
 
 			$fields_automation = array(
 				'automation_mode' => array(
-					'method' => 'drop_array',
+					'method' => 'checkbox',
 					'friendly_name' => __('Scan Mode'),
-					'array' => array('Enabled','Disabled'),
 					'value' => '|arg1:automation_mode|',
 				),
 				'automation_range' => array(


### PR DESCRIPTION
This commit addresses suggestions in #1627 by prompting for default SNMP options and installing these as the preferred connection method and device defaults.