### PR TITLE
Issue #3142 Don't set width to 0 on TreeNav

### DIFF
--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -187,11 +187,7 @@ function grow_dhtml_trees() {
 			var minWidth = <?php print read_user_setting('min_tree_width');?>;
 			var maxWidth = <?php print read_user_setting('max_tree_width');?>;
 
-			if (visWidth < 0) {
-				$('.cactiTreeNavigationArea').width(0);
-				$('.cactiGraphContentArea').css('margin-left', 0);
-				$('.cactiTreeNavigationArea').css('overflow-x', '');
-			} else if (visWidth < minWidth) {
+			if (visWidth < minWidth) {
 				$('.cactiTreeNavigationArea').width(minWidth);
 				$('.cactiGraphContentArea').css('margin-left', minWidth+5);
 				$('.cactiTreeNavigationArea').css('overflow-x', '');


### PR DESCRIPTION
I may be wrong but I don't believe that the cactiTreeNavigationArea class ever needs a width a 0. In my research it would appear that the css display setting is used to control whether or not it is visible making this functionality moot.