### PR TITLE
fix MySQL (8.0.1) reserved word function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#2721: When replacing '|input_xxxx|' strings, undefined index can occur
 -issue#2723: Undefined variable message raised by push_out_host() in lib/utility.php
 -issue#2724: In PHP strict standards mode, rrdtool_function_graph() generates ByRef message for HRULE items
+-issue#2736: Correct Cacti to handle new MySQL 8.0.1 reserved word `function`
 
 1.2.4
 -issue#2523: Send A Test Email stops working under PHP 7.3

--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -731,7 +731,7 @@ function api_plugin_register_hook($plugin, $hook, $function, $file, $enable = fa
 		}
 
 		db_execute_prepared('INSERT INTO plugin_hooks
-			(name, hook, function, file, status)
+			(name, hook, `function`, file, status)
 			VALUES (?, ?, ?, ?, ?)',
 			array($plugin, $hook, $function, $file, $status));
 	} else {


### PR DESCRIPTION
Problem with new MySQL version, `function` is reserved word now:
https://dev.mysql.com/doc/refman/8.0/en/keywords.html

2019/05/10 16:04:17 - CMDPHP SQL Backtrace: (/plugins.php[74]:api_plugin_install(), /lib/plugins.php[626]:plugin_intropage_install(), /plugins/intropage/setup.php[22]:api_plugin_register_hook(), /lib/plugins.php[736]:db_execute_prepared())
2019/05/10 16:04:17 - CMDPHP ERROR: A DB Exec Failed!, Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'function, file, status) VALUES ('intropage', 'poller_bottom', 'intropage_poller_' at line 1