### PR TITLE
Fixed: use single quot for column data type in sql-table-php-array

### DIFF
--- a/cli/sqltable_to_php.php
+++ b/cli/sqltable_to_php.php
@@ -115,7 +115,7 @@ function sqltable_to_php($table, $create, $plugin = '') {
 					$text .= ", 'unsigned' => true";
 				}
 
-				$text .= ", 'type' => \"" . $r['Type'] . "\"";
+				$text .= ", 'type' => " . db_qstr($r['Type']);
 				$text .= ", 'NULL' => " . (strtolower($r['Null']) == 'no' ? 'false' : 'true');
 
 				if (trim($r['Default']) != '') {


### PR DESCRIPTION
Fixed use single quot for column data type in sql-table-php-array, and support single quot in data type, e.g. enum type

Before fixing
```php
$data = array();
$data['columns'][] = array('name' => 'uintid', 'unsigned' => true, 'type' => "int(12)", 'NULL' => false, 'auto_increment' => true);
$data['columns'][] = array('name' => 'intid', 'type' => "int(10)", 'NULL' => true, 'default' => '0');
$data['columns'][] = array('name' => 'strname', 'type' => "varchar(50)", 'NULL' => false, 'default' => '');
$data['columns'][] = array('name' => 'strnullname', 'type' => "varchar(50)", 'NULL' => true, 'default' => '');
$data['columns'][] = array('name' => 'enumval', 'type' => "enum('0','1','2','3','4','5','6','7','8')", 'NULL' => false, 'default' => '0');
$data['primary'] = 'uintid';
$data['type'] = 'InnoDB';
$data['comment'] = '';
api_plugin_db_table_create ('license', 'test01', $data);
```
After fixing:
```php
$data = array();
$data['columns'][] = array('name' => 'uintid', 'unsigned' => true, 'type' => 'int(12)', 'NULL' => false, 'auto_increment' => true);
$data['columns'][] = array('name' => 'intid', 'type' => 'int(10)', 'NULL' => true, 'default' => '0');
$data['columns'][] = array('name' => 'strname', 'type' => 'varchar(50)', 'NULL' => false, 'default' => '');
$data['columns'][] = array('name' => 'strnullname', 'type' => 'varchar(50)', 'NULL' => true, 'default' => '');
$data['columns'][] = array('name' => 'enumval', 'type' => 'enum(\'0\',\'1\',\'2\',\'3\',\'4\',\'5\',\'6\',\'7\',\'8\')', 'NULL' => false, 'default' => '0');
$data['primary'] = 'uintid';
$data['type'] = 'InnoDB';
$data['comment'] = '';
api_plugin_db_table_create ('license', 'test01', $data);
```