### PR TITLE
tests: * inside quotes is not shell expanded

### DIFF
--- a/tests/tools/check_all_pages.sh
+++ b/tests/tools/check_all_pages.sh
@@ -224,7 +224,7 @@ save_log_files() {
 			cp -f "$logFile1" "${logBase}/wget_error.log"
 		fi
 
-		chmod a+r "${logBase}/*.log"
+		chmod a+r -R "${logBase}/"
 
 		if [ $DEBUG -eq 1 ];then
 			echo "DEBUG: Dumping ${CACTI_LOG}"


### PR DESCRIPTION
Without this commit I get:
chmod: cannot access '/tmp/check-all-pages/test.<number>/*.log': No such file or directory