### PR TITLE
Update default path cacti under *BSD

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,11 +16,13 @@ Cacti CHANGELOG
 -issue#4822: Cacti polling and boost report the wrong number of Data Sources when Devices are disabled
 -issue#4823: When editing Graph Template Items there are cases where VDEF's are hidden when they should be shown
 -issue#4831: Cactid lacks a default for $database_ssl
+-issue#4837: Add correct path for spine in *BSD systems
 -feature#4820: Make it possible to only import certain components when importing packages
 -feature#4825: Add update_device.php script to cli folder
 -feature#4827: installer could have links to docs.cacti.net
 -feature#4832: Show PHP INI locations during install
 -feature#4833: Detect PHP INI values that are different in the INI vs running config
+
 
 1.2.21
 -issue#4531: Correct duplicate keys within database

--- a/install/functions.php
+++ b/install/functions.php
@@ -706,6 +706,17 @@ function install_file_paths() {
 			'win32' => 'c:/spine/bin/spine.exe'
 		));
 
+	// Workaround to support *BSD systems
+	if ($config['cacti_server_os'] == 'unix') {
+		$paths = array('/usr/local/spine/bin/spine', '/usr/local/bin/spine');
+		foreach($paths as $path) {
+			if (file_exists($path)) {
+				$input['path_spine']['default'] = $path;
+				break;
+			}
+		}
+	}
+
 	$input['path_spine_config'] = $settings['path']['path_spine_config'];
 
 	/* log file path */


### PR DESCRIPTION
Small fix for correct FreeBSD (probably for all *BSD systems) spine path