### PR TITLE
cmd poller - add availability test for devices without poller items

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@ Cacti CHANGELOG
 -issue#5609: When parsing a Data Query resource, an error can be reported if no direction is specified
 -issue#5612: Database reconnection can cause errors to be reported incorrectly
 -issue#5613: fix returned value if $sau is empty
+-issue#5641: Cmd poller - add availability test for devices without poller items 
 -feature#5577: Add Aruba switch, Aruba controller and HPE iLO templates
 -feature#5597: Add OSCX 6x00 templates
 

--- a/cmd.php
+++ b/cmd.php
@@ -520,21 +520,17 @@ $hosts = db_fetch_assoc_prepared("SELECT h.id, h.hostname, h.ping_port, h.ping_m
 	);
 
 if (cacti_sizeof($hosts) > 0) {
-
 	cacti_log('NOTE: Found ' . cacti_sizeof($hosts) . ' device(s) for up/down testing only', true, 'POLLER', $medium);
 
 	foreach ($hosts as $host) {
-
 		$ping = new Net_Ping;
 		$ping->host = $host['id'];
 		$ping->port = $host['ping_port'];
 
 		// perform the appropriate ping check of the host
 		if ($ping->ping($host['availability_method'], $host['ping_method'], $host['ping_timeout'], $host['ping_retries'])) {
-
 			update_host_status(HOST_UP, $host['id'], $ping, $host['availability_method'], $print_data_to_stdout);
 			cacti_log("Device[" . $host['id'] ."] STATUS: Device '" . $host['hostname'] . "' is UP.", $print_data_to_stdout, 'POLLER', debug_level($host['id'], POLLER_VERBOSITY_MEDIUM));
-
 		} else {
 			update_host_status(HOST_DOWN, $host['id'], $ping, $host['availability_method'], $print_data_to_stdout);
 			cacti_log("Device[" . $host['id'] . "] STATUS: Device '" . $host['hostname'] . "' is Down.", $print_data_to_stdout, 'POLLER', debug_level($host['id'], POLLER_VERBOSITY_MEDIUM));

--- a/cmd.php
+++ b/cmd.php
@@ -511,16 +511,15 @@ if ($allhost) {
 
 $hosts = db_fetch_assoc_prepared("SELECT h.id, h.hostname, h.ping_port, h.ping_method, h.ping_retries, h.ping_timeout, h.availability_method
 	FROM host AS h
-	LEFT OUTER JOIN poller_item AS pi
+	LEFT JOIN poller_item AS pi
 	ON h.id=pi.host_id
 	WHERE pi.host_id IS NULL
 	AND (h.disabled = '' OR h.disabled IS NULL)
 	$sql_where",
-	$params
-	);
+	$params);
 
-if (cacti_sizeof($hosts) > 0) {
-	cacti_log('NOTE: Found ' . cacti_sizeof($hosts) . ' device(s) for up/down testing only', true, 'POLLER', $medium);
+if (cacti_sizeof($hosts)) {
+	cacti_log('NOTE: Found ' . cacti_sizeof($hosts) . ' Device(s) for up/down validation only', true, 'POLLER', $medium);
 
 	foreach ($hosts as $host) {
 		$ping = new Net_Ping;

--- a/cmd.php
+++ b/cmd.php
@@ -500,6 +500,48 @@ if (cacti_sizeof($poller_items) && read_config_option('poller_enabled') == 'on')
 	cacti_log('NOTE: There are no items in your poller for this polling cycle!', true, 'POLLER', $medium);
 }
 
+// Try to check device status only for devices without poller items
+if ($allhost) {
+	$sql_where = 'AND h.poller_id = ?';
+	$params    = array($poller_id);
+} else {
+	$sql_where = 'AND h.poller_id = ? AND h.id >= ? AND h.id <= ? ';
+	$params    = array($poller_id, $first, $last);
+}
+
+$hosts = db_fetch_assoc_prepared("SELECT h.id, h.hostname, h.ping_port, h.ping_method, h.ping_retries, h.ping_timeout, h.availability_method
+	FROM host AS h
+	LEFT OUTER JOIN poller_item AS pi
+	ON h.id=pi.host_id
+	WHERE pi.host_id IS NULL
+	AND (h.disabled = '' OR h.disabled IS NULL)
+	$sql_where",
+	$params
+	);
+
+if (cacti_sizeof($hosts) > 0) {
+
+	cacti_log('NOTE: Found ' . cacti_sizeof($hosts) . ' device(s) for up/down testing only', true, 'POLLER', $medium);
+
+	foreach ($hosts as $host) {
+
+		$ping = new Net_Ping;
+		$ping->host = $host['id'];
+		$ping->port = $host['ping_port'];
+
+		// perform the appropriate ping check of the host
+		if ($ping->ping($host['availability_method'], $host['ping_method'], $host['ping_timeout'], $host['ping_retries'])) {
+
+			update_host_status(HOST_UP, $host['id'], $ping, $host['availability_method'], $print_data_to_stdout);
+			cacti_log("Device[" . $host['id'] ."] STATUS: Device '" . $host['hostname'] . "' is UP.", $print_data_to_stdout, 'POLLER', debug_level($host['id'], POLLER_VERBOSITY_MEDIUM));
+
+		} else {
+			update_host_status(HOST_DOWN, $host['id'], $ping, $host['availability_method'], $print_data_to_stdout);
+			cacti_log("Device[" . $host['id'] . "] STATUS: Device '" . $host['hostname'] . "' is Down.", $print_data_to_stdout, 'POLLER', debug_level($host['id'], POLLER_VERBOSITY_MEDIUM));
+		}
+	}
+}
+
 // record the process as having completed
 record_cmdphp_done();
 


### PR DESCRIPTION
with cmd poller devices without items in poller table aren't tested for up/down state. It is different behavior compared to spine.

From our perspective it is wrong. We have devices when we need to know only status. It causes confusion when user switch between cmd and spine.