### PR TITLE
fix #3417 - add little statistics to support page, mail and log alert…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,7 @@ Cacti CHANGELOG
 -feature#3724: Create Spikekill method to kill values over an absolute maximum
 -feature#3725: Create the ability for Spikekill to modify only certain DSes within an RRD
 -feature#3738: Ability to see MySQL permissions associated with current database user
+-feature#3417: Add worst poller hosts to support page, log and email warning when poller time reached defined threshold
 
 1.2.14
 -issue#3676: Device not showing up in device page but showing up in Monitor tab

--- a/cacti.sql
+++ b/cacti.sql
@@ -2338,6 +2338,18 @@ CREATE TABLE poller_time (
 ) ENGINE=InnoDB ROW_FORMAT=Dynamic;
 
 --
+-- Table structure for table `poller_time_stats`
+--
+
+CREATE TABLE poller_time_stats (
+  id bigint(20) unsigned NOT NULL auto_increment,
+  poller_id int(10) unsigned NOT NULL default '1',
+  total_time double default NULL,
+  `time` timestamp NOT NULL default '0000-00-00 00:00:00',
+  PRIMARY KEY (id)
+) ENGINE=InnoDB ROW_FORMAT=Dynamic;
+
+--
 -- Table structure for table `processes`
 --
 
