### PR TITLE
Record rule used during automation and provide link when viewed via clog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#2721: When replacing '|input_xxxx|' strings, undefined index can occur
 -issue#2723: Undefined variable message raised by push_out_host() in lib/utility.php
 -issue#2724: In PHP strict standards mode, rrdtool_function_graph() generates ByRef message for HRULE items
+-issue#2726: Record rule used during automation and provide link when viewed via clog
 
 1.2.4
 -issue#2523: Send A Test Email stops working under PHP 7.3

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -2527,7 +2527,7 @@ function create_dq_graphs($host_id, $snmp_query_id, $rule) {
 						}
 					}
 
-					cacti_log('NOTE: Graph Added - Device[' . $host_id . '], Graph[' . $return_array['local_graph_id'] . "], DS[$data_source_id], Rule[" . $rule['name'] . ']', false, 'AUTOM8');
+					cacti_log('NOTE: Graph Added - Device[' . $host_id . '], Graph[' . $return_array['local_graph_id'] . "], DS[$data_source_id], Rule[" . $rule['id'] . ']', false, 'AUTOM8');
 				} else {
 					cacti_log('ERROR: Device[' . $host_id . '] Graph Not Added due to missing data sources.', false, 'AUTOM8');
 				}

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -2527,7 +2527,7 @@ function create_dq_graphs($host_id, $snmp_query_id, $rule) {
 						}
 					}
 
-					cacti_log('NOTE: Graph Added - Device[' . $host_id . '], Graph[' . $return_array['local_graph_id'] . "], DS[$data_source_id]", false, 'AUTOM8');
+					cacti_log('NOTE: Graph Added - Device[' . $host_id . '], Graph[' . $return_array['local_graph_id'] . "], DS[$data_source_id], Rule[" . $rule['name'] . ']', false, 'AUTOM8');
 				} else {
 					cacti_log('ERROR: Device[' . $host_id . '] Graph Not Added due to missing data sources.', false, 'AUTOM8');
 				}

--- a/lib/clog_webapi.php
+++ b/lib/clog_webapi.php
@@ -657,6 +657,7 @@ function clog_get_regex_array() {
 			8  => array('name' => 'Graphs', 'regex' => '( Graphs\[)([, \d]+)(\])',   'func' => 'clog_regex_graphs'),
 			9  => array('name' => 'User',   'regex' => '( User\[)([, \d]+)(\])',     'func' => 'clog_regex_users'),
 			10 => array('name' => 'User',   'regex' => '( Users\[)([, \d]+)(\])',    'func' => 'clog_regex_users'),
+			11 => array('name' => 'Rule',   'regex' => '( Rule\[)([, \d]+)(\])',   	 'func' => 'clog_regex_rule'),
 		);
 
 		$regex_array = api_plugin_hook_function('clog_regex_array',$regex_array);
@@ -960,5 +961,32 @@ function clog_regex_users($matches) {
 			$result .= $matches[3];
 		}
 	}
+	return $result;
+}
+
+function clog_regex_rule($matches) {
+	global $config;
+
+	$result = $matches[0];
+
+	$dev_ids = explode(',',str_replace(" ","",$matches[2]));
+	if (cacti_sizeof($dev_ids)) {
+		$result = '';
+		$rules = db_fetch_assoc('SELECT id, name
+			FROM automation_graph_rules
+			WHERE id in (' . implode(',',$dev_ids) . ')');
+
+		$ruleNames = array();
+		if (cacti_sizeof($rules)) {
+			foreach ($rules as $rule) {
+				$ruleNames[$rule['id']] = html_escape($rule['name']);
+			}
+		}
+
+		foreach ($dev_ids as $rule_id) {
+			$result .= $matches[1].'<a href=\'' . html_escape($config['url_path'] . 'automation_graph_rules.php?action=edit&id=' . $rule_id) . '\'>' . (isset($ruleNames[$rule_id]) ? $ruleNames[$rule_id]:$rule_id) . '</a>' . $matches[3];
+		}
+	}
+
 	return $result;
 }


### PR DESCRIPTION
Hi,
it only adds rule name:
2019/06/09 15:51:22 - AUTOM8 NOTE: Graph Added - Device[114], Graph[23079], DS[24407, 24407]
2019/06/09 15:52:50 - AUTOM8 NOTE: Graph Added - Device[114], Graph[23080], DS[24408, 24408], Rule[Win network]

It is very useful for me. I have a lot of automation graph rules and sometimes Cacti creates more graphs than I expected. With rule name in message I see problem rule and I don't need debugging.