### PR TITLE
Correct sorting of IP addresses to be numeric not alpha

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@ Cacti CHANGELOG
 -issue#3874: The SHIFT functionnality in graphs does not accept negative values
 -issue#3881: Fixed wrong error message when file was not readable in import_package.php
 -issue#3883: No way to remove integrated/orphaned Plugin references from the Plugin Management interface
+-issue#3888: Fix to IP sorting in single column
 -feature: Update FontAwesome to Version 5.14
 
 1.2.14

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -784,7 +784,11 @@ function update_order_string($inplace = false) {
 			unset($_SESSION['sort_string'][$page]);
 
 			$_SESSION['sort_data'][$page][get_request_var('sort_column')] = get_request_var('sort_direction');
-			$_SESSION['sort_string'][$page] = 'ORDER BY ' . $del . implode($del . '.'. $del, explode('.', get_request_var('sort_column'))) . $del . ' ' . get_request_var('sort_direction');
+			if ($column == 'hostname' || $column == 'ip' || $column == 'ip_address') {
+                               $_SESSION['sort_string'][$page] ='ORDER BY INET_ATON(' . $column . ") " . $direction;
+                        } else {
+				$_SESSION['sort_string'][$page] = 'ORDER BY ' . $del . implode($del . '.'. $del, explode('.', get_request_var('sort_column'))) . $del . ' ' . get_request_var('sort_direction');
+			}
 		} elseif (isset_request_var('sort_column')) {
 			if (isset_request_var('reset')) {
 				unset($_SESSION['sort_data'][$page]);

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -785,8 +785,8 @@ function update_order_string($inplace = false) {
 
 			$_SESSION['sort_data'][$page][get_request_var('sort_column')] = get_request_var('sort_direction');
 			if ($column == 'hostname' || $column == 'ip' || $column == 'ip_address') {
-                               $_SESSION['sort_string'][$page] ='ORDER BY INET_ATON(' . $column . ") " . $direction;
-                        } else {
+				$_SESSION['sort_string'][$page] ='ORDER BY INET_ATON(' . $column . ") " . $direction;
+			} else {
 				$_SESSION['sort_string'][$page] = 'ORDER BY ' . $del . implode($del . '.'. $del, explode('.', get_request_var('sort_column'))) . $del . ' ' . get_request_var('sort_direction');
 			}
 		} elseif (isset_request_var('sort_column')) {


### PR DESCRIPTION
The IP column sorting function on the automation-> discovered devices is not working when single sorting the column after the page has been loaded once. I was able to see that this is the area of the code that was dropping the INET_ATON from the order by query.

---
Notes from wrong commit to develop instead of 1.2.x:

This change allows for sort to work properly when sorting on the Automation-> Discovered Devices page using the IP address column. What would happen is when sorting by the IP address field the sort would look like the following:

- 192.168.2.10
- 192.168.2.100
- 192.168.2.22

The INET_ATON was not getting applied when sorting just by the IP address column. It would work when first going to the page after sorting by IP but if attempting to sort while staying on the page it would drop the INET_ATON(ip) to be just ip. It was also working properly when multi-sorting. This seems to only be an issue when clicking on the sort of the IP address column.

I attempted to follow the other places where this code looks to have been run to come up with a similar solutions.

TheWitness replied:

This isn't quite right, you have to inspect the entirety of the sort list which becomes problematic with multi-column sort. This has to be given some thought. It should also be against the 1.2.x branch an not develop.

---

In response I can see that the multisort happens in the next if statement below the one that I am editing. From what I can tell that if statement where I did make the changes would not work with a multisort as I think it is only when the columns are reset or only doing one column sort action at a time. 

![image](https://user-images.githubusercontent.com/73500597/97307219-ce652300-1835-11eb-88f2-326e87a0ebda.png)

I have a couple print statements with the sort query and the full SQL query above the table. I also have a flag to let me know which if statement I am in. 

That image is being sorted on the hostname column but it is the same idea. As you can see the INET_ATON(hostname) is not there. Which in a multisort or the initial load of the page it drops down to the third if statement in the block of code from 779-813. 

Thanks