### PR TITLE
Correct issue when file is unreadable reporting no file was specified

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.15
+-Fixed wrong error message when file was not readable in import_package.php
 -issue#3643: Maximum OIDs Per Get Request - field empty
 -issue#3656: Cacti V1.2.12 Boost running too often
 -issue#3693: Uptime Recache Event Loop on Devices Causing Interface Graph Gaps

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 Cacti CHANGELOG
 
 1.2.15
--Fixed wrong error message when file was not readable in import_package.php
 -issue#3643: Maximum OIDs Per Get Request - field empty
 -issue#3656: Cacti V1.2.12 Boost running too often
 -issue#3693: Uptime Recache Event Loop on Devices Causing Interface Graph Gaps
@@ -54,6 +53,7 @@ Cacti CHANGELOG
 -issue#3871: Import DataQuery show PHP Error: ERROR PHP NOTICE: Undefined index: fname
 -issue#3874: The SHIFT functionnality in graphs does not accept negative values
 -issue#3876: A javascript error in layout.js
+-issue#3881: Fixed wrong error message when file was not readable in import_package.php
 -feature: Update FontAwesome to Version 5.14
 
 1.2.14

--- a/cli/import_package.php
+++ b/cli/import_package.php
@@ -122,7 +122,7 @@ if (cacti_sizeof($parms)) {
 		$profile_id = db_fetch_cell('SELECT id FROM data_source_profiles ORDER BY `default` DESC LIMIT 1');
 	}
 
-	if ($filename != '' && is_readable($filename)) {
+	if ($filename != '') {
 		if (file_exists($filename) && is_readable($filename)) {
 			$fp = fopen($filename,'r');
 			$data = fread($fp,filesize($filename));


### PR DESCRIPTION
Script 'import_package.php' was throwing "ERROR: no filename specified" when file was not readable.