### PR TITLE
Update OIDs on net-snmp_devio.xml

### DIFF
--- a/resource/snmp_queries/net-snmp_devio.xml
+++ b/resource/snmp_queries/net-snmp_devio.xml
@@ -26,14 +26,14 @@
          <method>walk</method>
          <source>value</source>
          <direction>output</direction>
-         <oid>.1.3.6.1.4.1.2021.13.15.1.1.12</oid>
+         <oid>.1.3.6.1.4.1.2021.13.15.1.1.3</oid>
       </diskIONRead>
       <diskIONWritten>
          <name>BytesWritten</name>
          <method>walk</method>
          <source>value</source>
          <direction>output</direction>
-         <oid>.1.3.6.1.4.1.2021.13.15.1.1.13</oid>
+         <oid>.1.3.6.1.4.1.2021.13.15.1.1.4</oid>
       </diskIONWritten>
       <diskIOReads>
          <name>DeviceReads</name>


### PR DESCRIPTION
Graphs based on this XML file were not showing any data.  Did a review of all the OIDs and found the two had the wrong OIDs for IO Bytes read/written, being ...12 and ...13.  Changing them to 3 and 4 fixed the graphs.