### PR TITLE
Use pow() instead of ** to cope with old PHP

### DIFF
--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -3003,7 +3003,7 @@ function automation_get_valid_mask($range) {
 			$cidr = $range;
 			$mask = array(
 				'cidr' => $cidr,
-				'subnet' => long2ip((2**$range-1) << (32-$range)));
+				'subnet' => long2ip((pow(2,$range)-1) << (32-$range)));
 		} else {
 			$mask = false;
 		}


### PR DESCRIPTION
The ** operator was introduced in php 5.6, whereas pow() is available
everywhere.

I double checked the use of parenthesis, as we want to subtract 1 from the result of `pow()`, and not the exponent.

This further fixes issue #3310 