### PR TITLE
fixed 'Fatal error:  Uncaught Error: socket_clear_error(): Argument #…

### DIFF
--- a/lib/ping.php
+++ b/lib/ping.php
@@ -530,10 +530,10 @@ class Net_Ping
 					$this->ping_response = __('TCP ping: socket_connect(), reason: %s', socket_strerror($errno));
 					$this->ping_status   = 'down';
 
+					socket_clear_error($this->socket);
+
 					$this->close_socket();
 					$this->restore_cacti_error_handler();
-
-					socket_clear_error($this->socket);
 
 					return false;
 				}


### PR DESCRIPTION
If you use a tcp_ping and some host is down you receive an error below and part of hosts stop checked. It happens because socket closed before clear the errors. We need to move function socket_clear_error() before close_socket().

```
PHP Fatal error:  Uncaught Error: socket_clear_error(): Argument #1 ($socket) has already been closed in /var/www/cacti/lib/ping.php:552
Stack trace:
#0 /var/www/cacti/lib/ping.php(552): socket_clear_error()
#1 /var/www/cacti/lib/ping.php(662): Net_Ping->ping_tcp()
#2 /var/www/cacti/lib/api_device.php(1397): Net_Ping->ping()
#3 /var/www/cacti/host.php(141): api_device_ping_device()
#4 {main}
  thrown in /var/www/cacti/lib/ping.php on line 552

```