### PR TITLE
Adding datasource fails from CLI due to missing function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@ Cacti CHANGELOG
 -issue#3632: Some database conditions lead to warnings in the Cacti log
 -issue#3635: Backtrace Errors attempting to run AUTOM8 to Remote Data Collector
 -issue#3639: Duplicate Entry error when updating device
+-issue#3646: add_datasource.php fails calling api_data_source_cache_crc_update()
 
 1.2.12
 -security#3467: Lack of escaping of color items can lead to XSS exposure (CVE-2020-7106)

--- a/cli/add_datasource.php
+++ b/cli/add_datasource.php
@@ -24,6 +24,7 @@
 */
 
 require(__DIR__ . '/../include/cli_check.php');
+require_once($config['base_path'] . '/lib/api_data_source.php');
 require_once($config['base_path'] . '/lib/poller.php');
 require_once($config['base_path'] . '/lib/utility.php');
 require_once($config['base_path'] . '/lib/template.php');


### PR DESCRIPTION
With Cacti on Ubuntu 20.04:

```
$ sudo php /usr/share/cacti/cli/add_datasource.php --host-id=261 --data-template-id=90
PHP Fatal error:  Uncaught Error: Call to undefined function api_data_source_cache_crc_update() in /usr/share/cacti/site/lib/utility.php:745
Stack trace:
#0 /usr/share/cacti/cli/add_datasource.php(99): push_out_host()
#1 {main}
  thrown in /usr/share/cacti/site/lib/utility.php on line 745
```

This PR fixes that.

Closes: #3646