### PR TITLE
CVE-2025-24368: protect save_component_automation_tree_rule_item entry point

### DIFF
--- a/automation_tree_rules.php
+++ b/automation_tree_rules.php
@@ -133,19 +133,6 @@ function automation_tree_rules_form_save() {
 		$save['operator']  = form_input_validate((isset_request_var('operator') ? get_nfilter_request_var('operator') : ''), 'operator', '^[0-9]+$', true, 3);
 		$save['pattern']   = form_input_validate((isset_request_var('pattern') ? get_nfilter_request_var('pattern') : ''), 'pattern', '', true, 3);
 
-		/* Test for SQL injections */
-		$field_name = str_replace(array('ht.', 'h.', 'gt.'), '', $save['field']);
-
-		if (!db_column_exists('host', $field_name) && !db_column_exists('host_template', $field_name) && !db_column_exists('graph_templates', $field_name)) {
-			raise_message('sql_injection', __('An attempt was made to perform a SQL injection in Tree automation'), MESSAGE_LEVEL_ERROR);
-
-			cacti_log(sprintf('ERROR: An attempt was made to perform a SQL Injection in Tree automation from client address \'%s\'', get_client_addr()), false, 'SECURITY');
-
-			header('Location: automation_tree_rules.php?header=false&action=item_edit&id=' . get_request_var('id') . '&item_id=' . (empty($item_id) ? get_request_var('item_id') : $item_id) . '&rule_type=' . AUTOMATION_RULE_TYPE_TREE_MATCH);
-
-			exit;
-		}
-
 		if (!is_error_message()) {
 			$item_id = sql_save($save, 'automation_match_rule_items');
 
@@ -177,6 +164,19 @@ function automation_tree_rules_form_save() {
 		$save['propagate_changes'] = (isset_request_var('propagate_changes') ? 'on' : '');
 		$save['search_pattern']    = isset_request_var('search_pattern') ? form_input_validate(get_nfilter_request_var('search_pattern'), 'search_pattern', '', false, 3) : '';
 		$save['replace_pattern']   = isset_request_var('replace_pattern') ? form_input_validate(get_nfilter_request_var('replace_pattern'), 'replace_pattern', '', true, 3) : '';
+
+		/* Test for SQL injections */
+		$field_name = str_replace(array('ht.', 'h.', 'gt.'), '', $save['field']);
+
+		if (!db_column_exists('host', $field_name) && !db_column_exists('host_template', $field_name) && !db_column_exists('graph_templates', $field_name)) {
+			raise_message('sql_injection', __('An attempt was made to perform a SQL injection in Tree automation'), MESSAGE_LEVEL_ERROR);
+
+			cacti_log(sprintf('ERROR: An attempt was made to perform a SQL Injection in Tree automation from client address \'%s\'', get_client_addr()), false, 'SECURITY');
+
+			header('Location: automation_tree_rules.php?header=false&action=item_edit&id=' . get_request_var('id') . '&item_id=' . (empty($item_id) ? get_request_var('item_id') : $item_id) . '&rule_type=' . AUTOMATION_RULE_TYPE_TREE_MATCH);
+
+			exit;
+		}
 
 		if (!is_error_message()) {
 			$automation_graph_rule_item_id = sql_save($save, 'automation_tree_rule_items');


### PR DESCRIPTION
Hi,

I'm part of the Debian LTS Team and I'm testing our patch for GHSA-f9c7-7rc3-574c, hence trying to reproduce the vulnerability.

c7e4ee798d263a3209ae6e7ba182c7b65284d8f0 is the current Cacti official fix (+ 94526a92b96c01848748602977819cd403932f0a).

It seems that `automation_tree_rules.php` now protects the `save_component_automation_match_item` entry point, rather than the `save_component_automation_tree_rule_item` described in the GHSA.
This is also inconsistent with the automation_graph_rules.php fix which protects the `save_component_automation_graph_rule_item` entry point.

No directly usable PoC was published, so I can't guarantee it, but the following patch should be more consistent with the GHSA, and actually triggers when I try to recreate the payload described there (in particular `'save_component_automation_tree_rule_item' => 1`).

Please let me know if I'm mistaken :)