@@ -3103,3 +3115,4 @@ CREATE TABLE version (
 --
 
 INSERT INTO version VALUES ('new_install');
+

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -1253,7 +1253,7 @@ $settings = array(
 			),
 		'poller_warning_1h_count' => array(
 			'friendly_name' => __('1h count warning threshold'),
-			'description' => __('When this count of guarded ratio (below) is reached in one hour, warning log and email is launched. 0 = disable.'),
+			'description' => __('When this count of guarded ratio (below) is reached in one hour, warning will be written to log and email will be send. 0 = disable.'),
 			'method' => 'textbox',
 			'default' => '3',
 			'max_length' => 1,
@@ -1274,7 +1274,7 @@ $settings = array(
 			),
 		'poller_warning_24h_ratio' => array(
 			'friendly_name' => __('24 hours guarded poller ratio run/max'),
-			'description' => __('Define guarded average ratio poller run/max time (in percent). When it is reached, warning log and email is launched. 0 = disable'),
+			'description' => __('Define guarded average ratio poller run/max time (in percent). When it is reached, warning will be written to log and email will be send. 0 = disable'),
 			'method' => 'drop_array',
 			'default' => '60',
 			'array' => array(

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -1251,6 +1251,41 @@ $settings = array(
 				'14400' => __('%s Hours', 4),
 				'28800' => __('%s Hours', 8))
 			),
+		'poller_warning_1h_count' => array(
+			'friendly_name' => __('1h count warning threshold'),
+			'description' => __('When this count of guarded ratio (below) is reached in one hour, warning log and email is launched. 0 = disable.'),
+			'method' => 'textbox',
+			'default' => '3',
+			'max_length' => 1,
+			'size' => 4,
+			),
+		'poller_warning_1h_ratio' => array(
+			'friendly_name' => __('1 hour guarded poller ratio run/max'),
+			'description' => __('Define guarded ratio poller run/max time (in percent).'),
+			'method' => 'drop_array',
+			'default' => '70',
+			'array' => array(
+				'0' => '0',
+				'50' => '50',
+				'60' => '60',
+				'70' => '70',
+				'80' => '80',
+				'90' => '90',)
+			),
+		'poller_warning_24h_ratio' => array(
+			'friendly_name' => __('24 hours guarded poller ratio run/max'),
+			'description' => __('Define guarded average ratio poller run/max time (in percent). When it is reached, warning log and email is launched. 0 = disable'),
+			'method' => 'drop_array',
+			'default' => '60',
+			'array' => array(
+				'0' => '0',
+				'50' => '50',
+				'60' => '60',
+				'70' => '70',
+				'80' => '80',
+				'90' => '90',)
+			),
+			
 		'spine_header' => array(
 			'friendly_name' => __('Spine Specific Execution Parameters'),
 			'collapsible' => 'true',

--- a/poller.php
+++ b/poller.php
@@ -683,6 +683,7 @@ while ($poller_runs_completed < $poller_runs) {
 
 					log_cacti_stats($loop_start, $method, $concurrent_processes, $max_threads,
 						($poller_id == '1' ? cacti_sizeof($polling_hosts) - 1 : cacti_sizeof($polling_hosts)), $hosts_per_process, $num_polling_items, $rrds_processed);
+					poller_run_stats($loop_start);
 
 					break;
 				} else {
@@ -707,6 +708,7 @@ while ($poller_runs_completed < $poller_runs) {
 						api_plugin_hook_function('poller_exiting');
 						log_cacti_stats($loop_start, $method, $concurrent_processes, $max_threads,
 							($poller_id == '1' ? cacti_sizeof($polling_hosts) - 1 : cacti_sizeof($polling_hosts)), $hosts_per_process, $num_polling_items, $rrds_processed);
+						poller_run_stats($loop_start);
 
 						break;
 					} elseif (microtime(true) - $mtb < 1) {
@@ -802,6 +804,7 @@ while ($poller_runs_completed < $poller_runs) {
 	if (!$logged) {
 		log_cacti_stats($loop_start, $method, $concurrent_processes, $max_threads,
 			($poller_id == '1' ? cacti_sizeof($polling_hosts) - 1 : cacti_sizeof($polling_hosts)), $hosts_per_process, $num_polling_items, $rrds_processed);
+		poller_run_stats($loop_start);
 	}
 
 	// flush the boost table if in recovery mode
@@ -979,6 +982,57 @@ function log_cacti_stats($loop_start, $method, $concurrent_processes, $max_threa
 	$logged = true;
 }
 
+function poller_run_stats ($loop_start) {
+	global $poller_id, $poller_interval, $poller_lastrun;
+
+	$threshold_1h = read_config_option('poller_warning_1h_ratio');
+	$threshold_1h_count = read_config_option('poller_warning_1h_count');
+	$threshold_24h = read_config_option('poller_warning_24h_ratio');
+
+	$loop_end = microtime(true);
+	$total_time  = $loop_end-$loop_start;
+
+	// last day stats
+	if (date('j', $poller_lastrun) != date('j')) {
+		$min = db_fetch_cell('SELECT IFNULL(MIN(total_time),0) FROM poller_time_stats');
+		$max = db_fetch_cell('SELECT IFNULL(MAX(total_time),0) FROM poller_time_stats');
+		$sum = db_fetch_cell('SELECT IFNULL(SUM(total_time),0) FROM poller_time_stats');
+		$count = db_fetch_cell('SELECT COUNT(total_time) FROM poller_time_stats');
+
+		if ($count > 0) {
+			$ratio = round($sum/$count,2);
+
+			cacti_log(__("24 hours avg. poller run time is $ratio seconds, min: $min, max: $max") , true, 'POLLER');
+
+			if ($ratio/$poller_interval > $threshold_24h/100 && $threshold_24h > 0) {
+				cacti_log(__("WARNING: 24 hours poller avg. run time reached more than $threshold_24h% of time limit") , true, 'POLLER');
+				admin_email(__('Cacti System Warning'), __('WARNING: 24 hours poller (id %d) avg. run time is %f seconds (more than %d &#37; of time limit)', $poller_id, $ratio,$threshold_24h));
+			}
+		}
+	}
+
+	// last hour stats
+	if (date('G', $poller_lastrun) != date('G')) {
+
+		$count = db_fetch_cell_prepared('SELECT count(total_time) FROM poller_time_stats WHERE time > DATE_SUB(NOW(), INTERVAL 60 minute) 
+				AND (total_time/?) > (?/100)',
+				array($poller_interval, $threshold_1h));
+
+		if ($count > $threshold_1h_count && $threshold_1h_count > 0) {
+			cacti_log(__("WARNING: In last hour poller run time $count times (limit $threshold_1h_count) reached more than $threshold_1h% of time limit") , true, 'POLLER');
+			admin_email(__('Cacti System Warning'), __('WARNING: In last hour poller (id %d) run time %d times reached more than %d &#37; of time limit', $poller_id, $threshold_1h_count, $threshold_1h));
+		}
+	}
+
+	// poller time statistics for last day
+	db_execute_prepared('INSERT INTO poller_time_stats (poller_id,total_time,time)
+		VALUES (?,?,now())',
+		array($poller_id, round($total_time, 4)));
+
+	// delete old stats
+	db_execute('DELETE FROM poller_time_stats WHERE `time` <  DATE_SUB(NOW(), INTERVAL 24 HOUR)');
+}
+
 function multiple_poller_boost_check() {
 	$pollers = db_fetch_cell('SELECT COUNT(*) FROM poller WHERE disabled="" AND id > 1');
 
@@ -1020,4 +1074,5 @@ function display_help() {
 	print "    --force        Override poller overrun detection and force a poller run.\n";
 	print "    --debug|-d     Output debug information.  Similar to cacti's DEBUG logging level.\n\n";
 }
+
 

--- a/support.php
+++ b/support.php
@@ -54,6 +54,7 @@ function support_view_tech() {
 		'dbstatus'   => __('Database Status'),
 		'dbperms'    => __('Database Permissions'),
 		'phpinfo'    => __('PHP Info'),
+		'poller'     => __('Poller'),
 	);
 
 	/* set the default tab */
@@ -541,6 +542,72 @@ function support_view_tech() {
 		}
 		print '</td>';
 
+		form_end_row();
+	} elseif (get_request_var('tab') == 'poller') {
+		$problematic = db_fetch_assoc('SELECT id,description,polling_time, avg_time
+		FROM host WHERE disabled = "" ORDER BY polling_time DESC LIMIT 20');
+
+		html_section_header(__('Worst 20 polling time hosts'), 2);
+
+		form_alternate_row();
+		print "		<td colspan='2' style='text-align:left;padding:0px'>";
+
+		if (cacti_sizeof($problematic)) {
+			print "<table id='tables' class='cactiTable' style='width:100%'>";
+			print '<thead>';
+			print "<tr class='tableHeader'>";
+			print "  <th class='tableSubHeaderColumn'>" . __('ID') . '</th>';
+			print "  <th class='tableSubHeaderColumn'>" . __('Description') . '</th>';
+			print "  <th class='tableSubHeaderColumn'>" . __('Avg. polling time') . '</th>';
+			print "  <th class='tableSubHeaderColumn right'>" . __('Actual polling time') . '</th>';
+			print '</tr>';
+			print '</thead>';
+			foreach ($problematic as $host) {
+				form_alternate_row();
+				print '<td>' . $host['id'] . '</td>';
+				print '<td>' . $host['description'] . '</td>';
+				print '<td class="right">' . number_format_i18n($host['avg_time'],3) . '</td>';
+				print '<td class="right">' . number_format_i18n($host['polling_time'],3) . '</td>';
+				form_end_row();
+			}
+
+			print "</table>";
+		} else {
+			print __('No host found');
+		}
+		print '</td>';
+		form_end_row();
+
+		$problematic = db_fetch_assoc('SELECT id,description,failed_polls/total_polls as ratio
+			FROM host WHERE disabled = "" ORDER BY ratio DESC LIMIT 20');
+
+		html_section_header(__('Worst 20 failed/total polls ratio'), 2);
+
+		form_alternate_row();
+		print "		<td colspan='2' style='text-align:left;padding:0px'>";
+
+		if (cacti_sizeof($problematic)) {
+			print "<table id='tables' class='cactiTable' style='width:100%'>";
+			print '<thead>';
+			print "<tr class='tableHeader'>";
+			print "  <th class='tableSubHeaderColumn'>" . __('ID') . '</th>';
+			print "  <th class='tableSubHeaderColumn'>" . __('Description') . '</th>';
+			print "  <th class='tableSubHeaderColumn right'>" . __('Failed/Total polls') . '</th>';
+			print '</tr>';
+			print '</thead>';
+			foreach ($problematic as $host) {
+				form_alternate_row();
+				print '<td>' . $host['id'] . '</td>';
+				print '<td>' . $host['description'] . '</td>';
+				print '<td class="right">' . number_format_i18n($host['ratio'],3) . '</td>';
+				form_end_row();
+			}
+
+			print "</table>";
+		} else {
+			print __('No host found');
+		}
+		print '</td>';
 		form_end_row();
 	} else {
 		$php_info = utilities_php_modules();


### PR DESCRIPTION
Add 2 tables to support page (separated tab - Poller):
- top 20 worst polling time hosts
- top 20 worst polling ratio hosts

Add log record with poller statistics:
- average poller(s) run/max time ratio, min and max value

Add alert (log and admin email):
-  for 1 hour
- for 24 hours

This is my first bigger modification attempt in Cacti, please check it and let me know about your comments or remarks.