### PR TITLE
Ensure column names are escaped to prevent reserved word issues

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.31
+-issue#6210: Fix Error: You have an error in your SQL syntax due to using table field without backtick.
 -issue#6202: Adding devices via automation fails
 
 1.2.30

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -1856,11 +1856,11 @@ function replicate_out_table($conn, &$data, $table, $remote_poller_id, $truncate
 			foreach($cols as $col) {
 				if ($exclude !== false) {
 					if (array_search($col, $exclude) === false) {
-						$suffix .= ($i > 0 ? ', ':'') . " $col=VALUES($col)";
+						$suffix .= ($i > 0 ? ', ':'') . " `$col`=VALUES($col)";
 						$i++;
 					}
 				} else {
-					$suffix .= ($i > 0 ? ', ':'') . " $col=VALUES($col)";
+					$suffix .= ($i > 0 ? ', ':'') . " `$col`=VALUES($col)";
 					$i++;
 				}
 			}
@@ -1877,7 +1877,7 @@ function replicate_out_table($conn, &$data, $table, $remote_poller_id, $truncate
 			if (!db_column_exists($table, $c, false, $conn)) {
 				$skipcols[$index] = $c;
 			} else {
-				$prefix .= ($colcnt > 0 ? ', ':'') . $c;
+				$prefix .= ($colcnt > 0 ? ', ':'') . `$c`;
 				$colcnt++;
 			}
 		}


### PR DESCRIPTION
Fix to issue #6210 

A DB Exec Failed!, Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'function, status) VALUES ('1', 'internal', 'config_arrays', '', 'plugin_config_a' at line 1
A DB Exec Failed!, Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'function, status) VALUES ('1', 'internal', 'config_arrays', '', 'plugin_config_a' at line 1