### PR TITLE
Optimize the Graph Template picker query when editing a Data Query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@ Cacti CHANGELOG
 -issue#2500: Allow Data Source repairs from the Data Source Debug and Data Source Info pages
 -issue#2502: Unable to have a min or max value for RRDfile at zero '0'
 -issue#2503: The Cacti Statistics Device Template is not in the default Cacti
+-issue#2519: Optimize the Graph Template picker query when editing a Data Query
 -feature: Update phpseclib to version 2.0.15
 
 1.2.2

--- a/include/global_form.php
+++ b/include/global_form.php
@@ -1352,23 +1352,22 @@ $fields_data_query_item_edit = array(
 		'description' => __('Choose the Graph Template to use for this Data Query Graph Template item.'),
 		'value' => '|arg1:graph_template_id|',
 		'sql' => 'SELECT DISTINCT gt.id, gt.name
-			  FROM graph_templates AS gt,
-    			       graph_templates_item AS gti
-			  WHERE gt.id = gti.graph_template_id
-			  AND gti.id in (
-        		  	SELECT DISTINCT gti.id
-        			FROM graph_templates_item AS gti,
-             			     data_template_rrd AS dtr,
-             			     data_template_data AS dtd,
-             			     data_input AS di
-        			WHERE gti.local_graph_id=0
-        			AND gti.task_item_id = dtr.id
-        			AND dtr.local_data_id=0
-        			AND dtr.data_template_id = dtd.data_template_id
-        			AND dtd.local_data_id = 0
-        			AND dtd.data_input_id = di.id
-        			AND di.id IN (2, 11, 12))
-    			 ORDER BY gt.name'
+			  FROM graph_templates AS gt
+			  INNER JOIN graph_templates_item AS gti
+			  ON gt.id=gti.graph_template_id
+			  WHERE gti.id IN (
+  				SELECT DISTINCT gti.id
+				FROM graph_templates_item AS gti
+				INNER JOIN data_template_rrd AS dtr
+				ON gti.task_item_id=dtr.id
+				AND dtr.local_data_id = 0
+				INNER JOIN data_template_data AS dtd
+				ON dtd.data_template_id=dtr.data_template_id
+				AND dtd.local_data_id = 0
+				AND dtd.data_input_id in (2,11,12)
+				WHERE gti.local_graph_id = 0
+			  )
+			  ORDER BY gt.name'
 		),
 	'name' => array(
 		'method' => 'textbox',

--- a/include/global_form.php
+++ b/include/global_form.php
@@ -1352,21 +1352,23 @@ $fields_data_query_item_edit = array(
 		'description' => __('Choose the Graph Template to use for this Data Query Graph Template item.'),
 		'value' => '|arg1:graph_template_id|',
 		'sql' => 'SELECT DISTINCT gt.id, gt.name
-			FROM graph_templates AS gt
-			INNER JOIN graph_templates_graph AS gtg
-			ON gt.id = gtg.graph_template_id
-			INNER JOIN graph_templates_item AS gti
-			ON gtg.graph_template_id=gti.graph_template_id
-			INNER JOIN data_template_rrd AS dtr
-			ON gti.task_item_id=dtr.id
-			INNER JOIN data_template_data AS dtd
-			ON dtd.data_template_id=dtr.data_template_id
-			AND dtd.local_data_id = 0
-			WHERE gtg.local_graph_id=0
-			AND dtr.local_data_id = 0
-			AND dtd.local_data_id = 0
-			AND dtd.data_input_id in (2,11,12)
-			ORDER BY gt.name'
+			  FROM graph_templates AS gt,
+    			       graph_templates_item AS gti
+			  WHERE gt.id = gti.graph_template_id
+			  AND gti.id in (
+        		  	SELECT DISTINCT gti.id
+        			FROM graph_templates_item AS gti,
+             			     data_template_rrd AS dtr,
+             			     data_template_data AS dtd,
+             			     data_input AS di
+        			WHERE gti.local_graph_id=0
+        			AND gti.task_item_id = dtr.id
+        			AND dtr.local_data_id=0
+        			AND dtr.data_template_id = dtd.data_template_id
+        			AND dtd.local_data_id = 0
+        			AND dtd.data_input_id = di.id
+        			AND di.id IN (2, 11, 12))
+    			 ORDER BY gt.name'
 		),
 	'name' => array(
 		'method' => 'textbox',


### PR DESCRIPTION
This PR is my proposal for resolving #2519.

In my case, the old request was taking about 20 seconds to return 683 rows.
This one takes about 3 seconds.

However, I don't have much to test with except my own database. I hope I didn't miss anything when rewriting it.

```
MariaDB [cacti]> explain SELECT DISTINCT gt.id, gt.name   FROM graph_templates AS gt,            graph_templates_item AS gti   WHERE gt.id = gti.graph_template_id   AND gti.id in (           SELECT DISTINCT gti.id         FROM graph_templates_item AS gti,                   data_template_rrd AS dtr,                   data_template_data AS dtd,                   data_input AS di         WHERE gti.local_graph_id=0         AND gti.task_item_id = dtr.id         AND dtr.local_data_id=0         AND dtr.data_template_id = dtd.data_template_id         AND dtd.local_data_id = 0         AND dtd.data_input_id = di.id         AND di.id IN (2, 11, 12))      ORDER BY gt.name;
+------+-------------+-------+--------+-------------------------------------------------------------------+----------------------------+---------+-----------------------------+------+----------------------------------------------+
| id   | select_type | table | type   | possible_keys                                                     | key                        | key_len | ref                         | rows | Extra                                        |
+------+-------------+-------+--------+-------------------------------------------------------------------+----------------------------+---------+-----------------------------+------+----------------------------------------------+
|    1 | PRIMARY     | dtr   | ref    | PRIMARY,duplicate_dsname_contraint,local_data_id,data_template_id | duplicate_dsname_contraint | 3       | const                       | 1931 | Using index; Using temporary; Using filesort |
|    1 | PRIMARY     | gti   | ref    | PRIMARY,task_item_id,local_graph_id_sequence,lgi_gti              | task_item_id               | 3       | cacti.dtr.id                |    3 | Using where                                  |
|    1 | PRIMARY     | gti   | eq_ref | PRIMARY,graph_template_id                                         | PRIMARY                    | 4       | cacti.gti.id                |    1 |                                              |
|    1 | PRIMARY     | gt    | eq_ref | PRIMARY                                                           | PRIMARY                    | 3       | cacti.gti.graph_template_id |    1 |                                              |
|    1 | PRIMARY     | dtd   | ref    | local_data_id,data_template_id,data_input_id                      | data_template_id           | 3       | cacti.dtr.data_template_id  |  185 | Using where; Distinct                        |
|    1 | PRIMARY     | di    | eq_ref | PRIMARY                                                           | PRIMARY                    | 3       | cacti.dtd.data_input_id     |    1 | Using index; Distinct; FirstMatch(gt)        |
+------+-------------+-------+--------+-------------------------------------------------------------------+----------------------------+---------+-----------------------------+------+----------------------------------------------+
```

```
MariaDB [cacti]> SELECT DISTINCT gt.id, gt.name   FROM graph_templates AS gt,            graph_templates_item AS gti   WHERE gt.id = gti.graph_template_id   AND gti.id in (           SELECT DISTINCT gti.id         FROM graph_templates
_item AS gti,                   data_template_rrd AS dtr,                   data_template_data AS dtd,                   data_input AS di         WHERE gti.local_graph_id=0         AND gti.task_item_id = dtr.id         AND dtr.local_d
ata_id=0         AND dtr.data_template_id = dtd.data_template_id         AND dtd.local_data_id = 0         AND dtd.data_input_id = di.id         AND di.id IN (2, 11, 12))      ORDER BY gt.name;
+------+------------------------------------------------------------------------------+
| id   | name                                                                         |
+------+------------------------------------------------------------------------------+
[...]
683 rows in set (2.71 sec)
```

