### PR TITLE
Refactor poller rebuild (develop branch)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Cacti CHANGELOG
 -issue#3793: Calling function read_config_option in plugin's setup.php leads to error
 -issue#4362: Fix variable in change_device.php
 -issue#4347: race with proc_open leads to blocked rrdtool processes
+-issue#4373: fix Poller cache cannot be rebuilt from CLI, must use Web GUI
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1523: Value above RRD maximum value
 -feature#2437: Create system-wide Proxy settings for plugins

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -23,8 +23,9 @@
  +-------------------------------------------------------------------------+
 */
 require(__DIR__ . '/../include/cli_check.php');
-require_once($config['base_path'] . '/lib/poller.php');
-require_once($config['base_path'] . '/lib/utility.php');
+require_once($config['library_path'] . '/poller.php');
+require_once($config['library_path'] . '/utility.php');
+include_once($config['library_path'] . '/api_data_source.php');
 
 /* process calling arguments */
 $parms = $_SERVER['argv'];

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -102,25 +102,9 @@ verbose('Querying for data sources...');
 $data_sources = get_data_sources($host_id, $local_data_id, $data_template_id);
 verbose("There are " . cacti_sizeof($data_sources) . " data source elements to update.");
 
-
-/* get the data_local Id's for the poller cache */
-if ($host_id > 0) {
-	$poller_data  = db_fetch_assoc('SELECT * FROM data_local WHERE host_id=' . $host_id);
-} else {
-	$poller_data  = db_fetch_assoc('SELECT * FROM data_local');
-}
-
 /* initialize some variables */
 $current_ds = 1;
