### PR TITLE
Add IP address to the login audit for successful logins

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 Cacti CHANGELOG
 
+-issue#5772: Login log message unification - add client IP adress 
+
 1.2.27
 -security#GHSA-37x7-mfjv-mm7m: Authentication Bypass when using using older password hashes
 -security#GHSA-7cmj-g5qc-pj88: RCE vulnerability when importing packages

--- a/auth_login.php
+++ b/auth_login.php
@@ -155,13 +155,14 @@ if (get_nfilter_request_var('action') == 'login' || $auth_method == 2) {
 
 	/* We have a valid user, do final checks, log their login attempt, and redirect as required */
 	if (!$error && cacti_sizeof($user)) {
-		if (!$guest_user) {
-			cacti_log("LOGIN: User '" . $user['username'] . "' authenticated", false, 'AUTH');
-		} else {
-			cacti_log("LOGIN: Guest User '" . $user['username'] . "' in use", false, 'AUTH');
-		}
 
 		$client_addr = get_client_addr();
+
+		if (!$guest_user) {
+			cacti_log("LOGIN: User '" . $user['username'] . "' authenticated from IP Address '" . $client_addr . "'", false, 'AUTH');
+		} else {
+			cacti_log("LOGIN: Guest User '" . $user['username'] . "' in use from IP Address '" . $client_addr . "'", false, 'AUTH');
+		}
 
 		db_execute_prepared('INSERT IGNORE INTO user_log
 			(username, user_id, result, ip, time)

--- a/include/auth.php
+++ b/include/auth.php
@@ -98,9 +98,9 @@ if ($auth_method != 0) {
 			if (cacti_sizeof($current_user)) {
 				$_SESSION['sess_user_id'] = $current_user['id'];;
 
-				cacti_log("LOGIN: User '" . $current_user['username'] . "' authenticated via Basic Authentication.", false, 'AUTH');
-
 				$client_addr = get_client_addr();
+
+				cacti_log("LOGIN: User '" . $current_user['username'] . "' authenticated via Basic Authentication from IP Address '" . $client_addr . "'", false, 'AUTH');
 
 				db_execute_prepared('INSERT IGNORE INTO user_log
 					(username, user_id, result, ip, time)


### PR DESCRIPTION
Request from the forum. I agree with that. My customers use the log analyzer and the IP address information is missing for successful logins.

If you are agree with that I will prepare the same for 1.3