### PR TITLE
fix ipv6 colon format address

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -7454,3 +7454,16 @@ function cacti_unserialize($strobj) {
 		return unserialize($strobj);
 	}
 }
+
+function cacti_format_ipv6_colon($ipv6) {
+
+	if (strpos($ipv6, '[') !== false) {
+		return $ipv6;
+	}
+
+	if (strpos($ipv6, ':') !== false) {
+		return '[' . $ipv6 . ']';
+	}
+
+	return($ipv6);
+}

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -7456,7 +7456,10 @@ function cacti_unserialize($strobj) {
 }
 
 function cacti_format_ipv6_colon($ipv6) {
-
+	if (!filter_var($ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+		return $ipv6;
+	}
+	
 	if (strpos($ipv6, '[') !== false) {
 		return $ipv6;
 	}

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -174,6 +174,8 @@ function cacti_snmp_get($hostname, $community, $oid, $version, $auth_user = '', 
 	} else {
 		$snmp_value = '';
 
+		$hostname = cacti_format_ipv6_colon($hostname);
+
 		/* net snmp want the timeout in seconds */
 		$timeout_s = (int) ceil($timeout_ms / 1000);
 
@@ -266,6 +268,7 @@ function cacti_snmp_get_raw($hostname, $community, $oid, $version, $auth_user = 
 		}
 	} else {
 		$snmp_value = '';
+		$hostname = cacti_format_ipv6_colon($hostname);
 
 		/* net snmp want the timeout in seconds */
 		$timeout_s = (int) ceil($timeout_ms / 1000);
@@ -354,6 +357,7 @@ function cacti_snmp_getnext($hostname, $community, $oid, $version, $auth_user = 
 		}
 	} else {
 		$snmp_value = '';
+		$hostname = cacti_format_ipv6_colon($hostname);
 
 		/* net snmp want the timeout in seconds */
 		$timeout_s = (int) ceil($timeout_ms / 1000);
@@ -662,6 +666,7 @@ function cacti_snmp_walk($hostname, $community, $oid, $version, $auth_user = '',
 	} else {
 		/* ucd/net snmp want the timeout in seconds */
 		$timeout_s = (int) ceil($timeout_ms / 1000);
+		$hostname = cacti_format_ipv6_colon($hostname);
 
 		if ($version == '1') {
 			$snmp_auth = '-c ' . snmp_escape_string($community); /* v1/v2 - community string */


### PR DESCRIPTION
The problem is when the hostname of the device is in the format aaaa:bbbb:...This conflicts with cacti_snmp_get/walk functions due to the additional the port number
cacti_escapeshellarg($hostname) . ':' . $port . ' ' .