### PR TITLE
Fix netmask on 32bit arches

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Cacti CHANGELOG
 
+1.2.11
+-issue#3310: Fix automation_get_valid_mask() calculation on 32bit architectures
+
 1.2.10
 -security#3285: When guest users have access to realtime graphs, remote code could be executed (CVE-2020-8813)
 -issue#3240: When using User Domains, global template user is used instead of the configured domain template user

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -3003,7 +3003,7 @@ function automation_get_valid_mask($range) {
 			$cidr = $range;
 			$mask = array(
 				'cidr' => $cidr,
-				'subnet' => long2ip(bindec(str_repeat('1',$range) . str_repeat('0',32-$range))));
+				'subnet' => long2ip((2**$range-1) << (32-$range)));
 		} else {
 			$mask = false;
 		}


### PR DESCRIPTION
bindec() may produce a float if the resulting number is higher than
PHP_INT_MAX, and long2ip() will barf on that.

On armhf (32bit) for example:

php > $range = 24;
php > echo long2ip(bindec(str_repeat('1',$range) . str_repeat('0',32-$range)));
PHP Warning:  long2ip() expects parameter 1 to be int, float given in php shell code on line 1

This commit changes the calculation of the netmask so it works on both
32 and 64 bits, little and big endian.

Fixes issue #3310 