### PR TITLE
Fixes error callbacks for php 8.0+

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ Cacti CHANGELOG
 -issue#3636: Spikekill method variable is misinterpreted when calculating overall statistics
 -issue#3675: Spikekill fills in NaN values outside specified time range
 -issue#3793: Calling function read_config_option in plugin's setup.php leads to error
+-issue#4376: Fixes error callbacks for php 8.0+
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1523: Value above RRD maximum value
 -feature#2437: Create system-wide Proxy settings for plugins

--- a/lib/aggregate.php
+++ b/lib/aggregate.php
@@ -246,7 +246,7 @@ function api_aggregate_create($aggregate_name, $graphs, $agg_template_id = 0) {
  * @param int $linenum		- line of error
  * @param array $vars		- additional variables
  */
-function aggregate_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
+function aggregate_error_handler($errno, $errmsg, $filename, $linenum, $vars = []) {
 	$errno = $errno & error_reporting();
 
 	# return if error handling disabled by @

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -51,7 +51,7 @@ function boost_get_total_rows() {
 		OR table_name LIKE 'poller_output_boost')");
 }
 
-function boost_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
+function boost_error_handler($errno, $errmsg, $filename, $linenum, $vars = []) {
 	if (read_config_option('log_verbosity') >= POLLER_VERBOSITY_DEBUG) {
 		/* define all error types */
 		$errortype = array(

--- a/lib/dsdebug.php
+++ b/lib/dsdebug.php
@@ -60,7 +60,7 @@ function log_dsdebug_statistics($type, $checks, $issues) {
    @arg $linenum - (int) The line number where the error occurred
    @arg $vars - (mixed) The current state of PHP variables.
    @returns - (bool) always returns true for some reason */
-function dsdebug_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
+function dsdebug_error_handler($errno, $errmsg, $filename, $linenum, $vars = []) {
 	if (read_config_option('log_verbosity') >= POLLER_VERBOSITY_DEBUG) {
 		/* define all error types */
 		$errortype = array(

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -419,7 +419,7 @@ function log_dsstats_statistics($type) {
    @arg $linenum - (int) The line number where the error occurred
    @arg $vars - (mixed) The current state of PHP variables.
    @returns - (bool) always returns true for some reason */
-function dsstats_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
+function dsstats_error_handler($errno, $errmsg, $filename, $linenum, $vars = []) {
 	if (read_config_option('log_verbosity') >= POLLER_VERBOSITY_DEBUG) {
 		/* define all error types */
 		$errortype = array(

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -73,7 +73,7 @@ class Net_Ping
 		$this->request_len = strlen($this->request);
 	}
 
-	function ping_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
+	function ping_error_handler($errno, $errmsg, $filename, $linenum, $vars = []) {
 		return true;
 	}
 

--- a/rrdcleaner.php
+++ b/rrdcleaner.php
@@ -135,7 +135,7 @@ function rrdclean_truncate_tables() {
 /*
  * PHP Error Handler
  */
-function rrdclean_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
+function rrdclean_error_handler($errno, $errmsg, $filename, $linenum, $vars = []) {
 	global $debug;
 	if ($debug) {
 		/* define all error types */


### PR DESCRIPTION
In php 8.0, the callback set by set_error_handler receives 4 values instead of 5 before (docs here: https://www.php.net/manual/en/function.set-error-handler.php), so when the callback function has 5 parameters, a php error occurs.

The code I stumbled on about this is in `lib/ping.php`:
```
        function ping_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
                return true;
        }

        function set_ping_error_handler() {
                set_error_handler(array($this, 'ping_error_handler'));
        }
```

The error being that $vars is not provided.

The solution seems to be to set a default value for $vars, like `$vars = []`:
```
        function ping_error_handler($errno, $errmsg, $filename, $linenum, $vars = []) {
                return true;
        }
```

There are a few occurrences of this in the code.

Those changes should not cause any issue with older php versions.