### PR TITLE
graphs_new: page links to none-existing 'center' page due to input mismatch

### DIFF
--- a/graphs_new.php
+++ b/graphs_new.php
@@ -529,7 +529,7 @@ function graphs() {
 	$script = "<script type='text/javascript'>\nvar created_graphs = new Array();\n";
 
 	if (get_request_var('graph_type') < 0) {
-		html_start_box(__('New Graph Template'), '', '100%', '', '3', 'center', '');
+		html_start_box(__('New Graph Template'), '100%', '', '3', 'center', '');
 
 		$available_graph_templates = db_fetch_assoc_prepared('SELECT gt.id, gt.name
 			FROM graph_templates AS gt


### PR DESCRIPTION
Somehow the number of input arguments to `html_start_box got` wrong on one invocation (copy-paste mistake most likely). Running the recursive crawler on the cacti site fails due to this. (I had to reinstate my old crawler script because somehow the `tests/tools/check_all_pages.sh` doesn't really recurse anymore.)