### PR TITLE
When parsing a date value, there could be more than 30 chars

### DIFF
--- a/cli/splice_rrd.php
+++ b/cli/splice_rrd.php
@@ -850,7 +850,7 @@ function preProcessXML(&$output) {
 					$row = strpos($line, '<row>');
 
 					if ($row > 0) {
-						$date = trim(substr($line,$comment_start+30,11));
+						$date = trim(substr($line,strpos($line,'/')+1,11));
 					}
 
 					if ($comment_start == 0) {


### PR DESCRIPTION
!-- 2022-03-27 01:00:00 CET / 1648339200 --> <row><v>4.7640000000e+01</v></row>
!-- 2022-03-28 02:00:00 CEST / 1648425600 --> <row>