### PR TITLE
fix freebsd ipv6 ping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Cacti CHANGELOG
 -feature#2607: Allow adding sites from command line
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
 -issue#3074: ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php do now report mmcblk data.
+-issue#3141: Fix FreeBSD IPv6 ping
 
 1.2.8
 -security#3025: CVE-2019-17357 SQL Injection in graphs.php

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -166,12 +166,12 @@ class Net_Ping
 			} elseif (substr_count(strtolower(PHP_OS), 'mac')) {
 				$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
 			} elseif (substr_count(strtolower(PHP_OS), 'freebsd')) {
-                                if (strpos($this->host['hostname'], ':') !== false) {
-                                        $result = shell_exec('ping6 -X ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
-                                }
-                                else    {
-                                        $result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
-                                }			
+				if (strpos($this->host['hostname'], ':') !== false) {
+					$result = shell_exec('ping6 -X ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+				}
+				else    {
+					$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+				}
 			} elseif (substr_count(strtolower(PHP_OS), 'darwin')) {
 				$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
 			} elseif (substr_count(strtolower(PHP_OS), 'bsd')) {

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -166,7 +166,12 @@ class Net_Ping
 			} elseif (substr_count(strtolower(PHP_OS), 'mac')) {
 				$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
 			} elseif (substr_count(strtolower(PHP_OS), 'freebsd')) {
-				$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+                                if (strpos($this->host['hostname'], ':') !== false) {
+                                        $result = shell_exec('ping6 -X ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+                                }
+                                else    {
+                                        $result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+                                }			
 			} elseif (substr_count(strtolower(PHP_OS), 'darwin')) {
 				$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
 			} elseif (substr_count(strtolower(PHP_OS), 'bsd')) {

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -168,8 +168,7 @@ class Net_Ping
 			} elseif (substr_count(strtolower(PHP_OS), 'freebsd')) {
 				if (strpos($this->host['hostname'], ':') !== false) {
 					$result = shell_exec('ping6 -X ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
-				}
-				else {
+				} else {
 					$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
 				}
 			} elseif (substr_count(strtolower(PHP_OS), 'darwin')) {

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -169,7 +169,7 @@ class Net_Ping
 				if (strpos($this->host['hostname'], ':') !== false) {
 					$result = shell_exec('ping6 -X ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
 				}
-				else    {
+				else {
 					$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
 				}
 			} elseif (substr_count(strtolower(PHP_OS), 'darwin')) {


### PR DESCRIPTION
Fix IPv6 ping on FreeBSD. FreeBSD uses command ping6 for ipv6. Parameter -t has another meaning too (in 12.x, older version doesn't know -t) . Tested on FBSD 11.2.