### PR TITLE
Fixed: ensure “Distinguished Name” is searchable and equal to value of specified group member attribute

### DIFF
--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -1759,7 +1759,7 @@ $settings = array(
 		),
 		'ldap_dn' => array(
 			'friendly_name' => __('Distinguished Name (DN)'),
-			'description' => __('Distinguished Name syntax, such as for windows: <i>"&lt;username&gt;@win2kdomain.local"</i> or for OpenLDAP: <i>"uid=&lt;username&gt;,ou=people,dc=domain,dc=local"</i>.   "&lt;username&gt" is replaced with the username that was supplied at the login prompt.  This is only used when in "No Searching" mode.'),
+			'description' => __('The "Distinguished Name" syntax, applicable for both OpenLDAP and Windows AD configurations, offers flexibility in defining user identity. For OpenLDAP, the format follows this structure: <i>"uid=&lt;username&gt;,ou=people,dc=domain,dc=local"</i>. Windows AD provides an alternative syntax: <i>"&lt;username&gt;@win2kdomain.local"</i>, commonly known as "userPrincipalName (UPN)". In this context, "&lt;username&gt;" represents the specific username provided during the login prompt. This is particularly pertinent when operating in "No Searching" mode, or "Require Group Membership" enabled.'),
 			'method' => 'textbox',
 			'max_length' => '255',
 			'size' => '100'
@@ -1783,7 +1783,7 @@ $settings = array(
 		),
 		'ldap_group_attrib' => array(
 			'friendly_name' => __('Group Member Attribute'),
-			'description' => __('Name of the attribute that contains the usernames of the members.'),
+			'description' => __('This refers to the specific attribute within the LDAP directory that holds the usernames of group members. It is crucial to ensure that the attribute value aligns with the configuration specified in the "Distinguished Name" or that the actual attribute value is searchable using the settings outlined in the "Distinguished Name".'),
 			'method' => 'textbox',
 			'max_length' => '255',
 			'size' => '100'

--- a/lib/ldap.php
+++ b/lib/ldap.php
@@ -661,7 +661,7 @@ class Ldap {
 					 * And the patch against latest PHP release:
 					 * http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/databases/php-ldap/files/ldap-ctrl-exop.patch
 					*/
-					$true_dn_result = ldap_search($ldap_conn, $this->search_base, 'userPrincipalName=' . $this->dn, array('dn'));
+					$true_dn_result = ldap_search($ldap_conn, $this->search_base, '(|(uid=' . $this->dn . ')(cn=' . $this->dn . ')(userPrincipalName=' . $this->dn . '))', array('dn'));
 					$first_entry    = ldap_first_entry($ldap_conn, $true_dn_result);
 
 					/* we will test in two ways */

--- a/user_domains.php
+++ b/user_domains.php
@@ -420,7 +420,7 @@ function domain_edit() {
 			),
 		'dn' => array(
 			'friendly_name' => __('Distinguished Name (DN)'),
-			'description' => __('Distinguished Name syntax, such as for windows: <i>"&lt;username&gt;@win2kdomain.local"</i> or for OpenLDAP: <i>"uid=&lt;username&gt;,ou=people,dc=domain,dc=local"</i>.   "&lt;username&gt" is replaced with the username that was supplied at the login prompt.  This is only used when in "No Searching" mode.'),
+			'description' => __('The "Distinguished Name" syntax, applicable for both OpenLDAP and Windows AD configurations, offers flexibility in defining user identity. For OpenLDAP, the format follows this structure: <i>"uid=&lt;username&gt;,ou=people,dc=domain,dc=local"</i>. Windows AD provides an alternative syntax: <i>"&lt;username&gt;@win2kdomain.local"</i>, commonly known as "userPrincipalName (UPN)". In this context, "&lt;username&gt;" represents the specific username provided during the login prompt. This is particularly pertinent when operating in "No Searching" mode, or "Require Group Membership" enabled.'),
 			'method' => 'textbox',
 			'value' => '|arg1:dn|',
 			'max_length' => '255',
@@ -445,7 +445,7 @@ function domain_edit() {
 			),
 		'group_attrib' => array(
 			'friendly_name' => __('Group Member Attribute'),
-			'description' => __('Name of the attribute that contains the usernames of the members.'),
+			'description' => __('This refers to the specific attribute within the LDAP directory that holds the usernames of group members. It is crucial to ensure that the attribute value aligns with the configuration specified in the "Distinguished Name" or that the actual attribute value is searchable using the settings outlined in the "Distinguished Name".'),
 			'method' => 'textbox',
 			'value' => '|arg1:group_attrib|',
 			'max_length' => '255'


### PR DESCRIPTION
1. original "Distinguished Name" desc said：  format is "username@win2kdomain.local“ for Windows AD.
2. In some Windows AD env,  group member show as:   `member: CN=userA,OU=Users,OU=ou1,OU=ou2,DC=dc1,DC=dc2,DC=com`. 
3. ldap_compare fail for `member` attribute and `email` format user->dn
4. Also ldap_search return empty because filter include `userPrincipalName=` only

So I changed `Distinguished Name` and `Group Member Attribute` desc to reminder Cacti Admin.
And extend `ldap_search` filter to support any of  `accountname, username, userPrincipalName`.

Note:
  Non-actual testing because lack of test env,  need more reviewer attention.

BTW, desc sentence init by me, and reviewed by ChatGPT 😄 