### PR TITLE
Issue #4347 : Workaround PHP race that results in hanging rrdtool pro…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ Cacti CHANGELOG
 -issue#3636: Spikekill method variable is misinterpreted when calculating overall statistics
 -issue#3675: Spikekill fills in NaN values outside specified time range
 -issue#3793: Calling function read_config_option in plugin's setup.php leads to error
+-issue#4347: race with proc_open leads to blocked rrdtool processes
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1523: Value above RRD maximum value
 -feature#2437: Create system-wide Proxy settings for plugins

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -315,7 +315,7 @@ function __rrd_execute($command_line, $log_to_stdout, $output_flag, $rrdtool_pip
 			if (!is_resource($process)) {
 				unset($process);
 			} else {
-				fwrite($pipes[0], escape_command($command_line));
+				fwrite($pipes[0], escape_command($command_line) . "\r\nquit\r\n");
 				fclose($pipes[0]);
 				$fp = $pipes[1];
 			}


### PR DESCRIPTION
…cesses

There is a race in proc_open in PHP that is currently not avoided by
setting FD_CLOEXEC on the pipe file descriptors (with the 'e' flag for
the pipes). What happens, in a multithreaded Apache environment, when
multiple rrdtools are attempted to be launched (for example, when a lot
of graphs are requested at once) is this:

Thread 1: creates pipes for stdin/stdout
Thread 2: creates pipes for stdin/stdout
Thread 1: forks process x
Thread 2: forks process y
Process x: inherits pipes from Thread 1 and Thread 2
Process y: inherits pipes from Thread 1 and Thread 2
Process x: closes 'other side' of pipes from Thread 1
Process x: executes rrdtool
Thread 1: closes 'other side' of its pipes
Thread 1: writes command to rrdtool (no trailing newline)
Thread 1: closes stdin pipe to Process x
Process x: receives command from Thread 1
Process x: waits for more data, or stdin to close
Process x: hangs, because the pipe is still open in Process y
Thread 1: waits for data from rrdtool, which never comes
(meanwhile, the same thing happens between Thread 2 and Process y)

This is really a PHP bug, and I'll see if there's a possibility to get
that fixed there, but this at least fixes the problem by allowing
rrdtool to exit, itself, instead of waiting for stdin to be closed.