### PR TITLE
Fix #3496, percent sign(%) is doubled in graph item of AREA type with…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@ Cacti CHANGELOG
 -issue#3483: date time format in Clog is not compatiable with old cacti, and default format is not the same
 -issue#3484: 1.2.11 shows snmpv3 password is not obfuscated in device defaults screen
 -issue#3488: In automation, when viewing an 'SNMP option set', the private passphrase is in clear
+-issue#3496: Percent sign(%) is doubled in graph item of AREA type with text 
 -feature#3480: Apply 'custom_denied' hook to general permission denied interface
 
 1.2.11

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -2321,9 +2321,9 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 
 function rrdtool_escape_string($text, $ignore_percent = true) {
 	if ($ignore_percent) {
-		return str_replace(array('"', ":", '%'), array('\"', "\:", '%%'), $text);
+		return str_replace(array('"', ':'), array('\"', '\:'), $text);
 	} else {
-		return str_replace(array('"', ":", '%'), array('\"', "\:", '%%'), $text);
+		return str_replace(array('"', ':', '%'), array('\"', '\:', '%%'), $text);
 	}
 }
 


### PR DESCRIPTION
The rrdtool_escape_string() has bug.