### PR TITLE
Change description for snmp algorithms

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.15
+-issue#3643: Maximum OIDs Per Get Request - field empty
 -issue#3656: Cacti V1.2.12 Boost running too often
 -issue#3730: Change wording for the 21st century, but let's not forget our past
 -issue#3743: Description field allows more characters entered than is stored

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,7 @@ Cacti CHANGELOG
 -issue#3770: Column sizing is being lost between pages refreshes
 -issue#3771: All Cacti Console pages should include the ID of the object and the Data Input Method page is missing that ID
 -issue#3775: Search field strange behavior when hitting enter in 1.2.14
+-issue#3778: Export DataQuery show PHP Error: ERROR PHP NOTICE: Undefined index: fname
 -feature: Update FontAwesome to Version 5.14
 
 1.2.14

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ Cacti CHANGELOG
 -issue#3778: Export DataQuery show PHP Error: ERROR PHP NOTICE: Undefined index: fname
 -issue#3781: Cacti V1.2.14 php backtraces on Auth.php errors upon login
 -issue#3786: Cacti 1.2.12 Realtime index errors
+-issue#3790: Error Upgrading Cacti from Pre 1.x from Recent MariaDB version
 -feature: Update FontAwesome to Version 5.14
 
 1.2.14

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#3643: Maximum OIDs Per Get Request - field empty
 -issue#3656: Cacti V1.2.12 Boost running too often
 -issue#3711: Graphs New interface not validating page variables
+-issue#3722: External Links - switch between tabs
 -issue#3730: Change wording for the 21st century, but let's not forget our past
 -issue#3743: Description field allows more characters entered than is stored
 -issue#3747: ldap.php cannot be loaded while installer is running

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ Cacti CHANGELOG
 -issue#3775: Search field strange behavior when hitting enter in 1.2.14
 -issue#3778: Export DataQuery show PHP Error: ERROR PHP NOTICE: Undefined index: fname
 -issue#3781: Cacti V1.2.14 php backtraces on Auth.php errors upon login
+-issue#3786: Cacti 1.2.12 Realtime index errors
 -feature: Update FontAwesome to Version 5.14
 
 1.2.14

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ Cacti CHANGELOG
 -issue#3771: All Cacti Console pages should include the ID of the object and the Data Input Method page is missing that ID
 -issue#3775: Search field strange behavior when hitting enter in 1.2.14
 -issue#3778: Export DataQuery show PHP Error: ERROR PHP NOTICE: Undefined index: fname
+-issue#3781: Cacti V1.2.14 php backtraces on Auth.php errors upon login
 -feature: Update FontAwesome to Version 5.14
 
 1.2.14

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Cacti CHANGELOG
 1.2.15
 -issue#3643: Maximum OIDs Per Get Request - field empty
 -issue#3656: Cacti V1.2.12 Boost running too often
+-issue#3711: Graphs New interface not validating page variables
 -issue#3730: Change wording for the 21st century, but let's not forget our past
 -issue#3743: Description field allows more characters entered than is stored
 -issue#3747: ldap.php cannot be loaded while installer is running

