### PR TITLE
Improve security of CSRF Secret

### DIFF
--- a/cli/refresh_csrf.php
+++ b/cli/refresh_csrf.php
@@ -80,6 +80,7 @@ if (!file_exists(CACTI_CSRF_SECRET)) {
 $new_secret = csrf_generate_secret();
 
 if (csrf_writable(CACTI_CSRF_SECRET)) {
+	umask(0027);
 	$fh = fopen(CACTI_CSRF_SECRET, 'w');
 	fwrite($fh, '<?php $secret = "' . $new_secret . '";' . PHP_EOL);
 	fclose($fh);

--- a/include/vendor/csrf/csrf-magic.php
+++ b/include/vendor/csrf/csrf-magic.php
@@ -364,9 +364,11 @@ function csrf_get_secret() {
 		$new_secret = csrf_generate_secret();
 		foreach ($files as $file) {
 			if (csrf_writable($file)) {
+				$old_umask = umask(0027);
 				$fh = fopen($file, 'w');
 				fwrite($fh, $new_secret);
 				fclose($fh);
+				umask($old_umask);
 				$secret = $new_secret;
 				break;
 			}


### PR DESCRIPTION
By default the `csrf-secret.php` is being created with **0644** permissions.  This PR changes that to **0640**.