### PR TITLE
WIP: php argument composition

### DIFF
--- a/graph_realtime.php
+++ b/graph_realtime.php
@@ -166,16 +166,12 @@ case 'countdown':
 
 	/* call poller */
 	$graph_rrd = read_config_option('realtime_cache_path') . '/user_' . session_id() . '_lgi_' . get_request_var('local_graph_id') . '.png';
-	$command   = read_config_option('path_php_binary');
-	$ini_file  = php_ini_loaded_file();
+	$php = read_config_option('path_php_binary');
+	$args = ' ';
+	assemble_php_args($args);
+	$php_file = sprintf('poller_realtime.php --graph=%s --interval=%d --poller_id=' . session_id(), get_request_var('local_graph_id'), $graph_data_array['ds_step']);
 
-	if ($ini_file) {
-		$command = $command . ' -c ' . $ini_file;
-	}
-
-	$args = sprintf('poller_realtime.php --graph=%s --interval=%d --poller_id=' . session_id(), get_request_var('local_graph_id'), $graph_data_array['ds_step']);
-
-	shell_exec("$command $args");
+	shell_exec($php . $args . $php_file);
 
 	/* construct the image name  */
 	$graph_data_array['export_realtime'] = $graph_rrd;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5349,3 +5349,16 @@ function is_function_enabled($name) {
 		!in_array($name, array_map('trim', explode(', ', ini_get('disable_functions')))) &&
 		strtolower(ini_get('safe_mode')) != 1;
 }
