### PR TITLE
Applying fix to allow remote poller install DB check to function - #3459

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ Cacti CHANGELOG
 -issue#3450: Cacti can not be supported on XAMPP and PHP7.4
 -issue#3452: New Content-Security-Policy prevents External Links from Operating
 -issue#3454: Cacti Reports do not generate correct messages
+-issue#3459: New remote poller installation fails during connection test
 
 1.2.11
 -security#1566: Add SameSite support for cookies

--- a/install/functions.php
+++ b/install/functions.php
@@ -94,9 +94,9 @@ function install_test_local_database_connection() {
 
 	if (is_object($connection)) {
 		db_close($connection);
-		print json_encode(array('status' => 'true'));
+		return json_encode(array('status' => 'true'));
 	} else {
-		print json_encode(array('status' => 'false'));
+		return json_encode(array('status' => 'false'));
 	}
 }
 
@@ -112,9 +112,9 @@ function install_test_remote_database_connection() {
 
 	if (is_object($connection)) {
 		db_close($connection);
-		print json_encode(array('status' => 'true'));
+		return json_encode(array('status' => 'true'));
 	} else {
-		print json_encode(array('status' => 'false'));
+		return json_encode(array('status' => 'false'));
 	}
 }
 


### PR DESCRIPTION
Update `print json_encode` --> `request json_encode`. This restores the remote poller install check and no longer causes a `200` exception when testing database connectivity.

ref: https://github.com/Cacti/cacti/issues/3459