### PR TITLE
oauth2 completion

### DIFF
--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -2317,7 +2317,7 @@ $settings['mail'] = array(
 		'method'        => 'spacer',
 	),
 	'settings_oauth2_provider' => array(
-		'friendly_name' => __('Oauth2 Provider'),
+		'friendly_name' => __('OAuth2 Provider'),
 		'description'   => __('Choose your OAuth2 provider.'),
 		'method'        => 'drop_array',
 		'array'         => array(
@@ -2341,7 +2341,7 @@ $settings['mail'] = array(
 		'max_length'    => 255,
 	),
 	'settings_oauth2_client_secret' => array(
-		'friendly_name' => __('Oauth2 Client Secret'),
+		'friendly_name' => __('OAuth2 Client Secret'),
 		'description'   => __('Please enter OAuth secret'),
 		'method'        => 'textbox',
 		'max_length'    => 255,
@@ -2353,15 +2353,15 @@ $settings['mail'] = array(
 		'max_length'    => 255,
 	),
 	'settings_oauth2_redirect_uri' => array(
-		'friendly_name' => __('Oauth2 Redirect URI'),
+		'friendly_name' => __('OAuth2 Redirect URI'),
 		'description'   => __('Please check this URI. It could be accessible from internet.'),
 		'method'        => 'textbox',
 		'max_length'    => 255,
 		'default'       => read_config_option('base_url') . 'oauth2.php'
 	),
 	'settings_oauth2_refresh_token' => array(
-		'friendly_name' => __('Oauth2 refresh token'),
-		'description'   => __('From OAuth2 provider'),
+		'friendly_name' => __('OAuth2 refresh token'),
+		'description'   => __('You can insert here OAuth2 refresh token directly, if you know it. Second option is retrieved from oauth2 provider. In this case set correct OAuth2 setting, save setting and open new browser tab or window and go to OAuth2 Redirect URI'),
 		'method'        => 'textbox',
 		'max_length'    => 255,
 	),

--- a/oauth2.php
+++ b/oauth2.php
@@ -22,7 +22,6 @@
  +-------------------------------------------------------------------------+
 */
 
-//require('./include/auth.php');
 require('./include/global.php');
 
 if (read_config_option('settings_how') != 3) {

--- a/oauth2.php
+++ b/oauth2.php
@@ -111,6 +111,6 @@ if (!isset($_GET['code'])) { // If we don't have an authorization code then get 
 	//Use this to get a new access token if the old one expires
 	print __('Refresh Token: ') . $token->getRefreshToken();
 	print '<br/>' . __('Store this token in Settings -> Mail/Reporting/DNS -> Oauth2 refresh token. ');
-	print '<br/>' . __('if the token is empty, it means it stays the same. The Oatuh2 provider will not resend it in that case. ');
+	print '<br/>' . __('If the token is empty, it means it stays the same. The Oatuh2 provider will not resend it in that case. ');
 }
 

--- a/oauth2.php
+++ b/oauth2.php
@@ -22,7 +22,8 @@
  +-------------------------------------------------------------------------+
 */
 
-require('./include/auth.php');
+//require('./include/auth.php');
+require('./include/global.php');
 
 if (read_config_option('settings_how') != 3) {
 	cacti_log('WARNING: Trying get OAuth2 token but different mail method is configured');
@@ -110,6 +111,7 @@ if (!isset($_GET['code'])) { // If we don't have an authorization code then get 
 	//Use this to interact with an API on the users behalf
 	//Use this to get a new access token if the old one expires
 	print __('Refresh Token: ') . $token->getRefreshToken();
-	print '<br/>' . __('Store this token in Settings -> Mail/Reporting/DNS -> Oauth2 refresh token');
+	print '<br/>' . __('Store this token in Settings -> Mail/Reporting/DNS -> Oauth2 refresh token. ');
+	print '<br/>' . __('if the token is empty, it means it stays the same. The Oatuh2 provider will not resend it in that case. ');
 }
 

--- a/settings.php
+++ b/settings.php
@@ -449,7 +449,7 @@ function display_settings() {
 			}).trigger('change');
 		} else if (currentTab == 'mail') {
 			$('#row_settings_email_header div.formHeaderText').append('<div id="emailtest" class="emailtest"><?php print __('Send a Test Email');?></div>');
-			$('#row_settings_oauth2_header div.formHeaderText').append('<div id="oauth2token" class="emailtest"><?php print __('Generate OAuth2 Refresh Token');?></div>');
+			$('#row_settings_oauth2_header div.formHeaderText').append('<div id="oauth2token" class="emailtest"><?php print __('Generate OAuth2 Refresh Token in new window');?></div>');
 
 			initMail();
 
@@ -485,34 +485,9 @@ function display_settings() {
 						getPresentHTTPError(data);
 					});
 			});
-			
-			$('#oauth2token').click(function() {
-				$.get('oauth2.php')
-					.done(function(data) {
-						$('body').append('<div id="oatoken" title="<?php print __esc('Get OAuth2 Token');?>"></div>');
-						$('#oatoken').html(data);
 
-						$('#oatoken').dialog({
-							autoOpen: false,
-							modal: true,
-							minHeight: 300,
-							maxHeight: 600,
-							height: 450,
-							width: 500,
-							autoOpen: true,
-							show: {
-								effect: 'appear',
-								duration: 100
-							},
-							hide: {
-								effect: 'appear',
-								duration: 100
-							}
-						});
-					})
-					.fail(function(data) {
-						getPresentHTTPError(data);
-					});
+			$('#oauth2token').click(function() {
+				window.open('<?php print read_config_option('settings_oauth2_redirect_uri');?>', '_blank');
 			});
 		} else if (currentTab == 'visual') {
 			currentTheme = $('#selected_theme').val();


### PR DESCRIPTION
The user does not need to use the oauth2 wizard, if he knows the refresh token, he can insert it directly.

Oauth2 is called outside the cacti in a new window or browser tab to avoid cross site origin. Another problem is that the oauth2 provider returns the token as a GET parameter to a defined url and we would have to deal with a bit non-standard processing of the GET parameter. There is more than one problem - the token may not be returned always, cacti needs authentication again, ...

