### PR TITLE
Add 64-bit packet counters

### DIFF
--- a/resource/snmp_queries/interface.xml
+++ b/resource/snmp_queries/interface.xml
@@ -186,19 +186,33 @@
 			<oid>.1.3.6.1.2.1.2.2.1.18</oid>
 		</ifOutNUcastPkts>
 		<ifInUcastPkts>
-			<name>Unicast Packets In</name>
+			<name>Unicast Packets In (Legacy)</name>
 			<method>walk</method>
 			<source>value</source>
 			<direction>output</direction>
 			<oid>.1.3.6.1.2.1.2.2.1.11</oid>
 		</ifInUcastPkts>
 		<ifOutUcastPkts>
-			<name>Unicast Packets Out</name>
+			<name>Unicast Packets Out (Legacy)</name>
 			<method>walk</method>
 			<source>value</source>
 			<direction>output</direction>
 			<oid>.1.3.6.1.2.1.2.2.1.17</oid>
 		</ifOutUcastPkts>
+		<ifHCInUcastPkts>
+			<name>Unicast Packets In - 64-bit Counters</name>
+			<method>walk</method>
+			<source>value</source>
+			<direction>output</direction>
+			<oid>.1.3.6.1.2.1.31.1.1.1.7</oid>
+		</ifHCInUcastPkts>
+		<ifHCOutUcastPkts>
+			<name>Unicast Packets Out - 64-bit Counters</name>
+			<method>walk</method>
+			<source>value</source>
+			<direction>output</direction>
+			<oid>.1.3.6.1.2.1.31.1.1.1.11</oid>
+		</ifHCOutUcastPkts>
 		<ifInMulticastPkts>
 			<name>Multicast Packets In (Legacy)</name>
 			<method>walk</method>
@@ -213,6 +227,20 @@
 			<direction>output</direction>
 			<oid>.1.3.6.1.2.1.31.1.1.1.4</oid>
 		</ifOutMulticastPkts>
+		<ifHCInMulticastPkts>
+			<name>Multicast Packets In - 64-bit Counters</name>
+			<method>walk</method>
+			<source>value</source>
+			<direction>output</direction>
+			<oid>.1.3.6.1.2.1.31.1.1.1.8</oid>
+		</ifHCInMulticastPkts>
+		<ifHCOutMulticastPkts>
+			<name>Multicast Packets Out - 64-bit Counters</name>
+			<method>walk</method>
+			<source>value</source>
+			<direction>output</direction>
+			<oid>.1.3.6.1.2.1.31.1.1.1.12</oid>
+		</ifHCOutMulticastPkts>
 		<ifInBroadcastPkts>
 			<name>Broadcast Packets In (Legacy)</name>
 			<method>walk</method>
@@ -227,6 +255,20 @@
 			<direction>output</direction>
 			<oid>.1.3.6.1.2.1.31.1.1.1.5</oid>
 		</ifOutBroadcastPkts>
+		<ifHCInBroadcastPkts>
+			<name>Broadcast Packets In - 64-bit Counters</name>
+			<method>walk</method>
+			<source>value</source>
+			<direction>output</direction>
+			<oid>.1.3.6.1.2.1.31.1.1.1.9</oid>
+		</ifHCInBroadcastPkts>
+		<ifHCOutBroadcastPkts>
+			<name>Broadcast Packets Out - 64-bit Counters</name>
+			<method>walk</method>
+			<source>value</source>
+			<direction>output</direction>
+			<oid>.1.3.6.1.2.1.31.1.1.1.13</oid>
+		</ifHCOutBroadcastPkts>
 		<ifInErrors>
 			<name>Errors In</name>
 			<method>walk</method>


### PR DESCRIPTION
The 32-bit counters for Broadcast Packets and Multicast Packets have been renamed to Legacy, but as far as I can tell, the new 64-bit counters have not been added. The Unicast Packets have not been renamed to Legacy. The attached commit adds 64-bit counters for Broadcast Packets, Multicast Packets, and Unicast Packets. I've been using these counters for years, but it'd be nice to see them upstreamed.

I didn't include any graph template changes here, as: 1) I've been using this so long, I can't remember if/what changes are required. 2) I don't know how off the top of my head how to patch the Cacti source for that. Advice/help on these points is welcome.