### PR TITLE
When initialising fields in JavaScript, text/textarea elements have width set to zero if it is hidden by parent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ develop
 -issue#3288: When on Device page, pressing 'Go' on the filter caused Device New menu pick to appear
 -issue#3289: When using CMD.PHP, poller id is not always shown properly
 -issue#3290: When using CMD.PHP, inconsistent device logging levels may occur
+-issue#3298: When Text/textarea is invissble during page loading, its 'max-width' is set to zero.
 
 1.2.9
 -security#3191: Lack of escaping on some pages can lead to XSS exposure (CVE-2020-7106)

--- a/include/layout.js
+++ b/include/layout.js
@@ -1231,7 +1231,7 @@ function responsiveUI(event) {
 				$(this).css('max-width', (mainWidth - offset)+'px');
 			}
 
-			if ($(this).width() > $(this).parents('.formColumnRight').prop('clientWidth')) {
+			if ($(this).parents('.formColumnRight').is(":visible") && $(this).width() > $(this).parents('.formColumnRight').prop('clientWidth')) {
 				$(this).css('max-width', ($(this).parents('.formColumnRight').prop('clientWidth'))+'px');
 			} else {
 				$(this).css('max-width', '');


### PR DESCRIPTION
Fixed: text/textarea width is zero if it is hidden during page initialzation and become visible by local JS(Non-AJAX) 