### PR TITLE
Remove bogus early return from `nth_percentile_fetch_statistics`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -security#4261: Lack of escaping on file input fields can lead to XSS exposure under midwinter theme
 -issue#4254: When poller first runs, time since last run produces an error
 -issue#4259: A typo in variables.php leads to SQL error
+-issue#4263: Percentile not showing on partial data after fix for #3340
 -issue#4266: Incomplete Poller items from a previous run may be updated twice
 -feature#4258: Update phpseclib to version 2.0.31
 

--- a/lib/graph_variables.php
+++ b/lib/graph_variables.php
@@ -182,8 +182,6 @@ function nth_percentile_fetch_statistics($percentile, &$local_data_ids, &$fetch_
 							$asum_array[$ds_name][$timestamp]  = $data;
 						}
 					}
-				} else {
-					return false;
 				}
 			}
 		}


### PR DESCRIPTION
If there are more than one data source then the early return when a single
data source is missing data will cause all data sources to be ignored,  even
those that do have data.

Fixes #4263 