### PR TITLE
Fixing #4284 - Parameters in array_key_exists (1.2.17 database upgrade)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -139,6 +139,7 @@ Cacti CHANGELOG
 -feature#4113: Allow user to be automatically logged out after admin defined period by datatecuk
 -feature#4176: When replicating, ensure Cacti can detect and verify replica servers
 -feature#4210: Replace c3.js with billboard.js
+-issue#4284: Database upgrade can fail - Uncaught argument count error
 
 1.2.16
 -issue#3704: When generating a report, the Cascade to Branches function does not as expected

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Cacti CHANGELOG
 -issue#4269: Installation Wizard - Uncaught Error: Call to undefined function cacti_snmp_session()
 -issue#4271: Continued timeout of registered processes
 -issue#4272:  dns_get_record(): A temporary server error occurred
+-issue#4284: Database upgrade can fail - Uncaught argument count error
 -feature#4258: Update phpseclib to version 2.0.31
 
 1.2.17
@@ -139,7 +140,6 @@ Cacti CHANGELOG
 -feature#4113: Allow user to be automatically logged out after admin defined period by datatecuk
 -feature#4176: When replicating, ensure Cacti can detect and verify replica servers
 -feature#4210: Replace c3.js with billboard.js
--issue#4284: Database upgrade can fail - Uncaught argument count error
 
 1.2.16
 -issue#3704: When generating a report, the Cascade to Branches function does not as expected

--- a/install/upgrades/1_2_17.php
+++ b/install/upgrades/1_2_17.php
@@ -173,14 +173,14 @@ function database_fix_mediumint_columns() {
 		$table   = $t['Tables_in_' . $database_default];
 		$columns = array();
 
-		if (!array_key_exists($table, $tables, true)) {
+		if (!array_key_exists($table, $tables)) {
 			$columns = array_rekey(
 				db_fetch_assoc("SHOW COLUMNS FROM " . $table),
 					'Field', array('Type', 'Null', 'Key', 'Default', 'Extra')
 			);
 
 			foreach($columns as $field => $attribs) {
-				if (array_key_exists($field, $known_columns, true)) {
+				if (array_key_exists($field, $known_columns)) {
 					if (strpos($attribs['Type'], 'mediumint') === false) {
 						if (strpos($attribs['Type'], 'int(10) unsigned') !== false) {
 							continue;


### PR DESCRIPTION
Three parameters passed to array_key_exists function in 1_2_17.php.  Removed rogue third parameter.