+
+function assemble_php_args(&$args) {
+	$ini_file = php_ini_loaded_file();
+	if ($ini_file) {
+		$args = ' -c ' . $ini_file . ' ' . $args;
+	}
+	foreach (get_loaded_extensions() as $current_extension) {
+		$args = $args . ' -d extension='.$current_extension.' ';
+	}
+	$args = $args . ' -d memory_limit='. ini_get('memory_limit') . ' ';
+	$args = $args . ' -d max_execution_time='. ini_get('max_execution_time') . ' ';
+	$args = $args . ' -d date.timezone='. ini_get('date.timezone') . ' ';
+}

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5352,13 +5352,15 @@ function is_function_enabled($name) {
 
 function assemble_php_args(&$args) {
 	$ini_file = php_ini_loaded_file();
+	$prepend_args = '';
 	if ($ini_file) {
-		$args = ' -c ' . $ini_file . ' ' . $args;
+		$prepend_args = ' -c ' . $ini_file . ' ' . $args;
 	}
 	foreach (get_loaded_extensions() as $current_extension) {
-		$args = $args . ' -d extension='.$current_extension.' ';
+		$prepend_args = $prepend_args . ' -d extension='.$current_extension.' ';
 	}
-	$args = $args . ' -d memory_limit='. ini_get('memory_limit') . ' ';
-	$args = $args . ' -d max_execution_time='. ini_get('max_execution_time') . ' ';
-	$args = $args . ' -d date.timezone='. ini_get('date.timezone') . ' ';
+	$prepend_args = $prepend_args . ' -d memory_limit='. ini_get('memory_limit') . ' ';
+	$prepend_args = $prepend_args . ' -d max_execution_time='. ini_get('max_execution_time') . ' ';
+	$prepend_args = $prepend_args . ' -d date.timezone='. ini_get('date.timezone') . ' ';
+	$args = $prepend_args . $args;
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5354,7 +5354,7 @@ function assemble_php_args(&$args) {
 	$ini_file = php_ini_loaded_file();
 	$prepend_args = '';
 	if ($ini_file) {
-		$prepend_args = ' -c ' . $ini_file . ' ' . $args;
+		$prepend_args = ' -c ' . $ini_file . ' ';
 	}
 	foreach (get_loaded_extensions() as $current_extension) {
 		$prepend_args = $prepend_args . ' -d extension='.$current_extension.' ';

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -698,11 +698,7 @@ class Installer implements JsonSerializable {
 					if ($should_set && $name == 'path_php_binary') {
 						$input = mt_rand(2,64);
 						$args = ' -q ';
-						$ini_file = php_ini_loaded_file();
-
-						if ($ini_file) {
-							$args = ' -c ' . $ini_file . ' ' . $args;
-						}
+						assemble_php_args($args);
 
 						$output = shell_exec(
 							$path . $args . $config['base_path'] .
@@ -2936,11 +2932,7 @@ class Installer implements JsonSerializable {
 			log_install_always('', 'Device Template for First Cacti Device is ' . $host_template_id);
 			$command = read_config_option('path_php_binary');
 			$args = ' -q ';
-			$ini_file = php_ini_loaded_file();
-
-			if ($ini_file) {
-				$args = ' -c ' . $ini_file . ' ' . $args;
-			}
+			assemble_php_args($args);
 
 			$results = shell_exec( $command . $args . $config['base_path'] . '/cli/add_device.php' .
 				' --description=' . cacti_escapeshellarg($description) .
@@ -3030,11 +3022,7 @@ class Installer implements JsonSerializable {
 					log_install_always('', sprintf('Converting Table #%s \'%s\'', $i, $name));
 					$command = read_config_option('path_php_binary');
 					$args = ' -q ';
-					$ini_file = php_ini_loaded_file();
-
-					if ($ini_file) {
-						$args = ' -c ' . $ini_file . ' ' . $args;
-					}
+					assemble_php_args($args);
 
 					$results = shell_exec($command . $args . $config['base_path'] . '/cli/convert_tables.php' .
 						' --table=' . cacti_escapeshellarg($name) .

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -125,11 +125,7 @@ function exec_background($filename, $args = '', $redirect_args = '') {
 	if (file_exists($filename)) {
 		// when executing php, make sure to prepend the php.ini in use to the arguments
 		if (strpos($filename, 'php') !== false) {
-			$ini_file = php_ini_loaded_file();
-
-			if ($ini_file) {
-				$args = '-c ' . $ini_file . ' ' . $args;
-			}
+			assemble_php_args($args);
 		}
 
 		if ($config['cacti_server_os'] == 'win32') {

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -1311,11 +1311,7 @@ function utility_php_extensions() {
 
 	$php = read_config_option('path_php_binary', true);
 	$args = ' -q ';
-	$ini_file = php_ini_loaded_file();
-
-	if ($ini_file) {
-		$args = ' -c ' . $ini_file . ' ' . $args;
-	}
+	assemble_php_args($args);
 
 	$php_file = $config['base_path'] . '/install/cli_check.php extensions';
 	$json = shell_exec($php . $args . $php_file);
@@ -1375,11 +1371,7 @@ function utility_php_recommends() {
 
 	$php = read_config_option('path_php_binary', true);
 	$args = ' -q ';
-	$ini_file = php_ini_loaded_file();
-
-	if ($ini_file) {
-		$args = ' -c ' . $ini_file . ' ' . $args;
-	}
+	assemble_php_args($args);
 
 	$php_file = $config['base_path'] . '/install/cli_check.php recommends';
 	$json = shell_exec($php . $args . $php_file);
@@ -1457,11 +1449,7 @@ function utility_php_optionals() {
 
 	$php = read_config_option('path_php_binary', true);
 	$args = ' -q ';
-	$ini_file = php_ini_loaded_file();
-
-	if ($ini_file) {
-		$args = ' -c ' . $ini_file . ' ' . $args;
-	}
+	assemble_php_args($args);
 
 	$php_file = $config['base_path'] . '/install/cli_check.php optionals';
 	$json = shell_exec($php . $args . $php_file);

--- a/poller_realtime.php
+++ b/poller_realtime.php
@@ -128,13 +128,10 @@ $change_files = false;
 $max_threads = read_config_option('max_threads');
 
 /* Determine Command Name */
-$command_string = read_config_option('path_php_binary');
-$extra_args     = '-q ' . $config['base_path'] . "/cmd_realtime.php $poller_id $graph_id $interval";
-$ini_file       = php_ini_loaded_file();
-
-if ($ini_file) {
-	$extra_args = ' -c ' . $ini_file . ' ' . $extra_args;
-}
+$php = read_config_option('path_php_binary');
+$args = ' -q ';
+assemble_php_args($args);
+$php_file = $config['base_path'] . "/cmd_realtime.php $poller_id $graph_id $interval";
 
 /* Determine if Realtime will work or not */
 $cache_dir = read_config_option('realtime_cache_path');
@@ -146,7 +143,7 @@ if (!is_dir($cache_dir)) {
 	return -2;
 }
 
-shell_exec("$command_string $extra_args");
+shell_exec($php . $args . $php_file);
 
 /* open a pipe to rrdtool for writing */
 $rrdtool_pipe = rrd_init();

--- a/poller_spikekill.php
+++ b/poller_spikekill.php
@@ -188,15 +188,10 @@ function kill_spikes($templates, &$found) {
 	if (cacti_sizeof($rrdfiles)) {
 		foreach($rrdfiles as $f) {
 			debug("Removing Spikes from '$f'");
-			$ini_file = php_ini_loaded_file();
+			$args = ' -q ';
+			assemble_php_args($args);
 
-			if ($ini_file) {
-				$ini_file = ' -c ' . $ini_file;
-			} else {
-				$ini_file = '';
-			}
-
-			$response = exec(read_config_option('path_php_binary') . $ini_file . ' -q ' .
+			$response = exec(read_config_option('path_php_binary') . $args .
 				$config['base_path'] . '/cli/removespikes.php --rrdfile=' . $f . ($debug ? ' --debug':''));
 
 			if (substr_count($response, 'Spikes Found and Remediated')) {

--- a/snmpagent_mibcache.php
+++ b/snmpagent_mibcache.php
@@ -43,18 +43,15 @@ $path_mibcache_lock = $config['base_path'] . '/cache/mibcache/mibcache.lock';
 
 /* start background caching process if not running */
 $php = read_config_option("path_php_binary");
-$extra_args = " \"./snmpagent_mibcachechild.php\"";
-$ini_file   = php_ini_loaded_file();
-
-if ($ini_file) {
-	$extra_args = '-c ' . $ini_file . ' ' . $extra_args;
-}
+$args = ' ';
+assemble_php_args($args);
+$php_file = " \"./snmpagent_mibcachechild.php\"";
 
 while(1) {
 	if(strstr(PHP_OS, "WIN")) {
-		popen("start \"CactiSNMPCacheChild\" /I \"" . $php . "\" " . $extra_args, "r");
+		popen("start \"CactiSNMPCacheChild\" /I \"" . $php . "\" " . $args . $php_file , "r");
 	} else {
-		exec($php . " " . $extra_args . " > /dev/null &");
+		exec($php . $args . $php_file . " > /dev/null &");
 	}
 	sleep(30 - time() % 30);
 }

--- a/snmpagent_persist.php
+++ b/snmpagent_persist.php
@@ -75,21 +75,18 @@ $cache_last_refresh = false;
 
 /* start background caching process if not running */
 $php = read_config_option('path_php_binary');
-$extra_args = '-q "./snmpagent_mibcache.php"';
-$ini_file   = php_ini_loaded_file();
-
-if ($ini_file) {
-	$extra_args = '-c ' . $ini_file . ' ' . $extra_args;
-}
+$args = ' -q ';
+assemble_php_args($args);
+$php_file = ' "./snmpagent_mibcache.php"';
 
 if(strstr(PHP_OS, 'WIN')) {
 	/* windows part missing */
-	pclose(popen("start \"CactiSNMPCache\" /I /B \"" . $php . "\" " . $extra_args, "r"));
+	pclose(popen("start \"CactiSNMPCache\" /I /B \"" . $php . "\" " . $args . $php_file, "r"));
 } else {
 	exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 
 	if (!cacti_sizeof($output)) {
-		exec($php . " " . $extra_args . " > /dev/null &");
+		exec($php . $args . $php_file . " > /dev/null &");
 	}
 }
 


### PR DESCRIPTION
Moves the composition of arguments to a backgrounded php call (i.e. when using `shell_exec` or `exec`) to `assemble_php_args()` in `lib/functions.php`. Further establishes details discussed in #2643. 

This works for me during installation. However, when using an unset global php configuration (while serving cacti with all requirements via uwsgi) and spawning external php processes, these throw warnings as they can't load certain (probably builtin) extensions, which are not found in the default extensions path. I don't know what to do about that.
Therefore, please review and test! Also, please advise in regards to function documentation.

Also: I had to apply the directory for `$path_cactilog` twice during installation, before it got picked up and the next installation step gets started. However, this was also the case before applying this patch.