### PR TITLE
Rename "Show Exceptions" checkbox as "Only Show Exceptions" to match …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
 -issue#3074: ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php do now report mmcblk data.
 -issue#3141: Fix FreeBSD IPv6 ping
+-issue#4056: "Show Exceptions" checkbox appears to behave as if it were "Only Show Exceptions"
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1523: Value above RRD maximum value
 -feature#2474: Enable better version reporting for GitHub/Source/Package editions

--- a/locales/po/ar-SA.po
+++ b/locales/po/ar-SA.po
@@ -20093,7 +20093,7 @@ msgstr "إذن الأجهزة٪ s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "إظهار الاستثناءات"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/bg-BG.po
+++ b/locales/po/bg-BG.po
@@ -19724,7 +19724,7 @@ msgstr "Разрешение за устройства %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "Показване на изключения"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/cacti.pot
+++ b/locales/po/cacti.pot
@@ -16772,7 +16772,7 @@ msgstr ""
 #: user_admin.php:2817 user_admin.php:2902 user_admin.php:2987
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr ""
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/de-DE.po
+++ b/locales/po/de-DE.po
@@ -18993,7 +18993,7 @@ msgstr "Geräteberechtigung %s"
 #: user_admin.php:2817 user_admin.php:2902 user_admin.php:2987
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "Ausnahmen Anzeigen"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/el-GR.po
+++ b/locales/po/el-GR.po
@@ -19731,7 +19731,7 @@ msgstr "Συσκευές Άδεια %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "Προβολή εξαιρέσεων"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/es-ES.po
+++ b/locales/po/es-ES.po
@@ -16958,8 +16958,8 @@ msgstr "Permisos de Dispositivos %s"
 #: user_admin.php:2817 user_admin.php:2902 user_admin.php:2987
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
-msgid "Show Exceptions"
-msgstr "Mostrar Excepciones"
+msgid "Only Show Exceptions"
+msgstr "Solo mostrar Excepciones"
 
 #: user_admin.php:2870 user_group_admin.php:2357
 #, php-format

--- a/locales/po/fr-FR.po
+++ b/locales/po/fr-FR.po
@@ -18399,8 +18399,8 @@ msgstr "Appareils Permission %s"
 #: user_admin.php:3099 user_group_admin.php:2213 user_group_admin.php:2317
 #: user_group_admin.php:2402 user_group_admin.php:2487
 #, fuzzy
-msgid "Show Exceptions"
-msgstr "Afficher les exceptions"
+msgid "Only Show Exceptions"
+msgstr "Afficher uniquement les exceptions"
 
 #: user_admin.php:2897 user_group_admin.php:2370
 #, fuzzy, php-format

--- a/locales/po/he-IL.po
+++ b/locales/po/he-IL.po
@@ -19738,7 +19738,7 @@ msgstr "הרשאות התקנים %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "הצג חריגים"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/hi-IN.po
+++ b/locales/po/hi-IN.po
@@ -19692,7 +19692,7 @@ msgstr "उपकरण अनुमति %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "अपवाद दिखाएं"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/it-IT.po
+++ b/locales/po/it-IT.po
@@ -19393,8 +19393,8 @@ msgstr "Autorizzazione dei dispositivi %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
-msgstr "Mostra Eccezioni"
+msgid "Only Show Exceptions"
+msgstr "Mostra Solo Eccezioni"
 
 #: user_admin.php:2870 user_group_admin.php:2357
 #, fuzzy, php-format

--- a/locales/po/ja-JP.po
+++ b/locales/po/ja-JP.po
@@ -19312,7 +19312,7 @@ msgstr "デバイス許可％s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "例外を表示"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/ko-KR.po
+++ b/locales/po/ko-KR.po
@@ -19519,7 +19519,7 @@ msgstr "장치 사용 권한  %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "예외 표시"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/nl-NL.po
+++ b/locales/po/nl-NL.po
@@ -17863,7 +17863,7 @@ msgstr "Apparaat rechten %s"
 #: user_admin.php:2817 user_admin.php:2902 user_admin.php:2987
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "Toon uitzonderingen"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/pl-PL.po
+++ b/locales/po/pl-PL.po
@@ -19465,7 +19465,7 @@ msgstr "Urządzenia Uprawnienia"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "Pokaż wyjątki"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/pt-BR.po
+++ b/locales/po/pt-BR.po
@@ -19514,8 +19514,8 @@ msgstr "Dispositivos Permissão %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
-msgstr "Mostrar exceções"
+msgid "Only Show Exceptions"
+msgstr "Mostrar só exceções"
 
 #: user_admin.php:2870 user_group_admin.php:2357
 #, fuzzy, php-format

--- a/locales/po/pt-PT.po
+++ b/locales/po/pt-PT.po
@@ -19514,8 +19514,8 @@ msgstr "Dispositivos Permissão %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
-msgstr "Mostrar exceções"
+msgid "Only Show Exceptions"
+msgstr "Mostrar só exceções"
 
 #: user_admin.php:2870 user_group_admin.php:2357
 #, fuzzy, php-format

