### PR TITLE
Apply 'custom_denied' hook to permission denied branch in include/auth.php

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@ Cacti CHANGELOG
 -issue#3477: Boost leaking memory when a large number of Data Sources disabled
 -issue#3478: Data Query Re-Index is not optimal causing very long Re-Index times
 -issue#3479: When viewing the Data Query table interface, the Data Input Method should be right aligned
+-feature#3480: Apply 'custom_denied' hook to general permission denied interface
 
 1.2.11
 -security#1566: Add SameSite support for cookies

--- a/include/auth.php
+++ b/include/auth.php
@@ -267,6 +267,9 @@ if (read_config_option('auth_method') != 0) {
 		}
 
 		if ($realm_id != -1 && !$authorized) {
+			if (api_plugin_hook_function('custom_denied', OPER_MODE_NATIVE) == OPER_MODE_RESKIN) {
+				exit;
+			}
 			if (isset($_SERVER['HTTP_REFERER'])) {
 				$goBack = "<td colspan='2' class='center'>[<a href='" . sanitize_uri($_SERVER['HTTP_REFERER']) . "'>" . __('Return') . "</a> | <a href='" . $config['url_path'] . "logout.php'>" . __('Login Again') . "</a>]</td>";
 			} else {


### PR DESCRIPTION
Feature #3480: Apply 'custom_denied'(since #2426) hook to permission denied branch in include/auth.php 

[Plugin-Hook-API-Ref.md#custom_denied](https://github.com/Cacti/documentation/blob/develop/Plugin-Hook-API-Ref.md#custom_denied) is updated at https://github.com/Cacti/documentation/pull/73