### PR TITLE
More optimal query regarding #2175

### DIFF
--- a/poller_dsstats.php
+++ b/poller_dsstats.php
@@ -150,8 +150,10 @@ if (read_config_option('dsstats_enable') == 'on' || $forcerun) {
 	db_execute("INSERT INTO data_source_stats_hourly
 		(local_data_id, rrd_name, average, peak)
 		(SELECT local_data_id, rrd_name, AVG(`value`), MAX(`value`)
-		FROM (SELECT local_data_id, rrd_name, `value` FROM data_source_stats_hourly_cache WHERE `value` IS NOT NULL) AS sally
-		GROUP BY local_data_id, rrd_name)
+		 FROM data_source_stats_hourly_cache 
+		 WHERE `value` IS NOT NULL
+		 GROUP BY local_data_id, rrd_name
+		)
 		ON DUPLICATE KEY UPDATE average=VALUES(average), peak=VALUES(peak)");
 
 	log_dsstats_statistics('HOURLY');


### PR DESCRIPTION
I do not quite agree with just solving #2175 by saying 'we' should just increase the slow query limit.
Although there are a lot of factors for a slow insert, we as developers should always check if there is something wrong and if we can optimise something. The query showed in the slow log is, for me, not looking efficient (enough).

I think the query would be more optimal by writing it like this.
Also changing the primary key to "local_data_id, rrd_name, time", (which not only will be more logic regarding the table lay-out) we would result in having a more efficient index (with the same effect). Only thing is that I have not the correct tools for changing this at this moment. If you could change this PK, the select statement of this insert would have two key elements it could use instead of one (because the select does not have 'time' in it).

The more optimal query:

INSERT INTO data_source_stats_hourly (local_data_id, rrd_name, average, peak) 
(SELECT local_data_id, rrd_name, AVG(`value`), MAX(`value`) 
FROM data_source_stats_hourly_cache 
WHERE `value` IS NOT NULL
GROUP BY local_data_id, rrd_name)
ON DUPLICATE KEY UPDATE average=VALUES(average), peak=VALUES(peak);