### PR TITLE
Session IDs are not always recreated when logging out under PHP 5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Cacti CHANGELOG
 1.2.18
 -security#4261: Lack of escaping on file input fields can lead to XSS exposure under midwinter theme
 -security#4276: Lack of escaping on parameter graph_nolegend can lead to XSS exposure in graph_realtime.php
+-security#4282: Regenerate session id to avoid session fixation issue
 -issue#4254: When poller first runs, time since last run produces an error
 -issue#4259: A typo in variables.php leads to SQL error
 -issue#4263: Percentile not showing on partial data after fix for #3340

--- a/include/csrf.php
+++ b/include/csrf.php
@@ -21,6 +21,8 @@ function csrf_startup() {
 }
 
 function csrf_error_callback() {
+	//Resolve session fixation for PHP 5.4
+	session_regenerate_id();
 	raise_message('csrf_timeout');
 	ob_end_clean();
 	header('Location: ' . sanitize_uri($_SERVER['REQUEST_URI']));


### PR DESCRIPTION
Steps:
 1. access cacti/logout.php
 2. Open Firefox DevTools, modify cookie `Cacti` value to `randomsessionid`
 3. Input username/password, then click button `Login`
 4. Browser will forward to `cacti/index.php?csrf_timeout=true` with login UI
 5. Input username/password, then click button `Login` again
 6. Login success, and show `Console`
 7. Check cookie `Cacti` value, it's `randomsessionid`

Note:
 * Ubuntu 18 + PHP 7.2 has not this issue, and always regenerate session id to replace `randomsessionid`