### PR TITLE
When updating color template items, the table name used is incorrect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@ Cacti CHANGELOG
 -feature: Update phpseclib to version 2.0.15
 -feature@2505: Improve Data Source Statistics performance by using RRDtool functions to calculate average and peak values
 -feature#2515: Support multiple SNMP ports when adding devices via CLI
+-issue#2531: When updating color template items, the table name used is incorrect
 
 1.2.2
 -issue#599: Aggregate graph templates assume AVG consolidation function

--- a/install/upgrades/1_0_0.php
+++ b/install/upgrades/1_0_0.php
@@ -1237,7 +1237,7 @@ function upgrade_to_1_0_0() {
 						array($keephex, $hex['id']));
 
 					if (db_table_exists('color_template_items')) {
-						db_install_execute('UPDATE color_template_item
+						db_install_execute('UPDATE color_template_items
 							SET color_id = ?
 							WHERE color_id = ?',
 							array($keephex, $hex['id']));


### PR DESCRIPTION
This line halted my upgrade of 1.0.0 as the table name is 'color_template_items' and not 'color_template_items' as it is in the file.