### PR TITLE
Fix setting graph titles using add_graphs.php

### DIFF
--- a/cli/add_graphs.php
+++ b/cli/add_graphs.php
@@ -579,7 +579,7 @@ if (cacti_sizeof($parms)) {
 		if ($graphTitle != '') {
 			if (isset($returnArray['local_graph_id'])) {
 				db_execute_prepared('UPDATE graph_templates_graph
-					SET title_cache = ?
+					SET title = ?
 					WHERE local_graph_id = ?',
 					array($graphTitle, $returnArray['local_graph_id']));
 
@@ -662,7 +662,7 @@ if (cacti_sizeof($parms)) {
 				if (isset($existsAlready) && $existsAlready > 0) {
 					if ($graphTitle != '') {
 						db_execute_prepared('UPDATE graph_templates_graph
-							SET title_cache = ?
+							SET title = ?
 							WHERE local_graph_id = ?',
 							array($graphTitle, $existsAlready));
 
@@ -689,7 +689,7 @@ if (cacti_sizeof($parms)) {
 				if ($returnArray !== false) {
 					if ($graphTitle != '') {
 						db_execute_prepared('UPDATE graph_templates_graph
-							SET title_cache = ?
+							SET title = ?
 							WHERE local_graph_id = ?',
 							array($graphTitle, $returnArray['local_graph_id']));
 


### PR DESCRIPTION
add_graphs.php supports a --graph-title argument to set the title on an
existing graph or the graph being created.  Somewhere between 0.8.8f
and 1.1.38, this broke.  The current code sets the title_cache column
in graph_templates_graphs, which is then immediately overwritten by the
call to update_graph_title_cache().  The correct action is to update
the title, not the title_cache.