### PR TITLE
Fixed: audit_database.php set macro IN_PLUGIN_INSTALL for plugin upgrade

### DIFF
--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -173,6 +173,10 @@ function upgrade_database() {
 	$plugins = $preorder;
 
 	if (cacti_sizeof($plugins)) {
+		if (!defined('IN_PLUGIN_INSTALL')) {
+			define('IN_PLUGIN_INSTALL', 1);
+		}
+
 		foreach($plugins as $plugin) {
 			$parts = explode('/', $plugin);
 			$pname = end($parts);

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -536,7 +536,7 @@ function report_audit_results($output = true) {
 
 				if (cacti_sizeof($indexes)) {
 					foreach($indexes as $i) {
-						$key_exists = db_fetch_cell('SELECT COUNT(*)
+						$key_exists = db_fetch_cell_prepared('SELECT COUNT(*)
 							FROM table_indexes
 							WHERE idx_table_name = ?
 							AND idx_key_name = ?',


### PR DESCRIPTION
Fixed: audit_database.php set macro IN_PLUGIN_INSTALL to skip cache of db_column_exists function
