### PR TITLE
Fix for storage graphs for usb devices change devices on reboot

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@ Cacti CHANGELOG
 -issue#3105: Request variable delete_type not validated in host.php resulting in warnings
 -issue#3111: When updating an old Cacti version, the add_device.php will fail due to a bad snmp-version column
 -issue#3112: Zooming results in 2x the number of image requests
+-issue#3114: storage graphs for usb devices no longer change devices on reboot.
 
 1.2.7
 -security#2964: CVE-2019-16723 Security issue allows to view all graphs

--- a/resource/snmp_queries/host_disk.xml
+++ b/resource/snmp_queries/host_disk.xml
@@ -1,5 +1,6 @@
 <interface>
 	<name>Get Host Partition Information</name>
+	<index_order>hrStorageDescr:hrStorageIndex</index_order>
 	<index_order_type>numeric</index_order_type>
 	<oid_index>.1.3.6.1.2.1.25.2.3.1.1</oid_index>
 


### PR DESCRIPTION
Used the fix from user 'gandalf' for his 'disk_usage' template to prevent a different enumeration of usb devices to affect storage graphs created via 'host_disk.xml'.