### PR TITLE
Graph Templates filter is not updated after new graph created

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Cacti CHANGELOG
 -issue#3910: Banners are not showing up
 -issue#3912: Some pages that export data, when the export is complete, the progress bar remains
 -issue#3919: Log Administration show empty during page navigation if search field value length is 4
+-issue#3924: Graph Templates filter is not updated after new graph created
 -feature: Update phpseclib to version 2.0.29
 -feature: Update PHPMailer to version 6.1.8
 -feature: Use LSB shebang notation for cli scripts

--- a/lib/template.php
+++ b/lib/template.php
@@ -1361,6 +1361,8 @@ function create_complete_graph_from_template($graph_template_id, $host_id, $snmp
 		api_plugin_hook_function('create_complete_graph_from_template', $save);
 	}
 
+	set_config_option('sess_allowed_templates_lastchange', time());
+
 	return $cache_array;
 }
 


### PR DESCRIPTION
Fixed: More fixing about #2704 for Graph Preview-->Filter-->Template, mark timestamp 'cache last changed' after new graph created.