### PR TITLE
When obtaining graph records, error messages may be recorded

### DIFF
--- a/host.php
+++ b/host.php
@@ -1479,7 +1479,7 @@ function get_device_records(&$total_rows, $rows) {
 	$sql_order = get_order_string();
 	$sql_limit = 'LIMIT ' . ($rows*(get_request_var('page')-1)) . ',' . $rows;
 
-	$sql_query = "SELECT host.*, graphs, data_sources,
+	$sql_query = "SELECT host.*, gl.graphs, dl.data_sources,
 		CAST(IF(availability_method = 0, '0',
 			IF(status_event_count > 0 AND status IN (1, 2), status_event_count*$poller_interval,
 			IF(UNIX_TIMESTAMP(status_rec_date) < 943916400 AND status IN (0, 3), total_polls*$poller_interval,


### PR DESCRIPTION

  2023-11-12 21:34:13 - CMDPHP SQL Backtrace: (/host.php[176]:host(), /host.php[1797]:get_device_records(), /host.php[1498]:db_fetch_assoc(), /lib/database.php[684]:db_fetch_assoc_prepared(), /lib/database.php[704]:db_execute_prepared())
2023-11-12 21:34:13 - CMDPHP ERROR: A DB Row Failed!, Error: Column 'graphs' in field list is ambiguous 