### PR TITLE
Support disabling PHP SNMP extension

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ Cacti CHANGELOG
 -issue#2629: Authentication bug on Cacti upgrade
 -issue#2632: Automated Network Scans are Not Working
 -issue#2635: Multiple Database Sync Issues in v1.2.x
+-issue#2638: Support disabling PHP SNMP extension
 
 1.2.3
 -issue#1063: Tree View does not display the last item correctly under 'Modern' theme

--- a/include/config.php.dist
+++ b/include/config.php.dist
@@ -107,6 +107,13 @@ $disable_log_rotation = false;
 //$input_whitelist = '/usr/local/etc/cacti/input_whitelist.json';
 
 /*
+ * Optional parameter to disable the PHP SNMP extension. If not set, defaults
+ * to class_exists('SNMP').
+ */
+
+//$php_snmp_support = false;
+
+/*
  * The following are optional variables for debugging low level system
  * functions that are generally only used by Cacti Developers to help
  * identify potential issues in commonly used functions

--- a/include/global.php
+++ b/include/global.php
@@ -187,7 +187,11 @@ $colors = array();
 $config['cacti_server_os'] = (strstr(PHP_OS, 'WIN')) ? 'win32' : 'unix';
 
 /* built-in snmp support */
-$config['php_snmp_support'] = function_exists('snmpget');
+if (isset($php_snmp_support)) {
+	$config['php_snmp_support'] = $php_snmp_support;
+} else {
+	$config['php_snmp_support'] = class_exists('SNMP');
+}
 
 /* Set various debug fields */
 $config['DEBUG_READ_CONFIG_OPTION']         = defined('DEBUG_READ_CONFIG_OPTION');

--- a/include/vendor/phpsnmp/classSNMP.php
+++ b/include/vendor/phpsnmp/classSNMP.php
@@ -16,22 +16,15 @@
  +-------------------------------------------------------------------------+
 */
 
-define('SNMP_OID_OUTPUT_SUFFIX', 1);
-define('SNMP_OID_OUTPUT_MODULE', 2);
-define('SNMP_OID_OUTPUT_UCD', 5);
-define('SNMP_OID_OUTPUT_NONE', 6);
+namespace phpsnmp;
 
-if (!defined('SNMP_STRING_OUTPUT_GUESS')) {
-	define('SNMP_STRING_OUTPUT_GUESS', 1);
-}
-
-if (!defined('SNMP_STRING_OUTPUT_ASCII')) {
-	define('SNMP_STRING_OUTPUT_ASCII', 2);
-}
-
-if (!defined('SNMP_STRING_OUTPUT_HEX')) {
-	define('SNMP_STRING_OUTPUT_HEX', 3);
-}
+const SNMP_OID_OUTPUT_SUFFIX = 1;
+const SNMP_OID_OUTPUT_MODULE = 2;
+const SNMP_OID_OUTPUT_UCD = 5;
+const SNMP_OID_OUTPUT_NONE = 6;
+const SNMP_STRING_OUTPUT_GUESS = 1;
+const SNMP_STRING_OUTPUT_ASCII = 2;
+const SNMP_STRING_OUTPUT_HEX = 3;
 
 class SNMP {
 	const ERRNO_NOERROR = 0;

--- a/include/vendor/phpsnmp/extension.php
+++ b/include/vendor/phpsnmp/extension.php
@@ -1,0 +1,32 @@
+<?php
+/*
+   +-------------------------------------------------------------------------+
+   | Copyright (C) 2004-2019 The Cacti Group                                 |
+   |                                                                         |
+   | This program is free software; you can redistribute it and/or           |
+   | modify it under the terms of the GNU General Public License             |
+   | as published by the Free Software Foundation; either version 2          |
+   | of the License, or (at your option) any later version.                  |
+   |                                                                         |
+   | This program is snmpagent in the hope that it will be useful,           |
+   | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+   | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+   | GNU General Public License for more details.                            |
+   +-------------------------------------------------------------------------+
+   | Cacti: The Complete RRDtool-based Graphing Solution                     |
+   +-------------------------------------------------------------------------+
+   | This code is designed, written, and maintained by the Cacti Group. See  |
+   | about.php and/or the AUTHORS file for specific developer information.   |
+   +-------------------------------------------------------------------------+
+   | http://www.cacti.net/                                                   |
+   +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Alias the PHP SNMP extension to the phpsnmp namespace so it can be
+ * referenced as such in lib/snmp.php.
+ */
+
+namespace phpsnmp;
+
+class SNMP extends \SNMP {}

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -44,9 +44,12 @@ if (!defined('SNMP_STRING_OUTPUT_HEX')) {
 global $banned_snmp_strings;
 $banned_snmp_strings = array('End of MIB', 'No Such', 'No more');
 
-if (!class_exists('SNMP')) {
+if ($config['php_snmp_support']) {
+	include_once($config['include_path'] . '/vendor/phpsnmp/extension.php');
+} else {
 	include_once($config['include_path'] . '/vendor/phpsnmp/classSNMP.php');
 }
+use phpsnmp\SNMP;
 
 function cacti_snmp_session($hostname, $community, $version, $auth_user = '', $auth_pass = '',
 	$auth_proto = '', $priv_pass = '', $priv_proto = '', $context = '', $engineid = '',
@@ -869,7 +872,9 @@ function snmp_escape_string($string) {
 function snmp_get_method($type = 'walk', $version = 1, $context = '', $engineid = '',
 	$value_output_format = SNMP_STRING_OUTPUT_GUESS) {
 
-	if ($value_output_format == SNMP_STRING_OUTPUT_HEX) {
+	if (!read_config_option('php_snmp_support')) {
+		return SNMP_METHOD_BINARY;
+        } elseif ($value_output_format == SNMP_STRING_OUTPUT_HEX) {
 		return SNMP_METHOD_BINARY;
 	} elseif ($version == 3 && $context != '') {
 		return SNMP_METHOD_BINARY;


### PR DESCRIPTION
Re-purpose the existing `php_snmp_support` config setting to allow administrators to disable the built-in SNMP extension.

It can be desirable to force use of the Net-SNMP in some configurations, particularly when IPv6 is in use. This allows the Cacti administrator to set `$php_snmp_support = false` in `config.php`, which will then force use of the Net-SNMP binaries.

While some Cacti administrators may have control over the PHP extensions that are installed on their system, others may not. This allows those who are not in control of the loaded extensions to effectively the PHP SNMP extension.

I've tested this patch before and after removing the PHP SNMP extension. I see the expected results when the extension is installed, which is a failure to connect to `udp6:` hosts. Setting the config option to `true` then forces use of Net-SNMP binaries, and Cacti successfully polls those hosts.

Note that the long term fix here is bringing PHP's SNMP modules in line with the Net-SNMP binaries. However, I suspect that will take some work, and it'd be nice to remove my local hacks in the meantime.

Related to #1865.