### PR TITLE
Fixed parameter parsing in change_device.php

### DIFF
--- a/cli/change_device.php
+++ b/cli/change_device.php
@@ -54,7 +54,7 @@ $quietMode            = false;
 $overrides = array();
 foreach($parms as $parameter) {
 	if (strpos($parameter, '=')) {
-		list($arg, $value) = explode('=', $parameter);
+		list($arg, $value) = explode('=', $parameter, 2);
 	} else {
 		$arg = $parameter;
 		$value = '';


### PR DESCRIPTION
explode parses each parameter into more than just 2 parts, if the string contains more than one "=" character.

Can be fixed by limiting explode to output just two elements, then it automatically stops at the first "=" sign and keeps the rest of the string behind it untouched.