--- a/locales/po/ru-RU.po
+++ b/locales/po/ru-RU.po
@@ -19432,7 +19432,7 @@ msgstr "Устройства Разрешение %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "Показать исключения"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/sv-SE.po
+++ b/locales/po/sv-SE.po
@@ -19457,7 +19457,7 @@ msgstr "Enhetsbehörighet %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "Visa undantag"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/tr-TR.po
+++ b/locales/po/tr-TR.po
@@ -19500,7 +19500,7 @@ msgstr "Cihaz İzni %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "İstisnaları Göster"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/vi-VN.po
+++ b/locales/po/vi-VN.po
@@ -19561,7 +19561,7 @@ msgstr "Quyền thiết bị %s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "Hiển thị ngoại lệ"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/zh-CN.po
+++ b/locales/po/zh-CN.po
@@ -17065,7 +17065,7 @@ msgstr "设备权限 %s"
 #: user_admin.php:2817 user_admin.php:2902 user_admin.php:2987
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "显示例外"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/locales/po/zh-TW.po
+++ b/locales/po/zh-TW.po
@@ -19525,7 +19525,7 @@ msgstr "設備權限％s"
 #: user_admin.php:3072 user_group_admin.php:2200 user_group_admin.php:2304
 #: user_group_admin.php:2389 user_group_admin.php:2474
 #, fuzzy
-msgid "Show Exceptions"
+msgid "Only Show Exceptions"
 msgstr "顯示例外"
 
 #: user_admin.php:2870 user_group_admin.php:2357

--- a/user_admin.php
+++ b/user_admin.php
@@ -2814,7 +2814,7 @@ function device_filter($header_label) {
 					<td>
 						<span>
 							<input type='checkbox' name='associated' id='associated' onChange='applyFilter()' <?php print (get_request_var('associated') == 'true' || get_request_var('associated') == 'on' ? 'checked':'');?>>
-							<label for='associated'><?php print __('Show Exceptions');?></label>
+							<label for='associated'><?php print __('Only Show Exceptions');?></label>
 						</span>
 					</td>
 					<td>
@@ -2899,7 +2899,7 @@ function template_filter($header_label) {
 					<td>
 						<span>
 							<input type='checkbox' name='associated' id='associated' onChange='applyFilter()' <?php print (get_request_var('associated') == 'true' || get_request_var('associated') == 'on' ? 'checked':'');?>>
-							<label for='associated'><?php print __('Show Exceptions');?></label>
+							<label for='associated'><?php print __('Only Show Exceptions');?></label>
 						</span>
 					</td>
 					<td>
@@ -2984,7 +2984,7 @@ function tree_filter($header_label) {
 					<td>
 						<span>
 							<input type='checkbox' name='associated' id='associated' onChange='applyFilter()' <?php print (get_request_var('associated') == 'true' || get_request_var('associated') == 'on' ? 'checked':'');?>>
-							<label for='associated'><?php print __('Show Exceptions');?></label>
+							<label for='associated'><?php print __('Only Show Exceptions');?></label>
 						</span>
 					</td>
 					<td>
@@ -3069,7 +3069,7 @@ function member_filter($header_label) {
 					<td>
 						<span>
 							<input type='checkbox' name='associated' id='associated' onChange='applyFilter()' <?php print (get_request_var('associated') == 'true' || get_request_var('associated') == 'on' ? 'checked':'');?>>
-							<label for='associated'><?php print __('Show Exceptions');?></label>
+							<label for='associated'><?php print __('Only Show Exceptions');?></label>
 						</span>
 					</td>
 					<td>
@@ -3090,4 +3090,3 @@ function member_filter($header_label) {
 
 	html_end_box();
 }
-

--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -2197,7 +2197,7 @@ function graph_filter($header_label) {
 					<td>
 						<span>
 							<input type='checkbox' id='associated' onChange='applyFilter()' <?php print (get_request_var('associated') == 'true' || get_request_var('associated') == 'on' ? 'checked':'');?>>
-							<label for='associated'><?php print __('Show Exceptions');?></label>
+							<label for='associated'><?php print __('Only Show Exceptions');?></label>
 						</span>
 					</td>
 					<td>
@@ -2301,7 +2301,7 @@ function device_filter($header_label) {
 					<td>
 						<span>
 							<input type='checkbox' name='associated' id='associated' onChange='applyFilter()' <?php print (get_request_var('associated') == 'true' || get_request_var('associated') == 'on' ? 'checked':'');?>>
-							<label for='associated'><?php print __('Show Exceptions');?></label>
+							<label for='associated'><?php print __('Only Show Exceptions');?></label>
 						</span>
 					</td>
 					<td>
@@ -2386,7 +2386,7 @@ function template_filter($header_label) {
 					<td>
 						<span>
 							<input type='checkbox' name='associated' id='associated' onChange='applyFilter()' <?php print (get_request_var('associated') == 'true' || get_request_var('associated') == 'on' ? 'checked':'');?>>
-							<label for='associated'><?php print __('Show Exceptions');?></label>
+							<label for='associated'><?php print __('Only Show Exceptions');?></label>
 						</span>
 					</td>
 					<td>
@@ -2471,7 +2471,7 @@ function tree_filter($header_label) {
 					<td>
 						<span>
 							<input type='checkbox' name='associated' id='associated' onChange='applyFilter()' <?php print (get_request_var('associated') == 'true' || get_request_var('associated') == 'on' ? 'checked':'');?>>
-							<label for='associated'><?php print __('Show Exceptions');?></label>
+							<label for='associated'><?php print __('Only Show Exceptions');?></label>
 						</span>
 					</td>
 					<td>
@@ -2577,4 +2577,3 @@ function member_filter($header_label) {
 
 	html_end_box();
 }
-


### PR DESCRIPTION
…its behavior

Only fixed in English, pt-PT, pt-BR, es-ES, fr-FR and it-IT. Other languages need their respective translation to be updated, meaning that this won't fix the issue (#4056) for all languages.