### PR TITLE
Spikekill uses the wrong option for retention periods

### DIFF
--- a/poller_spikekill.php
+++ b/poller_spikekill.php
@@ -209,7 +209,7 @@ function debug($message) {
 
 function purge_spike_backups() {
 	$directory = read_config_option('spikekill_backupdir');
-	$retention = read_config_option('spikekil_backup');
+	$retention = read_config_option('spikekill_purge');
 
 	$purges = 0;
 


### PR DESCRIPTION
Corrects an issue where the spikekill backup retention was ignored due to referencing an incorrect key.