--- a/cdef.php
+++ b/cdef.php
@@ -503,7 +503,7 @@ function item_edit() {
 		break;
 	case '5':
 		$form_cdef['value']['method'] = 'drop_sql';
-		$form_cdef['value']['sql']    = 'SELECT name, id FROM cdef WHERE `system`=0 ORDER BY name';
+		$form_cdef['value']['sql']    = 'SELECT name, id FROM cdef WHERE `system` = 0 ORDER BY name';
 
 		break;
 	case '6':
@@ -831,9 +831,9 @@ function cdef() {
 
 	/* form the 'where' clause for our main sql query */
 	if (get_request_var('filter') != '') {
-		$sql_where = 'WHERE (name LIKE ' . db_qstr('%' . get_request_var('filter') . '%') . ' AND `system`=0)';
+		$sql_where = 'WHERE (name LIKE ' . db_qstr('%' . get_request_var('filter') . '%') . ' AND `system` = 0)';
 	} else {
-		$sql_where = 'WHERE `system`=0';
+		$sql_where = 'WHERE `system` = 0';
 	}
 
 	if (get_request_var('has_graphs') == 'true') {
@@ -872,7 +872,7 @@ function cdef() {
 				FROM graph_templates_item
 			) AS gti
 			ON gti.cdef_id=cd.id
-			WHERE `system`=0
+			WHERE `system` = 0
 			GROUP BY cd.id, gti.graph_template_id, gti.local_graph_id
 		) AS rs
 		$sql_where

--- a/graph_realtime.php
+++ b/graph_realtime.php
@@ -101,11 +101,15 @@ case 'countdown':
 	/* override: graph height (in pixels) */
 	if (!isempty_request_var('graph_height') && get_request_var('graph_height') < 3000) {
 		$graph_data_array['graph_height'] = get_request_var('graph_height');
+	} else {
+		$graph_data_array['graph_height'] = 125;
 	}
 
 	/* override: graph width (in pixels) */
 	if (!isempty_request_var('graph_width') && get_request_var('graph_width') < 3000) {
 		$graph_data_array['graph_width'] = get_request_var('graph_width');
+	} else {
+		$graph_data_array['graph_width'] = 425;
 	}
 
 	/* override: skip drawing the legend? */

--- a/graphs_new.php
+++ b/graphs_new.php
@@ -462,9 +462,19 @@ function graphs() {
 	}
 
 	if (get_request_var('graph_type') > 0) {
+		/* validate the page filter */
+		if (isset_request_var('page' . get_request_var('graph_type'))) {
+			get_filter_request_var('page' . get_request_var('graph_type'));
+		}
+
 		load_current_session_value('page' . get_request_var('graph_type'), 'sess_grn_page' . get_request_var('graph_type'), '1');
 	}else if (get_request_var('graph_type') == -2) {
 		foreach($snmp_queries as $query) {
+			/* validate the page filter */
+			if (isset_request_var('page' . $query['id'])) {
+				get_filter_request_var('page' . $query['id']);
+			}
+
 			load_current_session_value('page' . $query['id'], 'sess_grn_page' . $query['id'], '1');
 		}
 	}

--- a/include/layout.js
+++ b/include/layout.js
@@ -1200,7 +1200,7 @@ function setupResponsiveMenuAndTabs() {
 					menuShow();
 				}
 			}
-		} else if (pageName == page && pageName != 'graph_view.php') {
+		} else if (pageName == page && pageName != 'graph_view.php' && pageName != 'link.php') {
 			if ($('#navigation').length) {
 				if (menuOpen(page)) {
 					menuHide(true);

--- a/install/upgrades/1_0_0.php
+++ b/install/upgrades/1_0_0.php
@@ -1537,7 +1537,7 @@ function upgrade_to_1_0_0() {
 
 	// Update Aggregate CDEFs to become system level
 	db_install_add_column('cdef', array('name' => 'system', 'type' => 'mediumint(8) unsigned', 'NULL' => false, 'default' => '0', 'after' => 'hash'));
-	db_install_execute("UPDATE cdef SET system=1 WHERE name LIKE '\_%'");
+	db_install_execute("UPDATE cdef SET `system` = 1 WHERE name LIKE '\_%'");
 
 	// Add some important missing indexes
 	db_install_add_key('data_local', 'INDEX', 'data_template_id', array('data_template_id'));

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -717,7 +717,7 @@ function api_device_save($id, $host_template_id, $description, $hostname, $snmp_
 	$save['ping_port']            = form_input_validate($ping_port, 'ping_port', '^[0-9]+$', true, 3);
 	$save['ping_timeout']         = form_input_validate($ping_timeout, 'ping_timeout', '^[0-9]+$', true, 3);
 	$save['ping_retries']         = form_input_validate($ping_retries, 'ping_retries', '^[0-9]+$', true, 3);
-	$save['max_oids']             = form_input_validate($max_oids, 'max_oids', '^[0-9]+$', true, 3);
+	$save['max_oids']             = form_input_validate($max_oids, 'max_oids', '^[0-9]+$', false, 3);
 	$save['device_threads']       = form_input_validate($device_threads, 'device_threads', '^[0-9]+$', true, 3);
 
 	$host_id = 0;

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -593,6 +593,10 @@ function is_graph_template_allowed($graph_template_id, $user = 0) {
  */
 function is_view_allowed($view = 'show_tree') {
 	if (read_config_option('auth_method') != 0) {
+		if (!isset($_SESSION['sess_user_id'])) {
+			return false;
+		}
+
 		$values = array_rekey(
 			db_fetch_assoc_prepared("SELECT DISTINCT $view
 				FROM user_auth_group AS uag

--- a/lib/export.php
+++ b/lib/export.php
@@ -332,7 +332,7 @@ function data_input_method_to_xml($data_input_id) {
 
 	$xml_text .= "\t<fields>\n";
 
-	if (cacti_sizeof($data_input_fields) > 0) {
+	if (cacti_sizeof($data_input_fields)) {
 		foreach ($data_input_fields as $item) {
 			$hash['data_input_field'] = get_hash_version('data_input_field') . get_hash_data_input($item['id'], 'data_input_field');
 
@@ -342,7 +342,16 @@ function data_input_method_to_xml($data_input_id) {
 				if (($field_name == 'input_output') && (!empty($item[$field_name]))) {
 					$xml_text .= "\t\t\t<$field_name>" . xml_character_encode($item[$field_name]) . "</$field_name>\n";
 				} else {
-					if (($field_array['method'] != 'hidden_zero') && ($field_array['method'] != 'hidden')) {
+					$method = $field_array['method'];
+
+					if ($method != 'hidden_zero' && $method != 'hidden' && $method != 'spacer') {
+						// Work around renaming of field in form
+						// To get around JavaScript form issue
+						// In data_input.php
+						if ($field_name == 'fname') {
+							$field_name = 'name';
+						}
+
 						$xml_text .= "\t\t\t<$field_name>" . xml_character_encode($item[$field_name]) . "</$field_name>\n";
 					}
 				}

--- a/templates_export.php
+++ b/templates_export.php
@@ -182,10 +182,16 @@ function export() {
 
 	?>
 	<script type='text/javascript'>
+	var stopTimer;
+
 	$(function() {
 		$('#export_type').change(function() {
 			strURL = 'templates_export.php?header=false&export_type='+$('#export_type').val();
 			loadPageNoHeader(strURL);
+		});
+
+		$('form#export').submit(function(event) {
+			stopTimer = setTimeout(function() { Pace.stop() }, 1000);
 		});
 	});
 	</script>


### PR DESCRIPTION
Hello,

I opened a feature request in order to add SHA256 and AES256 for authentication and privacy protocol.
https://github.com/Cacti/cacti/issues/3787

The problem is that in Cacti device page for snmpv3 it's written SHA and AES.

This is not accurate and it's confusing. I suppose that the person who wrote the code based the name on what snmpwalk & co wrote
```
  -a PROTOCOL           set authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)
  -x PROTOCOL           set privacy protocol (DES|AES)
```

I think it's now necessary to specify which SHA and which AES we're talking about => SHA1 and AES128

Here's the patch

```
# cat include/patch_global_arrays
--- include/global_arrays.php.orig      Thu Sep  3 00:30:45 2020
+++ include/global_arrays.php   Thu Sep  3 00:44:54 2020
@@ -582,13 +582,13 @@
 $snmp_auth_protocols = array(
        '[None]' => __('[None]'),
        'MD5'    => __('MD5'),
-       'SHA'    => __('SHA')
+       'SHA'    => __('SHA1')
 );

 $snmp_priv_protocols = array(
        '[None]' => __('[None]'),
        'DES'    => __('DES'),
-       'AES128' => __('AES')
+       'AES128' => __('AES128')
 );

 $banned_snmp_strings = array(
```

