### PR TITLE
When viewing graphs, shifting time does not work when using non-english languages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@ Cacti CHANGELOG
 -issue#3507: New Storage API Not Compatible with Cacti
 -issue#3510: Normal user can not access '$guest_account=true' pages
 -issue#3512: Plugin realm files can not be updated by re-register due to delimiter typo
+-issue#3520: When viewing graphs, shifting time does not work when using non-english languages
 -feature#3480: Apply 'custom_denied' hook to general permission denied interface
 -feature: Update js.storage.js to 1.1.0
 -feature: Update jstree.js to 3.3.9

--- a/include/global_arrays.php
+++ b/include/global_arrays.php
@@ -1306,6 +1306,7 @@ $graph_timespans = array(
 	GT_PREV_YEAR      => __('Previous Year')
 );
 
+// ***** MUST BE KEPT IN SYNC WITH graph_timeshifts_vals *********
 $graph_timeshifts = array(
 	GTS_HALF_HOUR => __('%d Min', 30),
 	GTS_1_HOUR    => __('%d Hour', 1),
@@ -1326,6 +1327,29 @@ $graph_timeshifts = array(
 	GTS_6_MONTHS  => __('%d Months', 6),
 	GTS_1_YEAR    => __('%d Year', 1),
 	GTS_2_YEARS   => __('%d Years', 2)
+);
+
+// ***** MUST BE KEPT IN SYNC WITH graph_timeshifts *********
+$graph_timeshifts_vals = array(
+	GTS_HALF_HOUR => sprintf('%d Min', 30),
+	GTS_1_HOUR    => sprintf('%d Hour', 1),
+	GTS_2_HOURS   => sprintf('%d Hours', 2),
+	GTS_4_HOURS   => sprintf('%d Hours', 4),
+	GTS_6_HOURS   => sprintf('%d Hours', 6),
+	GTS_12_HOURS  => sprintf('%d Hours', 12),
+	GTS_1_DAY     => sprintf('%d Day', 1),
+	GTS_2_DAYS    => sprintf('%d Days', 2),
+	GTS_3_DAYS    => sprintf('%d Days', 3),
+	GTS_4_DAYS    => sprintf('%d Days', 4),
+	GTS_1_WEEK    => sprintf('%d Week', 1),
+	GTS_2_WEEKS   => sprintf('%d Weeks', 2),
+	GTS_1_MONTH   => sprintf('%d Month', 1),
+	GTS_2_MONTHS  => sprintf('%d Months', 2),
+	GTS_3_MONTHS  => sprintf('%d Months', 3),
+	GTS_4_MONTHS  => sprintf('%d Months', 4),
+	GTS_6_MONTHS  => sprintf('%d Months', 6),
+	GTS_1_YEAR    => sprintf('%d Year', 1),
+	GTS_2_YEARS   => sprintf('%d Years', 2)
 );
 
 $graph_weekdays = array(

--- a/lib/timespan_settings.php
+++ b/lib/timespan_settings.php
@@ -226,7 +226,7 @@ function finalize_timespan(&$timespan) {
 
 /* establish graph timeshift from either a user select or the default */
 function set_timeshift() {
-	global $config, $graph_timeshifts;
+	global $config, $graph_timeshifts_vals;
 
 	# no current timeshift: get default timeshift
 	if ((!isset($_SESSION['sess_current_timeshift'])) ||
@@ -237,6 +237,6 @@ function set_timeshift() {
 		$_SESSION['custom'] = 0;
 	}
 
-	return $timeshift = $graph_timeshifts[$_SESSION['sess_current_timeshift']];
+	return $timeshift = $graph_timeshifts_vals[$_SESSION['sess_current_timeshift']];
 }
 


### PR DESCRIPTION
When viewing graphs, shifting time does not work when using non-english languages

Closes #3520