### PR TITLE
FEATURE: Include api_plugin_hook_function for page buttons

### DIFF
--- a/graph_view.php
+++ b/graph_view.php
@@ -392,6 +392,15 @@ case 'preview':
 	html_graph_preview_filter('graph_view.php', 'preview');
 
 	html_end_box();
+		
+	api_plugin_hook_function('graph_tree_page_buttons',
+	  array(
+	     'mode'      => 'preview',
+	     'timespan'  => $_SESSION['sess_current_timespan'],
+	     'starttime' => get_current_graph_start(),
+	     'endtime'   => get_current_graph_end()
+	  )
+	);
 
 	/* the user select a bunch of graphs of the 'list' view and wants them displayed here */
 	$sql_or = '';


### PR DESCRIPTION
Can we add the api_plugin_hook_function for graph_tree_page_buttons for preview modes as well so additional features/buttons can be added to the preview page ?