### PR TITLE
delete dead code in utilities.php

### DIFF
--- a/utilities.php
+++ b/utilities.php
@@ -68,11 +68,6 @@ switch (get_request_var('action')) {
 		clog_purge_logfile();
 		utilities_view_logfile();
 		break;
-	case 'view_cleaner':
-		top_header();
-		utilities_view_cleaner();
-		bottom_footer();
-		break;
 	case 'view_user_log':
 		top_header();
 		utilities_view_user_log();


### PR DESCRIPTION
my IDE complained about `utilities_view_cleaner()` not being defined
anywhere. that's when I found out that this particular case branch
isn't used anywhere. out into the nullbucket it goes.