-$total_ds = cacti_sizeof($poller_data);
-
-/* setting local_data_ids to an empty array saves time during updates */
-$local_data_ids = array();
-$poller_items   = array();
-
-/* issue warnings and start message if applicable */
-print "WARNING: Do not interrupt this script.  Rebuilding the Poller Cache can take quite some time\n";
-debug("There are '" . cacti_sizeof($poller_data) . "' data source elements to update.");
+$total_ds = cacti_sizeof($data_sources);
 
 /* start rebuilding the poller cache */
 if (cacti_sizeof($poller_data)) {

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -98,7 +98,7 @@ verbose('Querying for data sources...');
 /* first of all, get all data sources and their corresponding information.
 	any param of get_data_sources() set to zero means as 'all'
 */
-$data_sources = get_data_sources($host_id, $local_data_id, $data_template_id);
+$data_sources = get_data_sources($host_id);
 verbose("There are " . cacti_sizeof($data_sources) . " data source elements to update.");
 
 /* initialize some variables */

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -22,7 +22,6 @@
  | http://www.cacti.net/                                                   |
  +-------------------------------------------------------------------------+
 */
-
 require(__DIR__ . '/../include/cli_check.php');
 require_once($config['base_path'] . '/lib/poller.php');
 require_once($config['base_path'] . '/lib/utility.php');
@@ -116,8 +115,8 @@ if (cacti_sizeof($data_sources)) {
 	foreach ($data_sources as $data_source) {
 		if (!$debug) {
 			$tcount++;
-			print CLI_CSI . CLI_EL_WHOLE . CLI_CR . "$tcount / " . count($poller_data) .
-			' (' . round($tcount/count($poller_data)*100,1) .  '%)';
+			print CLI_CSI . CLI_EL_WHOLE . CLI_CR . "$tcount / " . count($data_sources) .
+			' (' . round($tcount/count($data_sources)*100,1) .  '%)';
 		}
 
 		/* fill in hosts array, if not already present */

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -110,7 +110,7 @@ $total_ds = cacti_sizeof($data_sources);
 if (cacti_sizeof($data_sources)) {
 	if (!$debug) {
 		$tcount = 0;
-		print '\n';
+		print "\n";
 	}
 	verbose("Combing through all Data Sources, preparing data");
 	foreach ($data_sources as $data_source) {
@@ -155,6 +155,7 @@ if (cacti_sizeof($data_sources)) {
 		debug("Data Source Item '$current_ds' of '$total_ds' processed");
 		$current_ds++;
 	}
+	print "\n";
 	verbose('Preparation done');
 	verbose("Updating poller cache for ". count($local_data_ids) . " ID's / " .
 		count($poller_items) . " items." );

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -25,7 +25,7 @@
 require(__DIR__ . '/../include/cli_check.php');
 require_once($config['library_path'] . '/poller.php');
 require_once($config['library_path'] . '/utility.php');
-include_once($config['library_path'] . '/api_data_source.php');
+require_once($config['library_path'] . '/api_data_source.php');
 
 /* process calling arguments */
 $parms = $_SERVER['argv'];

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -107,19 +107,19 @@ $current_ds = 1;
 $total_ds = cacti_sizeof($data_sources);
 
 /* start rebuilding the poller cache */
-if (cacti_sizeof($poller_data)) {
+if (cacti_sizeof($data_sources)) {
 	if (!$debug) {
 		$tcount = 0;
 		print '\n';
 	}
-	foreach ($poller_data as $data) {
+	foreach ($data_sources as $data_source) {
 		if (!$debug) {
 			$tcount++;
 			print CLI_CSI . CLI_EL_WHOLE . CLI_CR . "$tcount / " . count($poller_data) .
 			' (' . round($tcount/count($poller_data)*100,1) .  '%)';
 		}
-		$local_data_ids[] = $data['id'];
-		$poller_items = array_merge($poller_items, update_poller_cache($data));
+		$local_data_ids[] = $data_source['id'];
+		$poller_items = array_merge($poller_items, update_poller_cache($data_source));
 
 		debug("Data Source Item '$current_ds' of '$total_ds' updated");
 		$current_ds++;

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -32,6 +32,7 @@ $parms = $_SERVER['argv'];
 array_shift($parms);
 
 $debug = false;
+$verbose = false;
 $host_id = 0;
 
 if (cacti_sizeof($parms)) {
@@ -47,6 +48,7 @@ if (cacti_sizeof($parms)) {
 			case '-d':
 			case '--debug':
 				$debug = true;
+				$verbose = true;
 				break;
 			case '--host-id':
 				$host_id = trim($value);
@@ -67,6 +69,9 @@ if (cacti_sizeof($parms)) {
 			case '-h':
 				display_help();
 				exit(0);
+			case '--verbose':
+				$verbose = true;
+				break;
 			default:
 				print 'ERROR: Invalid Parameter ' . $parameter . "\n\n";
 				display_help();
@@ -151,5 +156,12 @@ function debug($message) {
 
 	if ($debug) {
 		print 'DEBUG: ' . trim($message) . "\n";
+	}
+}
+
+function verbose($message) {
+	global $verbose;
+	if ($verbose) {
+		print 'INFO: ' . trim($message) . "\n";
 	}
 }

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -91,7 +91,7 @@ $local_data_ids  = array();
 $hosts           = array();
 $data_template_fields = array();
 
-print CLI_CSI . CLI_FG_RED . 'WARNING' . CLI_SGR_END .
+print CLI_CSI . CLI_FG_RED . CLI_SGR_END . 'WARNING' . CLI_CSI . CLI_SGR_RESET . CLI_SGR_END .
 	": Do not interrupt this script.  Rebuilding the Poller Cache can take quite some time\n";
 
 verbose('Querying for data sources...');

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -86,6 +86,23 @@ $max_execution = ini_get('max_execution_time');
 /* set new timeout */
 ini_set('max_execution_time', '0');
 
+/* prepare some variables that we're going to use. */
+$poller_items    = array();
+$local_data_ids  = array();
+$hosts           = array();
+$data_template_fields = array();
+
+print CLI_CSI . CLI_FG_RED . 'WARNING' . CLI_SGR_END .
+	": Do not interrupt this script.  Rebuilding the Poller Cache can take quite some time\n";
+
+verbose('Querying for data sources...');
+/* first of all, get all data sources and their corresponding information.
+	any param of get_data_sources() set to zero means as 'all'
+*/
+$data_sources = get_data_sources($host_id, $local_data_id, $data_template_id);
+verbose("There are " . cacti_sizeof($data_sources) . " data source elements to update.");
+
+
 /* get the data_local Id's for the poller cache */
 if ($host_id > 0) {
 	$poller_data  = db_fetch_assoc('SELECT * FROM data_local WHERE host_id=' . $host_id);

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -656,8 +656,10 @@ function push_out_host($host_id, $local_data_id = 0, $data_template_id = 0) {
 
 			/* get field information FROM the data template */
 			if (!isset($template_fields[$data_source['local_data_template_data_id']])) {
+				# we must briefly construct an array out of $data_source for get_template_fields()
+				$data_source_arr = array($data_source);
 				$data_template_fields[$data_source['local_data_template_data_id']] =
-					get_template_fields(array($data_source));
+					get_template_fields($data_source_arr);
 			}
 
 			/* push out host value if necessary */

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -659,7 +659,7 @@ function push_out_host($host_id, $local_data_id = 0, $data_template_id = 0) {
 				# we must briefly construct an array out of $data_source for get_data_template_fields()
 				$data_source_arr = array($data_source);
 				$data_template_fields[$data_source['local_data_template_data_id']] =
-					get_data_template_fields($data_source_arr);
+					get_data_template_fields($data_source_arr)[$data_source['local_data_template_data_id']];
 			}
 
 			/* push out host value if necessary */

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -638,7 +638,7 @@ function push_out_host($host_id, $local_data_id = 0, $data_template_id = 0) {
 	$poller_items    = array();
 	$local_data_ids  = array();
 	$hosts           = array();
-	$template_fields = array();
+	$data_template_fields = array();
 
 	$data_sources = get_data_sources($host_id, $local_data_id, $data_template_id);
 
@@ -655,15 +655,15 @@ function push_out_host($host_id, $local_data_id = 0, $data_template_id = 0) {
 			$host = $hosts[$data_source['host_id']];
 
 			/* get field information FROM the data template */
-			if (!isset($template_fields[$data_source['local_data_template_data_id']])) {
-				# we must briefly construct an array out of $data_source for get_template_fields()
+			if (!isset($data_template_fields[$data_source['local_data_template_data_id']])) {
+				# we must briefly construct an array out of $data_source for get_data_template_fields()
 				$data_source_arr = array($data_source);
 				$data_template_fields[$data_source['local_data_template_data_id']] =
-					get_template_fields($data_source_arr);
+					get_data_template_fields($data_source_arr);
 			}
 
 			/* push out host value if necessary */
-			if (cacti_sizeof($template_fields[$data_source['local_data_template_data_id']])) {
+			if (cacti_sizeof($data_template_fields[$data_source['local_data_template_data_id']])) {
 				push_out_data_input_data($data_template_fields, $data_source, $host);
 			}
 
@@ -753,7 +753,7 @@ function get_data_sources($host_id = 0 , $local_data_id = 0, $data_template_id =
  * @param   array &$data_sources - one or more data sources.
  * @return  array - array, indexed by local_data_template_data_id
 */
-function get_template_fields(&$data_sources) {
+function get_data_template_fields(&$data_sources) {
 	$template_fields = array();
 	foreach ($data_sources as $data_source) {
 		if (isset($template_fields[$data_source['local_data_template_data_id']])) continue;
@@ -787,8 +787,8 @@ function get_template_fields(&$data_sources) {
  * @param array &data_source - a single data source
  * @param array &$host - a single host data structure
  */
-function push_out_data_input_data(&$template_fields, &$data_source, &$host) {
-	foreach ($template_fields[$data_source['local_data_template_data_id']] as $template_field) {
+function push_out_data_input_data(&$data_template_fields, &$data_source, &$host) {
+	foreach ($data_template_fields[$data_source['local_data_template_data_id']] as $template_field) {
 		if (preg_match('/^' . VALID_HOST_FIELDS . '$/i', $template_field['type_code']) && $template_field['value'] == '' && $template_field['t_value'] == '') {
 			// handle special case type_code
 			if ($template_field['type_code'] == 'host_id') {

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -775,10 +775,8 @@ function get_data_template_fields(&$data_sources) {
 	return $template_fields;
 }
 
-/** this...replaces values in data_input_data. yes, the naming is very opaque,
- * and so to be honest, i have no idea what exactly this does in terms of cacti's logic.
+/**
  * The code was extracted verbatim from push_out_host().
- *
  * This is needed to do a proper flush of the poller cache.
  *
  * original description:

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -712,6 +712,7 @@ function push_out_host($host_id, $local_data_id = 0, $data_template_id = 0) {
  */
 function get_data_sources($host_id = 0 , $local_data_id = 0, $data_template_id = 0) {
 	$sql_where       = '';
+	$sql_args        = [];
 	/* setup the sql where, and if using a host, get it's host information */
 	if ($host_id != 0) {
 		/* get all information about this host so we can write it to the data source */
@@ -719,20 +720,23 @@ function get_data_sources($host_id = 0 , $local_data_id = 0, $data_template_id =
 			FROM host WHERE id = ?',
 			array($host_id));
 
-		$sql_where .= ' AND dl.host_id=' . $host_id;
+		$sql_where .= ' AND dl.host_id = ?';
+		$sql_args[] = $host_id;
 	}
 
 	/* sql WHERE for local_data_id */
 	if ($local_data_id != 0) {
-		$sql_where .= ' AND dl.id=' . $local_data_id;
+		$sql_where .= ' AND dl.id = ?';
+		$sql_args[] = $local_data_id;
 	}
 
 	/* sql WHERE for data_template_id */
 	if ($data_template_id != 0) {
-		$sql_where .= ' AND dtd.data_template_id=' . $data_template_id;
+		$sql_where .= ' AND dtd.data_template_id = ?';
+		$sql_args[] = $data_template_id;
 	}
 
-	$data_sources = db_fetch_assoc('SELECT ' . SQL_NO_CACHE . " dtd.id,
+	$data_sources = db_fetch_assoc_prepared('SELECT ' . SQL_NO_CACHE . " dtd.id,
 		dtd.data_input_id, dtd.local_data_id,
 		dtd.local_data_template_data_id, dl.host_id,
 		dl.snmp_query_id, dl.snmp_index
@@ -741,7 +745,7 @@ function get_data_sources($host_id = 0 , $local_data_id = 0, $data_template_id =
 		ON dl.id=dtd.local_data_id
 		WHERE dtd.data_input_id>0
 		AND (dl.snmp_query_id = 0 OR (dl.snmp_query_id > 0 AND dl.snmp_index != ''))
-		$sql_where");
+		$sql_where", $sql_args);
 
 	return $data_sources;
 }

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -656,16 +656,8 @@ function push_out_host($host_id, $local_data_id = 0, $data_template_id = 0) {
 
 			/* get field information FROM the data template */
 			if (!isset($template_fields[$data_source['local_data_template_data_id']])) {
-				$template_fields[$data_source['local_data_template_data_id']] = db_fetch_assoc_prepared('SELECT ' . SQL_NO_CACHE . '
-					did.value, did.t_value, dif.id, dif.type_code
-					FROM data_input_fields AS dif
-					LEFT JOIN data_input_data AS did
-					ON dif.id=did.data_input_field_id
-					WHERE dif.data_input_id = ?
-					AND did.data_template_data_id = ?
-					AND (did.t_value="" OR did.t_value is null)
-					AND dif.input_output = "in"',
-					array($data_source['data_input_id'], $data_source['local_data_template_data_id']));
+				$data_template_fields[$data_source['local_data_template_data_id']] =
+					get_template_fields(array($data_source));
 			}
 
 			/* loop through each field contained in the data template and push out a host value if:

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -767,6 +767,31 @@ function get_data_sources($host_id = 0 , $local_data_id = 0, $data_template_id =
 	return $data_sources;
 }
 
+/** get template fields&values for given data source(s).
+ * to increase performance, data_sources is expected to be a reference to an
+ * array, not an array directly.
+ *
+ * @param   array &$data_sources - one or more data sources.
+ * @return  array - array, indexed by local_data_template_data_id
+*/
+function get_template_fields(&$data_sources) {
+	$template_fields = array();
+	foreach ($data_sources as $data_source) {
+		if (isset($template_fields[$data_source['local_data_template_data_id']])) continue;
+		$template_fields[$data_source['local_data_template_data_id']] = db_fetch_assoc_prepared('SELECT ' . SQL_NO_CACHE . '
+			did.value, did.t_value, dif.id, dif.type_code
+			FROM data_input_fields AS dif
+			LEFT JOIN data_input_data AS did
+			ON dif.id=did.data_input_field_id
+			WHERE dif.data_input_id = ?
+			AND did.data_template_data_id = ?
+			AND (did.t_value="" OR did.t_value is null)
+			AND dif.input_output = "in"',
+			array($data_source['data_input_id'], $data_source['local_data_template_data_id']));
+	}
+	return $template_fields;
+}
+
 function data_input_whitelist_check($data_input_id) {
 	global $config;
 

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -660,24 +660,9 @@ function push_out_host($host_id, $local_data_id = 0, $data_template_id = 0) {
 					get_template_fields(array($data_source));
 			}
 
-			/* loop through each field contained in the data template and push out a host value if:
-			 - the field is a valid "host field"
-			 - the value of the field is empty
-			 - the field is set to 'templated' */
+			/* push out host value if necessary */
 			if (cacti_sizeof($template_fields[$data_source['local_data_template_data_id']])) {
-				foreach ($template_fields[$data_source['local_data_template_data_id']] as $template_field) {
-					if (preg_match('/^' . VALID_HOST_FIELDS . '$/i', $template_field['type_code']) && $template_field['value'] == '' && $template_field['t_value'] == '') {
-						// handle special case type_code
-						if ($template_field['type_code'] == 'host_id') {
-							$template_field['type_code'] = 'id';
-						}
-
-						db_execute_prepared('REPLACE INTO data_input_data
-							(data_input_field_id, data_template_data_id, value)
-							VALUES (?, ?, ?)',
-							array($template_field['id'], $data_source['id'], $host[$template_field['type_code']]));
-					}
-				}
+				push_out_data_input_data($data_template_fields, $data_source, $host);
 			}
 
 			/* flag an update to the poller cache as well */


### PR DESCRIPTION
Work in Progress!

Solves #4373.

This might need some guidance/feedback by principal maintainers, as I'm a rookie when it comes to cacti's codebase.

As described in the issue, the logic to refresh/rebuild the poller cache seems to be implemented multiple times. So far, I've discovered `push_out_host()` to work reliably. Simply plumbing up rebuild_poller_cache.php to this function would have several drawbacks: A lot of progress granularity would be lost (significant for bigger installations), and code/logic duplication in other places would remain.

Hence, I attempt to dissect the functional blocks of `push_out_host()` into their own methods, document them as much as possible, and then subsequently wire up push_out_host() and rebuild_poller_cache.php to these "new" functions. 

This should allow us then to reduce code complexity in other places, and generally create more stable code, as for example the SQL queries to retrieve hosts, data sources, etc. are in one place, one function, instead of copy/pasted in several places, sometimes ever-so-slightly different (valid performance reasons notwithstanding, of course).