### PR TITLE
fix condition (php8)

### DIFF
--- a/cli/genkey.php
+++ b/cli/genkey.php
@@ -137,7 +137,7 @@ if (cacti_sizeof($parms)) {
 	}
 }
 
-if (!$replace && !$generate) {
+if (!isset($replace) && !isset($generate)) {
 	display_help();
 	exit(0);
 }


### PR DESCRIPTION
when run without parameters generates 
Warning: Undefined variable $replace in /usr/local/share/cacti_develop/cli/genkey.php on line 140

Warning: Undefined variable $generate in /usr/local/share/cacti_develop/cli/genkey.php on line 140
