### PR TITLE
upgrades: 1.0.0: do not pass bind value / param that's not used

### DIFF
--- a/install/upgrades/1_0_0.php
+++ b/install/upgrades/1_0_0.php
@@ -1808,7 +1808,7 @@ function upgrade_to_1_0_0() {
 	db_install_add_key('data_local', 'INDEX', 'snmp_index', ['snmp_index(191)']);
 	db_install_add_key('graph_local', 'INDEX', 'snmp_index', ['snmp_index(191)']);
 
-	$wathermark_results = db_install_fetch_cell('SELECT name FROM settings WHERE name = "graph_wathermark"', 'name');
+	$wathermark_results = db_install_fetch_cell('SELECT name FROM settings WHERE name = "graph_wathermark"');
 	$wathermark         = $wathermark_results['data'];
 
 	if ($wathermark == 'graph_wathermark') {


### PR DESCRIPTION
Fix in 1.0.0 migration: `'name'` as param is not needed as it's not used in query in any way.

However, trying to upgrade to most recent version from a pre-1.0.0 installation gets an error about this and halts the process.