### PR TITLE
Allow application of automation rules on CLI

### DIFF
--- a/cli/apply_automation_rules.php
+++ b/cli/apply_automation_rules.php
@@ -45,7 +45,13 @@ require_once($config['base_path'] . '/lib/utility.php');
 #}
 
 # getopt
-$passed_options = getopt("hyv", ['help','ids::','hostname::','description::']);
+$passed_options = getopt("hyv", ['help','ids::','hostname::','description::','version']);
+
+# display version
+if (array_key_exists('version', $passed_options)) {
+  _aar_display_version(); exit(0);
+}
+# selection criteria may not be combined
 if ((array_key_exists('h', $passed_options) or
      array_key_exists('help', $passed_options)
    ) or !(
@@ -116,5 +122,13 @@ function _aar_usage() {
     -v:        Verbose mode; list matched hosts
 
 EOM;
+}
+function _aar_display_version() {
+  if (function_exists('get_cacti_cli_version')) {
+    $version = get_cacti_cli_version(); # >= 1.2.x
+  } else {
+    $version = get_cacti_version(); # just for funsies on 1.1.x
+  }
+  print "Cacti Apply Automation Rules Utility, Version $version, " . COPYRIGHT_YEARS . "\n";
 }
 ?>

--- a/cli/apply_automation_rules.php
+++ b/cli/apply_automation_rules.php
@@ -2,7 +2,7 @@
 <?php
 /*
  +-------------------------------------------------------------------------+
- | Copyright (C) 2019 Swisscom Schweiz AG                                  |
+ | Copyright (C) 2019 The Cacti Group                                      |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU General Public License             |

--- a/cli/apply_automation_rules.php
+++ b/cli/apply_automation_rules.php
@@ -45,13 +45,13 @@ require_once($config['base_path'] . '/lib/utility.php');
 #}
 
 # getopt
-$passed_options = getopt("hyv", ['help','ids::','hostname::','desc::']);
+$passed_options = getopt("hyv", ['help','ids::','hostname::','description::']);
 if ((array_key_exists('h', $passed_options) or
      array_key_exists('help', $passed_options)
    ) or !(
-      array_key_exists('ids',      $passed_options) xor
-      array_key_exists('hostname', $passed_options) xor
-      array_key_exists('desc',     $passed_options)
+      array_key_exists('ids',         $passed_options) xor
+      array_key_exists('hostname',    $passed_options) xor
+      array_key_exists('description', $passed_options)
     )
   ) {
   _aar_usage(); exit(0);
@@ -63,7 +63,7 @@ if (isset($passed_options['ids'])) {
   $ids=explode(' ', $passed_options['ids']);
 } elseif (isset($passed_options['hostname'])) {
   $ids=_aar_likefetch('hostname');
-} elseif (isset($passed_options['desc'])) {
+} elseif (isset($passed_options['description'])) {
   $ids=_aar_likefetch('description');
 }
 
@@ -108,7 +108,7 @@ function _aar_usage() {
   Where SELECTION_CRITERIA is one (not more) of:
     --ids="deviceid [deviceid...]"
     --hostname='LIKE-compatible hostname string'
-    --desc='LIKE-compatible host description string'
+    --description='LIKE-compatible host description string'
 
   Optional:
     -h|--help: Show this help

--- a/cli/apply_automation_rules.php
+++ b/cli/apply_automation_rules.php
@@ -1,0 +1,70 @@
+#!/usr/bin/php -q
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2019 Swisscom Schweiz AG                                  |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+*/
+/*
+  TODO:
+  0. clean up, document
+  1. allow device selection through regex instead of passing opts
+  2. improve logging
+*/
+
+# run from CLI only.
+if (php_sapi_name() != "cli") {
+  die('This script is intended to be run on the CLI only.');
+}
+
+# load globals and stuff
+$no_http_headers = true;
+require(__DIR__ . '/../include/global.php');
+require_once($config['base_path'] . '/lib/api_automation_tools.php');
+require_once($config['base_path'] . '/lib/api_automation.php');
+require_once($config['base_path'] . '/lib/api_data_source.php');
+require_once($config['base_path'] . '/lib/api_graph.php');
+require_once($config['base_path'] . '/lib/api_device.php');
+require_once($config['base_path'] . '/lib/data_query.php');
+require_once($config['base_path'] . '/lib/functions.php');
+require_once($config['base_path'] . '/lib/reports.php');
+require_once($config['base_path'] . '/lib/template.php');
+require_once($config['base_path'] . '/lib/utility.php');
+# this would be way nicer, but cannot be done as of 1.1.x
+#foreach(glob($config['base_path'] . '/lib/*.php') as $file){
+#  require_once($file);
+#}
+
+# getopt
+$passed_options = getopt("h", ['help','ids:']);
+if (array_key_exists('h', $passed_options) ||
+    array_key_exists('help', $passed_options) ||
+    !array_key_exists('ids',$passed_options)) {
+  usage(); exit(0);
+}
+
+foreach (explode(' ', $passed_options['ids']) as $device) {
+  cacti_log("CLI requesting to apply automation rules for Device id $device",
+    true,'CLI TRACE');
+  automation_update_device($device);
+  cacti_log("automation_update_device() has finished for $device",
+    true,'CLI TRACE');
+}
+
+function usage() {
+  print <<<EOM
+  Usage: apply_automation_rules.php [-h] --ids="deviceid [deviceid...]"
+
+EOM;
+}
+?>


### PR DESCRIPTION
This brings a CLI script which allows to apply automation rules to devices. This comes in handy for large(ish) installations that additionally make use of numerous automation rules (and possibly not all of them being optimized), where using this through the web interface often results in timeouts and/or incomplete runs, or
would require crazy high max_execution_time settings.

Tested on a 1.1.38 and a 1.2.2 installation, rebased commits against develop branch.