### PR TITLE
Fixed: Update mysql/mariadb in "Requirements" section  of Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ system with the following requirements:
 
 - PHP 7.2.5+
 
-- MySQL 5.6+
+- MySQL 5.6.5+, MariaDB 10.0+
 
 - RRDtool 1.3+, 1.5+ recommended
 


### PR DESCRIPTION
Fixed: Update mysql/mariadb in "Requirements" section because 'host' table include two timestamp columns