### PR TITLE
Make the local poller timezone configurable

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -124,15 +124,13 @@ function db_connect_real($device, $user, $pass, $db_name, $db_type = 'mysql', $p
 
 			db_execute_prepared('SET SESSION sql_mode = ?', array($sql_mode), false);
 
-			if ($config['poller_id'] > 1) {
-				$timezone = db_fetch_cell_prepared('SELECT timezone
-					FROM poller
-					WHERE id = ?',
-					array($config['poller_id']), false);
+			$timezone = db_fetch_cell_prepared('SELECT timezone
+				FROM poller
+				WHERE id = ?',
+				array($config['poller_id']), false);
 
-				if ($timezone != '') {
-					db_execute_prepared('SET SESSION time_zone = ?', array($timezone), false);
-				}
+			if ($timezone != '') {
+				db_execute_prepared('SET SESSION time_zone = ?', array($timezone), false);
 			}
 
 			if (!empty($config['DEBUG_READ_CONFIG_OPTION'])) {

--- a/pollers.php
+++ b/pollers.php
@@ -536,7 +536,7 @@ function poller_edit() {
 			unset($fields_poller_edit['dbsslca']);
 		}
 
-		if ($poller['timezone'] == '' || $poller['id'] == 1) {
+		if ($poller['timezone'] == '') {
 			$poller['timezone'] = ini_get('date.timezone');
 		}
 	}
@@ -623,8 +623,6 @@ function poller_edit() {
 			pt = <?php print $pt;?>;
 
 			$(function() {
-				$('#row_timezone').hide();
-
 				if (pt == 1) {
 					$('#row_threads').hide();
 				}


### PR DESCRIPTION
Some cloud SQL providers do not make the textual default_time_zone configurable. While a manual offset value (e.g. -04:00) can be configured for this value, that's not too convenient in places that observe DST.

By exposing the poller timezone configuration for all pollers, it's possible to override this default with a textual zone name if desired.

Related to #2516.