### PR TITLE
When storage units is blank, return correct response

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ Cacti CHANGELOG
 -issue#5602: Missing "break" for case statement in cli/add_device.php
 -issue#5609: XML Bug when parsing Data Query XML Resource File when no field direction attribute is specified
 -issue#5612: Function db_check_reconnect() does not properly return a value 
+-issue#5613: ss_host_disk_php doesn't return data in all possible cases
 -feature#5577: Provide new templates for ArubaOS switch, Aruba wifi controller and HPE iLO to be available during install 
 -feature#5597: Provide new templates for Arubai OSCX 6x00 switch to be available during install 
 

--- a/scripts/ss_host_disk.php
+++ b/scripts/ss_host_disk.php
@@ -146,6 +146,8 @@ function ss_host_disk($hostname = '', $host_id = 0, $snmp_auth = '', $cmd = 'ind
 					return (abs($snmp_data) + 2147483647) * $sau;
 				} elseif (is_numeric($snmp_data) && is_numeric($sau)) {
 					return $snmp_data * $sau;
+				} elseif (is_numeric($snmp_data) && !$sau) {
+					return $snmp_data;
 				} else {
 					return 'U';
 				}


### PR DESCRIPTION
I have few windows servers which stopped or never start working in cacti. It is disk utilization issue.
php ss_host_disk.php 'server_name' '961' '2:11165:1500:3:35:kaktus::::::' index            
1
2
3
4
5

php ss_host_disk.php 'server_name' '961' '2:11165:1500:3:35:kaktus::::::' query used
1!4231188
2!0
3!193027394
4!27669
5!36638

php ss_host_disk.php 'server_name' '961' '2:11165:1500:3:35:kaktus::::::' query total
1!15547647
2!0
3!536866303
4!76784
5!65520

Get specific value is problem:
php ss_host_disk.php 'server_name' '961' '2:11165:1500:3:35:kaktus::::::' get total 4
U
php ss_host_disk.php 'server_name' '961' '2:11165:1500:3:35:kaktus::::::' get used 1
U


Problem is here:
var_dump($sau) = string(0) ""
var_dump($snmp_data) = string(8) "20881406"

So these few lines returns 'U'

if ($snmp_data != '' && $snmp_data < 0) {
	return (abs($snmp_data) + 2147483647) * $sau;
} elseif (is_numeric($snmp_data) && is_numeric($sau)) {
	return $snmp_data * $sau;
} else {
	return 'U';
}