### PR TITLE
Fix#4289: Display color style instead of color_id or blank for new coloer.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -security#4356: Further fixes for grave character security protection
 -issue: Over aggressive escaping causes menu visibility issues on Create Device page
 -issue#3787: Add SHA256 and AES256 security levels for SNMP polling
+-issue#4289: Import graph template(Preview Only) show color_id new value as a blank area
 -issue#4341: Editing graphs can cause errors due to missing sequence
 -issue#4342: When hovering over a Tree Graph, row shows same highlighting as Graph Edit screen
 -issue#4343: When RealTime is not active, console errors may appear

--- a/lib/import.php
+++ b/lib/import.php
@@ -556,6 +556,9 @@ function xml_to_graph_template($hash, &$xml_array, &$hash_cache, $hash_version, 
 
 							$color_id = db_fetch_insert_id();
 						}
+						if (empty($color_id) && $preview_only) {
+							$color_id = $item_array[$field_name];
+						}
 
 						$save[$field_name] = $color_id;
 					} else {
@@ -1841,8 +1844,26 @@ function compare_data($save, $previous_data, $table) {
 					continue;
 				}
 
+				if($column == 'color_id') {
+					$oldvalue = db_fetch_cell_prepared('SELECT hex FROM colors WHERE id = ?', array($previous_data[$column]));
+					$oldvalue = html_escape($oldvalue);
+					$oldvalue = '<span style="background-color:#' . $oldvalue . '">' . $oldvalue . '</span>';
+
+					$newvalue = db_fetch_cell_prepared('SELECT hex FROM colors WHERE id = ?', array($value));
+					if (empty($newvalue) && $preview_only) {
+						$newvalue = html_escape($value);
+					} else {
+						$newvalue = html_escape($newvalue);
+					}
+					$newvalue = '<span style="background-color:#' . $newvalue . '">' . $newvalue . '</span>';
+				} else {
+					$oldvalue = html_escape($previous_data[$column]);
+					$newvalue = html_escape($value);
+				}
+
+
 				$different++;
-				$import_debug_info['differences'][] = 'Table: ' . $table . ', Column: ' . $column . ', New Value: ' . html_escape($value) . ', Old Value: ' . html_escape($previous_data[$column]);
+				$import_debug_info['differences'][] = 'Table: ' . $table . ', Column: ' . $column . ', New Value: ' . $newvalue . ', Old Value: ' . $oldvalue;
 			}
 		}
 
@@ -2169,7 +2190,7 @@ function import_display_results($import_debug_info, $filestatus, $web = false, $
 				if (isset($vals['differences'])) {
 					print '<ul class="monoSpace">';
 					foreach($vals['differences'] as $diff) {
-						print '<li>' . html_escape($diff) . '</li>';
+						print '<li>' . $diff . '</li>';
 					}
 					print '</ul>';
 				}

--- a/lib/import.php
+++ b/lib/import.php
@@ -556,6 +556,7 @@ function xml_to_graph_template($hash, &$xml_array, &$hash_cache, $hash_version, 
 
 							$color_id = db_fetch_insert_id();
 						}
+
 						if (empty($color_id) && $preview_only) {
 							$color_id = $item_array[$field_name];
 						}

--- a/lib/import.php
+++ b/lib/import.php
@@ -1845,23 +1845,24 @@ function compare_data($save, $previous_data, $table) {
 					continue;
 				}
 
-				if($column == 'color_id') {
+				if ($column == 'color_id') {
 					$oldvalue = db_fetch_cell_prepared('SELECT hex FROM colors WHERE id = ?', array($previous_data[$column]));
 					$oldvalue = html_escape($oldvalue);
 					$oldvalue = '<span style="background-color:#' . $oldvalue . '">' . $oldvalue . '</span>';
 
 					$newvalue = db_fetch_cell_prepared('SELECT hex FROM colors WHERE id = ?', array($value));
+
 					if (empty($newvalue) && $preview_only) {
 						$newvalue = html_escape($value);
 					} else {
 						$newvalue = html_escape($newvalue);
 					}
+
 					$newvalue = '<span style="background-color:#' . $newvalue . '">' . $newvalue . '</span>';
 				} else {
 					$oldvalue = html_escape($previous_data[$column]);
 					$newvalue = html_escape($value);
 				}
-
 
 				$different++;
 				$import_debug_info['differences'][] = 'Table: ' . $table . ', Column: ' . $column . ', New Value: ' . $newvalue . ', Old Value: ' . $oldvalue;


### PR DESCRIPTION
 *   Fix #4289: Display color style instead of color_id or blank for new coloer.
              Remove html_escape for import->result->differences display to avoid double escape
