### PR TITLE
Fixed: support pure-CLI upgrade from pre-1.2.11

### DIFF
--- a/install/upgrades/1_2_17.php
+++ b/install/upgrades/1_2_17.php
@@ -24,8 +24,8 @@
 
 function upgrade_to_1_2_17() {
 	// Correct max values in templates and data sources: GAUGE/ABSOLUTE (1,4)
-	db_install_execute("ALTER TABLE graph_templates_graph DROP INDEX title_cache, ADD INDEX title_cache(title_cache)");
-	db_install_execute("ALTER TABLE data_template_data DROP INDEX name_cache, ADD INDEX name_cache(name_cache)");
+	db_install_execute("ALTER TABLE graph_templates_graph ROW_FORMAT=Dynamic, DROP INDEX title_cache, ADD INDEX title_cache(title_cache)");
+	db_install_execute("ALTER TABLE data_template_data ROW_FORMAT=Dynamic, DROP INDEX name_cache, ADD INDEX name_cache(name_cache)");
 
 	// LDAP Search filter widening
 	db_install_execute('ALTER TABLE user_domains_ldap MODIFY COLUMN search_filter VARCHAR(512) NOT NULL default ""');

--- a/install/upgrades/1_2_19.php
+++ b/install/upgrades/1_2_19.php
@@ -34,6 +34,7 @@ function upgrade_to_1_2_19() {
 	}
 
 	db_install_execute('ALTER TABLE graph_templates
+		ROW_FORMAT=Dynamic,
 		DROP INDEX multiple_name,
 		DROP INDEX name,
 		ADD INDEX multiple_name(multiple, name),


### PR DESCRIPTION
Found SQL error about index length during upgrade Cacti from 1.2.10 and earlier to 1.2.19.
Note: do not convert table row format to "dynamic: