### PR TITLE
Location filter should remove blank entries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Cacti CHANGELOG
 -issue#3924: Graph Templates filter is not updated after new graph created
 -issue#3926: Username and password on the login page is not visible in Classic theme
 -issue#3929: Poller settings page is ambiguous on concurrent process and thread settings
+-issue#3930: Remove empty option from Devices-->Location filter
 -feature#3923: Added ability to Hide the Graph Drilldowns icons from the graph_view.php and graph.php pages
 -feature: Update c3.js to version 0.7.20
 -feature: Update d3.js to version 6.2.0

--- a/host.php
+++ b/host.php
@@ -1554,7 +1554,7 @@ function host() {
 							} else {
 								$sql_where = '';
 							}
-							$locations = db_fetch_assoc("SELECT DISTINCT IF(location='', '" . __('Undefined') . "', location) AS location
+							$locations = db_fetch_assoc("SELECT DISTINCT IF(IFNULL(host.location,'') = '', '" . __('Undefined') . "', location) AS location
 								FROM host
 								$sql_where
 								ORDER BY location");


### PR DESCRIPTION
host.location default is NULL. 
if create device both by API and Web without location specified, host.location will include 'NULL' and empty string.
Console-->Devices-->Location filter will show a empty option.