### PR TITLE
Improvements for Poller Last Run Date

### DIFF
--- a/cli/poller_reindex_hosts.php
+++ b/cli/poller_reindex_hosts.php
@@ -204,7 +204,7 @@ if (cacti_sizeof($data_queries)) {
 		$i++;
 	}
 
-	set_config_option('reindex_last_run_time', date('Y-m-d G:i:s', time()));
+	set_config_option('reindex_last_run_time', time());
 	unregister_process('reindex', 'master');
 
 }

--- a/cli/poller_reindex_hosts.php
+++ b/cli/poller_reindex_hosts.php
@@ -204,6 +204,7 @@ if (cacti_sizeof($data_queries)) {
 		$i++;
 	}
 
+	set_config_option('reindex_last_run_time', date('Y-m-d G:i:s', time()));
 	unregister_process('reindex', 'master');
 
 }

--- a/poller_maintenance.php
+++ b/poller_maintenance.php
@@ -279,7 +279,7 @@ function rrdfile_purge($force) {
 
 		/* record the start time */
 		$poller_end = microtime(true);
-		set_config_option('rrdcleaner_last_run_time', date('Y-m-d G:i:s', time()));
+		set_config_option('rrdcleaner_last_run_time', time());
 		$string = sprintf('RRDMAINT STATS: Time:%4.4f Purged:%s Archived:%s', ($poller_end - $poller_start), $purged, $archived);
 		cacti_log($string, true, 'SYSTEM');
 	}

--- a/poller_maintenance.php
+++ b/poller_maintenance.php
@@ -279,6 +279,7 @@ function rrdfile_purge($force) {
 
 		/* record the start time */
 		$poller_end = microtime(true);
+		set_config_option('rrdcleaner_last_run_time', date('Y-m-d G:i:s', time()));
 		$string = sprintf('RRDMAINT STATS: Time:%4.4f Purged:%s Archived:%s', ($poller_end - $poller_start), $purged, $archived);
 		cacti_log($string, true, 'SYSTEM');
 	}

--- a/poller_rrdcheck.php
+++ b/poller_rrdcheck.php
@@ -167,6 +167,8 @@ switch ($type) {
 
 rrdcheck_debug('Polling Ending');
 
+set_config_option('rrdchecker_last_run_time', date('Y-m-d G:i:s', time()));
+
 if (!$forcerun) {
 	unregister_process('rrdcheck', $type, $thread_id);
 }

--- a/poller_rrdcheck.php
+++ b/poller_rrdcheck.php
@@ -167,7 +167,7 @@ switch ($type) {
 
 rrdcheck_debug('Polling Ending');
 
-set_config_option('rrdchecker_last_run_time', date('Y-m-d G:i:s', time()));
+set_config_option('rrdchecker_last_run_time', time());
 
 if (!$forcerun) {
 	unregister_process('rrdcheck', $type, $thread_id);
@@ -204,12 +204,11 @@ function rrdcheck_master_handler($forcerun) {
 		// determine if it's time to determine hourly averages
 		if (empty($last_run)) {
 			// since the poller has never run before, let's fake it out
-			set_config_option('rrdcheck_last_run_time', date('Y-m-d G:i:s', $current_time));
+			set_config_option('rrdcheck_last_run_time', date($current_time));
 		}
 
 		// if it's time to check, do so now
 		if ((!empty($last_run) && ((strtotime($last_run) + ($run_interval * 60)) < $current_time)) || $forcerun) {
-			set_config_option('rrdcheck_last_run_time', date('Y-m-d G:i:s', $current_time));
 
 			rrdcheck_launch_children($type);
 


### PR DESCRIPTION
I don't know if 1.2.x is already frozen before release. I'd like to store information about the last run time of reindex, ... I want to use this in intropage -  notify if services have not been running for a long time.

If it's too late, I'll want to add it at least to 1.3