### PR TITLE
When using ping.php, UDP response times are not interpreted properly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@ Cacti CHANGELOG
 -issue#3942: The audit_database.php script will only modify columns, and add indexes, it does not add column
 -issue#3948: Required MariaDB/MySQL connection count is confusing
 -issue#3953: During upgrade, there are times when realms can be duplicated leading to SQL errors
+-issue: Timing measurement for UDP ping were wrong
 -feature#3923: Added ability to Hide the Graph Drilldowns icons from the graph_view.php and graph.php pages
 -feature: Update c3.js to version 0.7.20
 -feature: Update d3.js to version 6.2.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,7 +24,7 @@ Cacti CHANGELOG
 -issue#3942: The audit_database.php script will only modify columns, and add indexes, it does not add column
 -issue#3948: Required MariaDB/MySQL connection count is confusing
 -issue#3953: During upgrade, there are times when realms can be duplicated leading to SQL errors
--issue: Timing measurement for UDP ping were wrong
+-issue#3957: Cacti ping.php does not collect correct respone time when using UDP ping Timing
 -feature#3923: Added ability to Hide the Graph Drilldowns icons from the graph_view.php and graph.php pages
 -feature: Update c3.js to version 0.7.20
 -feature: Update d3.js to version 6.2.0

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -412,15 +412,15 @@ class Net_Ping
 					switch($num_changed_sockets) {
 					case 2: /* response received, so host is available */
 					case 1:
-						/* get the end time */
-						$this->time = $this->get_time($this->precision);
-
 						/* get packet response */
 						//$code = socket_recv($this->socket, $this->reply, 256, 0);
 						$code = socket_recv($this->socket, $this->reply, 256, 0);
+
+						/* get the end time after the packet was received */
+						$this->time = $this->get_time($this->precision);
+							
 						$errno = socket_last_error($this->socket);
 						socket_clear_error($this->socket);
-
 						if (($code == -1 || empty($code)) && 
 							($errno == EHOSTUNREACH || $errno == ECONNRESET || $errno == ECONNREFUSED)) {
 


### PR DESCRIPTION
Fix the timing measurement for UDP. Otherwise, the timing is measured _before_ the response of the client is received.