### PR TITLE
When attempting to get client address, incorrect information may be returned

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.17
+-issue#4058: When calling get_client_addr REMOTE_ADDR is always returned
 -security#4019: In a recent audit of core Cacti code, there were a few stored XSS issues that can be exposed
 -security#4022: SQL Injection in data_debug.php (CVE-2020-35701)
 -security#4035: XSS security issue from WebScan report

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 Cacti CHANGELOG
 
 1.2.17
--issue#4058: When calling get_client_addr REMOTE_ADDR is always returned
+-issue#4060: When calling get_client_addr REMOTE_ADDR is always returned
 -security#4019: In a recent audit of core Cacti code, there were a few stored XSS issues that can be exposed
 -security#4022: SQL Injection in data_debug.php (CVE-2020-35701)
 -security#4035: XSS security issue from WebScan report

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5406,7 +5406,7 @@ function get_client_addr($client_addr = false) {
 					} else {
 						$client_addr = $header_ip;
 						cacti_log('DEBUG: Using remote client IP Address found in header (' . $header . '): ' . $client_addr . ' (' . $_SERVER[$header] . ')', false, 'AUTH', POLLER_VERBOSITY_DEBUG);
-						break;
+						break 2;
 					}
 				}
 			}


### PR DESCRIPTION
When calling get_client_addr REMOTE_ADDR is always returned. I also updated the changelog.