### PR TITLE
Fixed #3422: COMMENT text_format does not replace Data Query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 Cacti CHANGELOG
 
+1.2.12
+-issue#3422: COMMENT text_format does not replace Data Query if graph item does not associate to any datasource.
+
 1.2.11
 -SECURITY#1566: Add SameSite support for cookies
 -SECURITY#1985: Cookie should be properly verified against password

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -2483,8 +2483,12 @@ function rrd_substitute_host_query_data($txt_graph_item, $graph, $graph_item) {
 	$txt_graph_item = substitute_host_data($txt_graph_item, '|', '|', $host_id);
 
 	/* replace query variables in graph elements */
-	if (strpos($txt_graph_item, '|query_') !== false && isset($graph_item['snmp_query_id'])) {
-		$txt_graph_item = substitute_snmp_query_data($txt_graph_item, $host_id, $graph_item['snmp_query_id'], $graph_item['snmp_index']);
+	if (strpos($txt_graph_item, '|query_') !== false){
+		if(isset($graph_item['snmp_query_id'])) {
+			$txt_graph_item = substitute_snmp_query_data($txt_graph_item, $host_id, $graph_item['snmp_query_id'], $graph_item['snmp_index']);
+		} else if (isset($graph['snmp_query_id'])) {
+			$txt_graph_item = substitute_snmp_query_data($txt_graph_item, $host_id, $graph['snmp_query_id'], $graph['snmp_index']);
+		}
 	}
 
 	/* replace query variables in graph elements */


### PR DESCRIPTION
Fixed #3422: COMMENT text_format does not replace Data Query if graph item does not associate to any datasource.