### PR TITLE
improve boost error message slightly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Cacti CHANGELOG
 1.2.22
 -issue#4802: Typo in lib/auth.php prevents users from changing their password and logging in
 -issue#4810: Call to undefined function boost_debug in Cacti log
+-issue#4796: Hint at poller issues when boost fails
 
 1.2.21
 -issue#4531: Correct duplicate keys within database

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -334,7 +334,7 @@ function boost_prepare_process_table() {
 	$arch_tables = boost_get_arch_table_names();
 
 	if (!cacti_sizeof($arch_tables)) {
-		cacti_log('ERROR: Failed to retrieve archive table name', false, 'BOOST');
+		cacti_log('ERROR: Failed to retrieve archive table name - check poller', false, 'BOOST');
 
 		return false;
 	}


### PR DESCRIPTION
Boost will fail with a cryptic error message in case the poller isn't
working. Hence, hint at polling issues in this error message.

New PR against 1.2.x as requested in PR #4805