### PR TITLE
Fixed: Remove 'active' class for all non-current expanded menu-parent.a

### DIFF
--- a/include/themes/dark/main.js
+++ b/include/themes/dark/main.js
@@ -213,19 +213,19 @@ function setMenuVisibility() {
 		var active = storage.get(id);
 		if (active != null && active == 'active') {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 		}
 
 		if ($(this).find('a.selected').length == 0) {
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'collapsed');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'active');
 		}
 	});
@@ -239,13 +239,16 @@ function setMenuVisibility() {
 		if ($(this).next().is(':visible')) {
 			$(this).next('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).next().slideUp( { duration: 200, easing: 'swing' } );
+			$(this).removeClass('active');
 			storage.set(id, 'collapsed');
 		} else {
 			$(this).next('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true');
 			$(this).next().slideToggle( { duration: 200, easing: 'swing' } );
 			if ($(this).next().is(':visible')) {
 				storage.set($(this).closest('.menuitem').attr('id'), 'active');
+				$(this).addClass('active');
 			} else {
+				$(this).removeClass('active');
 				storage.set(id, 'collapsed');
 			}
 		}
@@ -256,6 +259,7 @@ function setMenuVisibility() {
 
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).find('ul').slideUp( { duration: 200, easing: 'swing' } );
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).attr('id'), 'collapsed');
 		});
 	});

--- a/include/themes/modern/main.js
+++ b/include/themes/modern/main.js
@@ -171,20 +171,20 @@ function setMenuVisibility() {
 		var active = storage.get(id);
 		if (active != null && active == 'active') {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 		}
 
 		if ($(this).find('a.selected').length == 0) {
 			//console.log('hiding1:'+$(this).closest('.menuitem').attr('id'));
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'collapsed');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'active');
 		}
 	});
@@ -198,13 +198,16 @@ function setMenuVisibility() {
 		if ($(this).next().is(':visible')) {
 			$(this).next('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).next().slideUp( { duration: 200, easing: 'swing' } );
+			$(this).removeClass('active');
 			storage.set(id, 'collapsed');
 		} else {
 			$(this).next('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true');
 			$(this).next().slideToggle( { duration: 200, easing: 'swing' } );
 			if ($(this).next().is(':visible')) {
 				storage.set($(this).closest('.menuitem').attr('id'), 'active');
+				$(this).addClass('active');
 			} else {
+				$(this).removeClass('active');
 				storage.set(id, 'collapsed');
 			}
 		}
@@ -215,6 +218,7 @@ function setMenuVisibility() {
 
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).find('ul').slideUp( { duration: 200, easing: 'swing' } );
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).attr('id'), 'collapsed');
 		});
 	});

--- a/include/themes/paper-plane/main.js
+++ b/include/themes/paper-plane/main.js
@@ -243,20 +243,20 @@ function setMenuVisibility() {
 		var active = storage.get(id);
 		if (active != null && active == 'active') {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 		}
 
 		if ($(this).find('a.selected').length == 0) {
 			//console.log('hiding1:'+$(this).closest('.menuitem').attr('id'));
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'collapsed');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'active');
 		}
 	});
@@ -270,13 +270,16 @@ function setMenuVisibility() {
 		if ($(this).next().is(':visible')) {
 			$(this).next('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).next().slideUp( { duration: 200, easing: 'swing' } );
+			$(this).removeClass('active');
 			storage.set(id, 'collapsed');
 		} else {
 			$(this).next('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true');
 			$(this).next().slideToggle( { duration: 200, easing: 'swing' } );
 			if ($(this).next().is(':visible')) {
 				storage.set($(this).closest('.menuitem').attr('id'), 'active');
+				$(this).addClass('active');
 			} else {
+				$(this).removeClass('active');
 				storage.set(id, 'collapsed');
 			}
 		}
@@ -287,6 +290,7 @@ function setMenuVisibility() {
 
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).find('ul').slideUp( { duration: 200, easing: 'swing' } );
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).attr('id'), 'collapsed');
 		});
 	});

--- a/include/themes/paw/main.js
+++ b/include/themes/paw/main.js
@@ -225,20 +225,20 @@ function setMenuVisibility() {
 		var active = storage.get(id);
 		if (active != null && active == 'active') {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 		}
 
 		if ($(this).find('a.selected').length == 0) {
 			//console.log('hiding1:'+$(this).closest('.menuitem').attr('id'));
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'collapsed');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'active');
 		}
 	});
@@ -252,13 +252,16 @@ function setMenuVisibility() {
 		if ($(this).next().is(':visible')) {
 			$(this).next('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).next().slideUp( { duration: 200, easing: 'swing' } );
+			$(this).removeClass('active');
 			storage.set(id, 'collapsed');
 		} else {
 			$(this).next('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true');
 			$(this).next().slideToggle( { duration: 200, easing: 'swing' } );
 			if ($(this).next().is(':visible')) {
 				storage.set($(this).closest('.menuitem').attr('id'), 'active');
+				$(this).addClass('active');
 			} else {
+				$(this).removeClass('active');
 				storage.set(id, 'collapsed');
 			}
 		}
@@ -269,6 +272,7 @@ function setMenuVisibility() {
 
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).find('ul').slideUp( { duration: 200, easing: 'swing' } );
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).attr('id'), 'collapsed');
 		});
 	});

--- a/include/themes/sunrise/main.js
+++ b/include/themes/sunrise/main.js
@@ -281,20 +281,20 @@ function setMenuVisibility() {
 		var active = storage.get(id);
 		if (active != null && active == 'active') {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 		}
 
 		if ($(this).find('a.selected').length == 0) {
 			//console.log('hiding1:'+$(this).closest('.menuitem').attr('id'));
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false').hide();
-			$(this).next('a').hide();
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'collapsed');
 		} else {
 			$(this).find('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true').show();
-			$(this).next('a').show();
+			$(this).children('a:first').addClass('active');
 			storage.set($(this).closest('.menuitem').attr('id'), 'active');
 		}
 	});
@@ -308,13 +308,16 @@ function setMenuVisibility() {
 		if ($(this).next().is(':visible')) {
 			$(this).next('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).next().slideUp( { duration: 200, easing: 'swing' } );
+			$(this).removeClass('active');
 			storage.set(id, 'collapsed');
 		} else {
 			$(this).next('ul').attr('aria-hidden', 'false').attr('aria-expanded', 'true');
 			$(this).next().slideToggle( { duration: 200, easing: 'swing' } );
 			if ($(this).next().is(':visible')) {
 				storage.set($(this).closest('.menuitem').attr('id'), 'active');
+				$(this).addClass('active');
 			} else {
+				$(this).removeClass('active');
 				storage.set(id, 'collapsed');
 			}
 		}
@@ -325,6 +328,7 @@ function setMenuVisibility() {
 
 			$(this).find('ul').attr('aria-hidden', 'true').attr('aria-expanded', 'false');
 			$(this).find('ul').slideUp( { duration: 200, easing: 'swing' } );
+			$(this).children('a:first').removeClass('active');
 			storage.set($(this).attr('id'), 'collapsed');
 		});
 	});


### PR DESCRIPTION
Remove class 'active' from all non-current menu's parent label(<a>)