### PR TITLE
Update removespikes.php

### DIFF
--- a/cli/removespikes.php
+++ b/cli/removespikes.php
@@ -55,10 +55,10 @@ $avgnan   = read_config_option('spikekill_avgnan', 'last');
 
 switch($method) {
 	case '1':
-		$method = 'variance';
+		$method = 'stddev';
 		break;
 	case '2':
-		$method = 'stddev';
+		$method = 'variance';
 		break;
 	case '3':
 		$method = 'float';
@@ -166,6 +166,9 @@ if (cacti_sizeof($parms)) {
 				exit(-3);
 		}
 	}
+} else {
+	display_help();
+	exit(0);
 }
 
 $spiker = new spikekill($rrdfile, $method, $avgnan, $stddev, $out_start, $out_end, $outliers, $percent, $numspike);


### PR DESCRIPTION
1. Fixes #3670 
2. Prints the Help details when no arguments are provided on the command line