### PR TITLE
Fix to include mmcblk[0-9] devices in ss_net_snmp_disk_... scripts.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Cacti CHANGELOG
 -feature#2550: Enable use of authenticator codes for Two-Factor Authentication
 -feature#2607: Allow adding sites from command line
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
+-issue#3074: ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php do now report mmcblk data.
 
 1.2.8
 -security#3025: SQL Injection in graphs.php

--- a/scripts/ss_net_snmp_disk_bytes.php
+++ b/scripts/ss_net_snmp_disk_bytes.php
@@ -96,6 +96,14 @@ function ss_net_snmp_disk_bytes($host_id_or_hostname) {
 			$parts = explode('.', $measure['oid']);
 			$indexes[$parts[cacti_sizeof($parts)-1]] = $parts[cacti_sizeof($parts)-1];
 		}
+		if (substr($measure['value'],0,6) == 'mmcblk') {
+			if (strlen($measure['value']) > 7) {
+				continue;
+			}
+
+			$parts = explode('.', $measure['oid']);
+			$indexes[$parts[cacti_sizeof($parts)-1]] = $parts[cacti_sizeof($parts)-1];
+		}
 	}
 
 	$bytesread = $byteswritten = 0;

--- a/scripts/ss_net_snmp_disk_io.php
+++ b/scripts/ss_net_snmp_disk_io.php
@@ -96,6 +96,14 @@ function ss_net_snmp_disk_io($host_id_or_hostname) {
 			$parts = explode('.', $measure['oid']);
 			$indexes[$parts[cacti_sizeof($parts)-1]] = $parts[cacti_sizeof($parts)-1];
 		}
+		if (substr($measure['value'],0,6) == 'mmcblk') {
+			if (strlen($measure['value']) > 7) {
+				continue;
+			}
+
+			$parts = explode('.', $measure['oid']);
+			$indexes[$parts[cacti_sizeof($parts)-1]] = $parts[cacti_sizeof($parts)-1];
+		}
 	}
 
 	$reads = $writes = 0;


### PR DESCRIPTION
ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php did not report mmcblk data as found on Raspberry Pis. The data reported from snmp was filtered so that only 'sd[a-z]' devices are considered.  This change widens the filter so that also mmcblk[0-9] devices are included.