### PR TITLE
Check if local_db_conn_id is an object on remote poller recovery

### DIFF
--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -273,10 +273,13 @@ if ($run) {
 				}
 
 				/* remove the recovery records */
-				if ($purge_time == 0) {
-					db_execute("DELETE FROM poller_output_boost", true, $local_db_cnn_id);
-				} else {
-					db_execute("DELETE FROM poller_output_boost WHERE time $operator '$purge_time'", true, $local_db_cnn_id);
+				if (is_object($local_db_cnn_id)) {
+					// Only go through this if the local database is reachable
+					if ($purge_time == 0) {
+						db_execute("DELETE FROM poller_output_boost", true, $local_db_cnn_id);
+					} else {
+						db_execute("DELETE FROM poller_output_boost WHERE time $operator '$purge_time'", true, $local_db_cnn_id);
+					}
 				}
 			}
 


### PR DESCRIPTION
Check if local_db_conn_id is an object before deleting the poller_output_boost table data 

In case of the local mysql database on a remote poller not being available, the connection will be re-established with the remote database causing all data in the poller_output_boost table on the master system to be deleted.

see db_execute_prepared in lib/database.php for the fall-back in case $local_db_cnn_id is not an object.