### PR TITLE
function read_config_option returns null sometimes

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -675,7 +675,7 @@ function cache_common_config_settings():array {
  *                                    specified $settings array in
  *                                    'include/global_settings.php'
  *
- * @return string|false               The current value of the configuration option
+ * @return string|false|null          The current value of the configuration option
  */
 function read_config_option(string $config_name, bool $force = false):string|false|null {
 	global $config, $database_hostname, $database_default, $database_port, $database_sessions;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -677,7 +677,7 @@ function cache_common_config_settings():array {
  *
  * @return string|false               The current value of the configuration option
  */
-function read_config_option(string $config_name, bool $force = false):string|false|false {
+function read_config_option(string $config_name, bool $force = false):string|false|null {
 	global $config, $database_hostname, $database_default, $database_port, $database_sessions;
 
 	$loaded = false;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -677,7 +677,7 @@ function cache_common_config_settings():array {
  *
  * @return string|false               The current value of the configuration option
  */
-function read_config_option(string $config_name, bool $force = false):string|false {
+function read_config_option(string $config_name, bool $force = false):string|false|false {
 	global $config, $database_hostname, $database_default, $database_port, $database_sessions;
 
 	$loaded = false;


### PR DESCRIPTION
last develop code causes the problem that you can't even log in:
Fatal error: Uncaught TypeError: read_config_option(): Return value must be of type string|false, null returned in /usr/local/share/cacti_develop/lib/functions.php:741 Stack trace: #0 /usr/local/share/cacti_develop/lib/functions.php(1379): read_config_option('selective_debug') #1 /usr/local/share/cacti_develop/lib/functions.php(1432): get_selective_log_level() #2 /usr/local/share/cacti_develop/lib/functions.php(6909): cacti_log('Source: [168547...', false, 'DEBUG') #3 /usr/local/share/cacti_develop/include/global.php(247): format_cacti_version('1.3.0.-1', 0) #4 /usr/local/share/cacti_develop/include/auth.php(27): require_once('/usr/local/shar...') #5 /usr/local/share/cacti_develop/index.php(25): include('/usr/local/shar...') #6 {main} thrown in /usr/local/share/cacti_develop/lib/functions.php on line 741