### PR TITLE
When passed a null value, number_format_i18n() can return a invalid number

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#5127: Importing Local_Linux_Machine.xml.gz template raises PHP error
 -issue#5134: Display of "Memory Limit" on Boost Status page shows -1 and not "Unlimited"
 -issue#5135: Error in using RRDcleaner an RRDcheck causing SQL errors
+-issue#5136: Function number_format_i18n should return a valid number '0' for NULL input
 -issue#5137: When attempting to update structured paths, SQL errors occur
 
 1.2.23

--- a/include/global_languages.php
+++ b/include/global_languages.php
@@ -788,7 +788,7 @@ function number_format_i18n($number, $decimals = null, $baseu = 1024) {
 	}
 
 	if ($number == null) {
-		$number = '';
+		$number = 0;
 	} elseif ($decimals == -1 || $decimals == null) {
 		$number = number_format($number, 0, $locale['decimal_point'], $locale['thousands_sep']);
 	} elseif ($number>=pow($baseu, 4)) {


### PR DESCRIPTION
Fixed: functiom number_format_i18n should return a valid number '0' for NULL input