### PR TITLE
fix #5743 use of perl regexp vs sql like

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ Cacti CHANGELOG
 -issue#5731: Saving a Tree can cause the tree to become unpublished
 -issue#5732: Web Basic Authentication does not record user logins
 -issue#5733: When using Accent-based languages, translations may not work properly
+-issue#5743: Fix automation expressions for device rules
 -issue#5748: Improve PHP 8.1 Support during fresh install with boost
 -feature#5692: Add a device "enabled/disabled" indicator next to the graphs
 -feature#5710: Notify the admin periodically when a remote data collector goes into heartbeat status

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -3086,20 +3086,18 @@ function automation_add_tree($host_id, $tree) {
 function automation_find_os($sysDescr, $sysObject, $sysName) {
 	$sql_where  = '';
 
-	$qsysObject = trim(db_qstr($sysObject), "'");
-	$qsysDescr  = trim(db_qstr($sysDescr), "'");
-	$qsysName   = trim(db_qstr($sysName), "'");
+	$sql_where .= "WHERE (? REGEXP sysDescr OR ? LIKE CONCAT('%', sysDescr, '%'))";
+	$sql_where .= " AND (? REGEXP sysOid OR ? LIKE CONCAT('%', sysOid, '%'))";
+	$sql_where .= " AND (? REGEXP sysName OR ? LIKE CONCAT('%', sysName, '%'))";
 
-	$sql_where .= trim($sysDescr)  != '' ? 'WHERE (sysDescr REGEXP "(' . preg_quote($qsysDescr) . ')" OR ' . db_qstr($sysDescr) . ' LIKE CONCAT("%", sysDescr, "%"))':'';
-	$sql_where .= trim($sysObject) != '' ? ($sql_where != '' ? ' AND':'WHERE') . ' (sysOID REGEXP "(' . preg_quote($qsysObject) . ')" OR ' . db_qstr($sysObject) . ' LIKE CONCAT("%", sysOid, "%"))':'';
-	$sql_where .= trim($sysName)   != '' ? ($sql_where != '' ? ' AND':'WHERE') . ' (sysName REGEXP "(' . preg_quote($qsysName) . ')" OR ' . db_qstr($sysName) . ' LIKE CONCAT("%", sysName, "%"))':'';
+	$params = array($sysDescr, $sysDescr, $sysObject, $sysObject, $sysName, $sysName);
 
-	$result = db_fetch_row("SELECT at.*,ht.name
+	$result = db_fetch_row_prepared("SELECT at.*,ht.name
 		FROM automation_templates AS at
 		INNER JOIN host_template AS ht
 		ON ht.id=at.host_template
 		$sql_where
-		ORDER BY sequence LIMIT 1");
+		ORDER BY sequence LIMIT 1", $params);
 
 	if (cacti_sizeof($result)) {
 		return $result;


### PR DESCRIPTION
Fixes order of REGEXP parameters and avoids devices with empty sysDescr, sysName or sysOid to match device rules with set, non-empty matches.