### PR TITLE
When searching, valid pages can sometimes be shown as empty

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Cacti CHANGELOG
 -issue#3907: The cli script install_cacti.php does not exit with not zero exit code when errors occur
 -issue#3910: Banners are not showing up
 -issue#3912: Some pages that export data, when the export is complete, the progress bar remains
+-issue#3919: Log Administration show empty during page navigation if search field value length is 4
 -feature: Update phpseclib to version 2.0.29
 -feature: Update PHPMailer to version 6.1.8
 -feature: Use LSB shebang notation for cli scripts

--- a/utilities.php
+++ b/utilities.php
@@ -1247,7 +1247,7 @@ function utilities_view_logfile() {
 	$refreshTime  = get_request_var('refresh');
 	$message_type = get_request_var('message_type');
 	$tail_lines   = get_request_var('tail_lines');
-	$base_url     = 'utilities.php?action=view_logfile&rfilter='.$rfilter.'&reverse='.$reverse.'&refresh='.$refreshTime.'&message_type='.$message_type.'&tail_lines='.$tail_lines.'&filename='.basename($logfile);
+	$base_url     = 'utilities.php?action=view_logfile';
 
 	$nav = html_nav_bar($base_url, MAX_DISPLAY_PAGES, $page_nr, $number_of_lines, $total_rows, 13, __('Entries'), 'page', 'main');
 


### PR DESCRIPTION
Conditions:
1.  'rfilter' field value length is 4 or 4x
2.  'rfilter' value is base64_encoded by JS code
3.  page navigation base url include **decoded** 'rfilter' value again
4.  'is_base64_encoded' always return true in  'validate_store_request_vars', then 'rfilter' value will be **decoded** twice as a invalid value