### PR TITLE
Resolving issue #1845

### DIFF
--- a/poller.php
+++ b/poller.php
@@ -26,14 +26,14 @@
 /* tick use required as of PHP 4.3.0 to accomodate signal handling */
 declare(ticks = 1);
 
-require(__DIR__ . '/include/cli_check.php');
-require($config['base_path'] . '/lib/poller.php');
-require($config['base_path'] . '/lib/data_query.php');
-require($config['base_path'] . '/lib/rrd.php');
-require($config['base_path'] . '/lib/dsstats.php');
-require($config['base_path'] . '/lib/dsdebug.php');
-require($config['base_path'] . '/lib/boost.php');
-require($config['base_path'] . '/lib/reports.php');
+require_once(__DIR__ . '/include/cli_check.php');
+require_once($config['base_path'] . '/lib/poller.php');
+require_once($config['base_path'] . '/lib/data_query.php');
+require_once($config['base_path'] . '/lib/rrd.php');
+require_once($config['base_path'] . '/lib/dsstats.php');
+require_once($config['base_path'] . '/lib/dsdebug.php');
+require_once($config['base_path'] . '/lib/boost.php');
+require_once($config['base_path'] . '/lib/reports.php');
 
 function sig_handler($signo) {
 	switch ($signo) {

--- a/poller_reports.php
+++ b/poller_reports.php
@@ -26,10 +26,10 @@
 /* tick use required as of PHP 4.3.0 to accomodate signal handling */
 declare(ticks = 1);
 
-require(__DIR__ . '/include/cli_check.php');
-require($config['base_path'] . '/lib/poller.php');
-require($config['base_path'] . '/lib/rrd.php');
-require($config['base_path'] . '/lib/reports.php');
+require_once(__DIR__ . '/include/cli_check.php');
+require_once($config['base_path'] . '/lib/poller.php');
+require_once($config['base_path'] . '/lib/rrd.php');
+require_once($config['base_path'] . '/lib/reports.php');
 
 /*  display_version - displays version information */
 function display_version() {


### PR DESCRIPTION
This corrects an issue where the `lib/reports.php` file is included more than once.

During testing, I removed the include, but for safety, I switched from require to require_once.