### PR TITLE
Changed error for an invalid password to match error for an invalid u…

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4375,7 +4375,7 @@ function secpass_login_process(string $username): array {
 
 			if (!$error) {
 				$error     = true;
-				$error_msg = __('Access Denied! Login failed.') . ' <a href="auth_resetpassword.php">' . __('Reset password') . '</a>';
+				$error_msg = __('Access Denied! Login Failed.') . ' <a href="auth_resetpassword.php">' . __('Reset password') . '</a>';
 
 				cacti_log(sprintf('LOGIN FAILED: Local Login Failed for user %s from IP Address %s', $username, get_client_addr()), false, 'AUTH');
 			}


### PR DESCRIPTION
…sername.

Prior to this change, when logging in with an invalid username, Cacti would return "Access Denied! Login Failed!" However, if the username is valid, Cacti would instead return "Access Denied! Login failed." This change capitalizes the word "failed" when using a valid username, which makes it more difficult for an attacker to enumerate accounts with a brute force attack.