### PR TITLE
improve boost error message slightly

### DIFF
--- a/poller_boost.php
+++ b/poller_boost.php
@@ -333,7 +333,7 @@ function boost_prepare_process_table() {
 	$arch_tables = boost_get_arch_table_names();
 
 	if (!cacti_sizeof($arch_tables)) {
-		cacti_log('ERROR: Failed to retrieve archive table name', false, 'BOOST');
+		cacti_log('ERROR: Failed to retrieve archive table name - check poller', false, 'BOOST');
 
 		return false;
 	}


### PR DESCRIPTION
Boost will fail with a cryptic error message in case the poller isn't working. Hence, hint at polling issues in this error message. Discovered during #4796.

A very minor change, but might help others in the future.