### PR TITLE
fix add new root branch

### DIFF
--- a/lib/api_tree.php
+++ b/lib/api_tree.php
@@ -234,7 +234,7 @@ function api_tree_release_lock(string $lockname): void {
  *
  * @return void
  */
-function api_tree_create_node(int $tree_id, int $node_id, int $position, string $title = ''): void {
+function api_tree_create_node(int $tree_id, int|string $node_id, int $position, string $title = ''): void {
 	input_validate_input_number($tree_id, 'tree_id');
 	input_validate_input_number($position, 'position');
 


### PR DESCRIPTION
2025-03-13 16:10:06 - ERROR PHP ERROR: Uncaught TypeError: api_tree_create_node(): Argument #2 (**$node_id) must be of type int, string given,** called in /usr/local/share/cacti_develop/tree.php on line 151 and defined in /usr/local/share/cacti_develop/lib/api_tree.php:237 Stack trace: #0 /usr/local/share/cacti_develop/tree.php(151): api_tree_create_node(1, '#', '0', 'New Node') #1 {main} thrown in file: /usr/local/share/cacti_develop/lib/api_tree.php on line: 237 

id = #  is used if creating new root branch