### PR TITLE
Update user_group_admin.php to fix issue #3266

### DIFF
--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -35,7 +35,7 @@ $group_actions = array(
 
 $href_options = array(
 	3 => array(
-		'radio_value' => '4',
+		'radio_value' => '-1',
 		'radio_caption' => __('Defer to the Users Setting')
 		),
 	0 => array(


### PR DESCRIPTION
Fix issue #3266.

Make "Defer to the Users Setting" log-in opt as -1, so that when user in a user group, the $group_options will becomes -1, and auth_login.php will uses user specified login opts. 