### PR TITLE
Improve PHP 8.5 support

### DIFF
--- a/include/vendor/phpsnmp/mib_parser.php
+++ b/include/vendor/phpsnmp/mib_parser.php
@@ -166,7 +166,7 @@ class MibParser extends MibCache {
 						}
 
 						break;
-					case '"';
+          case '"':
 						$in_quote = true;
 
 						break;

--- a/include/vendor/phpsnmp/mib_parser.php
+++ b/include/vendor/phpsnmp/mib_parser.php
@@ -166,7 +166,7 @@ class MibParser extends MibCache {
 						}
 
 						break;
-          case '"':
+					case '"':
 						$in_quote = true;
 
 						break;

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -102,7 +102,7 @@ function exec_poll_php(string $command, bool $using_proc_function, array $pipes,
 
 			pclose($fp);
 		} else {
-			$output = `$command`;
+			$output = shell_exec($command);
 		}
 	}
 

--- a/lib/xml.php
+++ b/lib/xml.php
@@ -42,7 +42,9 @@ function xml2array(string $data) : mixed {
 	xml_parser_set_option($p, XML_OPTION_SKIP_WHITE, 1);
 	xml_parser_set_option($p, XML_OPTION_CASE_FOLDING, 0);
 	xml_parse_into_struct($p, $data, $vals, $index);
-	xml_parser_free($p);
+  if (version_compare(PHP_VERSION, '8.0', '<')) {
+    xml_parser_free($p);
+  }
 
 	$tree = [];
 	$i    = 0;
@@ -134,7 +136,9 @@ function rrdxport2array(string $data) : array {
 	xml_parser_set_option($p, XML_OPTION_CASE_FOLDING, 0);
 	xml_parser_set_option($p, XML_OPTION_TARGET_ENCODING, 'UTF-8');
 	xml_parse_into_struct($p, $data, $vals, $index);
-	xml_parser_free($p);
+  if (version_compare(PHP_VERSION, '8.0', '<')) {
+    xml_parser_free($p);
+  }
 
 	$tree   = [];
 	$i      = 0;

--- a/lib/xml.php
+++ b/lib/xml.php
@@ -42,6 +42,7 @@ function xml2array(string $data) : mixed {
 	xml_parser_set_option($p, XML_OPTION_SKIP_WHITE, 1);
 	xml_parser_set_option($p, XML_OPTION_CASE_FOLDING, 0);
 	xml_parse_into_struct($p, $data, $vals, $index);
+
 	if (version_compare(PHP_VERSION, '8.0', '<')) {
 		xml_parser_free($p);
 	}
@@ -136,6 +137,7 @@ function rrdxport2array(string $data) : array {
 	xml_parser_set_option($p, XML_OPTION_CASE_FOLDING, 0);
 	xml_parser_set_option($p, XML_OPTION_TARGET_ENCODING, 'UTF-8');
 	xml_parse_into_struct($p, $data, $vals, $index);
+
 	if (version_compare(PHP_VERSION, '8.0', '<')) {
 		xml_parser_free($p);
 	}

--- a/lib/xml.php
+++ b/lib/xml.php
@@ -42,9 +42,9 @@ function xml2array(string $data) : mixed {
 	xml_parser_set_option($p, XML_OPTION_SKIP_WHITE, 1);
 	xml_parser_set_option($p, XML_OPTION_CASE_FOLDING, 0);
 	xml_parse_into_struct($p, $data, $vals, $index);
-  if (version_compare(PHP_VERSION, '8.0', '<')) {
-    xml_parser_free($p);
-  }
+	if (version_compare(PHP_VERSION, '8.0', '<')) {
+		xml_parser_free($p);
+	}
 
 	$tree = [];
 	$i    = 0;
@@ -136,9 +136,9 @@ function rrdxport2array(string $data) : array {
 	xml_parser_set_option($p, XML_OPTION_CASE_FOLDING, 0);
 	xml_parser_set_option($p, XML_OPTION_TARGET_ENCODING, 'UTF-8');
 	xml_parse_into_struct($p, $data, $vals, $index);
-  if (version_compare(PHP_VERSION, '8.0', '<')) {
-    xml_parser_free($p);
-  }
+	if (version_compare(PHP_VERSION, '8.0', '<')) {
+		xml_parser_free($p);
+	}
 
 	$tree   = [];
 	$i      = 0;


### PR DESCRIPTION
* The backtick operator is now deprecated in favor of shell_exec.
* Terminating case statements with a semicolon instead of a colon has been deprecated.
* xml_parser_free was a noop since PHP 8.0 and is now deprecated.