### PR TITLE
GHSA-grj5-8fcj-34gh/CVE-2024-29894 follow-up fix

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1053,7 +1053,7 @@ function raise_message_javascript($title, $header, $message) {
 	var mixedReasonTitle = DOMPurify.sanitize(<?php print json_encode($title, JSON_THROW_ON_ERROR);?>);
 	var mixedOnPage      = DOMPurify.sanitize(<?php print json_encode($header, JSON_THROW_ON_ERROR);?>);
 	sessionMessage   = {
-		message: DOMPurify.sanitize('<?php print $message;?>'),
+		message: DOMPurify.sanitize(<?php print json_encode($message, JSON_THROW_ON_ERROR);?>),
 		level: MESSAGE_LEVEL_MIXED
 	};
 


### PR DESCRIPTION
Not sure how this was lost during the back&forth during the GHSA process but we missed escaping the 3rd parameter of raise_message_javascript().