### PR TITLE
Update main.css

### DIFF
--- a/include/themes/modern/main.css
+++ b/include/themes/modern/main.css
@@ -2507,7 +2507,7 @@ tr#realtime td:first-child {
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background-color: rgba(98,125,77,1);
+	background-color: rgba(200,200,200,1);
 	-webkit-transition: .4s;
 	transition: .4s;
 }

--- a/include/themes/modern/main.css
+++ b/include/themes/modern/main.css
@@ -2588,7 +2588,7 @@ input:checked + .checkboxSlider:before {
 	bottom: 0;
 	height: 24px;
 	width: 24px;
-	background-color: rgba(98,125,77,1);
+	background-color: rgba(200,200,200,1);
 	-webkit-transition: .4s;
 	transition: .4s;
 }


### PR DESCRIPTION
Make it more obvious that a slider or radio slider is disabled.
Previously both options were green which is not very clear, so the disabled one has been changed to a grey that works well on top of the other greys to make it clear when a slider is set to disabled or off.

![image](https://user-images.githubusercontent.com/5603694/95617949-1fb69980-0a64-11eb-9eb0-1f19e0bdc442.png) ![image](https://user-images.githubusercontent.com/5603694/95619809-1a0e8300-0a67-11eb-9ea0-cfb6bbcdd907.png)
