### PR TITLE
Fix overlapping items in directory permission checks in installation wizard

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Cacti CHANGELOG
 -issue#3436: Cannot login anymore with 1.2.11 due to Cookie domains being defaulted to on in default config.php.dist
 -issue#3442: Keeping received CMDPHP WARNING on cacti.log
 -issue#3447: SNMP Issues on recent versions of PHP
+-issue#3449: Items are overlapping in directory permission checks in installation wizard
 -issue#3450: Cacti can not be supported on XAMPP and PHP7.4
 -issue#3452: New Content-Security-Policy prevents External Links from Operating
 -issue#3454: Cacti Reports do not generate correct messages

--- a/include/themes/classic/main.css
+++ b/include/themes/classic/main.css
@@ -1247,7 +1247,7 @@ legend {
 .formRow {
 	width: 100%;
 	line-height: 30px;
-	overflow: hidden;
+	overflow-y: auto;
 }
 
 .formColumn {

--- a/include/themes/classic/main.css
+++ b/include/themes/classic/main.css
@@ -1245,20 +1245,18 @@ legend {
 }
 
 .formRow {
-	display: table-row;
 	width: 100%;
 	line-height: 30px;
+	overflow: hidden;
 }
 
 .formColumn {
 	float: left;
-	display: table-column;
 	text-align: left;
 }
 
 .formColumnLeft {
 	float: left;
-	display: table-column;
 	padding-left: 4px;
 	width: 45%;
 	text-align: left;
@@ -1266,7 +1264,6 @@ legend {
 
 .formColumnRight {
 	float: left;
-	display: table-column;
 	width: 45%;
 	text-align: left;
 }


### PR DESCRIPTION
**Explanation:**
Firefox 75.0 states that, regarding `display: table-column` in `.formColumnLeft` and `.formColumnRight`: 

> The **display** value has been changed by the engine to **block** because the element is **floated**.
> Try removing **float** or adding **display: block**.

Also, regarding `width: 100%` in `.formRow`:
> **width** has no effect on this element since it has a display of **table-row**.
> Try adding **display:inline-block** or **display:block**.

Which means there are "contradicting CSS properties".

**What I did:**
- Remove `display: table-column` from affected elements (`.formColumnLeft` and `.formColumnRight`), as these are floated. Also removed it from `.formColumn`, although it is not used in the page mentioned in the issue.
- Remove `display: table-row` from `.formRow`, so that `width:100%` applies.
- Add `overflow: hidden` to `.formRow`, which contains floating elements, so that its [height is not zero](https://stackoverflow.com/questions/9024494/css-floating-divs-have-0-height) and the background appears.

Use of "display: table-*" should probably be removed elsewhere, especially in floated elements. However, this is enough to fix this specific issue (#3449).

**Also, I did not check if it breaks things in other pages.**

Here's the result:
![Screenshot from 2020-04-19 04-12-23](https://user-images.githubusercontent.com/6828187/79678524-5a95ee00-81f4-11ea-8daf-fd177c63da82.png)
