### PR TITLE
Add ability to set how long a user can stay logged in before being au…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@ Cacti CHANGELOG
 -feature#3513: Add hooks for plugins to show customize graph source and customize template url
 -feature#4012: Provide CLI script to renew the CSRF security key for CSRF protection
 -feature#4013: Remote Poller - reset avg/max polling time
+-feature#4064: Add ability to set how long a user can stay logged in before being automatically logged out
 
 
 1.2.16

--- a/include/global_session.php
+++ b/include/global_session.php
@@ -71,7 +71,7 @@ if (read_user_setting('user_auto_logout_time')) {
 	$myrefresh['seconds'] = read_user_setting('user_auto_logout_time');
 	$myrefresh['page']    = $config['url_path'] . 'logout.php?action=timeout';
 	$refreshIsLogout      = 'true';
-}elseif (isset($_SESSION['refresh'])) {
+} elseif (isset($_SESSION['refresh'])) {
 	if (isset($_SESSION['refresh']['seconds'])) {
 		$myrefresh['seconds'] = $_SESSION['refresh']['seconds'];
 	} else {

--- a/include/global_session.php
+++ b/include/global_session.php
@@ -67,7 +67,11 @@ if ($script == 'graph_view.php' || $script == 'graph.php') {
 	}
 }
 
-if (isset($_SESSION['refresh'])) {
+if (read_user_setting('user_auto_logout_time')) {
+	$myrefresh['seconds'] = read_user_setting('user_auto_logout_time');
+	$myrefresh['page']    = $config['url_path'] . 'logout.php?action=timeout';
+	$refreshIsLogout      = 'true';
+}elseif (isset($_SESSION['refresh'])) {
 	if (isset($_SESSION['refresh']['seconds'])) {
 		$myrefresh['seconds'] = $_SESSION['refresh']['seconds'];
 	} else {

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -2289,6 +2289,22 @@ $settings_user = array(
 				'300' => __('%d Minutes', 5)
 			)
 		),
+		'user_auto_logout_time' => array(
+			'friendly_name' => __('Auto Log Out Time'),
+			'description' => __('How long this user can stay logged in before being automatically logged out.'),
+			'method' => 'drop_array',
+			'default' => '',
+			'array' => array(
+				''      => __('Never'),
+				'900'   => __('%d Minutes', 15),
+				'1200'  => __('%d Minutes', 20),
+				'1800'  => __('%d Minutes', 30),
+				'3600'  => __('1 Hour'),
+				'21600' => __('%d Hours', 6),
+				'43200' => __('%d Hours', 12),
+				'86400' => __('1 Day')
+			)
+		),
 		'preview_graphs_per_page' => array(
 			'friendly_name' => __('Preview Graphs Per Page'),
 			'description' => __('The number of graphs to display on one page in preview mode.'),


### PR DESCRIPTION
Add ability to set how long a user can stay logged in before being automatically logged out

Added an option in the **Configuration** > **Users** > **User Account**  under the **User Settings** tab to set how long they are allowed to stay signed in before being automatically logged out.
This is great for security where you do not want some users to stay signed in who quite often use shared computers and forget to logout.

The additional option is called **Auto Log Out Time** within the **User Settings** tab of the user account.
![image](https://user-images.githubusercontent.com/5603694/105219912-e9061a00-5b4e-11eb-9a52-53f72aca63f7.png)


The default behaviour has not been changed and it is set to be **Never** as default so you have to enable this on per user if required.