### PR TITLE
Update html_utility.php to fix sorting issue

### DIFF
--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -782,9 +782,14 @@ function update_order_string($inplace = false) {
 		} elseif (isset_request_var('add') && get_nfilter_request_var('add') == 'reset') {
 			unset($_SESSION['sort_data'][$page]);
 			unset($_SESSION['sort_string'][$page]);
-
+			$column = get_request_var('sort_column');
+			$direction = get_request_var('sort_direction');
 			$_SESSION['sort_data'][$page][get_request_var('sort_column')] = get_request_var('sort_direction');
-			$_SESSION['sort_string'][$page] = 'ORDER BY ' . $del . implode($del . '.'. $del, explode('.', get_request_var('sort_column'))) . $del . ' ' . get_request_var('sort_direction');
+			if ($column == 'hostname' || $column == 'ip' || $column == 'ip_address') {
+				$_SESSION['sort_string'][$page] = 'ORDER BY INET_ATON(' . $column . ') ' . $direction;
+			} else {
+				$_SESSION['sort_string'][$page] = 'ORDER BY ' . $del . implode($del . '.'. $del, explode('.', get_request_var('sort_column'))) . $del . ' ' . get_request_var('sort_direction');
+			}
 		} elseif (isset_request_var('sort_column')) {
 			if (isset_request_var('reset')) {
 				unset($_SESSION['sort_data'][$page]);


### PR DESCRIPTION
This change allows for sort to work properly when sorting on the Automation-> Discovered Devices page using the IP address column. What would happen is when sorting by the IP address field the sort would look like the following:

- 192.168.2.10
- 192.168.2.100
-192.168.2.22

The INET_ATON was not getting applied when sorting just by the IP address column. It would work when first going to the page after sorting by IP but if attempting to sort while staying on the page it would drop the INET_ATON(ip) to be just `ip`. It was also working properly when multi-sorting. This seems to only be an issue when clicking on the sort of the IP address column. 

I attempted to follow the other places where this code looks to have been run to come up with a similar solutions.

