### PR TITLE
Auth settings do not always properly reflect the options selected

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@ Cacti CHANGELOG
 -issue#4866: Using ${var} in strings is deprecated, use {$var} instead in file
 -issue#4867: In Graph Management, filtering for "Device: None" shows all graphs
 -issue#4871: Realtime popup window experiences issues on some browsers
+-issue#4873: Correct Settings-->Authentication fields visible status
 -feature#4820: Make it possible to only import certain components when importing packages
 -feature#4825: Add update_device.php script to cli folder
 -feature#4827: Move all Help pages to docs.cacti.net if the page is reachable

--- a/settings.php
+++ b/settings.php
@@ -963,9 +963,10 @@ default:
 	function initAuth() {
 		switch($('#auth_method').val()) {
 		case '0': // None
-			$('#row_path_basic_mapfile').hide();
-			$('#row_special_users_header').hide();
+			$('#row_auth_method').show();
 			$('#row_auth_cache_enabled').hide();
+			$('#row_special_users_header').hide();
+			$('#row_admin_user').hide();
 			$('#row_guest_user').hide();
 			$('#row_user_template').hide();
 			$('#row_ldap_general_header').hide();
@@ -1012,9 +1013,10 @@ default:
 			$('#row_ldap_tls_certificate').hide();
 			break;
 		case '1': // Builtin
-			$('#row_path_basic_mapfile').hide();
-			$('#row_special_users_header').show();
+			$('#row_auth_method').show();
 			$('#row_auth_cache_enabled').show();
+			$('#row_special_users_header').show();
+			$('#row_admin_user').show();
 			$('#row_guest_user').show();
 			$('#row_user_template').show();
 			$('#row_ldap_general_header').hide();
@@ -1062,9 +1064,10 @@ default:
 			$('#row_ldap_debug').hide();
 			break;
 		case '2': // Web Basic
-			$('#row_path_basic_mapfile').show();
-			$('#row_special_users_header').show();
+			$('#row_auth_method').show();
 			$('#row_auth_cache_enabled').hide();
+			$('#row_special_users_header').show();
+			$('#row_admin_user').show();
 			$('#row_guest_user').show();
 			$('#row_user_template').show();
 			$('#row_ldap_general_header').hide();
@@ -1112,15 +1115,16 @@ default:
 			$('#row_ldap_debug').hide();
 			break;
 		case '4': // Multiple Domains
-			$('#row_path_basic_mapfile').hide();
-			$('#row_special_users_header').show();
+			$('#row_auth_method').show();
 			$('#row_auth_cache_enabled').show();
+			$('#row_special_users_header').show();
+			$('#row_admin_user').show();
 			$('#row_guest_user').show();
 			$('#row_user_template').hide();
-			$('#row_ldap_general_header').hide();
-			$('#row_ldap_server').hide();
-			$('#row_ldap_port').hide();
-			$('#row_ldap_port_ssl').hide();
+			$('#row_ldap_general_header').show();
+			$('#row_ldap_server').show();
+			$('#row_ldap_port').show();
+			$('#row_ldap_port_ssl').show();
 			$('#row_ldap_version').hide();
 			$('#row_ldap_encryption').hide();
 			$('#row_ldap_referrals').hide();
@@ -1162,8 +1166,10 @@ default:
 			$('#row_ldap_debug').show();
 			break;
 		case '3': // Single Domain
-			$('#row_special_users_header').show();
+			$('#row_auth_method').show();
 			$('#row_auth_cache_enabled').show();
+			$('#row_special_users_header').show();
+			$('#row_admin_user').show();
 			$('#row_guest_user').show();
 			$('#row_user_template').show();
 			$('#row_ldap_general_header').show();
@@ -1213,8 +1219,10 @@ default:
 			initGroupMember();
 			break;
 		default:
-			$('#row_special_users_header').show();
+			$('#row_auth_method').show();
 			$('#row_auth_cache_enabled').show();
+			$('#row_special_users_header').show();
+			$('#row_admin_user').show();
 			$('#row_guest_user').show();
 			$('#row_user_template').show();
 			$('#row_ldap_general_header').hide();


### PR DESCRIPTION
Current incorrect behavior below:
1.  Collapse all section,  reload page,  `Authentication Method` field is hide
2.  Remove duplicate codeline about `row_path_basic_mapfile`
3.  Collapse "Special Users" section,  switch `Authentication Method` and click  `General` header,  "Primary Admin" is hide
4.  Select `Multiple LDAP/AD Domains`,  "LDAP General Settings" header is hide. User domain editor initial with `ldap_server`, `ldap_port`, and `ldap_port_ssl`, but they are hide
