### PR TITLE
Honor php.ini when php is used in exec() and shell_exec() calls

### DIFF
--- a/graph_realtime.php
+++ b/graph_realtime.php
@@ -169,7 +169,7 @@ case 'countdown':
 	$command   = read_config_option('path_php_binary');
 	$ini_file = php_ini_loaded_file();
 	if($ini_file) {
-		$command = $command . '-c ' . $ini_file;
+		$command = $command . ' -c ' . $ini_file;
 	}
 	$args      = sprintf('poller_realtime.php --graph=%s --interval=%d --poller_id=' . session_id(), get_request_var('local_graph_id'), $graph_data_array['ds_step']);
 

--- a/graph_realtime.php
+++ b/graph_realtime.php
@@ -167,6 +167,10 @@ case 'countdown':
 	/* call poller */
 	$graph_rrd = read_config_option('realtime_cache_path') . '/user_' . session_id() . '_lgi_' . get_request_var('local_graph_id') . '.png';
 	$command   = read_config_option('path_php_binary');
+	$ini_file = php_ini_loaded_file();
+	if($ini_file) {
+		$command = $command . '-c ' . $ini_file;
+	}
 	$args      = sprintf('poller_realtime.php --graph=%s --interval=%d --poller_id=' . session_id(), get_request_var('local_graph_id'), $graph_data_array['ds_step']);
 
 	shell_exec("$command $args");

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -697,8 +697,13 @@ class Installer implements JsonSerializable {
 
 					if ($should_set && $name == 'path_php_binary') {
 						$input = mt_rand(2,64);
+						$args = ' -q';
+						$ini_file = php_ini_loaded_file();
+						if($ini_file) {
+							$args = ' -c ' . $ini_file . ' ' . $args;
+						}
 						$output = shell_exec(
-							$path . ' -q ' . $config['base_path'] .
+							$path . $args . $config['base_path'] .
 							'/install/cli_test.php ' . $input);
 
 						if ($output != $input * $input) {
@@ -2926,8 +2931,14 @@ class Installer implements JsonSerializable {
 		if (!empty($host_template_id)) {
 			$this->setProgress(Installer::PROGRESS_DEVICE_TEMPLATE);
 			log_install_always('', 'Device Template for First Cacti Device is ' . $host_template_id);
+			$command = read_config_option('path_php_binary');
+			$args = ' -q';
+			$ini_file = php_ini_loaded_file();
+			if($ini_file) {
+				$args = ' -c ' . $ini_file . ' ' . $args;
+			}
 
-			$results = shell_exec(read_config_option('path_php_binary') . ' -q ' . $config['base_path'] . '/cli/add_device.php' .
+			$results = shell_exec( $command . $args . $config['base_path'] . '/cli/add_device.php' .
 				' --description=' . cacti_escapeshellarg($description) .
 				' --ip=' . cacti_escapeshellarg($ip) .
 				' --template=' . $host_template_id .
@@ -2958,7 +2969,7 @@ class Installer implements JsonSerializable {
 
 					$this->setProgress(Installer::PROGRESS_DEVICE_TREE);
 					log_install_always('', 'Adding Device to Default Tree');
-					shell_exec(read_config_option('path_php_binary') . ' -q ' . $config['base_path'] . '/cli/add_tree.php' .
+					shell_exec($command . $args . $config['base_path'] . '/cli/add_tree.php' .
 						' --type=node' .
 						' --node-type=host' .
 						' --tree-id=1' .
@@ -3013,7 +3024,13 @@ class Installer implements JsonSerializable {
 				$name = $table['value'];
 				if (!empty($name)) {
 					log_install_always('', sprintf('Converting Table #%s \'%s\'', $i, $name));
-					$results = shell_exec(read_config_option('path_php_binary') . ' -q ' . $config['base_path'] . '/cli/convert_tables.php' .
+					$command = read_config_option('path_php_binary');
+					$args = ' -q';
+					$ini_file = php_ini_loaded_file();
+					if($ini_file) {
+						$args = ' -c ' . $ini_file . ' ' . $args;
+					}
+					$results = shell_exec($command . $args . $config['base_path'] . '/cli/convert_tables.php' .
 						' --table=' . cacti_escapeshellarg($name) .
 						' --utf8 --innodb');
 

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -123,6 +123,13 @@ function exec_background($filename, $args = '', $redirect_args = '') {
 	cacti_log("DEBUG: About to Spawn a Remote Process [CMD: $filename, ARGS: $args]", true, 'POLLER', ($debug ? POLLER_VERBOSITY_NONE:POLLER_VERBOSITY_DEBUG));
 
 	if (file_exists($filename)) {
+		// when executing php, make sure to prepend the php.ini in use to the arguments
+		if (strpos($filename, 'php') !== false) {
+			$ini_file = php_ini_loaded_file();
+			if($ini_file) {
+				$args = '-c ' . $ini_file . ' ' . $args;
+			}
+		}
 		if ($config['cacti_server_os'] == 'win32') {
 			if ($redirect_args == '') {
 				pclose(popen("start \"Cactiplus\" /I \"" . $filename . "\" " . $args, 'r'));

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -1310,8 +1310,13 @@ function utility_php_extensions() {
 	global $config;
 
 	$php = read_config_option('path_php_binary', true);
+	$args = ' -q';
+	$ini_file = php_ini_loaded_file();
+	if($ini_file) {
+		$args = ' -c ' . $ini_file . ' ' . $args;
+	}
 	$php_file = $config['base_path'] . '/install/cli_check.php extensions';
-	$json = shell_exec($php . ' -q ' . $php_file);
+	$json = shell_exec($php . $args . $php_file);
 	$ext = @json_decode($json, true);
 
 	utility_php_verify_extensions($ext, 'web');
@@ -1367,8 +1372,13 @@ function utility_php_recommends() {
 	global $config;
 
 	$php = read_config_option('path_php_binary', true);
+	$args = ' -q';
+	$ini_file = php_ini_loaded_file();
+	if($ini_file) {
+		$args = ' -c ' . $ini_file . ' ' . $args;
+	}
 	$php_file = $config['base_path'] . '/install/cli_check.php recommends';
-	$json = shell_exec($php . ' -q ' . $php_file);
+	$json = shell_exec($php . $args . $php_file);
 	$ext = array('web'=>'','cli'=>'');
 	$ext['cli'] = @json_decode($json, true);
 
@@ -1442,8 +1452,13 @@ function utility_php_optionals() {
 	global $config;
 
 	$php = read_config_option('path_php_binary', true);
+	$args = ' -q';
+	$ini_file = php_ini_loaded_file();
+	if($ini_file) {
+		$args = ' -c ' . $ini_file . ' ' . $args;
+	}
 	$php_file = $config['base_path'] . '/install/cli_check.php optionals';
-	$json = shell_exec($php . ' -q ' . $php_file);
+	$json = shell_exec($php . $args . $php_file);
 	$opt = @json_decode($json, true);
 
 	utility_php_verify_optionals($opt, 'web');

--- a/poller_realtime.php
+++ b/poller_realtime.php
@@ -130,6 +130,10 @@ $max_threads = read_config_option('max_threads');
 /* Determine Command Name */
 $command_string = read_config_option('path_php_binary');
 $extra_args     = '-q ' . $config['base_path'] . "/cmd_realtime.php $poller_id $graph_id $interval";
+$ini_file = php_ini_loaded_file();
+if($ini_file) {
+	$extra_args = ' -c ' . $ini_file . ' ' . $extra_args;
+}
 
 /* Determine if Realtime will work or not */
 $cache_dir = read_config_option('realtime_cache_path');

--- a/poller_spikekill.php
+++ b/poller_spikekill.php
@@ -188,7 +188,13 @@ function kill_spikes($templates, &$found) {
 	if (cacti_sizeof($rrdfiles)) {
 	foreach($rrdfiles as $f) {
 		debug("Removing Spikes from '$f'");
-		$response = exec(read_config_option('path_php_binary') . ' -q ' .
+		$ini_file = php_ini_loaded_file();
+		if($ini_file) {
+			$ini_file = '-c ' . $ini_file . ' ';
+		}else{
+			$ini_file = '';
+		}
+		$response = exec(read_config_option('path_php_binary') . $ini_file . ' -q ' .
 			$config['base_path'] . '/cli/removespikes.php --rrdfile=' . $f . ($debug ? ' --debug':''));
 		if (substr_count($response, 'Spikes Found and Remediated')) {
 			$found++;

--- a/snmpagent_mibcache.php
+++ b/snmpagent_mibcache.php
@@ -44,6 +44,10 @@ $path_mibcache_lock = $config['base_path'] . '/cache/mibcache/mibcache.lock';
 /* start background caching process if not running */
 $php = read_config_option("path_php_binary");
 $extra_args     = " \"./snmpagent_mibcachechild.php\"";
+$ini_file = php_ini_loaded_file();
+if($ini_file) {
+	$extra_args = '-c ' . $ini_file . ' ' . $extra_args;
+}
 
 while(1) {
 	if(strstr(PHP_OS, "WIN")) {

--- a/snmpagent_persist.php
+++ b/snmpagent_persist.php
@@ -76,6 +76,10 @@ $cache_last_refresh = false;
 /* start background caching process if not running */
 $php = read_config_option('path_php_binary');
 $extra_args     = '-q "./snmpagent_mibcache.php"';
+$ini_file = php_ini_loaded_file();
+if($ini_file) {
+	$extra_args = '-c ' . $ini_file . ' ' . $extra_args;
+}
 
 if(strstr(PHP_OS, 'WIN')) {
 	/* windows part missing */


### PR DESCRIPTION
Introduces the prepending of the current php.ini file (if any) to the extra arguments of backgrounded php calls (used with [exec_background()](https://github.com/Cacti/cacti/blob/develop/lib/poller.php#L120) or directly with [exec()](https://www.php.net/manual/en/function.exec.php) or [shell_exec()](https://www.php.net/manual/en/function.shell-exec.php)).

This enables the backgrounded process to stay in the same environment as the main one and not default back to a system wide default configuration file (which might or might not have configurations setup properly).

Attempts to fix #2643.