### PR TITLE
Fixed: Create a new function cacti_unserialize for PHP 5.4 and 7.0+

### DIFF
--- a/data_debug.php
+++ b/data_debug.php
@@ -582,7 +582,7 @@ function debug_wizard() {
 	if (cacti_sizeof($checks)) {
 		foreach ($checks as $check) {
 			if (isset($check['info']) && $check['info'] != '') {
-				$info = unserialize($check['info'], array('allowed_classes' => false));
+				$info = cacti_unserialize($check['info']);
 			} else {
 				$info = '';
 			}
@@ -672,7 +672,7 @@ function debug_view() {
 	$check_exists = cacti_sizeof($check);
 
 	if (isset($check) && is_array($check)) {
-		$check['info'] = unserialize($check['info'], array('allowed_classes' => false));
+		$check['info'] = cacti_unserialize($check['info']);
 	}
 
 	$dtd = db_fetch_row_prepared('SELECT *

--- a/graphs_new.php
+++ b/graphs_new.php
@@ -193,11 +193,7 @@ function host_reload_query() {
    ------------------- */
 
 function host_new_graphs_save($host_id) {
-	if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
-		$selected_graphs_array = unserialize(stripslashes(get_nfilter_request_var('selected_graphs_array')), array('allowed_classes' => false));
-	} else {
-		$selected_graphs_array = unserialize(stripslashes(get_nfilter_request_var('selected_graphs_array')));
-	}
+	$selected_graphs_array = cacti_unserialize(stripslashes(get_nfilter_request_var('selected_graphs_array')));
 
 	$values = array();
 	$form_data = array();

--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -1649,7 +1649,7 @@ function rewrite_snmp_enum_value($field_name, $value = null, $map = null) {
 
 		$map = $newmap;
 	} else {
-		$map = unserialize($map, array('allowed_classes' => false));
+		$map = cacti_unserialize($map);
 	}
 
 	if ($map === false || !is_array($map)) {

--- a/lib/dsdebug.php
+++ b/lib/dsdebug.php
@@ -119,7 +119,7 @@ function dsdebug_poller_output(&$rrd_update_array) {
 				foreach($rrd_update_array as $item) {
 					if ($c['datasource'] == $item['local_data_id']) {
 						if (isset($item['times'][key($item['times'])])) {
-							$c['info'] = unserialize($c['info'], array('allowed_classes' => false));
+							$c['info'] = cacti_unserialize($c['info']);
 							$c['info']['last_result'] = $item['times'][key($item['times'])];
 							$c['info'] = serialize($c['info']);
 							db_execute_prepared('UPDATE data_debug SET `info` = ? WHERE `id` = ?', array($c['info'], $c['id']));
@@ -157,7 +157,7 @@ function dsdebug_poller_bottom() {
 
 		foreach ($checks as $c) {
 			$c['issue'] = array();
-			$info = unserialize($c['info'], array('allowed_classes' => false));
+			$info = cacti_unserialize($c['info']);
 
 			$dtd = db_fetch_row_prepared('SELECT *
 				FROM data_template_data
@@ -334,7 +334,7 @@ function dsdebug_run_repair($id) {
 		array($id));
 
 	if (cacti_sizeof($check)) {
-		$check['info'] = unserialize($check['info'], array('allowed_classes' => false));
+		$check['info'] = cacti_unserialize($check['info']);
 
 		if (isset($check['info']['rrd_match_array']['tune'])) {
 			$path = get_data_source_path($id, true);

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -7322,3 +7322,11 @@ function debounce_run_notification($id, $frequency = 7200) {
 
 	return false;
 }
+
+function cacti_unserialize($strobj) {
+	if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+		return unserialize($strobj, array('allowed_classes' => false));
+	} else {
+		return unserialize($strobj);
+	}
+}

--- a/managers.php
+++ b/managers.php
@@ -913,11 +913,7 @@ function form_actions() {
 
 	if (isset_request_var('selected_items')) {
 		if (isset_request_var('action_receivers')) {
-			if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
-				$selected_items = unserialize(stripslashes(get_nfilter_request_var('selected_graphs_array')), array('allowed_classes' => false));
-			} else {
-				$selected_items = unserialize(stripslashes(get_nfilter_request_var('selected_graphs_array')));
-			}
+			$selected_items = cacti_unserialize(stripslashes(get_nfilter_request_var('selected_graphs_array')));
 
 			if ($selected_items != false) {
 				if (get_nfilter_request_var('drp_action') == '1') { // delete
@@ -938,7 +934,7 @@ function form_actions() {
 			get_filter_request_var('id');
 			/* ==================================================== */
 
-			$selected_items = unserialize(stripslashes(get_nfilter_request_var('selected_items')), array('allowed_classes' => false));
+			$selected_items = cacti_unserialize(stripslashes(get_nfilter_request_var('selected_items')));
 
 			if ($selected_items !== false) {
 				if (get_nfilter_request_var('drp_action') == '1') { // disable


### PR DESCRIPTION
Create a new function cacti_unserialize to cover all function unserialize() usage cross PHP 5.4 and 7.0+