### PR TITLE
Hide disabled issue in get_allowed_devices

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -2737,7 +2737,7 @@ function get_allowed_devices($sql_where = '', $sql_order = 'description', $sql_l
 		$sql_order = "ORDER BY $sql_order";
 	}
 
-	if (read_user_setting('hide_disabled') == 'on') {
+	if (read_user_setting('hide_disabled', false, false, $user_id) == 'on') {
 		$sql_where .= ($sql_where != '' ? ' AND ':'') . '(h.disabled = "" OR h.disabled IS NULL)';
 	}
 


### PR DESCRIPTION
function read_user_setting($config_name, $default = false, $force = false, $user = 0)
This function contains condition for user_id:
if ($user == 0 && isset($_SESSION['sess_user_id'])) {

Current code causes issue in intropage (maybe more). Few things are called from poller without SESSION['sess_user_id']
So get_allowed_issues never returns disabled devices in list.
