### PR TITLE
copy graph link doesn't work

### DIFF
--- a/lib/boost.php
+++ b/lib/boost.php
@@ -468,7 +468,7 @@ function boost_return_cached_image(&$graph_data_array) : bool {
  * @throws Exception If there are issues with the cache directory or file operations.
  *
  */
-function boost_graph_cache_check(int $local_graph_id, int $rra_id, mixed $rrdtool_pipe = null, array &$graph_data_array = [], bool $return = true) : string|false {
+function boost_graph_cache_check(int $local_graph_id, int|null $rra_id, mixed $rrdtool_pipe = null, array &$graph_data_array = [], bool $return = true) : string|false {
 	/* include poller processing routines */
 	include_once(CACTI_PATH_LIBRARY . '/poller.php');
 
@@ -683,7 +683,7 @@ function boost_prep_graph_array(array $graph_data_array) : array {
  *
  * @return void
  */
-function boost_graph_set_file( string|null &$output, int $local_graph_id, int $rra_id) : void {
+function boost_graph_set_file( string|null &$output, int $local_graph_id, int|null $rra_id) : void {
 	global $graph_data_array;
 
 	/* get access to the SNMP Cache of BOOST*/


### PR DESCRIPTION
I can copy the link using the right mouse button on the graphs but attempt to use it causes:

Fatal error: Uncaught TypeError: boost_graph_cache_check(): Argument #2 ($rra_id).
must be of type int, null given, called in /usr/local/share/cacti_develop/lib/rrd.php on line 1512.
and defined in /usr/local/share/cacti_develop/lib/boost.php:471 Stack trace:.
#0 /usr/local/share/cacti_develop/lib/rrd.php(1512):
 boost_graph_cache_check(33, NULL, '', Array, false).
 #1 /usr/local/share/cacti_develop/graph_image.php(143):.
 rrdtool_function_graph(33, NULL, Array, '', Array, 1) #2 {main}
  thrown in /usr/local/share/cacti_develop/lib/boost.php on line 471
