### PR TITLE
Fix cli scripts

### DIFF
--- a/cli/add_device.php
+++ b/cli/add_device.php
@@ -50,7 +50,7 @@ if (cacti_sizeof($parms)) {
 	$ip            = '';
 	$poller_id     = $config['poller_id'];
 	$site_id       = read_config_option('default_site');
-	$template_id   = read_config_option('default_template');
+	$template_id   = (int) read_config_option('default_template');
 	$community     = read_config_option('snmp_community');
 	$snmp_ver      = read_config_option('snmp_version');
 	$disable       = 0;

--- a/cli/change_device.php
+++ b/cli/change_device.php
@@ -82,7 +82,7 @@ foreach($parms as $parameter) {
 			break;
 
 		case '--template':
-			$overrides['template_id'] = $value;
+			$overrides['host_template_id'] = $value;
 			break;
 
 		case '--community':

--- a/cli/change_device.php
+++ b/cli/change_device.php
@@ -301,6 +301,11 @@ if (!cacti_sizeof($host)) {
 /* merge overriden parameters onto host */
 $host    = array_merge($host, $overrides);
 
+/* exception for IP */
+if (isset($overrides['ip'])) {
+	$host['hostname'] = $overrides['ip'];
+}
+
 /* process the various lists into validation arrays */
 $host_templates = getHostTemplates();
 $hosts          = getHostsByDescription();
@@ -367,7 +372,7 @@ if (!$quietMode) {
 	print "Changing device-id: $device_id to {$host['description']} ({$host['hostname']}) as \"{$host_templates[$host['host_template_id']]}\" using SNMP v{$host['snmp_version']} with community \"{$host['snmp_community']}\"\n";
 }
 
-$host_id = api_device_save($device_id, $host['host_template_id'], $host['description'], $host['ip'],
+$host_id = api_device_save($device_id, $host['host_template_id'], $host['description'], $host['hostname'],
 	$host['snmp_community'], $host['snmp_version'], $host['snmp_username'], $host['snmp_password'],
 	$host['snmp_port'], $host['snmp_timeout'], $host['disabled'], $host['availability_method'], $host['ping_method'],
 	$host['ping_port'], $host['ping_timeout'], $host['ping_retries'], $host['notes'],


### PR DESCRIPTION
Script change_device.php has error:
PHP Warning:  Undefined array key "ip" in /usr/local/share/cacti_develop/cli/change_device.php on line 370
In scripts is used variable $ip instead of $hostname. I don't want to change it. So only small fix.


Script add_device.php - PHP 8 issue. Without define --template=X is $template_id defaulted  from settings and it could be string(0) ""
It is incorrect compare here:
if (!isset($host_templates[$template_id])) {
}
ERROR: Unknown template id ()

array(2) {
  [0]=>
  string(4) "None"
  [1]=>
  string(19) "Generic SNMP Device"
