### PR TITLE
CVE-2024-54146 / GHSA-vj9g-p7f2-4wqj fix

### DIFF
--- a/host_templates.php
+++ b/host_templates.php
@@ -850,7 +850,7 @@ function template() {
 	}
 
 	if (get_request_var('graph_template') != '-1') {
-		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . '(gt_id = ' . intval(get_request_var('graph_template')) . ')';
+		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . '(gt_id = ' . get_filter_request_var('graph_template') . ')';
 		$sql_join   = "INNER JOIN (
 			SELECT DISTINCT host_template_id, id AS gt_id
 			FROM (

--- a/host_templates.php
+++ b/host_templates.php
@@ -850,7 +850,7 @@ function template() {
 	}
 
 	if (get_request_var('graph_template') != '-1') {
-		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . '(gt_id = ' . get_request_var('graph_template') . ')';
+		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . '(gt_id = ' . intval(get_request_var('graph_template')) . ')';
 		$sql_join   = "INNER JOIN (
 			SELECT DISTINCT host_template_id, id AS gt_id
 			FROM (


### PR DESCRIPTION
Hi,

c7e4ee798d263a3209ae6e7ba182c7b65284d8f0 doesn't seem to fix the SQL Injection, which is still reproducible in 1.2.29 following GHSA-vj9g-p7f2-4wqj.

This is a quick fix that blocks the SQLI (perhaps you'll want something more complex involving full-parameterized queries).

Cheers!