### PR TITLE
Fixed: audit_database.php Invalid parameter number

### DIFF
--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -536,7 +536,7 @@ function report_audit_results($output = true) {
 
 				if (cacti_sizeof($indexes)) {
 					foreach($indexes as $i) {
-						$key_exists = db_fetch_cell('SELECT COUNT(*)
+						$key_exists = db_fetch_cell_prepared('SELECT COUNT(*)
 							FROM table_indexes
 							WHERE idx_table_name = ?
 							AND idx_key_name = ?',


### PR DESCRIPTION
cli/audit_database.php[543]: Error: PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number: no parameters were bound 