### PR TITLE
Only show Auto Log Out Time if you have the User Management role

### DIFF
--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -2289,22 +2289,6 @@ $settings_user = array(
 				'300' => __('%d Minutes', 5)
 			)
 		),
-		'user_auto_logout_time' => array(
-			'friendly_name' => __('Auto Log Out Time'),
-			'description' => __('How long this user can stay logged in before being automatically logged out.'),
-			'method' => 'drop_array',
-			'default' => '',
-			'array' => array(
-				''      => __('Never'),
-				'900'   => __('%d Minutes', 15),
-				'1200'  => __('%d Minutes', 20),
-				'1800'  => __('%d Minutes', 30),
-				'3600'  => __('1 Hour'),
-				'21600' => __('%d Hours', 6),
-				'43200' => __('%d Hours', 12),
-				'86400' => __('1 Day')
-			)
-		),
 		'preview_graphs_per_page' => array(
 			'friendly_name' => __('Preview Graphs Per Page'),
 			'description' => __('The number of graphs to display on one page in preview mode.'),
@@ -2548,6 +2532,25 @@ if (is_realm_allowed(25)) {
 			'2' => __('New Window')
 		),
 		'default' => '1'
+	);
+}
+
+if (is_realm_allowed(1)) {
+	$settings_user['general']['user_auto_logout_time'] = array(
+		'friendly_name' => __('Auto Log Out Time'),
+		'description' => __('How long this user can stay logged in before being automatically logged out.'),
+		'method' => 'drop_array',
+		'default' => '',
+		'array' => array(
+			''      => __('Never'),
+			'900'   => __('%d Minutes', 15),
+			'1200'  => __('%d Minutes', 20),
+			'1800'  => __('%d Minutes', 30),
+			'3600'  => __('1 Hour'),
+			'21600' => __('%d Hours', 6),
+			'43200' => __('%d Hours', 12),
+			'86400' => __('1 Day')
+		)
 	);
 }
 


### PR DESCRIPTION
Changed the new feature in Pull Request #4064 to only show if the user has the **User Management** role set on their account.
This was requested by @TheWitness 


If a **User** needs to be able to set their own **Auto Log Out Time** they need to have the **Maintain Custom Graph and User Settings** enabled under **Configuration** > **Users** > **User Account** under the **General** tab
![image](https://user-images.githubusercontent.com/5603694/105344881-70996a80-5bdb-11eb-84f4-5dbda80a1f9d.png)
and have the **Update Profile** and **User Management** enabled under **Configuration** > **Users** > **User Account** under the **Permissions** tab
![image](https://user-images.githubusercontent.com/5603694/105345156-d1c13e00-5bdb-11eb-9295-cfcd0df78ca0.png)
Then the user will be able to see the **Auto Log Out Time**  option when they edit their profile
![image](https://user-images.githubusercontent.com/5603694/105347078-4a28fe80-5bde-11eb-9841-5f63d3a6ea47.png)


If an **Administrator** needs to set this for other users they must have the **Console Access** and **User Management** enabled under **Configuration** > **Users** > **User Account** under the **Permissions** tab
![image](https://user-images.githubusercontent.com/5603694/105345906-c02c6600-5bdc-11eb-93c1-5a0eb2fe5708.png)

Then when they are editing a user account the additional option called **Auto Log Out Time** can be found within the User Settings tab.
![image](https://user-images.githubusercontent.com/5603694/105347639-16020d80-5bdf-11eb-8f04-e79151600e4a.png)

The default behaviour has not been changed and it is set to be Never as default so you have to enable this on per user if required.