### PR TITLE
Support for PDO::MYSQL_ATTR_SSL_CAPATH  and PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT

### DIFF
--- a/cacti.sql
+++ b/cacti.sql
@@ -2260,6 +2260,8 @@ CREATE TABLE `poller` (
   `dbsslkey` varchar(255) default NULL,
   `dbsslcert` varchar(255) default NULL,
   `dbsslca` varchar(255) default NULL,
+  `dbsslcapath` varchar(255) default NULL,
+  `dbsslverifyservercert` char(3) default 'on',
   `total_time` double default '0',
   `max_time` double default NULL,
   `min_time` double default NULL,

--- a/docs/audit_schema.sql
+++ b/docs/audit_schema.sql
@@ -713,6 +713,8 @@ INSERT INTO `table_columns` VALUES ('poller',14,'dbssl','char(3)','YES','','',''
 INSERT INTO `table_columns` VALUES ('poller',15,'dbsslkey','varchar(255)','YES','',NULL,'');
 INSERT INTO `table_columns` VALUES ('poller',16,'dbsslcert','varchar(255)','YES','',NULL,'');
 INSERT INTO `table_columns` VALUES ('poller',17,'dbsslca','varchar(255)','YES','',NULL,'');
+INSERT INTO `table_columns` VALUES ('poller',17,'dbsslcapath','varchar(255)','YES','',NULL,'');
+INSERT INTO `table_columns` VALUES ('poller',14,'dbsslverifyservercert','char(3)','YES','','on','');
 INSERT INTO `table_columns` VALUES ('poller',18,'total_time','double','YES','','0','');
 INSERT INTO `table_columns` VALUES ('poller',19,'max_time','double','YES','',NULL,'');
 INSERT INTO `table_columns` VALUES ('poller',20,'min_time','double','YES','',NULL,'');

--- a/include/config.php.dist
+++ b/include/config.php.dist
@@ -26,18 +26,20 @@
  * Make sure these values reflect your actual database/host/user/password
  */
 
-$database_type     = 'mysql';
-$database_default  = 'cacti';
-$database_hostname = 'localhost';
-$database_username = 'cactiuser';
-$database_password = 'cactiuser';
-$database_port     = '3306';
-$database_retries  = 5;
-$database_ssl      = false;
-$database_ssl_key  = '';
-$database_ssl_cert = '';
-$database_ssl_ca   = '';
-$database_persist  = false;
+$database_type        = 'mysql';
+$database_default     = 'cacti';
+$database_hostname    = 'localhost';
+$database_username    = 'cactiuser';
+$database_password    = 'cactiuser';
+$database_port        = '3306';
+$database_retries     = 5;
+$database_ssl         = false;
+$database_ssl_key     = '';
+$database_ssl_cert    = '';
+$database_ssl_ca      = '';
+$database_ssl_capath  = '';
+$database_ssl_verify_server_cert = true;
+$database_persist     = false;
 
 /*
  * When the cacti server is a remote poller, then these entries point to
@@ -45,18 +47,19 @@ $database_persist  = false;
  * must remain commented out.
  */
 
-#$rdatabase_type     = 'mysql';
-#$rdatabase_default  = 'cacti';
-#$rdatabase_hostname = 'localhost';
-#$rdatabase_username = 'cactiuser';
-#$rdatabase_password = 'cactiuser';
-#$rdatabase_port     = '3306';
-#$rdatabase_retries  = 5;
-#$rdatabase_ssl      = false;
-#$rdatabase_ssl_key  = '';
-#$rdatabase_ssl_cert = '';
-#$rdatabase_ssl_ca   = '';
-
+#$rdatabase_type       = 'mysql';
+#$rdatabase_default    = 'cacti';
+#$rdatabase_hostname   = 'localhost';
+#$rdatabase_username   = 'cactiuser';
+#$rdatabase_password   = 'cactiuser';
+#$rdatabase_port       = '3306';
+#$rdatabase_retries    = 5;
+#$rdatabase_ssl        = false;
+#$rdatabase_ssl_key    = '';
+#$rdatabase_ssl_cert   = '';
+#$rdatabase_ssl_ca     = '';
+#$rdatabase_ssl_capath = '';
+#$rdatabase_ssl_verify_server_cert = true;
 /*
  * The poller_id of this system.  set to `1` for the main cacti web server.
  * Otherwise, you this value should be the poller_id for the remote poller.

--- a/include/global.php
+++ b/include/global.php
@@ -88,11 +88,13 @@ $database_password = 'cactiuser';
 $database_port     = '3306';
 $database_retries  = 2;
 
-$database_ssl      = false;
-$database_ssl_key  = '';
-$database_ssl_cert = '';
-$database_ssl_ca   = '';
-$database_persist  = true;
+$database_ssl        = false;
+$database_ssl_key    = '';
+$database_ssl_cert   = '';
+$database_ssl_ca     = '';
+$database_ssl_capath = '';
+$database_ssl_verify_server_cert = true;
+$database_persist    = true;
 
 /* Default session name - Session name must contain alpha characters */
 $cacti_session_name = 'Cacti';
@@ -131,17 +133,19 @@ if (isset($poller_id)) {
 }
 
 $db_var_defaults = array(
-	'database_type'     => 'mysql',
-	'database_default'  => null,
-	'database_hostname' => null,
-	'database_username' => null,
-	'database_password' => null,
-	'database_port'     => '3306',
-	'database_retries'  => 2,
-	'database_ssl'      => false,
-	'database_ssl_key'  => '',
-	'database_ssl_cert' => '',
-	'database_ssl_ca'   => '',
+	'database_type'       => 'mysql',
+	'database_default'    => null,
+	'database_hostname'   => null,
+	'database_username'   => null,
+	'database_password'   => null,
+	'database_port'       => '3306',
+	'database_retries'    => 2,
+	'database_ssl'        => false,
+	'database_ssl_key'    => '',
+	'database_ssl_cert'   => '',
+	'database_ssl_ca'     => '',
+        'database_ssl_capath' => '',
+        'database_ssl_verify_server_cert' => true,
 );
 
 $db_var_prefixes = array('');
@@ -279,26 +283,34 @@ $lu = $config['is_web'] ? '</ul>' : '';
 $il = $config['is_web'] ? '</li>' : '';
 
 if ($config['poller_id'] > 1 || isset($rdatabase_hostname)) {
-	$local_db_cnn_id = db_connect_real($database_hostname, $database_username, $database_password, $database_default, $database_type, $database_port, $database_retries, $database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca);
+	$local_db_cnn_id = db_connect_real($database_hostname, $database_username, $database_password, $database_default, $database_type, $database_port, $database_retries, $database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca, $database_ssl_capath, $database_ssl_verify_server_cert);
 
 	if (!isset($rdatabase_retries)) {
 		$rdatabase_retries  = 2;
 	}
 
 	if (!isset($rdatabase_ssl)) {
-		$rdatabase_ssl      = false;
+		$rdatabase_ssl        = false;
 	}
 
 	if (!isset($rdatabase_ssl_key)) {
-		$rdatabase_ssl_key  = false;
+		$rdatabase_ssl_key    = false;
 	}
 
 	if (!isset($rdatabase_ssl_cert)) {
-		$rdatabase_ssl_cert = false;
+		$rdatabase_ssl_cert   = false;
 	}
 
 	if (!isset($rdatabase_ssl_ca)) {
-		$rdatabase_ssl_ca   = false;
+		$rdatabase_ssl_ca     = false;
+	}
+
+        if (!isset($rdatabase_ssl_capath)) {
+		$rdatabase_ssl_capath = false;
+	}
+
+        if (!isset($rdatabase_ssl_verify_server_cert)) {
+		$rdatabase_ssl_verify_server_cert = true;
 	}
 
 	// Check for recovery
@@ -319,22 +331,24 @@ if ($config['poller_id'] > 1 || isset($rdatabase_hostname)) {
 	 * a remote poller, let's attempt to get back online.
 	 */
 	if ($conn_mode != 'offline') {
-		$remote_db_cnn_id = db_connect_real($rdatabase_hostname, $rdatabase_username, $rdatabase_password, $rdatabase_default, $rdatabase_type, $rdatabase_port, $database_retries, $rdatabase_ssl, $rdatabase_ssl_key, $rdatabase_ssl_cert, $rdatabase_ssl_ca);
+		$remote_db_cnn_id = db_connect_real($rdatabase_hostname, $rdatabase_username, $rdatabase_password, $rdatabase_default, $rdatabase_type, $rdatabase_port, $database_retries, $rdatabase_ssl, $rdatabase_ssl_key, $rdatabase_ssl_cert, $rdatabase_ssl_ca, $rdatabase_ssl_capath, $rdatabase_ssl_verify_server_cert);
 	}
 
 	if ($config['is_web'] && is_object($remote_db_cnn_id) &&
 		$config['connection']       != 'recovery' &&
 		$config['cacti_db_version'] != 'new_install') {
 		// Connection worked, so now override the default settings so that it will always utilize the remote connection
-		$database_default   = $rdatabase_default;
-		$database_hostname  = $rdatabase_hostname;
-		$database_username  = $rdatabase_username;
-		$database_password  = $rdatabase_password;
-		$database_port      = $rdatabase_port;
-		$database_ssl       = $rdatabase_ssl;
-		$database_ssl_key   = $rdatabase_ssl_key;
-		$database_ssl_cert  = $rdatabase_ssl_cert;
-		$database_ssl_ca    = $rdatabase_ssl_ca;
+		$database_default    = $rdatabase_default;
+		$database_hostname   = $rdatabase_hostname;
+		$database_username   = $rdatabase_username;
+		$database_password   = $rdatabase_password;
+		$database_port       = $rdatabase_port;
+		$database_ssl        = $rdatabase_ssl;
+		$database_ssl_key    = $rdatabase_ssl_key;
+		$database_ssl_cert   = $rdatabase_ssl_cert;
+		$database_ssl_ca     = $rdatabase_ssl_ca;
+		$database_ssl_capath = $rdatabase_ssl_capath;
+		$database_ssl_verify_server_cert = $rdatabase_verify_server_cert;
 	} elseif (is_object($remote_db_cnn_id)) {
 		if ($config['connection'] != 'recovery') {
 			$config['connection'] = 'online';
@@ -344,22 +358,30 @@ if ($config['poller_id'] > 1 || isset($rdatabase_hostname)) {
 	}
 } else {
 	if (!isset($database_ssl)) {
-		$database_ssl      = false;
+		$database_ssl        = false;
 	}
 
 	if (!isset($database_ssl_key)) {
-		$database_ssl_key  = false;
+		$database_ssl_key    = false;
 	}
 
 	if (!isset($database_ssl_cert)) {
-		$database_ssl_cert = false;
+		$database_ssl_cert   = false;
 	}
 
 	if (!isset($database_ssl_ca)) {
-		$database_ssl_ca   = false;
+		$database_ssl_ca     = false;
 	}
 
-	if (!db_connect_real($database_hostname, $database_username, $database_password, $database_default, $database_type, $database_port, $database_retries, $database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca)) {
+        if (!isset($database_ssl_capath)) {
+		$database_ssl_capath = false;
+	}
+
+        if (!isset($database_ssl_verify_server_cert)) {
+		$database_ssl_verify_server_cert = false;
+	}
+
+	if (!db_connect_real($database_hostname, $database_username, $database_password, $database_default, $database_type, $database_port, $database_retries, $database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca, $database_ssl_capath, $database_ssl_verify_server_cert)) {
 		print $ps . 'FATAL: Connection to Cacti database failed. Please ensure: ' . $ul;
 		print $li . 'the PHP MySQL module is installed and enabled.' . $il;
 		print $li . 'the database is running.' . $il;

--- a/install/functions.php
+++ b/install/functions.php
@@ -92,22 +92,30 @@ function install_unlink($file) {
 }
 
 function install_test_local_database_connection() {
-	global $database_type, $database_hostname, $database_username, $database_password, $database_default, $database_type, $database_port, $database_retries, $database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca;
+	global $database_type, $database_hostname, $database_username, $database_password, $database_default, $database_type, $database_port, $database_retries, $database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca, $database_ssl_capath, $database_ssl_verify_server_cert;
 
 	if (!isset($database_ssl)) {
-		$database_ssl      = false;
+		$database_ssl        = false;
 	}
 
 	if (!isset($database_ssl_key)) {
-		$database_ssl_key  = false;
+		$database_ssl_key    = false;
 	}
 
 	if (!isset($database_ssl_cert)) {
-		$database_ssl_cert = false;
+		$database_ssl_cert   = false;
 	}
 
 	if (!isset($database_ssl_ca)) {
-		$database_ssl_ca   = false;
+		$database_ssl_ca     = false;
+	}
+
+	if (!isset($database_ssl_capath)) {
+		$database_ssl_capath = false;
+	}
+
+	if (!isset($database_ssl_verify_server_cert)) {
+		$database_ssl_verify_server_cert = false;
 	}
 
 	$connection = db_connect_real(
@@ -121,7 +129,9 @@ function install_test_local_database_connection() {
 		$database_ssl,
 		$database_ssl_key,
 		$database_ssl_cert,
-		$database_ssl_ca
+		$database_ssl_ca,
+                $database_ssl_capath,
+                $database_ssl_verify_server_cert
 	);
 
 	if (is_object($connection)) {
@@ -134,24 +144,32 @@ function install_test_local_database_connection() {
 }
 
 function install_test_remote_database_connection() {
-	global $rdatabase_type, $rdatabase_hostname, $rdatabase_username, $rdatabase_password, $rdatabase_default, $rdatabase_type, $rdatabase_port, $rdatabase_retries, $rdatabase_ssl, $rdatabase_ssl_key, $rdatabase_ssl_cert, $rdatabase_ssl_ca;
+	global $rdatabase_type, $rdatabase_hostname, $rdatabase_username, $rdatabase_password, $rdatabase_default, $rdatabase_type, $rdatabase_port, $rdatabase_retries, $rdatabase_ssl, $rdatabase_ssl_key, $rdatabase_ssl_cert, $rdatabase_ssl_ca, $rdatabase_ssl_capath, $rdatabase_ssl_verify_server_cert;
 
 	if (!isset($rdatabase_ssl)) {
-		$rdatabase_ssl      = false;
+		$rdatabase_ssl        = false;
 	}
 
 	if (!isset($rdatabase_ssl_key)) {
-		$rdatabase_ssl_key  = false;
+		$rdatabase_ssl_key    = false;
 	}
 
 	if (!isset($rdatabase_ssl_cert)) {
-		$rdatabase_ssl_cert = false;
+		$rdatabase_ssl_cert   = false;
 	}
 
 	if (!isset($rdatabase_ssl_ca)) {
-		$rdatabase_ssl_ca   = false;
+		$rdatabase_ssl_ca     = false;
 	}
 
+	if (!isset($rdatabase_ssl_capath)) {
+		$rdatabase_ssl_capath = false;
+	}
+
+	if (!isset($rdatabase_ssl_verify_server_cert)) {
+		$rdatabase_ssl_verify_server_cert = false;
+	}
+        
 	$connection = db_connect_real(
 		$rdatabase_hostname,
 		$rdatabase_username,
@@ -163,7 +181,9 @@ function install_test_remote_database_connection() {
 		$rdatabase_ssl,
 		$rdatabase_ssl_key,
 		$rdatabase_ssl_cert,
-		$rdatabase_ssl_ca
+		$rdatabase_ssl_ca,
+		$rdatabase_ssl_capath,
+		$rdatabase_ssl_verify_server_path                
 	);
 
 	if (is_object($connection)) {
@@ -907,11 +927,12 @@ function install_file_paths() {
 function remote_update_config_file() {
 	global $config, $rdatabase_type, $rdatabase_hostname, $rdatabase_username,
 	$rdatabase_password, $rdatabase_default, $rdatabase_type, $rdatabase_port, $rdatabase_retries,
-	$rdatabase_ssl, $rdatabase_ssl_key, $rdatabase_ssl_cert, $rdatabase_ssl_ca;
+	$rdatabase_ssl, $rdatabase_ssl_key, $rdatabase_ssl_cert, $rdatabase_ssl_ca, $rdatabase_ssl_capath, $rdatabase_verify_server_cert;
 
 	global $database_type, $database_hostname, $database_username,
 	$database_password, $database_default, $database_type, $database_port, $database_retries,
-	$database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca;
+	$database_ssl, $database_ssl_key, $database_ssl_cert, $database_ssl_ca,
+	$database_ssl_capath, $database_verify_server_cert;
 
 	$failure     = '';
 	$newfile     = array();
@@ -928,7 +949,9 @@ function remote_update_config_file() {
 		$rdatabase_ssl,
 		$rdatabase_ssl_key,
 		$rdatabase_ssl_cert,
-		$rdatabase_ssl_ca
+		$rdatabase_ssl_ca,
+                $rdatabase_ssl_capath,
+                $rdatabase_ssl_verify_server_cert
 	);
 
 	if (is_object($connection)) {
@@ -945,18 +968,20 @@ function remote_update_config_file() {
 			array($hostname), true, $connection);
 
 		if (empty($poller_id)) {
-			$save['name']      = __('New Poller');
-			$save['hostname']  = $hostname;
-			$save['dbdefault'] = $database_default;
-			$save['dbhost']    = $database_hostname;
-			$save['dbuser']    = $database_username;
-			$save['dbpass']    = $database_password;
-			$save['dbport']    = $database_port;
-			$save['dbretries'] = $database_retries;
-			$save['dbssl']     = $database_ssl ? 'on' : '';
-			$save['dbsslkey']  = $database_ssl_key;
-			$save['dbsslcert'] = $database_ssl_cert;
-			$save['dbsslca']   = $database_ssl_ca;
+			$save['name']        = __('New Poller');
+			$save['hostname']    = $hostname;
+			$save['dbdefault']   = $database_default;
+			$save['dbhost']      = $database_hostname;
+			$save['dbuser']      = $database_username;
+			$save['dbpass']      = $database_password;
+			$save['dbport']      = $database_port;
+			$save['dbretries']   = $database_retries;
+			$save['dbssl']       = $database_ssl ? 'on' : '';
+			$save['dbsslkey']    = $database_ssl_key;
+			$save['dbsslcert']   = $database_ssl_cert;
+			$save['dbsslca']     = $database_ssl_ca;
+			$save['dbsslcapath'] = $database_ssl_ca_path;
+			$save['dbsslverifyservercert'] = $database_ssl_verify_server_cert ? 'on' : '';
 
 			$poller_id = sql_save($save, 'poller', 'id', true, $connection);
 		}

--- a/install/upgrades/1_2_0.php
+++ b/install/upgrades/1_2_0.php
@@ -39,7 +39,8 @@ function upgrade_to_1_2_0() {
 	db_install_add_column('poller', array('name' => 'dbsslkey', 'type' => 'varchar(255)', 'after' => 'dbssl'));
 	db_install_add_column('poller', array('name' => 'dbsslcert', 'type' => 'varchar(255)', 'after' => 'dbssl'));
 	db_install_add_column('poller', array('name' => 'dbsslca', 'type' => 'varchar(255)', 'after' => 'dbssl'));
-
+	db_install_add_column('poller', array('name' => 'dbsslcapath', 'type' => 'varchar(255)', 'after' => 'dbssl'));
+	db_install_add_column('poller', array('name' => 'dbsslverifyservercert', 'type' => 'char(3)', 'after' => 'dbssl', 'default' => 'on'));
 	if (!$poller_exists) {
 		// Take the value from the settings table and translate to
 		// the new Data Collector table settings

--- a/lib/database.php
+++ b/lib/database.php
@@ -48,12 +48,14 @@
  * @param mixed $db_ssl_key
  * @param mixed $db_ssl_cert
  * @param mixed $db_ssl_ca
+ * @param mixed $db_ssl_capath
+ * @param mixed $db_ssl_verify_server_cert
  * @param mixed $persist
  *
  * @returns (bool|object) connection object on success, false for error
  */
 function db_connect_real($device, $user, $pass, $db_name, $db_type = 'mysql', $port = '3306', $retries = 20,
-	$db_ssl = false, $db_ssl_key = '', $db_ssl_cert = '', $db_ssl_ca = '', $persist = false) {
+	$db_ssl = false, $db_ssl_key = '', $db_ssl_cert = '', $db_ssl_ca = '', $db_ssl_capath = '', $db_ssl_verify_server_cert = true, $persist = false) {
 	global $database_sessions, $database_details, $database_total_queries, $database_persist, $config;
 
 	$database_total_queries = 0;
@@ -99,7 +101,15 @@ function db_connect_real($device, $user, $pass, $db_name, $db_type = 'mysql', $p
 				if (file_exists($db_ssl_ca)) {
 					$flags[PDO::MYSQL_ATTR_SSL_CA] = $db_ssl_ca;
 				}
-			}
+			} else if ($db_ssl_capath != '') {
+                            if (is_dir($db_ssl_capath)) {
+                                $flags[PDO::MYSQL_ATTR_SSL_CAPATH] = $db_ssl_capath;
+                            }
+                        }
+
+                        if ($db_ssl_verify_server_cert) {
+                            $flags[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = $db_ssl_verify_server_cert;
+                        }
 
 			if ($db_ssl_key != '' && $db_ssl_cert != '') {
 				if (file_exists($db_ssl_key) && file_exists($db_ssl_cert)) {
@@ -150,6 +160,8 @@ function db_connect_real($device, $user, $pass, $db_name, $db_type = 'mysql', $p
 				'database_ssl_key'  => $db_ssl_key,
 				'database_ssl_cert' => $db_ssl_cert,
 				'database_ssl_ca'   => $db_ssl_ca,
+				'database_ssl_capath'   => $db_ssl_capath,
+				'database_ssl_verify_server_cert'   => $db_verify_server_cert,
 				'database_persist'  => $persist,
 			);
 
@@ -259,22 +271,26 @@ function db_check_reconnect(object|false $db_conn = false, $log = true) {
 		global $database_ssl_key;
 		global $database_ssl_cert;
 		global $database_ssl_ca;
+                global $database_ssl_capath;
+                global $database_ssl_verify_server_cert;
 	}
 
 	if (cacti_sizeof($database_details) && $db_conn !== false) {
 		foreach ($database_details as $det) {
 			if (spl_object_hash($det['database_conn']) == spl_object_hash($db_conn)) {
-				$database_hostname = $det['database_hostname'];
-				$database_username = $det['database_username'];
-				$database_password = $det['database_password'];
-				$database_default  = $det['database_default'];
-				$database_type     = $det['database_type'];
-				$database_port     = $det['database_port'];
-				$database_retries  = $det['database_retries'];
-				$database_ssl      = $det['database_ssl'];
-				$database_ssl_key  = $det['database_ssl_key'];
-				$database_ssl_cert = $det['database_ssl_cert'];
-				$database_ssl_ca   = $det['database_ssl_ca'];
+				$database_hostname   = $det['database_hostname'];
+				$database_username   = $det['database_username'];
+				$database_password   = $det['database_password'];
+				$database_default    = $det['database_default'];
+				$database_type       = $det['database_type'];
+				$database_port       = $det['database_port'];
+				$database_retries    = $det['database_retries'];
+				$database_ssl        = $det['database_ssl'];
+				$database_ssl_key    = $det['database_ssl_key'];
+				$database_ssl_cert   = $det['database_ssl_cert'];
+				$database_ssl_ca     = $det['database_ssl_ca'];
+				$database_ssl_capath = $det['database_ssl_capath'];
+				$database_ssl_verify_server_cert = $det['database_ssl_verify_server_cert'];
 
 				break;
 			}
@@ -294,6 +310,14 @@ function db_check_reconnect(object|false $db_conn = false, $log = true) {
 
 		if (!isset($database_ssl_ca)) {
 			$database_ssl_ca   = '';
+		}
+
+                if (!isset($database_ssl_capath)) {
+			$database_ssl_capath   = '';
+		}
+
+                if (!isset($database_ssl_verify_server_cert)) {
+			$database_ssl_verify_server_cert   = false;
 		}
 
 		if (!isset($database_retries)) {
@@ -330,7 +354,9 @@ function db_check_reconnect(object|false $db_conn = false, $log = true) {
 			$database_ssl,
 			$database_ssl_key,
 			$database_ssl_cert,
-			$database_ssl_ca
+			$database_ssl_ca,
+                        $database_ssl_capath,
+                        $database_ssl_verify_server_cert
 		);
 	}
 }

--- a/lib/database.php
+++ b/lib/database.php
@@ -161,7 +161,7 @@ function db_connect_real($device, $user, $pass, $db_name, $db_type = 'mysql', $p
 				'database_ssl_cert' => $db_ssl_cert,
 				'database_ssl_ca'   => $db_ssl_ca,
 				'database_ssl_capath'   => $db_ssl_capath,
-				'database_ssl_verify_server_cert'   => $db_verify_server_cert,
+				'database_ssl_verify_server_cert'   => $db_ssl_verify_server_cert,
 				'database_persist'  => $persist,
 			);
 

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -1507,7 +1507,9 @@ function poller_connect_to_remote($poller_id) {
 			$cinfo['dbssl'],
 			$cinfo['dbsslkey'],
 			$cinfo['dbsslcert'],
-			$cinfo['dbsslca']);
+			$cinfo['dbsslca'],
+			$cinfo['dbsslcapath'],
+			$cinfo['dbsslverifyservercert']);
 
 		if (!is_object($rcnn_id)) {
 			cacti_log('ERROR: Unable to connect to Remote Data Collector ' . $cinfo['name'], false, 'REPLICATE');

--- a/pollers.php
+++ b/pollers.php
@@ -223,6 +223,22 @@ $fields_poller_edit = array(
 		'default'       => $database_ssl_ca,
 		'max_length'    => '255'
 	),
+ 	'dbsslcapath' => array(
+		'method'        => 'textbox',
+		'friendly_name' => __('Remote Database SSL Authorities directory'),
+		'description'   => __('The file path to the directory that contains the trusted SSL Certificate Authority certificates. This is an optional parameter that can used instead of giving the path to an individual Certificate Authority file. This parameter can be required by the database provider if they have started SSL using the --ssl-mode=VERIFY_CA option.'),
+		'value'         => '|arg1:dbsslcapath|',
+		'size'          => '50',
+		'default'       => $database_ssl_capath,
+		'max_length'    => '255'
+	),
+	'dbsslverifyservercert' => array(
+		'method'        => 'checkbox',
+		'friendly_name' => __('Remote Database SSL'),
+		'description'   => __("Provides a way to disable verification of the server's SSL certificate Common Name against the server's hostname when connecting. This verification is enabled by default."),
+		'value'         => '|arg1:dbsslverifyservercert|',
+		'default'       => $database_ssl_verify_server_cert ? 'on' : ''
+	),        
 	'id' => array(
 		'method' => 'hidden',
 		'value'  => '|arg1:id|',
@@ -315,6 +331,8 @@ function form_save() {
 			$save['dbsslkey']      = form_input_validate(get_nfilter_request_var('dbsslkey'),  'dbsslkey',  '', true, 3);
 			$save['dbsslcert']     = form_input_validate(get_nfilter_request_var('dbsslcert'), 'dbsslcert', '', true, 3);
 			$save['dbsslca']       = form_input_validate(get_nfilter_request_var('dbsslca'),   'dbsslca',   '', true, 3);
+			$save['dbsslcapath']   = form_input_validate(get_nfilter_request_var('dbsslcapath'), 'dbsslcapath',   '', true, 3);
+			$save['dbsslverifyservercert'] = isset_request_var('dbsslverifyservercert') ? 'on' : '';
 		}
 
 		// Check for duplicate hostname
@@ -703,6 +721,8 @@ function poller_edit() {
 			unset($fields_poller_edit['dbsslkey']);
 			unset($fields_poller_edit['dbsslcert']);
 			unset($fields_poller_edit['dbsslca']);
+			unset($fields_poller_edit['dbsslcapath']);
+			unset($fields_poller_edit['dbsslverifyservercert']);
 
 			$fields_poller_edit['log_level']['method'] = 'hidden';
 		}
@@ -766,6 +786,7 @@ function poller_edit() {
 
 				function ping_database() {
 					dbssl = $('#dbssl').is(':checked') ? 'on' : '';
+					dbsslverifyservercert = $('#dbsslverifyservercert').is(':checked') ? 'on' : '';
 
 					var options = {
 						url: 'pollers.php',
@@ -785,7 +806,9 @@ function poller_edit() {
 						dbssl: dbssl,
 						dbsslkey: $('#dbsslkey').val(),
 						dbsslcert: $('#dbsslcert').val(),
-						dbsslca: $('#dbsslca').val()
+						dbsslca: $('#dbsslca').val(),
+						dbsslcapath: $('#dbsslcapath').val(),
+						dbsslverifyservercert: dbsslverifyservercert
 					};
 
 					postUrl(options, data);
@@ -844,7 +867,9 @@ function test_database_connection($poller = array()) {
 			'dbssl',
 			'dbsslkey',
 			'dbsslcert',
-			'dbsslca'
+			'dbsslca',
+			'dbsslcapath',
+			'dbsslverifyservercert'
 		);
 
 		foreach ($fields as $field) {
@@ -853,6 +878,12 @@ function test_database_connection($poller = array()) {
 					$poller['dbssl'] = 'on';
 				} else {
 					$poller['dbssl'] = '';
+				}
+			elseif ($field == 'dbsslverifyservercert') {
+				if (isset_request_var('dbsslverifyservercert') && get_nfilter_request_var('dbsslverifyservercert') == 'on') {
+					$poller['dbsslverifyservercert'] = 'on';
+				} else {
+					$poller['dbsslverifyservercert'] = '';
 				}
 			} elseif (isset_request_var($field)) {
 				$poller[$field] = get_nfilter_request_var($field);
@@ -875,7 +906,9 @@ function test_database_connection($poller = array()) {
 		$poller['dbssl'],
 		$poller['dbsslkey'],
 		$poller['dbsslcert'],
-		$poller['dbsslca']
+		$poller['dbsslca'],
+		$poller['dbsslcapath'],
+		$poller['dbsslverifyservercert']
 	);
 
 	if (is_object($connection)) {

--- a/pollers.php
+++ b/pollers.php
@@ -879,7 +879,7 @@ function test_database_connection($poller = array()) {
 				} else {
 					$poller['dbssl'] = '';
 				}
-			elseif ($field == 'dbsslverifyservercert') {
+			} elseif ($field == 'dbsslverifyservercert') {
 				if (isset_request_var('dbsslverifyservercert') && get_nfilter_request_var('dbsslverifyservercert') == 'on') {
 					$poller['dbsslverifyservercert'] = 'on';
 				} else {


### PR DESCRIPTION
Hi.

Cacti was missing these two attributes that are available with PHP PDO [1]:

 **PDO::MYSQL_ATTR_SSL_CAPATH (int)**

The file path to the directory that contains the trusted SSL CA certificates, which are stored in PEM format.

=> This has the advantage that you just need to drop your CA cert to a known place (like /etc/ssl/certs) and point the config file to it. It's sometimes more practical than having to point directly to a certificate. 

**PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT (int)** 

Provides a way to disable verification of the server SSL certificate. 

 PDO has this attribute enabled by default (at least according to the doc). It allows to verify that a cert's CN corresponds to the hostname. If for any reason (like when you use self-signed certs, don't have a wildcard cert, ...) this is hampering you, you can disable this check by setting this attribute to false. 

I had patched a local install of cacti to support these attributes and it works well, without any issue.

For preparing my contribution. I used as a template the work you had already done for supporting the other PDO MYSQL SSL attributes. Unfortunately, I was only able to do a summary check by installing cacti and weeding out some typos. 

I think that the changes for supporting SSL_CAPATH are correct.

I'd ask you take a look at the changes for SSL_VERIFY_SERVER_CERT as it looked a bit more tricky. By default it is enabled and you should be able to disable it. I was expecting to have a UI checkbox in the configuration UI. However said UI is not proposing me any mysql or supported  PDO SSL options, even if the code in pollers.php seems to point out this could be possible.

I don't know how cacti is supposed to update the poller table when you do changes in config.php.

[1] https://www.php.net/manual/en/ref.pdo-mysql.php