### PR TITLE
When plugins update, registered files list cannot always be updated

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@ Cacti CHANGELOG
 -issue#3505: Calendar can not work after click go in graph page 
 -issue#3506: "Login as Regular User" always forward to "Automatic Logout....timeout"
 -issue#3507: New Storage API Not Compatible with Cacti
+-issue#3512: Plugin realm files can not be updated by re-register due to delimiter typo
 -feature#3480: Apply 'custom_denied' hook to general permission denied interface
 -feature: Update js.storage.js to 1.1.0
 -feature: Update jstree.js to 3.3.9

--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -792,7 +792,7 @@ function api_plugin_disable_hooks_all($plugin) {
 }
 
 function api_plugin_register_realm($plugin, $file, $display, $admin = true) {
-	$files = explode(':', $file);
+	$files = explode(',', $file);
 
 	$i = 0;
 	$sql_where = '(';


### PR DESCRIPTION
Fixed a typo in api_plugin_register_realm because all other code use `,` to parsing/combine realm files