### PR TITLE
fix SQL where condition - auth.php

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -2663,7 +2663,7 @@ function get_allowed_devices($sql_where = '', $sql_order = 'description', $sql_l
 	if ($sql_where != '') {
 		$sql_where = "WHERE ((h.id > 0 AND h.deleted = '') OR h.id IS NULL) AND $sql_where";
 	} else {
-		$sql_where = "WHERE ((h.id > 0 AND h.deleted = '') OR h.id IS NULL) AND";
+		$sql_where = "WHERE ((h.id > 0 AND h.deleted = '') OR h.id IS NULL) ";
 	}
 
 	if ($host_id > 0) {
@@ -2840,7 +2840,7 @@ function get_allowed_site_devices($site_id, $sql_where = '', $sql_order = 'descr
 	if ($sql_where != '') {
 		$sql_where = "WHERE ((h.id > 0 AND h.deleted = '') OR h.id IS NULL) AND $sql_where";
 	} else {
-		$sql_where = "WHERE ((h.id > 0 AND h.deleted = '') OR h.id IS NULL) AND";
+		$sql_where = "WHERE ((h.id > 0 AND h.deleted = '') OR h.id IS NULL) ";
 	}
 
 	if ($site_id > 0) {


### PR DESCRIPTION
Last few changes in auth.php in where condition cause SQL ERROR:
WHERE ((h.id > 0 AND h.deleted = '') OR h.id IS NULL**) AND ) A**S rs1 ) AS rs2 ON rs2.id=h1.id
when call get_allowed_devices('', 'null', -1, $x, $user_id);