### PR TITLE
Fix INNODB Unset message on MariaDB

### DIFF
--- a/lib/utility.php
+++ b/lib/utility.php
@@ -1001,7 +1001,7 @@ function utilities_get_mysql_recommendations() {
 	} else {
 		if (version_compare($link_ver, '5.2', '>=')) {
 			if (!isset($variables['innodb_version']) &&
-				($database == 'MySQL' || ($database == 'MariaDB' && version_compare($link_ver, '11.0', '<')))) {
+				($database == 'MySQL' || ($database == 'MariaDB' && version_compare($link_ver, '10.10', '<')))) {
 
 				$recommendations += array(
 					'innodb' => array(


### PR DESCRIPTION
Similar to https://github.com/Cacti/cacti/issues/5030 The original scripts checks if MariaDB is 11 to not check if INNODB variable doesn't exists, but it was removed on 10.10 and not on 11 (as can be seen in https://github.com/Cacti/cacti/issues/5030 and https://serverfault.com/questions/1128160/removing-innodb-parameter-not-on-error-when-installing-%D0%A1a%D1%81ti). This fixes an issue that fixes the UNSET message on Cacti 1.1.25 on Windows All-in-One Beta installer.