### PR TITLE
add td->title for text overflow

### DIFF
--- a/graphs_new.php
+++ b/graphs_new.php
@@ -896,7 +896,7 @@ function graphs() {
 									if ($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') {
 										if (in_array($field_name, $fields)) {
 											if (isset($row[$field_name])) {
-												print "<td><span class='textOverflow' id='text$query_row" . '_' . $column_counter . "'>" . filter_value($row[$field_name], get_request_var('filter')) . '</span></td>';
+												print "<td title='" . html_escape($row[$field_name]) . "'><span class='textOverflow' id='text$query_row" . '_' . $column_counter . "'>" . filter_value($row[$field_name], get_request_var('filter')) . '</span></td>';
 											} else {
 												print "<td><span class='textOverflow' id='text$query_row" . '_' . $column_counter . "'></span></td>";
 											}


### PR DESCRIPTION
Use CSS text-overflow ellipsis could be problematic on tables. It needs fixed layout or (max-)width specified. I don't know why it isn't work in graphs_new.php. So returning back TD parameter title.  

It was removed in 1.2.20:
https://github.com/Cacti/cacti/commit/3e08169be6d78e12ece1803c5168d00c9e46e315

It is very usefull for longer texts. 