### PR TITLE
Add Interactive mode for test script

### DIFF
--- a/tests/tools/check_all_pages.sh
+++ b/tests/tools/check_all_pages.sh
@@ -3,6 +3,40 @@
 # each link is tried. I mean to add checks for new CVE's (at least those that I
 # can trigger with wget) as well.
 
+
+
+# ------------------------------------------------------------------------------
+# Get inputs from user (Interactive mode)
+# ------------------------------------------------------------------------------
+
+
+interactive="yes"
+
+if [[ $interactive = "no" ]]
+then
+
+echo "Enter Database username"
+read -r database_user
+echo "Enter Database Password"
+read -r database_pw
+echo "Enter Cacti Admin password"
+read -r login_pw
+
+else
+
+
+echo "Script is running in non-interactive mode ensure you fill out the DB credentials!!!"
+sleep 2 #Give user a chance to see the prompt
+
+database_user="cactiuser"
+database_pw="cactiuser"
+login_pw="admin"
+
+fi
+
+
+
+
 # ------------------------------------------------------------------------------
 # Debugging
 # ------------------------------------------------------------------------------
@@ -137,13 +171,6 @@ echo "My current directory is `pwd`"
 /bin/chown $WEBUSER:$WEBUSER $CACTI_LOG
 /bin/chown $WEBUSER:$WEBUSER $CACTI_ERRLOG
 
-# ------------------------------------------------------------------------------
-# Get the current database password, which by default is also used for the
-# admin.
-# ------------------------------------------------------------------------------
-database_user="cactiuser"
-database_pw="cactiuser"
-login_pw="admin"
 
 # ------------------------------------------------------------------------------
 # Make a backup copy of the Cacti settings table and enable log validation

--- a/tests/tools/check_all_pages.sh
+++ b/tests/tools/check_all_pages.sh
@@ -12,7 +12,7 @@
 
 interactive="yes"
 
-if [[ $interactive = "no" ]]
+if [[ $interactive = "yes" ]]
 then
 
 echo "Enter Database username"
@@ -33,6 +33,8 @@ database_pw="cactiuser"
 login_pw="admin"
 
 fi
+
+echo $interactive
 
 
 

--- a/tests/tools/check_all_pages.sh
+++ b/tests/tools/check_all_pages.sh
@@ -1,48 +1,41 @@
 #!/bin/bash
+# ------------------------------------------------------------------------------
 # This script is supposed to test cacti a little bit. At least each page and
 # each link is tried. I mean to add checks for new CVE's (at least those that I
 # can trigger with wget) as well.
+# ------------------------------------------------------------------------------
 
-
+mode=$1
 
 # ------------------------------------------------------------------------------
 # Get inputs from user (Interactive mode)
 # ------------------------------------------------------------------------------
-
-
-interactive="yes"
-
-if [[ $interactive = "yes" ]]
-then
-
-echo "Enter Database username"
-read -r database_user
-echo "Enter Database Password"
-read -r database_pw
-echo "Enter Cacti Admin password"
-read -r login_pw
-
+if [ "$mode" = "--interactive" ]; then
+	echo "Enter Database username"
+	read -r database_user
+	echo "Enter Database Password"
+	read -r database_pw
+	echo "Enter Cacti Admin password"
+	read -r login_pw
+elif [ "$mode" = "--help" ]; then
+	echo "Checks all Cacti pages using wget options"
+	echo "Original script by team Debian."
+	echo ""
+	echo "usage: check_all_pages.sh [--interactive]"
+	echo ""
 else
+	echo "Script is running in non-interactive mode ensure you fill out the DB credentials!!!"
+	sleep 2 #Give user a chance to see the prompt
 
-
-echo "Script is running in non-interactive mode ensure you fill out the DB credentials!!!"
-sleep 2 #Give user a chance to see the prompt
-
-database_user="cactiuser"
-database_pw="cactiuser"
-login_pw="admin"
-
+	database_user="cactiuser"
+	database_pw="cactiuser"
+	login_pw="admin"
 fi
-
-echo $interactive
-
-
-
 
 # ------------------------------------------------------------------------------
 # Debugging
 # ------------------------------------------------------------------------------
-set -xv
+#set -xv
 
 exec 2>&1
 


### PR DESCRIPTION
Add an interactive mode to the check_all_pages.sh script so the user can enter DB and login credentials when the script is run
or choose the non-interactive mode for scheduled automated testing 
