### PR TITLE
MySQL 8 change needs: NO_AUTO_CREATE_USER and grouping keyword

### DIFF
--- a/cacti.sql
+++ b/cacti.sql
@@ -3,7 +3,61 @@
 -- Allow MySQL to handle Cacti's legacy syntax
 --
 
-SET SESSION sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+
+DROP FUNCTION IF EXISTS NOAUTOCREATENEEDED//
+CREATE FUNCTION NOAUTOCREATENEEDED()
+RETURNS BOOL DETERMINISTIC
+
+BEGIN
+
+DECLARE ret BOOL;
+DECLARE ismaria BOOL;
+
+DECLARE majv INT;
+DECLARE medv INT;
+DECLARE minv INT;
+
+DECLARE realversion VARCHAR(16);
+
+DECLARE majn INT;
+DECLARE medn INT;
+DECLARE minn INT;
+
+SET ret = TRUE;
+
+
+SELECT LOCATE('MariaDB', @@version) > 0 INTO ismaria;
+
+IF ismaria THEN
+        -- MariaDB version NO_AUTO_CREATE_USER started to be default
+        SET majn = 10;
+        SET medn = 1;
+        SET minn = 7;
+ELSE
+        -- MySQL version it started to be default (8.0.11)
+        SET majn = 8;
+        SET medn = 0;
+        SET minn = 11;
+END IF;
+
+SELECT SUBSTRING_INDEX(SUBSTRING_INDEX(@@VERSION, '.', 3),'-',1) INTO realversion;
+SELECT CONVERT(SUBSTRING_INDEX(realversion, '.', 1), SIGNED INTEGER) INTO majv;
+SELECT CONVERT(SUBSTRING_INDEX(SUBSTRING_INDEX(realversion, '.', 2), '.', -1), SIGNED INTEGER) INTO medv;
+SELECT CONVERT(SUBSTRING_INDEX(SUBSTRING_INDEX(realversion, '.', 3), '.', -1), SIGNED INTEGER) INTO minv;
+
+IF majv >= majn AND medv >= medn AND minv >= minn THEN
+        SET ret = FALSE;
+END IF;
+
+RETURN ret;
+END //
+
+DELIMITER ;
+
+SET @sqlmode= "";
+SELECT IF(NOAUTOCREATENEEDED(), 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION', 'NO_ENGINE_SUBSTITUTION') INTO @sqlmode;
+SET SESSION sql_mode = @sqlmode;
 
 --
 -- Table structure for table `aggregate_graph_templates`
@@ -1699,8 +1753,8 @@ CREATE TABLE graph_templates_graph (
   auto_padding char(2) default NULL,
   t_base_value char(2) default '',
   base_value mediumint(8) NOT NULL default '0',
-  t_grouping char(2) default '',
-  grouping char(2) NOT NULL default '',
+  `t_grouping` char(2) default '',
+  `grouping` char(2) NOT NULL default '',
   t_unit_value char(2) default '',
   unit_value varchar(20) default NULL,
   t_unit_exponent_value char(2) default '',


### PR DESCRIPTION
Fixes: 2872

Newer MySQL versions include "grouping" as a keyword:

- https://dev.mysql.com/doc/refman/8.0/en/keywords.html

  GROUPING (R); added in 8.0.1 (reserved)
  GROUPS (R); added in 8.0.2 (reserved)

And they also have NO_AUTO_CREATE_USER as the default SQL mode:

- https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-11.html

  Using GRANT to create users. Instead, use CREATE USER. Following this
  practice makes the NO_AUTO_CREATE_USER SQL mode immaterial for GRANT
  statements, so it too is removed.

This patch addresses those 2 issues.

Signed-off-by: Rafael David Tinoco <rafaeldtinoco@ubuntu.com>