### PR TITLE
Fixing a couple database related typos and adding support for SSL CA checking without client side certificates (1.2.x)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -109,6 +109,8 @@ Cacti CHANGELOG
 -issue#4227: When remote poller is in offline mode data is written to poller_output as well as poller_output_boost
 -issue#4228: Redirection issues after login under specific circumstances
 -issue#4229: Errors running autom8 without snmp option set
+-issue#4232: Database TLS configuration requires client certificates as well
+-issue#4233: Potential typos and incomplete parameter lists for database connection variables
 -issue: Normalize plugin hooks between user_admin.php and user_group_admin.php
 -issue: CLI scripts should not have a max allowed runtime
 -feature: Update phpseclib to version 2.0.30

--- a/install/functions.php
+++ b/install/functions.php
@@ -85,10 +85,10 @@ function install_create_csrf_secret($file) {
 function install_test_local_database_connection() {
 	global $database_type, $database_hostname, $database_username, $database_password, $database_default, $database_type, $database_port, $database_retries, $database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca;
 
-	if (!isset($database_ssl)) $rdatabase_ssl = false;
-	if (!isset($database_ssl_key)) $rdatabase_ssl_key = false;
-	if (!isset($database_ssl_cert)) $rdatabase_ssl_cert = false;
-	if (!isset($database_ssl_ca)) $rdatabase_ssl_ca = false;
+	if (!isset($database_ssl)) $database_ssl = false;
+	if (!isset($database_ssl_key)) $database_ssl_key = false;
+	if (!isset($database_ssl_cert)) $database_ssl_cert = false;
+	if (!isset($database_ssl_ca)) $database_ssl_ca = false;
 
 	$connection = db_connect_real($database_hostname, $database_username, $database_password, $database_default, $database_type, $database_port, $database_retries, $database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca);
 
@@ -726,16 +726,18 @@ function install_file_paths() {
 
 function remote_update_config_file() {
 	global $config, $rdatabase_type, $rdatabase_hostname, $rdatabase_username,
-		$rdatabase_password, $rdatabase_default, $rdatabase_type, $rdatabase_port, $rdatabase_ssl;
+		$rdatabase_password, $rdatabase_default, $rdatabase_type, $rdatabase_port, 
+		$rdatabase_ssl, $rdatabase_ssl_key, $rdatabase_ssl_cert, $rdatabase_ssl_ca;
 
 	global $database_type, $database_hostname, $database_username,
-		$database_password, $database_default, $database_type, $database_port, $database_ssl;
+		$database_password, $database_default, $database_type, $database_port, 
+		$database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca;
 
 	$failure     = '';
 	$newfile     = array();
 	$config_file = $config['base_path'] . '/include/config.php';
 
-	$connection = db_connect_real($rdatabase_hostname, $rdatabase_username, $rdatabase_password, $rdatabase_default, $rdatabase_type, $rdatabase_port, $rdatabase_ssl);
+	$connection = db_connect_real($rdatabase_hostname, $rdatabase_username, $rdatabase_password, $rdatabase_default, $rdatabase_type, $rdatabase_port, $rdatabase_ssl, $rdatabase_ssl_key, $rdatabase_ssl_cert, $rdatabase_ssl_ca);
 
 	if (is_object($connection)) {
 		if (function_exists('gethostname')) {
@@ -759,6 +761,9 @@ function remote_update_config_file() {
 			$save['dbpass']    = $database_password;
 			$save['dbport']    = $database_port;
 			$save['dbssl']     = $database_ssl ? 'on' : '';
+			$save['dbsslkey']  = $database_ssl_key;
+			$save['dbsslcert'] = $database_ssl_cert;
+			$save['dbsslca']   = $database_ssl_ca;
 
 			$poller_id = sql_save($save, 'poller', 'id', true, $connection);
 		}

--- a/lib/database.php
+++ b/lib/database.php
@@ -70,12 +70,13 @@ function db_connect_real($device, $user, $pass, $db_name, $db_type = 'mysql', $p
 
 		$flags[PDO::MYSQL_ATTR_FOUND_ROWS] = true;
 		if ($db_ssl) {
-			if ($db_ssl_key != '' && $db_ssl_cert != '' && $db_ssl_ca != '') {
-				if (file_exists($db_ssl_key) && file_exists($db_ssl_cert) && file_exists($db_ssl_ca)) {
-					$flags[PDO::MYSQL_ATTR_SSL_KEY]  = $db_ssl_key;
-					$flags[PDO::MYSQL_ATTR_SSL_CERT] = $db_ssl_cert;
-					$flags[PDO::MYSQL_ATTR_SSL_CA]   = $db_ssl_ca;
-				} elseif (file_exists($db_ssl_key) && file_exists($db_ssl_cert)) {
+			if ($db_ssl_ca != '') {
+				if (file_exists($db_ssl_ca)) {
+					$flags[PDO::MYSQL_ATTR_SSL_CA] = $db_ssl_ca;
+				}
+			}
+			if ($db_ssl_key != '' && $db_ssl_cert != '') {
+				if (file_exists($db_ssl_key) && file_exists($db_ssl_cert)) {
 					$flags[PDO::MYSQL_ATTR_SSL_KEY]  = $db_ssl_key;
 					$flags[PDO::MYSQL_ATTR_SSL_CERT] = $db_ssl_cert;
 				}


### PR DESCRIPTION
We run Percona with TLS enforced but without client side certificates and in it's current form Cacti does not support that. From what I can tell our configuration is a bit unusual but certainly is valid. The change to database.php is sufficient to get Cacti to install for us however when looking around I saw a few other places where it looked like there were copy and paste errors or missing parameters that I tried to fix up. As I am definitely not a PHP expert it's entirely possible I missed things somewhere or was misguided in my fixing so please review this carefully!

I believe this addresses both #4232 and #4233 