### PR TITLE
Fix unused variable

### DIFF
--- a/cmd.php
+++ b/cmd.php
@@ -392,7 +392,6 @@ if (cacti_sizeof($poller_items) && read_config_option('poller_enabled') == 'on')
 
 			if (read_config_option('poller_debug') == 'on' && strlen($output) > $maxwidth) {
 				$width_dses[] = $ds;
-				$width_errors++;
 			}
 
 			if ($set_spike_kill && !substr_count($output, ':')) {


### PR DESCRIPTION
cacti_stderr.log:PHP Warning:  Undefined variable $width_errors in /var/www/html/cacti-1.2.27/cmd.php on line 395

Variable $width_errors is never user anywhere.