### PR TITLE
Print the DS ID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -43,6 +43,7 @@ Cacti CHANGELOG
 -issue#3632: Some database conditions lead to warnings in the Cacti log
 -issue#3635: Backtrace Errors attempting to run AUTOM8 to Remote Data Collector
 -issue#3639: Duplicate Entry error when updating device
+-feature#3647: add_datasource.php should print the created ID
 
 1.2.12
 -security#3467: Lack of escaping of color items can lead to XSS exposure (CVE-2020-7106)

--- a/cli/add_datasource.php
+++ b/cli/add_datasource.php
@@ -99,6 +99,8 @@ if (!empty($host_id)) {
 	push_out_host($host_id, $local_data_id);
 }
 
+print "DS Added - DS[$local_data_id]\n";
+
 /*  display_version - displays version information */
 function display_version() {
 	$version = get_cacti_cli_version();


### PR DESCRIPTION
add_datasource.php doesn't print the DS ID. This is a quick patch that prints it out in a format similar to how add_graphs.php does it. Feedback welcome.

Closes: #3647