### PR TITLE
fix PHP error - incorrect parameter

### DIFF
--- a/user_admin.php
+++ b/user_admin.php
@@ -2274,7 +2274,7 @@ function user() {
 				$enabled = __('No');
 			}
 
-			if (isset($auth_realms[$user['realm']])) {
+			if (isset($auth_realms[$user['realm']]['name'])) {
 				$realm = $auth_realms[$user['realm']]['name'];
 			} else {
 				$realm = __('Unavailable');

--- a/user_admin.php
+++ b/user_admin.php
@@ -2275,7 +2275,7 @@ function user() {
 			}
 
 			if (isset($auth_realms[$user['realm']])) {
-				$realm = $auth_realms[$user['realm']];
+				$realm = $auth_realms[$user['realm']]['name'];
 			} else {
 				$realm = __('Unavailable');
 			}


### PR DESCRIPTION
Fatal error: Uncaught TypeError: form_selectable_cell(): Argument #1 ($contents) must be of type ?string, array given, called in /usr/local/share/cacti_develop/user_admin.php on line 2297 and defined in /usr/local/share/cacti_develop/lib/html_utility.php:249 Stack trace: #0 /usr/local/share/cacti_develop/user_admin.php(2297): form_selectable_cell(Array, 1) #1 /usr/local/share/cacti_develop/user_admin.php(76): user() #2 {main} thrown in /usr/local/share/cacti_develop/lib/html_utility.php on line 249