### PR TITLE
update audit_database.php

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ Cacti CHANGELOG
 -issue#3636: Spikekill method variable is misinterpreted when calculating overall statistics
 -issue#3675: Spikekill fills in NaN values outside specified time range
 -issue#3793: Calling function read_config_option in plugin's setup.php leads to error
+-issue#4079: current_timestamp() issue when running audit_database.php
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1523: Value above RRD maximum value
 -feature#2437: Create system-wide Proxy settings for plugins

--- a/src/cli/audit_database.php
+++ b/src/cli/audit_database.php
@@ -438,7 +438,7 @@ function report_audit_results($output = true) {
 
 			$status  = db_fetch_row('SHOW TABLE STATUS LIKE "' . $table_name . '"');
 
-			if ($status['Collation'] == 'utf8mb4_unicode_ci' || $status['Collation'] == 'utf8_general_ci') {
+			if ($status['Collation'] == 'utf8mb4_unicode_ci' || $status['Collation'] == 'utf8_general_ci' || $status['Collation'] == 'utf8mb4_general_ci') {
 				$text = 'mediumtext';
 			} else {
 				$text = 'text';


### PR DESCRIPTION
On mysql 10 or above, if table collection value is utf8mb4_general_ci then running audit_database.php may get below error:
Checking Table: 'XXXXX'
ERROR Col: 'lastUpdated', Attribute 'Default' invalid. Should be: 'CURRENT_TIMESTAMP', Is: 'current_timestamp()'
ERROR Col: 'lastUpdated', Attribute 'Extra' invalid. Should be: 'on update CURRENT_TIMESTAMP', Is: 'on update current_timestamp()'