### PR TITLE
When running under PHP 5.4, certain operators are not valid

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 
 1.2.21
 -issue#4683: When adding device, errors may be reported whilst updating templates
+-issue#4688: Two syntax error for PHP 5.4
 
 1.2.20
 -security#4562: When using LDAP, authentication process may be bypassed
@@ -193,7 +194,6 @@ Cacti CHANGELOG
 -issue#4273: When adding a device from command line, testing of data sources can cause errors to be recorded
 -issue#4274: When you start to zoom a graph, the auto graph refresh should be disabled
 -issue#4279: Default Setting "Device Threads" will not be saved correctly
--issue#4284: Database upgrade can fail - Uncaught argument count error
 -issue#4293: Tree search does not take hosts belonging to a site into account
 -issue#4284: Whilst upgrading, errors in upgrade scripts prevent properly execution
 -issue#4294: Tables outside of pre-built list that need fixing, cause bad unknown column errors

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -194,6 +194,7 @@ Cacti CHANGELOG
 -issue#4273: When adding a device from command line, testing of data sources can cause errors to be recorded
 -issue#4274: When you start to zoom a graph, the auto graph refresh should be disabled
 -issue#4279: Default Setting "Device Threads" will not be saved correctly
+-issue#4284: Database upgrade can fail - Uncaught argument count error
 -issue#4293: Tree search does not take hosts belonging to a site into account
 -issue#4284: Whilst upgrading, errors in upgrade scripts prevent properly execution
 -issue#4294: Tables outside of pre-built list that need fixing, cause bad unknown column errors

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -1211,7 +1211,7 @@ function api_device_update_host_template($host_id, $host_template_id) {
 						raise_message('poller_down_' . $poller_id, __('Remote Poller %s is Down, you will need to perform a FullSync once it is up again', $poller_id), MESSAGE_LEVEL_WARN);
 						$raised[$poller_id] = true;
 					}
-				} elseif (!$isset(raised[$poller_id])) {
+				} elseif (!$isset($raised[$poller_id])) {
 					raise_message('poller_down_' . $poller_id, __('Remote Poller %s is Down, you will need to perform a FullSync once it is up again', $poller_id), MESSAGE_LEVEL_WARN);
 					$raised[$poller_id] = true;
 				}

--- a/pollers.php
+++ b/pollers.php
@@ -1023,7 +1023,7 @@ function pollers() {
 				$poller['status'] = 6;
 			}
 
-			$mma = round($poller['avg_time']??0, 2) . '/' .  round(max($poller['max_time']??1,1), 2);
+			$mma = round($poller['avg_time']?:0, 2) . '/' .  round(max($poller['max_time']?:1,1), 2);
 
 			if (empty($poller['name'])) {
 				$poller['name'] = '&lt;no name&gt;';


### PR DESCRIPTION
In Readme, Cacti 1.2.x support PHP 5.4+, so replace PHP 7.0 operator `??` with `?:`
Related to #4475 and #4662
These two errors are introduced after 1.2.19. CHANGELOG might be not required if @netniV recreate release/1.2.20 tag