### PR TITLE
Print the DS ID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@ Cacti CHANGELOG
 -issue#3632: Some database conditions lead to warnings in the Cacti log
 -issue#3635: Backtrace Errors attempting to run AUTOM8 to Remote Data Collector
 -issue#3639: Duplicate Entry error when updating device
+-feature#3647: add_datasource.php should print the created ID
 
 1.2.12
 -security#3467: Lack of escaping of color items can lead to XSS exposure (CVE-2020-7106)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -83,6 +83,7 @@ Cacti CHANGELOG
 -issue#3512: When plugins update, registered files list cannot always be updated by ddb4github
 -issue#3520: When viewing graphs, shifting time does not work when using non-english languages
 -issue#3576: LDAP Authentication succeeds, but login fails due to bad session handling
+-issue#3629: Log files are not rotated properly on remote pollers
 -feature#3480: Created 'custom_denied' hook to allow customisation of permission denied notifications
 -feature#3498: Update js.storage.js to 1.1.0
 -feature#3499: Update jstree.js to 3.3.9

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,6 +82,7 @@ Cacti CHANGELOG
 -issue#3510: Only guests can actually guest only pages, logged in users are denied access incorrectly
 -issue#3512: When plugins update, registered files list cannot always be updated by ddb4github
 -issue#3520: When viewing graphs, shifting time does not work when using non-english languages
+-issue#3576: LDAP Authentication succeeds, but login fails due to bad session handling
 -feature#3480: Created 'custom_denied' hook to allow customisation of permission denied notifications
 -feature#3498: Update js.storage.js to 1.1.0
 -feature#3499: Update jstree.js to 3.3.9

--- a/cli/add_datasource.php
+++ b/cli/add_datasource.php
@@ -99,6 +99,8 @@ if (!empty($host_id)) {
 	push_out_host($host_id, $local_data_id);
 }
 
+print "DS Added - DS[$local_data_id]\n";
+
 /*  display_version - displays version information */
 function display_version() {
 	$version = get_cacti_cli_version();

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1052,7 +1052,7 @@ function tail_file($file_name, $number_of_lines, $message_type = -1, $filter = '
 		$start = 0;
 	}
 
-	cacti_session_close();
+	force_session_data();
 
 	/* load up the lines into an array */
 	$file_array = array();
@@ -1076,8 +1076,6 @@ function tail_file($file_name, $number_of_lines, $message_type = -1, $filter = '
 	}
 
 	fclose($fp);
-
-	cacti_session_start();
 
 	return $file_array;
 }
@@ -5539,6 +5537,7 @@ function cacti_session_start() {
 	}
 
 	session_name($config['cacti_session_name']);
+
 	if (!session_id()) {
 		session_start($config['cookie_options']);
 	}

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5538,8 +5538,16 @@ function cacti_session_start() {
 
 	session_name($config['cacti_session_name']);
 
+	$session_restart = '';
 	if (!session_id()) {
-		session_start($config['cookie_options']);
+		$session_result = session_start($config['cookie_options']);
+	} else {
+		$session_restart = 're';
+		$session_result  = session_start();
+	}
+
+	if (!$session_result) {
+		cacti_log('Session "' . session_id() . '" ' . $session_restart . 'start failed! ' . cacti_debug_backtrace('', false, false, 0, 1), false, 'WARNING:');
 	}
 }
 

--- a/lib/ldap.php
+++ b/lib/ldap.php
@@ -371,6 +371,8 @@ class Ldap {
 
 		/* set an error handler for ldap */
 		set_error_handler(array($this, 'ErrorHandler'));
+
+		cacti_session_close();
 	}
 
 	function RestoreCactiHandler() {
@@ -379,6 +381,8 @@ class Ldap {
 
 		/* set an error handler for Cacti */
 		set_error_handler('CactiErrorHandler');
+
+		cacti_session_open();
 	}
 
 	function RecordError($output, $section = 'LDAP') {

--- a/lib/ldap.php
+++ b/lib/ldap.php
@@ -371,8 +371,6 @@ class Ldap {
 
 		/* set an error handler for ldap */
 		set_error_handler(array($this, 'ErrorHandler'));
-
-		cacti_session_close();
 	}
 
 	function RestoreCactiHandler() {
@@ -381,8 +379,6 @@ class Ldap {
 
 		/* set an error handler for Cacti */
 		set_error_handler('CactiErrorHandler');
-
-		cacti_session_start();
 	}
 
 	function RecordError($output, $section = 'LDAP') {

--- a/lib/ldap.php
+++ b/lib/ldap.php
@@ -382,7 +382,7 @@ class Ldap {
 		/* set an error handler for Cacti */
 		set_error_handler('CactiErrorHandler');
 
-		cacti_session_open();
+		cacti_session_start();
 	}
 
 	function RecordError($output, $section = 'LDAP') {

--- a/poller_maintenance.php
+++ b/poller_maintenance.php
@@ -115,6 +115,8 @@ unregister_process('maintenance', 'master', $config['poller_id']);
 exit(0);
 
 function logrotate_check($force) {
+	global $disable_log_rotation;
+
 	// Check whether the cacti log.  Rotations takes place around midnight
 	if (isset($disable_log_rotation) && $disable_log_rotation == true) {
 		// Skip log rotation as it's handled by logrotate.d


### PR DESCRIPTION
add_datasource.php doesn't print the DS ID. This is a quick patch that prints it out in a format similar to how add_graphs.php does it. Feedback welcome.