### PR TITLE
Allow Spikekill to work on time windows for stddev and variance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: local
+    hooks:
+      - id: lintcheck
+        name: PHPStan Validate
+        entry: composer run-script lint
+        language: system
+        files: ^app/
+        always_run: true
+
+      - id: phpcsfixer
+        name: PHP CS Fixer Validate
+        entry: composer run-script phpcsfixer
+        language: system
+        files: ^app/
+        always_run: true
+
+      - id: phpstan
+        name: PHPStan Validate
+        entry: composer run-script phpstan
+        language: system
+        files: ^app/
+        always_run: true
+
+
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,25 +2,22 @@ repos:
   - repo: local
     hooks:
       - id: lintcheck
-        name: PHPStan Validate
+        name: PHP Lint Checking
         entry: composer run-script lint
         language: system
         files: ^app/
         always_run: true
 
       - id: phpcsfixer
-        name: PHP CS Fixer Validate
+        name: PHP CS Fixer Validation
         entry: composer run-script phpcsfixer
         language: system
         files: ^app/
         always_run: true
 
       - id: phpstan
-        name: PHPStan Validate
+        name: PHPStan Validation
         entry: composer run-script phpstan
         language: system
         files: ^app/
         always_run: true
-
-
-

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -237,6 +237,11 @@ Cacti CHANGELOG
 -issue#6516: SQL Errors in Automation Graph Rules processing
 -issue#6518: Ensure that the csrf-secret file is written in a less permissive way
 -issue#6519: Realtime generates errors in the Cacti Log after a Graph has been removed
+-issue#6546: Add missing xml and script files for NetSNMP LMSensor
+-issue#6551: Fix paths in audit_database script (FreeBSD)
+-issue: Correct some PHPStan issues found in audit of Aggregate that can lead to warnings
+-issue: Using the rrd_splice.php cli can result in the loss of data
+-issue: Defect in SpikeKill algorithm was causing a loss of data for Gap Fill and Float methods
 -feature#6523: When disabling a users, ensure that their stored authentication cookies are remove and any sessions cleared
 -feature#6524: When changing your password, logout from all sessions
 -feature: Close user sessions after a password change is forced

--- a/cli/removespikes.php
+++ b/cli/removespikes.php
@@ -203,7 +203,7 @@ if ($out_start != '' && !is_numeric($out_start)) {
 	$out_start      = strtotime($out_start);
 
 	if ($out_start == false) {
-		print "ERROR: The outlier start value '$orig_out_start' is invalid.  Use either a timestamp of a datetime format." . PHP_EOL;
+		print "ERROR: The outlier start value '$orig_out_start' is invalid.  Use either a timestamp or a datetime format." . PHP_EOL;
 		exit(1);
 	}
 }
@@ -213,7 +213,7 @@ if ($out_end != '' && !is_numeric($out_end)) {
 	$out_end      = strtotime($out_end);
 
 	if ($out_end == false) {
-		print "ERROR: The outlier end value '$orig_out_end' is invalid.  Use either a timestamp of a datetime format." . PHP_EOL;
+		print "ERROR: The outlier end value '$orig_out_end' is invalid.  Use either a timestamp or a datetime format." . PHP_EOL;
 		exit(1);
 	}
 }

--- a/cli/removespikes.php
+++ b/cli/removespikes.php
@@ -198,6 +198,26 @@ if (cacti_sizeof($parms)) {
 	exit(0);
 }
 
+if ($out_start != '' false && !is_numeric($out_start)) {
+	$orig_out_start = $out_end;
+	$out_start = strtotime($out_start);
+
+	if ($out_start == false) {
+		print "ERROR: The outlier start value '$orig_out_start' is invalid.  Use either a timestamp of a datetime format" . PHP_EOL;
+		exit(1);
+	}
+}
+
+if ($out_end != '' && !is_numeric($out_end)) {
+	$orig_out_end = $out_end;
+	$out_end = strtotime($out_end);
+
+	if ($out_end == false) {
+		print "ERROR: The outlier start value '$orig_out_end' is invalid.  Use either a timestamp of a datetime format" . PHP_EOL;
+		exit(1);
+	}
+}
+
 $spiker = new spikekill($rrdfile, $method, $avgnan, $stddev, $out_start, $out_end, $outliers, $percent, $numspike, $dsfilter, $absmax);
 
 if ($debug) {
@@ -267,9 +287,9 @@ function display_help() : void {
 	print '    --number        - The maximum number of spikes to remove from the RRDfile' . PHP_EOL;
 	print '    --absmax        - The absolute maximum value of a data point to remove from the RRDfile' . PHP_EOL;
 	print '    --dsfilter      - Specifies the DSes inside an RRD upon which Spikekill will operate' . PHP_EOL;
-	print '    --outlier-start - A start date of an incident where all data should be considered' . PHP_EOL;
+	print '    --outlier-start - A start date or timestamp of an incident where all data should be considered' . PHP_EOL;
 	print '                      invalid data and should be excluded from average calculations.' . PHP_EOL;
-	print '    --outlier-end   - An end date of an incident where all data should be considered' . PHP_EOL;
+	print '    --outlier-end   - An end date or timestamp of an incident where all data should be considered' . PHP_EOL;
 	print '                      invalid data and should be excluded from average calculations.' . PHP_EOL;
 	print '    --outliers      - The number of outliers to ignore when calculating average.' . PHP_EOL;
 	print '    --dryrun        - If specified, the RRDfile will not be changed.  Instead a summary of' . PHP_EOL;

--- a/cli/removespikes.php
+++ b/cli/removespikes.php
@@ -51,14 +51,14 @@ $html      = false;
 $backup    = false;
 $user      = get_current_user();
 
-$method   = read_config_option('spikekill_method',true);
-$numspike = read_config_option('spikekill_number',true);
-$stddev   = read_config_option('spikekill_deviations',true);
-$percent  = read_config_option('spikekill_percent',true);
-$outliers = read_config_option('spikekill_outliers',true);
-$avgnan   = read_config_option('spikekill_avgnan',true);
-$absmax   = read_config_option('spikekill_absmax',true);
-$dsfilter = read_config_option('spikekill_dsfilter',true);
+$method   = read_config_option('spikekill_method', true);
+$numspike = read_config_option('spikekill_number', true);
+$stddev   = read_config_option('spikekill_deviations', true);
+$percent  = read_config_option('spikekill_percent', true);
+$outliers = read_config_option('spikekill_outliers', true);
+$avgnan   = read_config_option('spikekill_avgnan', true);
+$absmax   = read_config_option('spikekill_absmax', true);
+$dsfilter = read_config_option('spikekill_dsfilter', true);
 
 switch($method) {
 	case '1':
@@ -199,21 +199,21 @@ if (cacti_sizeof($parms)) {
 }
 
 if ($out_start != '' && !is_numeric($out_start)) {
-	$orig_out_start = $out_end;
-	$out_start = strtotime($out_start);
+	$orig_out_start = $out_start;
+	$out_start      = strtotime($out_start);
 
 	if ($out_start == false) {
-		print "ERROR: The outlier start value '$orig_out_start' is invalid.  Use either a timestamp of a datetime format" . PHP_EOL;
+		print "ERROR: The outlier start value '$orig_out_start' is invalid.  Use either a timestamp of a datetime format." . PHP_EOL;
 		exit(1);
 	}
 }
 
 if ($out_end != '' && !is_numeric($out_end)) {
 	$orig_out_end = $out_end;
-	$out_end = strtotime($out_end);
+	$out_end      = strtotime($out_end);
 
 	if ($out_end == false) {
-		print "ERROR: The outlier start value '$orig_out_end' is invalid.  Use either a timestamp of a datetime format" . PHP_EOL;
+		print "ERROR: The outlier end value '$orig_out_end' is invalid.  Use either a timestamp of a datetime format." . PHP_EOL;
 		exit(1);
 	}
 }

--- a/cli/removespikes.php
+++ b/cli/removespikes.php
@@ -198,7 +198,7 @@ if (cacti_sizeof($parms)) {
 	exit(0);
 }
 
-if ($out_start != '' false && !is_numeric($out_start)) {
+if ($out_start != '' && !is_numeric($out_start)) {
 	$orig_out_start = $out_end;
 	$out_start = strtotime($out_start);
 

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -275,7 +275,7 @@ class spikekill {
 		}
 
 		// the order of the following case statements reflects the order in the spikekill menu in the GUI.
-		$dismethod = '';
+		$dispmethod = '';
 
 		switch($this->method) {
 			case 'stddev':

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -25,30 +25,31 @@
 // setup constants
 define('SPIKE_METHOD_STDDEV',   1);
 define('SPIKE_METHOD_VARIANCE', 2);
-define('SPIKE_METHOD_FILL',     4);
 define('SPIKE_METHOD_FLOAT',    3);
+define('SPIKE_METHOD_FILL',     4);
+define('SPIKE_METHOD_ABSOLUTE', 5);
 
 class spikekill {
 	// setup defaults
-	private mixed $std_kills = false;
-	private mixed $var_kills = false;
-	private mixed $out_kills = false;
-	private string $username = '';
-	private string $user     = '';
-	private array $user_info = [];
+	private mixed  $std_kills = false;
+	private mixed  $var_kills = false;
+	private mixed  $out_kills = false;
+	private string $username  = '';
+	private string $user      = '';
+	private array  $user_info = [];
 
 	// Required variables
-	public string $rrdfile   = '';
-	public mixed $method     = '';
-	public mixed $avgnan     = '';
-	public mixed $stddev     = '';
-	public mixed $out_start  = '';
-	public mixed $out_end    = '';
-	public mixed $outliers   = '';
-	public mixed  $percent   = '';
-	public mixed $numspike   = '';
-	public mixed $dsfilter   = '';
-	public string $absmax    = '';
+	public string $rrdfile    = '';
+	public mixed  $method     = '';
+	public mixed  $avgnan     = '';
+	public mixed  $stddev     = '';
+	public mixed  $out_start  = 0;
+	public mixed  $out_end    = 0;
+	public mixed  $outliers   = '';
+	public mixed  $percent    = '';
+	public mixed  $numspike   = '';
+	public mixed  $dsfilter   = '';
+	public string $absmax     = '';
 
 	// Overridable
 	public bool $html        = true;
@@ -149,12 +150,14 @@ class spikekill {
 			$this->absmax = $absmax;
 		}
 
-		$this->dmethod   = intval(read_config_option('spikekill_method', true));
+		$this->dmethod   = read_config_option('spikekill_method', true);
+		$this->davgnan   = read_config_option('spikekill_avgnan', true);
+		$this->ddsfilter = read_config_option('spikekill_dsfilter', true);
 		$this->dnumspike = intval(read_config_option('spikekill_number', true));
 		$this->dstddev   = intval(read_config_option('spikekill_deviations', true));
 		$this->dpercent  = intval(read_config_option('spikekill_percent', true));
 		$this->doutliers = intval(read_config_option('spikekill_outliers', true));
-		$this->davgnan   = read_config_option('spikekill_avgnan', true);
+		$this->dabsmax   = intval(read_config_option('spikekill_absmax', true));
 	}
 
 	public function __destruct() {
@@ -185,7 +188,7 @@ class spikekill {
 		return $this->strout;
 	}
 
-	private function initialize_spikekill() : bool {
+	private function initializeSpikekill() : void {
 		// additional error check
 		if ($this->rrdfile == '') {
 			$this->set_error('FATAL: You must specify an RRDfile!');
@@ -198,15 +201,17 @@ class spikekill {
 		}
 
 		$umethod   = read_user_setting('spikekill_method', $this->dmethod, true);
-		$unumspike = read_user_setting('spikekill_number', $this->dnumspike, true);
-		$ustddev   = read_user_setting('spikekill_deviations', $this->dstddev, true);
-		$upercent  = read_user_setting('spikekill_percent', $this->dpercent, true);
-		$uoutliers = read_user_setting('spikekill_outliers', $this->doutliers, true);
 		$uavgnan   = read_user_setting('spikekill_avgnan', $this->davgnan, true);
+		$udsfilter = read_user_setting('spikekill_dsfilter', $this->dsfilter, true);
+		$unumspike = intval(read_user_setting('spikekill_number', $this->dnumspike, true));
+		$ustddev   = intval(read_user_setting('spikekill_deviations', $this->dstddev, true));
+		$upercent  = intval(read_user_setting('spikekill_percent', $this->dpercent, true));
+		$uoutliers = intval(read_user_setting('spikekill_outliers', $this->doutliers, true));
+		$uabsmax   = intval(read_user_setting('spikekill_absmax', $this->absmax, true));
 
 		// set the correct value
 		if ($this->avgnan == '') {
-			if (!isset($uavgnan)) {
+			if (!empty($uavgnan)) {
 				$this->avgnan = $this->davgnan;
 			} else {
 				$this->avgnan = $uavgnan;
@@ -214,7 +219,7 @@ class spikekill {
 		}
 
 		if ($this->method == '') {
-			if (!isset($umethod)) {
+			if (!empty($umethod)) {
 				$this->method = $this->dmethod;
 			} else {
 				$this->method = $umethod;
@@ -222,7 +227,7 @@ class spikekill {
 		}
 
 		if ($this->numspike == '') {
-			if (!isset($unumspike)) {
+			if (!empty($unumspike)) {
 				$this->numspike = $this->dnumspike;
 			} else {
 				$this->numspike = $unumspike;
@@ -230,7 +235,7 @@ class spikekill {
 		}
 
 		if ($this->stddev == '') {
-			if (!isset($ustddev)) {
+			if (!empty($ustddev)) {
 				$this->stddev = $this->dstddev;
 			} else {
 				$this->stddev = $ustddev;
@@ -238,26 +243,87 @@ class spikekill {
 		}
 
 		if ($this->percent == '') {
-			if (!isset($upercent)) {
+			if (!empty($upercent)) {
 				$this->percent = $this->dpercent;
 			} else {
 				$this->percent = $upercent;
 			}
 		}
 
+		if ($this->dsfilter == '') {
+			if (!empty($udsfilter)) {
+				$this->dsfilter = $this->ddsfilter;
+			} else {
+				$this->outliers = $udsfilter;
+			}
+		}
+
+		if ($this->dabsmax == '') {
+			if (!empty($uabsmax)) {
+				$this->absmax = $this->dabsmax;
+			} else {
+				$this->absmax = $uabsmax;
+			}
+		}
+
 		if ($this->outliers == '') {
-			if (!isset($uoutliers)) {
+			if (!empty($uoutliers)) {
 				$this->outliers = $this->doutliers;
 			} else {
 				$this->outliers = $uoutliers;
 			}
 		}
 
+		// the order of the following case statements reflects the order in the spikekill menu in the GUI.
+		$dismethod = '';
+
+		switch($this->method) {
+			case 'stddev':
+				$this->method = SPIKE_METHOD_STDDEV;
+				$dispmethod = __('StdDev');
+
+				break;
+			case 'variance':
+				$this->method = SPIKE_METHOD_VARIANCE;
+				$dispmethod = __('Variance');
+
+				break;
+			case 'fill':
+				$this->method = SPIKE_METHOD_FILL;
+				$dispmethod = __('Gap Fill');
+
+				break;
+			case 'float':
+				$this->method = SPIKE_METHOD_FLOAT;
+				$dispmethod = __('Float Range');
+
+				break;
+			case 'absolute':
+				$this->method = SPIKE_METHOD_ABSOLUTE;
+				$dispmethod = __('Absolute Max');
+
+				break;
+			default:
+				$this->set_error("FATAL: You must specify either 'stddev', 'variance', 'float', or 'fill' as methods.");
+		}
+
 		if (!is_numeric($this->stddev) || ($this->stddev < 1)) {
 			$this->set_error('FATAL: Standard Deviation must be a positive integer.');
 		}
 
-		if ($this->method == 'float' || $this->method == 'fill') {
+		if (!is_numeric($this->out_start)) {
+			$this->set_error('FATAL: The Spike Kill Window Start must be a date or timestamp.');
+		}
+
+		if (!is_numeric($this->out_end)) {
+			$this->set_error('FATAL: The Spike Kill Window End must be a date or timestamp.');
+		}
+
+		/**
+		 * The fill, float, and absolute require a time range.  It's optional for stddev and variance.
+		 * Convert these to timestamps if they are not already so.
+		 */
+		if ($this->method ==  SPIKE_METHOD_FLOAT || $this->method == SPIKE_METHOD_FILL || $this->method == SPIKE_METHOD_ABSOLUTE) {
 			if (!is_numeric($this->out_start)) {
 				$this->out_start = strtotime($this->out_start);
 			}
@@ -267,14 +333,15 @@ class spikekill {
 			}
 
 			if ($this->out_start === false || $this->out_end === false) {
-				$this->set_error('FATAL: The outlier-start and outlier-end arguments must be in the format of YYYY-MM-DD HH:MM.');
-			}
-
-			if (!is_numeric($this->outliers) || ($this->outliers < 1)) {
-				$this->set_error('FATAL: The number of outliers to exclude must be a positive integer.');
+				$this->set_error('FATAL: The outlier-start and outlier-end arguments must be in the format of YYYY-MM-DD HH:MM or a UNIX timestamp.');
 			}
 		}
 
+		if (!is_numeric($this->outliers) || ($this->outliers < 1)) {
+			$this->set_error('FATAL: The number of outliers to exclude must be a positive integer.');
+		}
+
+		// Convert the percent to a decimal number aka 50% == 0.5
 		if ($this->percent != '') {
 			if (is_numeric($this->percent) && $this->percent > 0) {
 				$this->percent /= 100;
@@ -289,46 +356,37 @@ class spikekill {
 			}
 		}
 
+		if (!$this->absmax != '') {
+			if (!is_numeric($this->absmax) || ($this->absmax < 1)) {
+				$this->set_error('FATAL: Number value for absolute maximum value positive integer');
+			}
+		}
+
+		// Make sure both ends of the time range are set
 		if ((!empty($this->out_start) && empty($this->out_end)) || (!empty($this->out_end) && empty($this->out_start))) {
 			$this->set_error('FATAL: Outlier time range requires outlier-start and outlier-end to be specified.');
 		}
 
-		if (!empty($this->out_start)) {
+		// Check a bad range of the window start and end
+		if (empty($this->out_start)) {
 			if ($this->out_start >= $this->out_end) {
 				$this->set_error('FATAL: Outlier time range requires outlier-start to be less than outlier-end.');
 			}
 		}
 
-		switch($this->method) {
-			// the order of the following case statements reflects the order in the spikekill menu in the GUI.
-			case 'stddev':
-				$this->method = SPIKE_METHOD_STDDEV;
-
-				break;
-			case 'variance':
-				$this->method = SPIKE_METHOD_VARIANCE;
-
-				break;
-			case 'fill':
-				$this->method = SPIKE_METHOD_FILL;
-
-				break;
-			case 'float':
-				$this->method = SPIKE_METHOD_FLOAT;
-
-				break;
-			default:
-				$this->set_error("FATAL: You must specify either 'stddev', 'variance', 'float', or 'fill' as methods.");
+		if ($this->method == SPIKE_METHOD_FLOAT && $this->out_start == 0) {
+			$this->set_error("FATAL: The 'float' removal method requires the specification of a start and end date or timestamp.");
 		}
 
-		if ($this->method == SPIKE_METHOD_FLOAT && empty($this->out_start)) {
-			$this->set_error("FATAL: The 'float' removal method requires the specification of a start and end date.");
+		if ($this->method == SPIKE_METHOD_FILL && $this->out_start == 0) {
+			$this->set_error("FATAL: The 'fill' removal method requires the specification of a start and end date or timestamp.");
 		}
 
-		if ($this->method == SPIKE_METHOD_FILL && empty($this->out_start)) {
-			$this->set_error("FATAL: The 'gapfill' removal method requires the specification of a start and end date.");
+		if ($this->method == SPIKE_METHOD_ABSOLUTE && $this->out_start == 0) {
+			$this->set_error("FATAL: The 'absolute' removal method requires the specification of a start and end date or timestamp.");
 		}
 
+		// Verify the replacement methods
 		switch($this->avgnan) {
 			case 'avg':
 			case 'last':
@@ -338,18 +396,37 @@ class spikekill {
 				$this->set_error("FATAL: You must specify either 'last', 'avg' or 'nan' as a replacement method.");
 		}
 
-		$this->debug('Type:          ' . ucfirst($this->method));
-		$this->debug('RRDfile:       ' . $this->rrdfile);
-		$this->debug('Num Outliers:  ' . $this->outliers);
-		$this->debug('Percent:       ' . $this->outliers);
-		$this->debug(sprintf('Outlier Start: %s (%s)', $this->out_start, date('Y-m-d H:i', $this->out_start)));
-		$this->debug(sprintf('Outlier End:   %s (%s)', $this->out_end, date('Y-m-d H:i', $this->out_end)));
+		printf('Spike Kill Settings Used for Analysis/Correction' . PHP_EOL);
+		printf('------------------------------------------------' . PHP_EOL);
+		printf('Method:        %s' . PHP_EOL, $dispmethod);
+		printf('RRDfile:       %s' . PHP_EOL, $this->rrdfile);
+		printf('Repair Type:   %s' . PHP_EOL, $this->avgnan);
 
-		return false;
+		if ($this->method == SPIKE_METHOD_STDDEV || $this->method == SPIKE_METHOD_VARIANCE) {
+			printf('Num Outliers:  %s' . PHP_EOL, $this->outliers);
+			printf('Max Kills:     %s' . PHP_EOL, $this->numspike);
+		} else {
+			printf('Max Kills:     Unlimited' . PHP_EOL, $this->numspike);
+		}
+
+		if ($this->method == SPIKE_METHOD_STDDEV) {
+			printf('Standard Devs: %s' . PHP_EOL, $this->stddev);
+		} elseif ($this->method == SPIKE_METHOD_VARIANCE) {
+			printf('Variance %%:    %s %%' . PHP_EOL, number_format_i18n($this->percent * 100, 2));
+		} elseif ($this->method == SPIKE_METHOD_ABSOLUTE) {
+			printf('Absolute Max:  %s' . PHP_EOL, $this->absmax);
+		}
+
+		if ($this->out_start > 0) {
+			printf('Window Start:  %s (%s)' . PHP_EOL, $this->out_start, date('Y-m-d H:i', $this->out_start));
+			printf('Window End:    %s (%s)' . PHP_EOL . PHP_EOL, $this->out_end, date('Y-m-d H:i', $this->out_end));
+		} else {
+			printf('Window Range:  All' . PHP_EOL . PHP_EOL, $this->out_end, date('Y-m-d H:i', $this->out_end));
+		}
 	}
 
 	public function remove_spikes() : bool {
-		$this->initialize_spikekill();
+		$this->initializeSpikekill();
 
 		if ($this->is_error_set()) {
 			return false;
@@ -396,6 +473,11 @@ class spikekill {
 					break;
 				case SPIKE_METHOD_FILL:
 					$mm  = 'GapFill';
+					$mes = "$this->username, File:" . basename($this->rrdfile) . ", Method:$mm, OutStart:$this->out_start, OutEnd:$this->out_end, AvgNan:$this->avgnan";
+
+					break;
+				case SPIKE_METHOD_ABSOLUTE:
+					$mm  = 'AbsMax';
 					$mes = "$this->username, File:" . basename($this->rrdfile) . ", Method:$mm, OutStart:$this->out_start, OutEnd:$this->out_end, AvgNan:$this->avgnan";
 
 					break;
@@ -474,9 +556,9 @@ class spikekill {
 		 * The we don't need to know the type of rra, only it's number for this analysis
 		 * the same applies for the ds' as well.
 		 */
-		$rra     = array();
-		$this->rra_cf  = array();
-		$this->rra_pdp = array();
+		$rra           = [];
+		$this->rra_cf  = [];
+		$this->rra_pdp = [];
 
 		$rra_num = 0;
 		$ds_num  = 0;
@@ -528,18 +610,30 @@ class spikekill {
 
 						// check for outlier territory
 						if ($timestamp > 0) {
-							if ($this->method == SPIKE_METHOD_FILL || $this->method == SPIKE_METHOD_FLOAT) {
+							if ($this->method == SPIKE_METHOD_FILL || $this->method == SPIKE_METHOD_FLOAT || $this->method == SPIKE_METHOD_ABSOLUTE) {
 								if ($timestamp < $this->out_start) {
 									$rra[$rra_num][$ds_num]['last'] = $dsvalue;
 
 									$process = true;
 								} elseif ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
-									if ($this->method == SPIKE_METHOD_FILL) {
-										if (strtolower($dsvalue) == 'nan' || $dsvalue == 0) {
-											$this->debug(sprintf('Fill Found, RRA:%s, DSNum:%s, Date:%s, CurVal:%0.4e NewVal:%0.4e', $rra_num, $ds_num, date('Y-m-d H:i:s', $timestamp), $dsvalue, $rra[$rra_num][$ds_num]['last']));
-										}
+									if ($this->avgnan == 'last') {
+										$newval = $rra[$rra_num][$ds_num]['variance_avg'];
+									} elseif ($this->avgnan = 'avg') {
+										$newval = $rra[$rra_num][$ds_num]['last'];
 									} else {
-										$this->debug(sprintf('Float Found, RRA:%s, DSNum:%s, Date:%s, CurVal:%0.4e NewVal:%0.4e', $rra_num, $ds_num, date('Y-m-d H:i:s', $timestamp), $dsvalue, $rra[$rra_num][$ds_num]['last']));
+										$newval = 'NaN';
+									}
+
+									if ($this->method == SPIKE_METHOD_FILL) {
+										if (strtolower($dsvalue) == 'nan') {
+											$this->debug(sprintf('Fill Found, RRA:%s, DSNum:%s, Date:%s, CurVal:%0.4e NewVal:%0.4e', $rra_num, $ds_num, date('Y-m-d H:i:s', $timestamp), $dsvalue, $newval));
+										}
+									} elseif ($this->method == SPIKE_METHOD_FLOAT) {
+										$this->debug(sprintf('Float Found, RRA:%s, DSNum:%s, Date:%s, CurVal:%0.4e NewVal:%0.4e', $rra_num, $ds_num, date('Y-m-d H:i:s', $timestamp), $dsvalue, $newval));
+									} else {
+										if ($dsvalue >= $this->absmax) {
+											$this->debug(sprintf('AbsMax Found, RRA:%s, DSNum:%s, Date:%s, CurVal:%0.4e NewVal:%0.4e', $rra_num, $ds_num, date('Y-m-d H:i:s', $timestamp), $dsvalue, $newval));
+										}
 									}
 
 									$process = false;
@@ -658,25 +752,25 @@ class spikekill {
 		$new_output = '';
 		$continue   = false;
 
-		/* create an output array */
+		// create an output array
 		if ($this->std_kills || $this->out_kills) {
 			$this->debug('Either std_kills or out_kills found');
 
 			if (!$this->dryrun) {
 				$new_output = $this->updateXML($output, $rra);
-				$output   = true;
-				$continue = true;
+				$output     = true;
+				$continue   = true;
 			} else {
 				$new_output = $this->updateXML($output, $rra);
 				$output     = false;
 				$continue   = false;
 			}
 		} elseif ($this->out_start > 0) {
-			$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
-				"NOTE: No Window Spikes found in '$this->rrdfile'" . ($this->html ? "</p>\n":"\n");
+			$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
+				"NOTE: No Window Spikes found in '$this->rrdfile'" . ($this->html ? "</p>\n" : "\n");
 		} else {
-			$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
-				"NOTE: No Spikes found in '$this->rrdfile'" . ($this->html ? "</p>\n":"\n");
+			$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
+				"NOTE: No Spikes found in '$this->rrdfile'" . ($this->html ? "</p>\n" : "\n");
 		}
 
 		// finally update the file XML file and Reprocess the RRDfile
@@ -686,19 +780,19 @@ class spikekill {
 					if ($this->writeXMLFile($new_output, $xmlfile)) {
 						if ($this->backupRRDFile($this->rrdfile)) {
 							$this->createRRDFileFromXML($xmlfile, $this->rrdfile);
-							$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
-								"NOTE: Spikes Found and Remediated.  Total Spikes ($this->total_kills)" . ($this->html ? "</p>\n":"\n");
+							$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
+								"NOTE: Spikes Found and Remediated.  Total Spikes ($this->total_kills)" . ($this->html ? "</p>\n" : "\n");
 						} else {
-							$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
-								"FATAL: Unable to backup '$this->rrdfile'" . ($this->html ? "</p>\n":"\n");
+							$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
+								"FATAL: Unable to backup '$this->rrdfile'" . ($this->html ? "</p>\n" : "\n");
 						}
 					} else {
-						$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
-							"FATAL: Unable to write XML file '$xmlfile'" . ($this->html ? "</p>\n":"\n");
+						$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
+							"FATAL: Unable to write XML file '$xmlfile'" . ($this->html ? "</p>\n" : "\n");
 					}
 				} else {
-					$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
-						"NOTE: No Spikes Found." . ($this->html ? "</p>\n":"\n");
+					$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
+						'NOTE: No Spikes Found.' . ($this->html ? "</p>\n" : "\n");
 				}
 			}
 		} else {
@@ -823,6 +917,7 @@ class spikekill {
 					foreach ($dses as $ds) {
 						if (isset($samples[$rra_num][$ds_num])) {
 							$rra[$rra_num][$ds_num]['stddev'] = $this->processStandardDeviationCalculation($samples[$rra_num][$ds_num]);
+
 							if ($rra[$rra_num][$ds_num]['stddev'] == 'NAN') {
 								$rra[$rra_num][$ds_num]['stddev'] = 0;
 							}
@@ -838,11 +933,13 @@ class spikekill {
 							}
 
 							$rra[$rra_num][$ds_num]['min_cutoff'] = $rra[$rra_num][$ds_num]['average'] - ($this->stddev * $rra[$rra_num][$ds_num]['stddev']);
+
 							if ($rra[$rra_num][$ds_num]['min_cutoff'] < $this->ds_min[$ds_num]) {
 								$rra[$rra_num][$ds_num]['min_cutoff'] = $this->ds_min[$ds_num];
 							}
 
 							$rra[$rra_num][$ds_num]['max_cutoff'] = $rra[$rra_num][$ds_num]['average'] + ($this->stddev * $rra[$rra_num][$ds_num]['stddev']);
+
 							if ($rra[$rra_num][$ds_num]['max_cutoff'] > $this->ds_max[$ds_num]) {
 								$rra[$rra_num][$ds_num]['max_cutoff'] = $this->ds_max[$ds_num];
 							}
@@ -854,53 +951,106 @@ class spikekill {
 							// go through values and find cutoffs
 							$rra[$rra_num][$ds_num]['stddev_killed']   = 0;
 							$rra[$rra_num][$ds_num]['variance_killed'] = 0;
+							$rra[$rra_num][$ds_num]['outwind_samples'] = 0;
 							$rra[$rra_num][$ds_num]['outwind_killed']  = 0;
 
 							// count the number of kills required
 							if (cacti_sizeof($samples[$rra_num][$ds_num])) {
-								foreach($samples[$rra_num][$ds_num] as $timestamp => $sample) {
+								foreach ($samples[$rra_num][$ds_num] as $timestamp => $sample) {
 									if ($this->method == SPIKE_METHOD_FLOAT || $this->method == SPIKE_METHOD_FILL) {
 										if ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
+											$rra[$rra_num][$ds_num]['outwind_samples']++;
+
 											if ($this->method == SPIKE_METHOD_FLOAT) {
-												if (strtolower($sample) == 'nan' || $sample == 0) {
-													$this->debug(sprintf("Window Float Found, Date:%s, Value:%s", date('Y-m-d H:i', $timestamp), $sample));
+												$this->debug(sprintf('Window Float Found, Date:%s, Value:%s', date('Y-m-d H:i', $timestamp), $sample));
 
-													$rra[$rra_num][$ds_num]['outwind_killed']++;
-													$this->out_kills = true;
-												}
+												$rra[$rra_num][$ds_num]['outwind_killed']++;
+												$this->out_kills = true;
 											} elseif ($this->method == SPIKE_METHOD_FILL) {
-												if (strtolower($sample) == 'nan' || $sample == 0) {
-													$this->debug(sprintf("Window GapFill Found, Date:%s, Value:%s", date('Y-m-d H:i', $timestamp), $sample));
+												if (strtolower($sample) == 'nan') { // Gap Fill Means 'NaN's only
+													$this->debug(sprintf('Window GapFill Found, Date:%s, Value:%s', date('Y-m-d H:i', $timestamp), $sample));
 
 													$rra[$rra_num][$ds_num]['outwind_killed']++;
 													$this->out_kills = true;
 												}
+											} elseif (strtolower($sample) !== 'nan') {
+												$rra[$rra_num][$ds_num]['numnksamples']++;
+												$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 											}
+										} elseif (strtolower($sample) !== 'nan') {
+											$rra[$rra_num][$ds_num]['numnksamples']++;
+											$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 										}
-									} elseif (($sample > $rra[$rra_num][$ds_num]['max_cutoff']) || ($sample < $rra[$rra_num][$ds_num]['min_cutoff'])) {
-										if ($this->method == SPIKE_METHOD_STDDEV) {
-											$this->debug(sprintf("StdDev Found, Date:%s, Value:%0.4e, StandardDev:%0.4e, StdDevLimit:%0.4e, Date:%s", date('Y-m-d H:i', $timestamp), $sample, $rra[$rra_num][$ds_num]['stddev'], ($rra[$rra_num][$ds_num]['max_cutoff'] * (1+$this->percent))));
+									} elseif ($this->method == SPIKE_METHOD_ABSOLUTE) {
+										if ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
+											if ($this->out_start > 0) {
+												$rra[$rra_num][$ds_num]['outwind_samples']++;
+											}
 
-											$rra[$rra_num][$ds_num]['stddev_killed']++;
-											$this->std_kills = true;
+											if ($sample > $this->absmax) {
+												$this->debug(sprintf('Window AbsMax Found, Date:%s, Value:%s', date('Y-m-d H:i', $timestamp), $sample));
+
+												if ($this->out_start > 0) {
+													$rra[$rra_num][$ds_num]['outwind_killed']++;
+												}
+
+												$this->out_kills = true;
+											} elseif (strtolower($sample) !== 'nan') {
+												$rra[$rra_num][$ds_num]['numnksamples']++;
+												$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
+											}
+										} elseif (strtolower($sample) !== 'nan') {
+											$rra[$rra_num][$ds_num]['numnksamples']++;
+											$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 										}
-									} elseif (is_numeric($sample)) {
+									} elseif ($this->method == SPIKE_METHOD_STDDEV) {
+										if ($this->out_start == 0 || ($timestamp >= $this->out_start && $timestamp <= $this->out_end)) {
+											if ($this->out_start > 0) {
+												$rra[$rra_num][$ds_num]['outwind_samples']++;
+											}
+
+											if ($sample > $rra[$rra_num][$ds_num]['max_cutoff'] || $sample < $rra[$rra_num][$ds_num]['min_cutoff']) {
+												$this->debug(sprintf('StdDev Found, Date:%s, Value:%0.4e, StandardDev:%0.4e, StdDevLimit:%0.4e, Date:%s', date('Y-m-d H:i', $timestamp), $sample, $rra[$rra_num][$ds_num]['stddev'], ($rra[$rra_num][$ds_num]['max_cutoff'] * (1 + $this->percent))));
+
+												$rra[$rra_num][$ds_num]['stddev_killed']++;
+
+												if ($this->out_start > 0) {
+													$rra[$rra_num][$ds_num]['outwind_killed']++;
+												}
+
+												$this->std_kills = true;
+											} elseif (strtolower($sample) !== 'nan') {
+												$rra[$rra_num][$ds_num]['numnksamples']++;
+												$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
+											}
+										} elseif (strtolower($sample) !== 'nan') {
+											$rra[$rra_num][$ds_num]['numnksamples']++;
+											$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
+										}
+									} elseif ($this->method == SPIKE_METHOD_VARIANCE) {
+										if ($this->out_start == 0 || ($timestamp >= $this->out_start && $timestamp <= $this->out_end)) {
+											if ($this->out_start > 0) {
+												$rra[$rra_num][$ds_num]['outwind_samples']++;
+											}
+
+											if ($sample > ($rra[$rra_num][$ds_num]['variance_avg'] * (1 + $this->percent))) {
+												$this->debug(sprintf('Variance Found, Date:%s, Value:%0.4e, VarianceDev:%0.4e, VarianceLimit:%0.4e', date('Y-m-d H:i', $timestamp), $sample, $rra[$rra_num][$ds_num]['variance_avg'], ($rra[$rra_num][$ds_num]['variance_avg'] * (1 + $this->percent))));
+
+												$rra[$rra_num][$ds_num]['variance_killed']++;
+												$rra[$rra_num][$ds_num]['outwind_killed']++;
+
+												$this->var_kills = true;
+											} elseif (strtolower($sample) !== 'nan') {
+												$rra[$rra_num][$ds_num]['numnksamples']++;
+												$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
+											}
+										} elseif (strtolower($sample) !== 'nan') {
+											$rra[$rra_num][$ds_num]['numnksamples']++;
+											$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
+										}
+									} elseif (strtolower($sample) !== 'nan') {
 										$rra[$rra_num][$ds_num]['numnksamples']++;
 										$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
-									}
-
-									if (!empty($this->out_start) && $timestamp >= $this->out_start && $timestamp <= $this->out_end) {
-										// Already calculated
-									} elseif ($rra[$rra_num][$ds_num]['variance_avg'] == 'NAN') {
-										// not enough samples to calculate
-									} elseif ($sample > ($rra[$rra_num][$ds_num]['variance_avg'] * (1 + $this->percent))) {
-										if ($this->method == SPIKE_METHOD_VARIANCE) {
-											/* kill based upon variance */
-											$this->debug(sprintf("Variance Found, Date:%s, Value:%0.4e, VarianceDev:%0.4e, VarianceLimit:%0.4e", date('Y-m-d H:i', $timestamp), $sample, $rra[$rra_num][$ds_num]['variance_avg'], ($rra[$rra_num][$ds_num]['variance_avg'] * (1+$this->percent))));
-
-											$rra[$rra_num][$ds_num]['variance_killed']++;
-											$this->var_kills = true;
-										}
 									}
 								}
 							}
@@ -917,10 +1067,11 @@ class spikekill {
 								$rra[$rra_num][$ds_num]['avgnksamples']       = 'N/A';
 								$rra[$rra_num][$ds_num]['stddev_killed']      = 'N/A';
 								$rra[$rra_num][$ds_num]['variance_killed']    = 'N/A';
+								$rra[$rra_num][$ds_num]['outwind_samples']    = 'N/A';
 								$rra[$rra_num][$ds_num]['outwind_killed']     = 'N/A';
 							}
 						} else {
-							$rra[$rra_num][$ds_num]['stddev'] = 'N/A';
+							$rra[$rra_num][$ds_num]['stddev']             = 'N/A';
 							$rra[$rra_num][$ds_num]['average']            = 'N/A';
 							$rra[$rra_num][$ds_num]['min_cutoff']         = 'N/A';
 							$rra[$rra_num][$ds_num]['max_cutoff']         = 'N/A';
@@ -929,6 +1080,7 @@ class spikekill {
 							$rra[$rra_num][$ds_num]['avgnksamples']       = 'N/A';
 							$rra[$rra_num][$ds_num]['stddev_killed']      = 'N/A';
 							$rra[$rra_num][$ds_num]['variance_killed']    = 'N/A';
+							$rra[$rra_num][$ds_num]['outwind_samples']    = 'N/A';
 							$rra[$rra_num][$ds_num]['outwind_killed']     = 'N/A';
 						}
 
@@ -945,27 +1097,25 @@ class spikekill {
 		if (cacti_sizeof($rra)) {
 			if (!$this->html) {
 				$this->strout .= "\n";
-				$this->strout .= sprintf("%10s %16s %10s %7s %7s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s\n",
+				$this->strout .= sprintf("%10s %16s %10s %7s %7s %10s %10s %10s %10s %10s %10s %10s %10s %12s %10s\n",
 					'Size', 'DataSource', 'CF', 'Samples', 'NonNan', 'Avg', 'StdDev',
-					'MaxValue', 'MinValue', 'MaxStdDev', 'MinStdDev', 'StdKilled', 'VarKilled', 'WindFilled', 'StdDevAvg', 'VarAvg');
-				$this->strout .= sprintf("%10s %16s %10s %7s %7s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s %10s\n",
+					'MaxValue', 'MinValue', 'MaxStdDev', 'MinStdDev', 'StdKilled', 'VarKilled', 'WindSamples', 'WindKilled');
+				$this->strout .= sprintf("%10s %16s %10s %7s %7s %10s %10s %10s %10s %10s %10s %10s %10s %12s %10s\n",
 					'----------', '---------------', '----------', '-------', '-------', '----------', '----------',
-					'----------', '----------', '----------', '----------', '----------', '----------', '----------',
+					'----------', '----------', '----------', '----------', '----------', '----------', '------------',
 					'----------', '----------');
 
 				foreach ($rra as $rra_key => $dses) {
 					if (cacti_sizeof($dses)) {
 						foreach ($dses as $dskey => $ds) {
 							$this->strout .= sprintf('%10s %16s %10s %7s %7s ' .
-								($ds['average'] < 1E6 ? '%10s ':'%10.4e ') .
-								($ds['stddev'] < 1E6 ? '%10s ':'%10.4e ') .
-								(isset($ds['max_value'])  ? ($ds['max_value']  < 1E6 ? '%10s ':'%10.4e ') : '%10s ') .
-								(isset($ds['min_value'])  ? ($ds['min_value']  < 1E6 ? '%10s ':'%10.4e ') : '%10s ') .
-								(isset($ds['max_cutoff']) ? ($ds['max_cutoff'] < 1E6 ? '%10s ':'%10.4e ') : '%10s ') .
-								(isset($ds['min_cutoff']) ? ($ds['min_cutoff'] < 1E6 ? '%10s ':'%10.4e ') : '%10s ') .
-								'%10s %10s %10s ' .
-								(isset($ds['avgnksamples']) ? ($ds['avgnksamples'] < 1E6 ? '%10s ' : '%10.4e ') : '%10.4E ') .
-								(isset($ds['variance_avg']) ? ($ds['variance_avg'] < 1E6 ? '%10s ' : '%10.4e ') : '%10.4E ') . "\n",
+								($ds['average'] < 1E6 ? '%10s ' : '%10.4e ') .
+								($ds['stddev'] < 1E6 ? '%10s ' : '%10.4e ') .
+								(isset($ds['max_value']) ? ($ds['max_value'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
+								(isset($ds['min_value']) ? ($ds['min_value'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
+								(isset($ds['max_cutoff']) ? ($ds['max_cutoff'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
+								(isset($ds['min_cutoff']) ? ($ds['min_cutoff'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
+								'%10s %10s %12s %10s' . PHP_EOL,
 								$this->displayTime($this->rra_pdp[$rra_key]),
 								$this->ds_name[$dskey],
 								$this->rra_cf[$rra_key],
@@ -979,9 +1129,8 @@ class spikekill {
 								($ds['min_cutoff'] != 'N/A' ? round($ds['min_cutoff'],2) : $ds['min_cutoff']),
 								$ds['stddev_killed'],
 								$ds['variance_killed'],
-								$ds['outwind_killed'],
-								($ds['avgnksamples'] != 'N/A' ? round($ds['avgnksamples'],2) : $ds['avgnksamples']),
-								(isset($ds['variance_avg']) ? round($ds['variance_avg'],2) : 'N/A'));
+								$ds['outwind_samples'],
+								$ds['outwind_killed']);
 						}
 					}
 				}
@@ -990,21 +1139,20 @@ class spikekill {
 			} else {
 				$this->strout .= sprintf("<tr class='tableHeader'><th style='width:10%%;'>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th></tr>\n",
 					'Size', 'DataSource', 'CF', 'Samples', 'NonNan', 'Avg', 'StdDev',
-					'MaxValue', 'MinValue', 'MaxStdDev', 'MinStdDev', 'StdKilled', 'VarKilled', 'WindFilled', 'StdDevAvg', 'VarAvg');
+					'MaxValue', 'MinValue', 'MaxStdDev', 'MinStdDev', 'StdKilled', 'VarKilled', 'WindSamples', 'WindKilled');
 
 				foreach ($rra as $rra_key => $dses) {
 					if (cacti_sizeof($dses)) {
 						foreach ($dses as $dskey => $ds) {
 							$this->strout .= sprintf('<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td>' .
-								($ds['average'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') .
-								($ds['stddev'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') .
-								(isset($ds['max_value']) ? ($ds['max_value'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') : '<td>%s</td>') .
-								(isset($ds['min_value']) ? ($ds['min_value'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') : '<td>%s</td>') .
-								(isset($ds['max_cutoff']) ? ($ds['max_cutoff'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') : '<td>%s</td>') .
-								(isset($ds['min_cutoff']) ? ($ds['min_cutoff'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') : '<td>%s</td>') .
+								($ds['average'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') .
+								($ds['stddev'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') .
+								(isset($ds['max_value']) ? ($ds['max_value'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
+								(isset($ds['min_value']) ? ($ds['min_value'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
+								(isset($ds['max_cutoff']) ? ($ds['max_cutoff'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
+								(isset($ds['min_cutoff']) ? ($ds['min_cutoff'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
 								'<td>%s</td><td>%s</td><td>%s</td>' .
-								(isset($ds['avgnksampled']) ? ($ds['avgnksamples'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
-								(isset($ds['variance_avg']) ? ($ds['variance_avg'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
+								'<td>%s</td>' .
 								"</tr>\n\n",
 								$this->displayTime($this->rra_pdp[$rra_key]),
 								$this->ds_name[$dskey],
@@ -1019,9 +1167,8 @@ class spikekill {
 								($ds['min_cutoff'] != 'N/A' ? round($ds['min_cutoff'],2) : $ds['min_cutoff']),
 								$ds['stddev_killed'],
 								$ds['variance_killed'],
-								$ds['outwind_killed'],
-								($ds['avgnksamples'] != 'N/A' ? round($ds['avgnksamples'],2) : $ds['avgnksamples']),
-								(isset($ds['variance_avg']) ? round($ds['variance_avg'],2) : 'N/A'));
+								$ds['outwind_samples'],
+								$ds['outwind_killed']);
 						}
 					}
 				}
@@ -1068,7 +1215,7 @@ class spikekill {
 							case SPIKE_METHOD_FLOAT:
 								if ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
 									if ($this->avgnan == 'avg') {
-										$message = sprintf('Replacing dsvalue %s with variance_avg %s', $dsvalue, $rra[$rra_num][$ds_num]['variance_avg']);
+										$message = sprintf('Replacing dsvalue %s with average %s', $dsvalue, $rra[$rra_num][$ds_num]['variance_avg']);
 
 										cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
 										$this->debug($message);
@@ -1076,6 +1223,8 @@ class spikekill {
 										$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['variance_avg']);
 										$kills++;
 										$this->total_kills++;
+									} elseif ($this->avgnan == 'nan') {
+										// Not supported for fill and float modes
 									} elseif ($this->avgnan == 'last' && isset($rra[$rra_num][$ds_num]['last'])) {
 										$message = sprintf('Replacing dsvalue %s with last value %s', $dsvalue, $rra[$rra_num][$ds_num]['last']);
 
@@ -1089,11 +1238,13 @@ class spikekill {
 								} else {
 									cacti_log("DEBUG: ignoring dsvalue {$dsvalue} as we are outside of the time range!", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
 								}
+
+								break;
 							case SPIKE_METHOD_FILL:
 								if ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
 									if ($this->avgnan == 'avg') {
 										if (strtolower($dsvalue) == 'nan' || $dsvalue == 0) {
-											$message = sprintf('Replacing dsvalue %s with variance_avg %s', $dsvalue, $rra[$rra_num][$ds_num]['variance_avg']);
+											$message = sprintf('Replacing dsvalue %s with average %s', $dsvalue, $rra[$rra_num][$ds_num]['variance_avg']);
 
 											cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
 											$this->debug($message);
@@ -1102,6 +1253,8 @@ class spikekill {
 											$kills++;
 											$this->total_kills++;
 										}
+									} elseif ($this->avgnan == 'nan') {
+										// Not supported for fill and float modes
 									} elseif ($this->avgnan == 'last' && isset($rra[$rra_num][$ds_num]['last'])) {
 										if (strtolower($dsvalue) == 'nan' || $dsvalue == 0) {
 											$message = sprintf('Replacing dsvalue %s with last value %s', $dsvalue, $rra[$rra_num][$ds_num]['last']);
@@ -1124,21 +1277,30 @@ class spikekill {
 									if ($dsvalue > (1 + $this->percent) * (float) $rra[$rra_num][$ds_num]['variance_avg']) {
 										if ($kills < $this->numspike) {
 											if ($this->avgnan == 'avg') {
-												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with variance_avg {$rra[$rra_num][$ds_num]['variance_avg']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$message = sprintf('Replacing dsvalue %s with average %s', $dsvalue, $rra[$rra_num][$ds_num]['variance_avg']);
+
+												cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$this->debug($message);
 
 												$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['variance_avg']);
 												$this->total_kills++;
 												$kills++;
+											} elseif ($this->avgnan == 'nan') {
+												$message = sprintf('Replacing dsvalue %s with NaN', $dsvalue);
+
+												cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$this->debug($message);
+
+												$dsvalue = 'NaN';
 											} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
-												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$message = sprintf('Replacing dsvalue %s with last value %s', $dsvalue, $last_num[$ds_num]);
+
+												cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$this->debug($message);
 
 												$dsvalue = $last_num[$ds_num];
 												$this->total_kills++;
 												$kills++;
-											} elseif ($this->avgnan == 'nan') {
-												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with NaN", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-
-												$dsvalue = 'NaN';
 											}
 										}
 									}
@@ -1153,26 +1315,72 @@ class spikekill {
 									if (empty($this->out_start) || ($timestamp >= $this->out_start && $timestamp <= $out_end)) {
 										if ($kills < $this->numspike) {
 											if ($this->avgnan == 'avg') {
-												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with average {$rra[$rra_num][$ds_num]['average']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$message = sprintf('Replacing dsvalue %s with average %s', $dsvalue, $rra[$rra_num][$ds_num]['average']);
+
+												cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$this->debug($message);
 
 												$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['average']);
 												$this->total_kills++;
 												$kills++;
+											} elseif ($this->avgnan == 'nan') {
+												$message = sprintf('Replacing dsvalue %s with NaN', $dsvalue);
+
+												cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$this->debug($message);
+
+												$dsvalue = 'NaN';
 											} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
-												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$message = sprintf('Replacing dsvalue %s with last value %s', $dsvalue, $last_num[$ds_num]);
+
+												cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+												$this->debug($message);
 
 												$dsvalue = $last_num[$ds_num];
 												$this->total_kills++;
 												$kills++;
-											} elseif ($this->avgnan == 'nan') {
-												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with NaN", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-
-												$dsvalue = 'NaN';
 											}
 										}
 									}
 								} elseif (strtolower($dsvalue) !== 'nan' && $dsvalue != 0) {
 									$last_num[$ds_num] = $dsvalue;
+								}
+
+								break;
+							case SPIKE_METHOD_ABSOLUTE:
+								if ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
+									if ($dsvalue >= $this->absmax) {
+										if ($this->avgnan == 'avg') {
+											$message = sprintf('Replacing dsvalue %s with average %s', $dsvalue, $rra[$rra_num][$ds_num]['variance_avg']);
+
+											cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+											$this->debug($message);
+
+											$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['variance_avg']);
+											$kills++;
+											$this->total_kills++;
+										} elseif ($this->avgnan == 'nan') {
+											$message = sprintf('Replacing dsvalue %s with NaN', $dsvalue);
+
+											cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+											$this->debug($message);
+
+											$dsvalue = 'NaN';
+											$kills++;
+											$this->total_kills++;
+										} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
+											$message = sprintf('Replacing dsvalue %s with last value %s', $dsvalue, $last_num[$ds_num]);
+
+											cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+											$this->debug($message);
+
+											$dsvalue = $last_num[$ds_num];
+											$this->total_kills++;
+											$kills++;
+										}
+									}
+								} else {
+									cacti_log("DEBUG: ignoring dsvalue {$dsvalue} as we are outside of the time range!", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
 								}
 
 								break;
@@ -1285,11 +1493,9 @@ class spikekill {
 	private function processStandardDeviationCalculation(array $samples) : mixed {
 		$my_samples = $samples;
 
-		if (!empty($this->out_start)) {
-			foreach ($samples as $timestamp => $value) {
-				if ($timestamp < $this->out_start || $timestamp > $this->out_end) {
-					$my_samples[] = $value;
-				}
+		foreach ($samples as $timestamp => $value) {
+			if ((empty($this->out_start) || $timestamp < $this->out_start || $timestamp > $this->out_end) && strtolower($value) != 'nan') {
+				$my_samples[] = $value;
 			}
 		}
 
@@ -1297,6 +1503,34 @@ class spikekill {
 	}
 
 	private function calculateStandardDeviation(array $items) : mixed {
-		return stats_standard_deviation($items, false);
+		$sum         = 0;
+		$total_items = 0;
+
+		/* remove NaN entries from the data set */
+		if (cacti_sizeof($items)) {
+			foreach($items as $key => $value) {
+				if ($value != 'NaN') {
+					$total_items++;
+
+					$sum += $value;
+				} else {
+					unset($items[$key]);
+				}
+			}
+		}
+
+		if ($total_items < 2) {
+			return false;
+		}
+
+		$mean  = $sum / $total_items;
+		$carry = 0.0;
+
+		foreach ($items as $val) {
+			$d = ((double) $val) - $mean;
+			$carry += $d * $d;
+		}
+
+		return sqrt($carry / $total_items);
 	}
 }

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -1508,7 +1508,7 @@ class spikekill {
 		// remove NaN entries from the data set
 		if (cacti_sizeof($items)) {
 			foreach ($items as $key => $value) {
-				if ($value != 'NaN') {
+				if (is_numeric($value)) {
 					$total_items++;
 
 					$sum += $value;

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -620,7 +620,7 @@ class spikekill {
 								} elseif ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
 									if ($this->avgnan == 'last') {
 										$newval = $rra[$rra_num][$ds_num]['variance_avg'];
-									} elseif ($this->avgnan = 'avg') {
+									} elseif ($this->avgnan == 'avg') {
 										$newval = $rra[$rra_num][$ds_num]['last'];
 									} else {
 										$newval = 'NaN';

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -396,32 +396,34 @@ class spikekill {
 				$this->set_error("FATAL: You must specify either 'last', 'avg' or 'nan' as a replacement method.");
 		}
 
-		printf('Spike Kill Settings Used for Analysis/Correction' . PHP_EOL);
-		printf('------------------------------------------------' . PHP_EOL);
-		printf('Method:        %s' . PHP_EOL, $dispmethod);
-		printf('RRDfile:       %s' . PHP_EOL, $this->rrdfile);
-		printf('Repair Type:   %s' . PHP_EOL, $this->avgnan);
+		if (!$this->html) {
+			printf('Spike Kill Settings Used for Analysis/Correction' . PHP_EOL);
+			printf('------------------------------------------------' . PHP_EOL);
+			printf('Method:        %s' . PHP_EOL, $dispmethod);
+			printf('RRDfile:       %s' . PHP_EOL, $this->rrdfile);
+			printf('Repair Type:   %s' . PHP_EOL, $this->avgnan);
 
-		if ($this->method == SPIKE_METHOD_STDDEV || $this->method == SPIKE_METHOD_VARIANCE) {
-			printf('Num Outliers:  %s' . PHP_EOL, $this->outliers);
-			printf('Max Kills:     %s' . PHP_EOL, $this->numspike);
-		} else {
-			printf('Max Kills:     Unlimited' . PHP_EOL, $this->numspike);
-		}
+			if ($this->method == SPIKE_METHOD_STDDEV || $this->method == SPIKE_METHOD_VARIANCE) {
+				printf('Num Outliers:  %s' . PHP_EOL, $this->outliers);
+				printf('Max Kills:     %s' . PHP_EOL, $this->numspike);
+			} else {
+				printf('Max Kills:     Unlimited' . PHP_EOL, $this->numspike);
+			}
 
-		if ($this->method == SPIKE_METHOD_STDDEV) {
-			printf('Standard Devs: %s' . PHP_EOL, $this->stddev);
-		} elseif ($this->method == SPIKE_METHOD_VARIANCE) {
-			printf('Variance %%:    %s %%' . PHP_EOL, number_format_i18n($this->percent * 100, 2));
-		} elseif ($this->method == SPIKE_METHOD_ABSOLUTE) {
-			printf('Absolute Max:  %s' . PHP_EOL, $this->absmax);
-		}
+			if ($this->method == SPIKE_METHOD_STDDEV) {
+				printf('Standard Devs: %s' . PHP_EOL, $this->stddev);
+			} elseif ($this->method == SPIKE_METHOD_VARIANCE) {
+				printf('Variance %%:    %s %%' . PHP_EOL, number_format_i18n($this->percent * 100, 2));
+			} elseif ($this->method == SPIKE_METHOD_ABSOLUTE) {
+				printf('Absolute Max:  %s' . PHP_EOL, $this->absmax);
+			}
 
-		if ($this->out_start > 0) {
-			printf('Window Start:  %s (%s)' . PHP_EOL, $this->out_start, date('Y-m-d H:i', $this->out_start));
-			printf('Window End:    %s (%s)' . PHP_EOL . PHP_EOL, $this->out_end, date('Y-m-d H:i', $this->out_end));
-		} else {
-			printf('Window Range:  All' . PHP_EOL . PHP_EOL, $this->out_end, date('Y-m-d H:i', $this->out_end));
+			if ($this->out_start > 0) {
+				printf('Window Start:  %s (%s)' . PHP_EOL, $this->out_start, date('Y-m-d H:i', $this->out_start));
+				printf('Window End:    %s (%s)' . PHP_EOL . PHP_EOL, $this->out_end, date('Y-m-d H:i', $this->out_end));
+			} else {
+				printf('Window Range:  All' . PHP_EOL . PHP_EOL);
+			}
 		}
 	}
 
@@ -1275,7 +1277,7 @@ class spikekill {
 
 								break;
 							case SPIKE_METHOD_VARIANCE:
-								if (empty($this->out_start) || ($timestamp >= $this->out_start && $timestamp <= $out_end)) {
+								if (empty($this->out_start) || ($timestamp >= $this->out_start && $timestamp <= $this->out_end)) {
 									if ($dsvalue > (1 + $this->percent) * (float) $rra[$rra_num][$ds_num]['variance_avg']) {
 										if ($kills < $this->numspike) {
 											if ($this->avgnan == 'avg') {
@@ -1314,7 +1316,7 @@ class spikekill {
 							case SPIKE_METHOD_STDDEV:
 								if (($dsvalue > $rra[$rra_num][$ds_num]['max_cutoff']) ||
 									($dsvalue < $rra[$rra_num][$ds_num]['min_cutoff'])) {
-									if (empty($this->out_start) || ($timestamp >= $this->out_start && $timestamp <= $out_end)) {
+									if (empty($this->out_start) || ($timestamp >= $this->out_start && $timestamp <= $this->out_end)) {
 										if ($kills < $this->numspike) {
 											if ($this->avgnan == 'avg') {
 												$message = sprintf('Replacing dsvalue %s with average %s', $dsvalue, $rra[$rra_num][$ds_num]['average']);

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -561,7 +561,7 @@ class spikekill {
 		 * Also track the min and max value for each ds and store it into the two
 		 * arrays: ds_min[ds#], ds_max[ds#].
 		 *
-		 * The we don't need to know the type of rra, only it's number for this analysis
+		 * Then we don't need to know the type of rra, only its number for this analysis
 		 * the same applies for the ds' as well.
 		 */
 		$rra           = [];

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -260,7 +260,7 @@ class spikekill {
 			}
 		}
 
-		if ($this->dabsmax == '') {
+		if ($this->absmax == '') {
 			if (!empty($uabsmax)) {
 				$this->absmax = $this->dabsmax;
 			} else {

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -49,7 +49,7 @@ class spikekill {
 	public mixed  $percent    = '';
 	public mixed  $numspike   = '';
 	public mixed  $dsfilter   = '';
-	public string $absmax     = '';
+	public mixed  $absmax     = '';
 
 	// Overridable
 	public bool $html        = true;
@@ -58,12 +58,14 @@ class spikekill {
 	public bool $dryrun      = false;
 
 	// Defaults from cacti settings
-	private int $dmethod     = 1;
-	private int $dnumspike   = 10;
-	private int $dstddev     = 10;
-	private int $dpercent    = 500;
-	private int $doutliers   = 5;
-	private string $davgnan  = 'last';
+	private int $dmethod      = 1;
+	private int $dnumspike    = 10;
+	private int $dstddev      = 10;
+	private int $dpercent     = 500;
+	private int $doutliers    = 5;
+	private float $dabsmax    = 1E9;
+	private string $davgnan   = 'last';
+	private string $ddsfilter = '';
 
 	// Internal globals
 	private string $tempdir  = '';
@@ -407,7 +409,7 @@ class spikekill {
 				printf('Num Outliers:  %s' . PHP_EOL, $this->outliers);
 				printf('Max Kills:     %s' . PHP_EOL, $this->numspike);
 			} else {
-				printf('Max Kills:     Unlimited' . PHP_EOL, $this->numspike);
+				printf('Max Kills:     Unlimited' . PHP_EOL);
 			}
 
 			if ($this->method == SPIKE_METHOD_STDDEV) {
@@ -451,6 +453,10 @@ class spikekill {
 
 		if (!empty($this->out_start) && !$this->dryrun) {
 			$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') . 'NOTE: Removing Outliers in Range and Replacing with Last' . ($this->html ? "</p>\n" : "\n");
+		}
+
+		if ($this->method == SPIKE_METHOD_VARIANCE) {
+			$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') . sprintf('NOTE: Variance Calculation removes top and bottom %s samples due to Outliers setting', $this->outliers) . ($this->html ? "</p>\n" : "\n");
 		}
 
 		// execute the dump command
@@ -597,7 +603,7 @@ class spikekill {
 					if (str_contains($timestamp_part, '<timestamp>')) {
 						$timestamp_part = str_replace('<row><timestamp>', '', $timestamp_part);
 						$timestamp_part = str_replace('</timestamp>', '', $timestamp_part);
-						$timestamp      = trim($timestamp_part);
+						$timestamp      = intval(trim($timestamp_part));
 					} else {
 						$timestamp = 0;
 					}
@@ -621,7 +627,7 @@ class spikekill {
 									$process = true;
 								} elseif ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
 									if ($this->avgnan == 'last') {
-										$newval = $rra[$rra_num][$ds_num]['variance_avg'];
+										$newval = $rra[$rra_num][$ds_num]['average']; // @phpstan-ignore-line
 									} elseif ($this->avgnan == 'avg') {
 										$newval = $rra[$rra_num][$ds_num]['last'];
 									} else {
@@ -757,7 +763,7 @@ class spikekill {
 		$continue   = false;
 
 		// create an output array
-		if ($this->std_kills || $this->out_kills) {
+		if ($this->std_kills || $this->out_kills || $this->var_kills) {
 			$this->debug('Either std_kills or out_kills found');
 
 			if (!$this->dryrun) {
@@ -864,44 +870,32 @@ class spikekill {
 			foreach ($samples as $rra_num => $dses) {
 				if (cacti_sizeof($dses)) {
 					foreach ($dses as $ds_num => $ds) {
-						if (empty($this->out_start)) {
-							if (cacti_sizeof($ds) < $this->outliers * 3) {
-								$rra[$rra_num][$ds_num]['variance_avg'] = 'NAN';
-							} else {
-								$myds = $ds;
+						if (cacti_sizeof($ds) < $this->outliers * 3) {
+							$rra[$rra_num][$ds_num]['variance_avg'] = 'NAN';
+						} else {
+							$myds = $ds;
 
-								// remove NaN entries from the data set
-								if (cacti_sizeof($myds)) {
-									foreach ($myds as $timestamp => $value) {
-										if (stripos($value, 'nan') !== false) {
-											unset($myds[$timestamp]);
-										}
+							// remove NaN entries from the data set
+							if (cacti_sizeof($myds)) {
+								foreach ($myds as $timestamp => $value) {
+									if (stripos($value, 'nan') !== false) {
+										unset($myds[$timestamp]);
 									}
 								}
-
-								// remove high outliers
-								rsort($myds, SORT_NUMERIC);
-								$myds = array_slice($myds, $this->outliers);
-
-								// remove low outliers
-								sort($myds, SORT_NUMERIC);
-								$myds = array_slice($myds, $this->outliers);
-
-								if (cacti_sizeof($myds)) {
-									$rra[$rra_num][$ds_num]['variance_avg'] = array_sum($myds) / cacti_sizeof($myds);
-								} else {
-									$rra[$rra_num][$ds_num]['variance_avg'] = 'NAN';
-								}
 							}
-						} else {
-							if (isset($rra[$rra_num][$ds_num]['sumofsamples']) && isset($rra[$rra_num][$ds_num]['numsamples'])) {
-								if ($rra[$rra_num][$ds_num]['numsamples'] > 0) {
-									$rra[$rra_num][$ds_num]['variance_avg'] = $rra[$rra_num][$ds_num]['sumofsamples'] / $rra[$rra_num][$ds_num]['numsamples'];
-								} else {
-									$rra[$rra_num][$ds_num]['variance_avg'] = 0;
-								}
+
+							// remove high outliers
+							rsort($myds, SORT_NUMERIC);
+							$myds = array_slice($myds, $this->outliers);
+
+							// remove low outliers
+							sort($myds, SORT_NUMERIC);
+							$myds = array_slice($myds, $this->outliers);
+
+							if (cacti_sizeof($myds)) {
+								$rra[$rra_num][$ds_num]['variance_avg'] = array_sum($myds) / cacti_sizeof($myds);
 							} else {
-								$rra[$rra_num][$ds_num]['variance_avg'] = 0;
+								$rra[$rra_num][$ds_num]['variance_avg'] = 'NAN';
 							}
 						}
 					}
@@ -1014,7 +1008,7 @@ class spikekill {
 											}
 
 											if ($sample > $rra[$rra_num][$ds_num]['max_cutoff'] || $sample < $rra[$rra_num][$ds_num]['min_cutoff']) {
-												$this->debug(sprintf('StdDev Found, Date:%s, Value:%0.4e, StandardDev:%0.4e, StdDevLimit:%0.4e, Date:%s', date('Y-m-d H:i', $timestamp), $sample, $rra[$rra_num][$ds_num]['stddev'], ($rra[$rra_num][$ds_num]['max_cutoff'] * (1 + $this->percent))));
+												$this->debug(sprintf('StdDev Found, Date:%s, Value:%0.4e, StandardDev:%0.4e, StdDevLimit:%0.4e', date('Y-m-d H:i', $timestamp), $sample, $rra[$rra_num][$ds_num]['stddev'], ($rra[$rra_num][$ds_num]['max_cutoff'] * (1 + $this->percent))));
 
 												$rra[$rra_num][$ds_num]['stddev_killed']++;
 
@@ -1101,13 +1095,13 @@ class spikekill {
 		if (cacti_sizeof($rra)) {
 			if (!$this->html) {
 				$this->strout .= "\n";
-				$this->strout .= sprintf("%10s %16s %10s %7s %7s %10s %10s %10s %10s %10s %10s %10s %10s %12s %10s\n",
-					'Size', 'DataSource', 'CF', 'Samples', 'NonNan', 'Avg', 'StdDev',
+				$this->strout .= sprintf("%10s %16s %10s %7s %7s %10s %10s %10s %10s %10s %10s %10s %10s %10s %12s %10s\n",
+					'Size', 'DataSource', 'CF', 'Samples', 'NonNan', 'Avg', 'StdDev', 'Variance',
 					'MaxValue', 'MinValue', 'MaxStdDev', 'MinStdDev', 'StdKilled', 'VarKilled', 'WindSamples', 'WindKilled');
-				$this->strout .= sprintf("%10s %16s %10s %7s %7s %10s %10s %10s %10s %10s %10s %10s %10s %12s %10s\n",
-					'----------', '---------------', '----------', '-------', '-------', '----------', '----------',
+				$this->strout .= sprintf("%10s %16s %10s %7s %7s %10s %10s %10s %10s %10s %10s %10s %10s %10s %12s %10s\n",
+					'----------', '---------------', '----------', '-------', '-------', '----------', '----------', '----------',
 					'----------', '----------', '----------', '----------', '----------', '----------', '------------',
-					'----------', '----------');
+					'----------');
 
 				foreach ($rra as $rra_key => $dses) {
 					if (cacti_sizeof($dses)) {
@@ -1119,7 +1113,7 @@ class spikekill {
 								(isset($ds['min_value']) ? ($ds['min_value'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
 								(isset($ds['max_cutoff']) ? ($ds['max_cutoff'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
 								(isset($ds['min_cutoff']) ? ($ds['min_cutoff'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
-								'%10s %10s %12s %10s' . PHP_EOL,
+								'%10s %10s %10s %12s %10s' . PHP_EOL,
 								$this->displayTime($this->rra_pdp[$rra_key]),
 								$this->ds_name[$dskey],
 								$this->rra_cf[$rra_key],
@@ -1127,6 +1121,7 @@ class spikekill {
 								($ds['numsamples'] ?? '0'),
 								($ds['average'] != 'N/A' ? round($ds['average'],2) : $ds['average']),
 								($ds['stddev'] != 'N/A' ? round($ds['stddev'],2) : $ds['stddev']),
+								($ds['variance_avg'] != 'N/A' ? round($ds['variance_avg'],2) : $ds['variance_avg']),
 								(isset($ds['max_value']) ? round($ds['max_value'],2) : 'N/A'),
 								(isset($ds['min_value']) ? round($ds['min_value'],2) : 'N/A'),
 								($ds['max_cutoff'] != 'N/A' ? round($ds['max_cutoff'],2) : $ds['max_cutoff']),
@@ -1141,7 +1136,7 @@ class spikekill {
 
 				$this->strout .= "\n";
 			} else {
-				$this->strout .= sprintf("<tr class='tableHeader'><th style='width:10%%;'>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th></tr>\n",
+				$this->strout .= sprintf("<tr class='tableHeader'><th style='width:10%%;'>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th><th>%s</th></tr>\n",
 					'Size', 'DataSource', 'CF', 'Samples', 'NonNan', 'Avg', 'StdDev',
 					'MaxValue', 'MinValue', 'MaxStdDev', 'MinStdDev', 'StdKilled', 'VarKilled', 'WindSamples', 'WindKilled');
 

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -1492,9 +1492,13 @@ class spikekill {
 	private function processStandardDeviationCalculation(array $samples) : mixed {
 		$my_samples = $samples;
 
-		foreach ($samples as $timestamp => $value) {
-			if ((empty($this->out_start) || $timestamp < $this->out_start || $timestamp > $this->out_end) && is_numeric($value)) {
-				$my_samples[] = $value;
+		if ($this->out_start > 0) {
+			$my_samples = [];
+
+			foreach ($samples as $timestamp => $value) {
+				if (($timestamp < $this->out_start || $timestamp > $this->out_end) && is_numeric($value)) {
+					$my_samples[] = $value;
+				}
 			}
 		}
 

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -280,27 +280,27 @@ class spikekill {
 		switch($this->method) {
 			case 'stddev':
 				$this->method = SPIKE_METHOD_STDDEV;
-				$dispmethod = __('StdDev');
+				$dispmethod   = __('StdDev');
 
 				break;
 			case 'variance':
 				$this->method = SPIKE_METHOD_VARIANCE;
-				$dispmethod = __('Variance');
+				$dispmethod   = __('Variance');
 
 				break;
 			case 'fill':
 				$this->method = SPIKE_METHOD_FILL;
-				$dispmethod = __('Gap Fill');
+				$dispmethod   = __('Gap Fill');
 
 				break;
 			case 'float':
 				$this->method = SPIKE_METHOD_FLOAT;
-				$dispmethod = __('Float Range');
+				$dispmethod   = __('Float Range');
 
 				break;
 			case 'absolute':
 				$this->method = SPIKE_METHOD_ABSOLUTE;
-				$dispmethod = __('Absolute Max');
+				$dispmethod   = __('Absolute Max');
 
 				break;
 			default:
@@ -323,7 +323,7 @@ class spikekill {
 		 * The fill, float, and absolute require a time range.  It's optional for stddev and variance.
 		 * Convert these to timestamps if they are not already so.
 		 */
-		if ($this->method ==  SPIKE_METHOD_FLOAT || $this->method == SPIKE_METHOD_FILL || $this->method == SPIKE_METHOD_ABSOLUTE) {
+		if ($this->method == SPIKE_METHOD_FLOAT || $this->method == SPIKE_METHOD_FILL || $this->method == SPIKE_METHOD_ABSOLUTE) {
 			if (!is_numeric($this->out_start)) {
 				$this->out_start = strtotime($this->out_start);
 			}
@@ -1506,9 +1506,9 @@ class spikekill {
 		$sum         = 0;
 		$total_items = 0;
 
-		/* remove NaN entries from the data set */
+		// remove NaN entries from the data set
 		if (cacti_sizeof($items)) {
-			foreach($items as $key => $value) {
+			foreach ($items as $key => $value) {
 				if ($value != 'NaN') {
 					$total_items++;
 

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -114,10 +114,18 @@ class spikekill {
 		}
 
 		if ($out_start != '') {
+			if (!is_numeric($out_start)) {
+				$this->out_start = strtotime($out_start);
+			}
+
 			$this->out_start = $out_start;
 		}
 
 		if ($out_end != '') {
+			if (!is_numeric($out_end)) {
+				$this->out_end = strtotime($out_end);
+			}
+
 			$this->out_end = $out_end;
 		}
 
@@ -330,6 +338,13 @@ class spikekill {
 				$this->set_error("FATAL: You must specify either 'last', 'avg' or 'nan' as a replacement method.");
 		}
 
+		$this->debug('Type:          ' . ucfirst($this->method));
+		$this->debug('RRDfile:       ' . $this->rrdfile);
+		$this->debug('Num Outliers:  ' . $this->outliers);
+		$this->debug('Percent:       ' . $this->outliers);
+		$this->debug(sprintf('Outlier Start: %s (%s)', $this->out_start, date('Y-m-d H:i', $this->out_start)));
+		$this->debug(sprintf('Outlier End:   %s (%s)', $this->out_end, date('Y-m-d H:i', $this->out_end)));
+
 		return false;
 	}
 
@@ -424,42 +439,44 @@ class spikekill {
 		// process the xml file and remove all comments
 		$output = $this->removeComments($output);
 
-		/* Read all the rra's ds values and obtain the following pieces of information from each
-		   rra archive.
-
-		   * numsamples - The number of 'valid' non-nan samples
-		   * sumofsamples - The sum of all 'valid' samples.
-		   * average - The average of all samples
-		   * standard_deviation - The standard deviation of all samples
-		   * max_value - The maximum value of all samples
-		   * min_value - The minimum value of all samples
-		   * max_cutoff - Any value above this value will be set to the average.
-		   * min_cutoff - Any value lower than this value will be set to the average.
-
-		   This will end up being a n-dimensional array as follows:
-		   rra[x][ds#]['totalsamples'];
-		   rra[x][ds#]['numsamples'];
-		   rra[x][ds#]['sumofsamples'];
-		   rra[x][ds#]['average'];
-		   rra[x][ds#]['stddev'];
-		   rra[x][ds#]['max_value'];
-		   rra[x][ds#]['min_value'];
-		   rra[x][ds#]['max_cutoff'];
-		   rra[x][ds#]['min_cutoff'];
-
-		   There will also be a secondary array created with the actual samples.  This
-		   array will be used to calculate the standard deviation of the sample set.
-		   samples[rra_num][ds_num][timestamp];
-
-		   Also track the min and max value for each ds and store it into the two
-		   arrays: ds_min[ds#], ds_max[ds#].
-
-		   The we don't need to know the type of rra, only it's number for this analysis
-		   the same applies for the ds' as well.
-		*/
-		$rra           = [];
-		$this->rra_cf  = [];
-		$this->rra_pdp = [];
+		/**
+		 * Read all the rra's ds values and obtain the following pieces of information from each
+		 *  rra archive.
+		 *
+		 *  - numsamples   - The number of 'valid' non-nan samples
+		 *  - sumofsamples - The sum of all 'valid' samples.
+		 *  - average      - The average of all samples
+		 *  - stddev       - The standard deviation of all samples
+		 *  - max_value    - The maximum value of all samples
+		 *  - min_value    - The minimum value of all samples
+		 *  - max_cutoff   - Any value above this value will be set to the average.
+		 *  - min_cutoff   - Any value lower than this value will be set to the average.
+		 *
+		 * This will end up being a n-dimensional array as follows:
+		 *
+		 * rra[x][ds#]['totalsamples'];
+		 * rra[x][ds#]['numsamples'];
+		 * rra[x][ds#]['sumofsamples'];
+		 * rra[x][ds#]['average'];
+		 * rra[x][ds#]['stddev'];
+		 * rra[x][ds#]['max_value'];
+		 * rra[x][ds#]['min_value'];
+		 * rra[x][ds#]['max_cutoff'];
+		 * rra[x][ds#]['min_cutoff'];
+		 *
+		 * There will also be a secondary array created with the actual samples.  This
+		 * array will be used to calculate the standard deviation of the sample set.
+		 * samples[rra_num][ds_num][timestamp];
+		 *
+		 * Also track the min and max value for each ds and store it into the two
+		 * arrays: ds_min[ds#], ds_max[ds#].
+		 *
+		 * The we don't need to know the type of rra, only it's number for this analysis
+		 * the same applies for the ds' as well.
+		 */
+		$rra     = array();
+		$this->rra_cf  = array();
+		$this->rra_pdp = array();
 
 		$rra_num = 0;
 		$ds_num  = 0;
@@ -511,16 +528,30 @@ class spikekill {
 
 						// check for outlier territory
 						if ($timestamp > 0) {
-							if (!empty($this->out_start) && $timestamp < $this->out_start) {
-								$process = true;
-							} elseif (!empty($this->out_end) && $timestamp > $this->out_end) {
-								$process = true;
-							} elseif (empty($this->out_start)) {
-								$process = true;
+							if ($this->method == SPIKE_METHOD_FILL || $this->method == SPIKE_METHOD_FLOAT) {
+								if ($timestamp < $this->out_start) {
+									$rra[$rra_num][$ds_num]['last'] = $dsvalue;
+
+									$process = true;
+								} elseif ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
+									if ($this->method == SPIKE_METHOD_FILL) {
+										if (strtolower($dsvalue) == 'nan' || $dsvalue == 0) {
+											$this->debug(sprintf('Fill Found, RRA:%s, DSNum:%s, Date:%s, CurVal:%0.4e NewVal:%0.4e', $rra_num, $ds_num, date('Y-m-d H:i:s', $timestamp), $dsvalue, $rra[$rra_num][$ds_num]['last']));
+										}
+									} else {
+										$this->debug(sprintf('Float Found, RRA:%s, DSNum:%s, Date:%s, CurVal:%0.4e NewVal:%0.4e', $rra_num, $ds_num, date('Y-m-d H:i:s', $timestamp), $dsvalue, $rra[$rra_num][$ds_num]['last']));
+									}
+
+									$process = false;
+								} else {
+									$process = true;
+								}
 							} else {
-								$process = false;
+								$process = true;
 							}
 						} else {
+							$this->debug('WARNING: Illegal Timestamp Found');
+
 							$process = true;
 						}
 
@@ -625,61 +656,50 @@ class spikekill {
 		}
 
 		$new_output = '';
+		$continue   = false;
 
-		// create an output array
-		if ($this->method == SPIKE_METHOD_STDDEV) {
-			// standard deviation subroutine
-			if ($this->std_kills || $this->out_kills) {
-				$this->debug('Either std_kills or out_kills found');
+		/* create an output array */
+		if ($this->std_kills || $this->out_kills) {
+			$this->debug('Either std_kills or out_kills found');
 
-				if (!$this->dryrun) {
-					$new_output = $this->updateXML($output, $rra);
-					$output     = true;
-				}
-			} elseif (!empty($this->out_start)) {
-				$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
-					"NOTE: No Window Spikes found in '$this->rrdfile'" . ($this->html ? "</p>\n" : "\n");
+			if (!$this->dryrun) {
+				$new_output = $this->updateXML($output, $rra);
+				$output   = true;
+				$continue = true;
 			} else {
-				$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
-					"NOTE: No Standard Deviation Spikes found in '$this->rrdfile'" . ($this->html ? "</p>\n" : "\n");
+				$new_output = $this->updateXML($output, $rra);
+				$output     = false;
+				$continue   = false;
 			}
+		} elseif ($this->out_start > 0) {
+			$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
+				"NOTE: No Window Spikes found in '$this->rrdfile'" . ($this->html ? "</p>\n":"\n");
 		} else {
-			// variance subroutine
-			if ($this->var_kills || $this->out_kills) {
-				$this->debug('Either variance or out_kills found');
-
-				if (!$this->dryrun) {
-					$new_output = $this->updateXML($output, $rra);
-					$output     = true;
-				}
-			} elseif (!empty($this->out_start)) {
-				$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
-					"NOTE: No Window Fills found in '$this->rrdfile'" . ($this->html ? "</p>\n" : "\n");
-			} else {
-				$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
-					"NOTE: No Variance Spikes found in '$this->rrdfile'" . ($this->html ? "</p>\n" : "\n");
-			}
+			$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
+				"NOTE: No Spikes found in '$this->rrdfile'" . ($this->html ? "</p>\n":"\n");
 		}
 
 		// finally update the file XML file and Reprocess the RRDfile
 		if (!$this->dryrun) {
-			if ($output == true && $new_output != '') {
-				if ($this->writeXMLFile($new_output, $xmlfile)) {
-					if ($this->backupRRDFile($this->rrdfile)) {
-						$this->createRRDFileFromXML($xmlfile, $this->rrdfile);
-						$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
-							"NOTE: Spikes Found and Remediated.  Total Spikes ($this->total_kills)" . ($this->html ? "</p>\n" : "\n");
+			if ($continue) {
+				if ($output == true && $new_output != '') {
+					if ($this->writeXMLFile($new_output, $xmlfile)) {
+						if ($this->backupRRDFile($this->rrdfile)) {
+							$this->createRRDFileFromXML($xmlfile, $this->rrdfile);
+							$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
+								"NOTE: Spikes Found and Remediated.  Total Spikes ($this->total_kills)" . ($this->html ? "</p>\n":"\n");
+						} else {
+							$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
+								"FATAL: Unable to backup '$this->rrdfile'" . ($this->html ? "</p>\n":"\n");
+						}
 					} else {
-						$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
-							"FATAL: Unable to backup '$this->rrdfile'" . ($this->html ? "</p>\n" : "\n");
+						$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
+							"FATAL: Unable to write XML file '$xmlfile'" . ($this->html ? "</p>\n":"\n");
 					}
 				} else {
-					$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
-						"FATAL: Unable to write XML file '$xmlfile'" . ($this->html ? "</p>\n" : "\n");
+					$this->strout .= ($this->html ? "<p class='spikekillNote'>":'') .
+						"NOTE: No Spikes Found." . ($this->html ? "</p>\n":"\n");
 				}
-			} else {
-				$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
-					'NOTE: No Spikes Found.' . ($this->html ? "</p>\n" : "\n");
 			}
 		} else {
 			$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
@@ -802,10 +822,9 @@ class spikekill {
 				if (cacti_sizeof($dses)) {
 					foreach ($dses as $ds) {
 						if (isset($samples[$rra_num][$ds_num])) {
-							$rra[$rra_num][$ds_num]['standard_deviation'] = $this->processStandardDeviationCalculation($samples[$rra_num][$ds_num]);
-
-							if ($rra[$rra_num][$ds_num]['standard_deviation'] == 'NAN') {
-								$rra[$rra_num][$ds_num]['standard_deviation'] = 0;
+							$rra[$rra_num][$ds_num]['stddev'] = $this->processStandardDeviationCalculation($samples[$rra_num][$ds_num]);
+							if ($rra[$rra_num][$ds_num]['stddev'] == 'NAN') {
+								$rra[$rra_num][$ds_num]['stddev'] = 0;
 							}
 
 							if (isset($rra[$rra_num][$ds_num]['sumofsamples']) && isset($rra[$rra_num][$ds_num]['numsamples'])) {
@@ -818,14 +837,12 @@ class spikekill {
 								$rra[$rra_num][$ds_num]['average'] = 0;
 							}
 
-							$rra[$rra_num][$ds_num]['min_cutoff'] = $rra[$rra_num][$ds_num]['average'] - ($this->stddev * $rra[$rra_num][$ds_num]['standard_deviation']);
-
+							$rra[$rra_num][$ds_num]['min_cutoff'] = $rra[$rra_num][$ds_num]['average'] - ($this->stddev * $rra[$rra_num][$ds_num]['stddev']);
 							if ($rra[$rra_num][$ds_num]['min_cutoff'] < $this->ds_min[$ds_num]) {
 								$rra[$rra_num][$ds_num]['min_cutoff'] = $this->ds_min[$ds_num];
 							}
 
-							$rra[$rra_num][$ds_num]['max_cutoff'] = $rra[$rra_num][$ds_num]['average'] + ($this->stddev * $rra[$rra_num][$ds_num]['standard_deviation']);
-
+							$rra[$rra_num][$ds_num]['max_cutoff'] = $rra[$rra_num][$ds_num]['average'] + ($this->stddev * $rra[$rra_num][$ds_num]['stddev']);
 							if ($rra[$rra_num][$ds_num]['max_cutoff'] > $this->ds_max[$ds_num]) {
 								$rra[$rra_num][$ds_num]['max_cutoff'] = $this->ds_max[$ds_num];
 							}
@@ -841,25 +858,28 @@ class spikekill {
 
 							// count the number of kills required
 							if (cacti_sizeof($samples[$rra_num][$ds_num])) {
-								foreach ($samples[$rra_num][$ds_num] as $timestamp => $sample) {
-									if (!empty($this->out_start) && $timestamp >= $this->out_start && $timestamp <= $this->out_end) {
-										if ($this->method == SPIKE_METHOD_FLOAT) {
-											$this->debug(sprintf("Window Float Kill: Value '%.4e', Time '%s'", $sample, date('Y-m-d H:i', $timestamp)));
+								foreach($samples[$rra_num][$ds_num] as $timestamp => $sample) {
+									if ($this->method == SPIKE_METHOD_FLOAT || $this->method == SPIKE_METHOD_FILL) {
+										if ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
+											if ($this->method == SPIKE_METHOD_FLOAT) {
+												if (strtolower($sample) == 'nan' || $sample == 0) {
+													$this->debug(sprintf("Window Float Found, Date:%s, Value:%s", date('Y-m-d H:i', $timestamp), $sample));
 
-											$rra[$rra_num][$ds_num]['outwind_killed']++;
-											$this->out_kills = true;
-										} elseif ($this->method == SPIKE_METHOD_FILL) {
-											if ($sample > (1 + $this->percent) * $rra[$rra_num][$ds_num]['variance_avg'] || strtolower($sample) == 'nan') {
-												$this->debug(sprintf("Window GapFill Kill: Value '%.4e', Time '%s'", $sample, date('Y-m-d H:i', $timestamp)));
+													$rra[$rra_num][$ds_num]['outwind_killed']++;
+													$this->out_kills = true;
+												}
+											} elseif ($this->method == SPIKE_METHOD_FILL) {
+												if (strtolower($sample) == 'nan' || $sample == 0) {
+													$this->debug(sprintf("Window GapFill Found, Date:%s, Value:%s", date('Y-m-d H:i', $timestamp), $sample));
 
-												$rra[$rra_num][$ds_num]['outwind_killed']++;
-												$this->out_kills = true;
+													$rra[$rra_num][$ds_num]['outwind_killed']++;
+													$this->out_kills = true;
+												}
 											}
 										}
-									} elseif (($sample > $rra[$rra_num][$ds_num]['max_cutoff']) ||
-										($sample < $rra[$rra_num][$ds_num]['min_cutoff'])) {
+									} elseif (($sample > $rra[$rra_num][$ds_num]['max_cutoff']) || ($sample < $rra[$rra_num][$ds_num]['min_cutoff'])) {
 										if ($this->method == SPIKE_METHOD_STDDEV) {
-											$this->debug(sprintf("StdDev Kill: Value '%.4e', StandardDev '%.4e', StdDevLimit '%.4e'", $sample, $rra[$rra_num][$ds_num]['standard_deviation'], ($rra[$rra_num][$ds_num]['max_cutoff'] * (1 + $this->percent))));
+											$this->debug(sprintf("StdDev Found, Date:%s, Value:%0.4e, StandardDev:%0.4e, StdDevLimit:%0.4e, Date:%s", date('Y-m-d H:i', $timestamp), $sample, $rra[$rra_num][$ds_num]['stddev'], ($rra[$rra_num][$ds_num]['max_cutoff'] * (1+$this->percent))));
 
 											$rra[$rra_num][$ds_num]['stddev_killed']++;
 											$this->std_kills = true;
@@ -875,8 +895,8 @@ class spikekill {
 										// not enough samples to calculate
 									} elseif ($sample > ($rra[$rra_num][$ds_num]['variance_avg'] * (1 + $this->percent))) {
 										if ($this->method == SPIKE_METHOD_VARIANCE) {
-											// kill based upon variance
-											$this->debug(sprintf("Var Kill: Value '%.4e', VarianceDev '%.4e', VarianceLimit '%.4e'", $sample, $rra[$rra_num][$ds_num]['variance_avg'], ($rra[$rra_num][$ds_num]['variance_avg'] * (1 + $this->percent))));
+											/* kill based upon variance */
+											$this->debug(sprintf("Variance Found, Date:%s, Value:%0.4e, VarianceDev:%0.4e, VarianceLimit:%0.4e", date('Y-m-d H:i', $timestamp), $sample, $rra[$rra_num][$ds_num]['variance_avg'], ($rra[$rra_num][$ds_num]['variance_avg'] * (1+$this->percent))));
 
 											$rra[$rra_num][$ds_num]['variance_killed']++;
 											$this->var_kills = true;
@@ -900,7 +920,7 @@ class spikekill {
 								$rra[$rra_num][$ds_num]['outwind_killed']     = 'N/A';
 							}
 						} else {
-							$rra[$rra_num][$ds_num]['standard_deviation'] = 'N/A';
+							$rra[$rra_num][$ds_num]['stddev'] = 'N/A';
 							$rra[$rra_num][$ds_num]['average']            = 'N/A';
 							$rra[$rra_num][$ds_num]['min_cutoff']         = 'N/A';
 							$rra[$rra_num][$ds_num]['max_cutoff']         = 'N/A';
@@ -937,12 +957,12 @@ class spikekill {
 					if (cacti_sizeof($dses)) {
 						foreach ($dses as $dskey => $ds) {
 							$this->strout .= sprintf('%10s %16s %10s %7s %7s ' .
-								($ds['average'] < 1E6 ? '%10s ' : '%10.4e ') .
-								($ds['standard_deviation'] < 1E6 ? '%10s ' : '%10.4e ') .
-								(isset($ds['max_value']) ? ($ds['max_value'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
-								(isset($ds['min_value']) ? ($ds['min_value'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
-								(isset($ds['max_cutoff']) ? ($ds['max_cutoff'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
-								(isset($ds['min_cutoff']) ? ($ds['min_cutoff'] < 1E6 ? '%10s ' : '%10.4e ') : '%10s ') .
+								($ds['average'] < 1E6 ? '%10s ':'%10.4e ') .
+								($ds['stddev'] < 1E6 ? '%10s ':'%10.4e ') .
+								(isset($ds['max_value'])  ? ($ds['max_value']  < 1E6 ? '%10s ':'%10.4e ') : '%10s ') .
+								(isset($ds['min_value'])  ? ($ds['min_value']  < 1E6 ? '%10s ':'%10.4e ') : '%10s ') .
+								(isset($ds['max_cutoff']) ? ($ds['max_cutoff'] < 1E6 ? '%10s ':'%10.4e ') : '%10s ') .
+								(isset($ds['min_cutoff']) ? ($ds['min_cutoff'] < 1E6 ? '%10s ':'%10.4e ') : '%10s ') .
 								'%10s %10s %10s ' .
 								(isset($ds['avgnksamples']) ? ($ds['avgnksamples'] < 1E6 ? '%10s ' : '%10.4e ') : '%10.4E ') .
 								(isset($ds['variance_avg']) ? ($ds['variance_avg'] < 1E6 ? '%10s ' : '%10.4e ') : '%10.4E ') . "\n",
@@ -952,7 +972,7 @@ class spikekill {
 								$ds['totalsamples'],
 								($ds['numsamples'] ?? '0'),
 								($ds['average'] != 'N/A' ? round($ds['average'],2) : $ds['average']),
-								($ds['standard_deviation'] != 'N/A' ? round($ds['standard_deviation'],2) : $ds['standard_deviation']),
+								($ds['stddev'] != 'N/A' ? round($ds['stddev'],2) : $ds['stddev']),
 								(isset($ds['max_value']) ? round($ds['max_value'],2) : 'N/A'),
 								(isset($ds['min_value']) ? round($ds['min_value'],2) : 'N/A'),
 								($ds['max_cutoff'] != 'N/A' ? round($ds['max_cutoff'],2) : $ds['max_cutoff']),
@@ -976,12 +996,12 @@ class spikekill {
 					if (cacti_sizeof($dses)) {
 						foreach ($dses as $dskey => $ds) {
 							$this->strout .= sprintf('<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%s</td>' .
-								($ds['average'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') .
-								($ds['standard_deviation'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') .
-								(isset($ds['max_value']) ? ($ds['max_value'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
-								(isset($ds['min_value']) ? ($ds['min_value'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
-								(isset($ds['max_cutoff']) ? ($ds['max_cutoff'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
-								(isset($ds['min_cutoff']) ? ($ds['min_cutoff'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
+								($ds['average'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') .
+								($ds['stddev'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') .
+								(isset($ds['max_value']) ? ($ds['max_value'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') : '<td>%s</td>') .
+								(isset($ds['min_value']) ? ($ds['min_value'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') : '<td>%s</td>') .
+								(isset($ds['max_cutoff']) ? ($ds['max_cutoff'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') : '<td>%s</td>') .
+								(isset($ds['min_cutoff']) ? ($ds['min_cutoff'] < 1E6 ? '<td>%s</td>':'<td>%.4e</td>') : '<td>%s</td>') .
 								'<td>%s</td><td>%s</td><td>%s</td>' .
 								(isset($ds['avgnksampled']) ? ($ds['avgnksamples'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
 								(isset($ds['variance_avg']) ? ($ds['variance_avg'] < 1E6 ? '<td>%s</td>' : '<td>%.4e</td>') : '<td>%s</td>') .
@@ -992,7 +1012,7 @@ class spikekill {
 								$ds['totalsamples'],
 								($ds['numsamples'] ?? '0'),
 								($ds['average'] != 'N/A' ? round($ds['average'],2) : $ds['average']),
-								($ds['standard_deviation'] != 'N/A' ? round($ds['standard_deviation'],2) : $ds['standard_deviation']),
+								($ds['stddev'] != 'N/A' ? round($ds['stddev'],2) : $ds['stddev']),
 								(isset($ds['max_value']) ? round($ds['max_value'],2) : 'N/A'),
 								(isset($ds['min_value']) ? round($ds['min_value'],2) : 'N/A'),
 								($ds['max_cutoff'] != 'N/A' ? round($ds['max_cutoff'],2) : $ds['max_cutoff']),
@@ -1044,129 +1064,118 @@ class spikekill {
 						// peel off garbage
 						$dsvalue = trim(str_replace('</row>', '', str_replace('</v>', '', $dsvalue)));
 
-						if (strtolower($dsvalue) == 'nan' && !isset($last_num[$ds_num])) {
-							// do nothing, it's a NaN, and the first one
-						} elseif (!empty($this->out_start) && $timestamp > $this->out_start && $timestamp < $this->out_end) {
-							// a window is specified, and the timestamp is inside the window
-							if ($this->method == SPIKE_METHOD_FLOAT) {
-								if ($this->avgnan == 'avg') {
-									cacti_log("DEBUG: replacing dsvalue {$dsvalue} with variance_avg {$rra[$rra_num][$ds_num]['variance_avg']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-									$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['variance_avg']);
-									$kills++;
-									$this->total_kills++;
-								} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
-									cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-									$dsvalue = $last_num[$ds_num];
-									$kills++;
-									$this->total_kills++;
-								}
-							} elseif ($this->method == SPIKE_METHOD_FILL) {
-								if ($dsvalue > (1 + (float) $this->percent) * $rra[$rra_num][$ds_num]['variance_avg'] || strtolower($dsvalue) == 'nan') {
+						switch($this->method) {
+							case SPIKE_METHOD_FLOAT:
+								if ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
 									if ($this->avgnan == 'avg') {
-										cacti_log("DEBUG: replacing dsvalue {$dsvalue} with variance_avg {$rra[$rra_num][$ds_num]['variance_avg']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+										$message = sprintf('Replacing dsvalue %s with variance_avg %s', $dsvalue, $rra[$rra_num][$ds_num]['variance_avg']);
+
+										cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+										$this->debug($message);
+
 										$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['variance_avg']);
 										$kills++;
 										$this->total_kills++;
-									} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
-										cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-										$dsvalue = $last_num[$ds_num];
+									} elseif ($this->avgnan == 'last' && isset($rra[$rra_num][$ds_num]['last'])) {
+										$message = sprintf('Replacing dsvalue %s with last value %s', $dsvalue, $rra[$rra_num][$ds_num]['last']);
+
+										cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+										$this->debug($message);
+
+										$dsvalue = $rra[$rra_num][$ds_num]['last'];
 										$kills++;
 										$this->total_kills++;
 									}
+								} else {
+									cacti_log("DEBUG: ignoring dsvalue {$dsvalue} as we are outside of the time range!", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
 								}
-							} elseif ($this->method == SPIKE_METHOD_VARIANCE) {
-								if ($kills < $this->numspike) {
+							case SPIKE_METHOD_FILL:
+								if ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
 									if ($this->avgnan == 'avg') {
-										cacti_log("DEBUG: replacing dsvalue {$dsvalue} with variance_avg {$rra[$rra_num][$ds_num]['variance_avg']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-										$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['variance_avg']);
-										$this->total_kills++;
-										$kills++;
-									} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
-										cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-										$dsvalue = $last_num[$ds_num];
-										$this->total_kills++;
-										$kills++;
-									} else {
-										cacti_log("DEBUG: replacing dsvalue {$dsvalue} with NaN", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-										$dsvalue = 'NaN';
-									}
-								}
-							} elseif ($this->method == SPIKE_METHOD_STDDEV) {
-								if ($kills < $this->numspike) {
-									if ($this->avgnan == 'avg') {
-										cacti_log("DEBUG: replacing dsvalue {$dsvalue} with average {$rra[$rra_num][$ds_num]['average']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-										$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['average']);
-										$this->total_kills++;
-										$kills++;
-									} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
-										cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-										$dsvalue = $last_num[$ds_num];
-										$this->total_kills++;
-										$kills++;
-									} else {
-										cacti_log("DEBUG: replacing dsvalue {$dsvalue} with NaN", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-										$dsvalue = 'NaN';
-									}
-								}
-							}
-						} elseif (strtolower($dsvalue) == 'nan' && isset($last_num[$ds_num])) {
-							/**
-							 * We need to ignore this case as it's only a gap file when
-							 * There is a time range
-							 */
-							if ($this->method == SPIKE_METHOD_VARIANCE) {
-								cacti_log("DEBUG: ignoring dsvalue {$dsvalue} as NaN values are left along when using the Variance Method!", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-							} elseif ($this->method == SPIKE_METHOD_STDDEV) {
-								cacti_log("DEBUG: ignoring dsvalue {$dsvalue} as NaN values are left alone when using the Standard Deviation Method!", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-							} else {
-								cacti_log("DEBUG: replacing dsvalue {$dsvalue} with NaN", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-								$dsvalue = 'NaN';
-							}
-						} else {
-							if ($this->method == SPIKE_METHOD_VARIANCE) {
-								if ($dsvalue > (1 + (float) $this->percent) * (float) $rra[$rra_num][$ds_num]['variance_avg']) {
-									if ($kills < $this->numspike) {
-										if ($this->avgnan == 'avg') {
-											cacti_log("DEBUG: replacing dsvalue {$dsvalue} with variance_avg {$rra[$rra_num][$ds_num]['variance_avg']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+										if (strtolower($dsvalue) == 'nan' || $dsvalue == 0) {
+											$message = sprintf('Replacing dsvalue %s with variance_avg %s', $dsvalue, $rra[$rra_num][$ds_num]['variance_avg']);
+
+											cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+											$this->debug($message);
+
 											$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['variance_avg']);
 											$kills++;
 											$this->total_kills++;
-										} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
-											cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-											$dsvalue = $last_num[$ds_num];
+										}
+									} elseif ($this->avgnan == 'last' && isset($rra[$rra_num][$ds_num]['last'])) {
+										if (strtolower($dsvalue) == 'nan' || $dsvalue == 0) {
+											$message = sprintf('Replacing dsvalue %s with last value %s', $dsvalue, $rra[$rra_num][$ds_num]['last']);
+
+											cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+											$this->debug($message);
+
+											$dsvalue = $rra[$rra_num][$ds_num]['last'];
 											$kills++;
 											$this->total_kills++;
-										} else {
-											cacti_log("DEBUG: replacing dsvalue {$dsvalue} with NaN", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-											$dsvalue = 'NaN';
 										}
 									}
 								} else {
+									cacti_log("DEBUG: ignoring dsvalue {$dsvalue} as we are outside of the time range!", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+								}
+
+								break;
+							case SPIKE_METHOD_VARIANCE:
+								if (empty($this->out_start) || ($timestamp >= $this->out_start && $timestamp <= $out_end)) {
+									if ($dsvalue > (1 + $this->percent) * (float) $rra[$rra_num][$ds_num]['variance_avg']) {
+										if ($kills < $this->numspike) {
+											if ($this->avgnan == 'avg') {
+												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with variance_avg {$rra[$rra_num][$ds_num]['variance_avg']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+
+												$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['variance_avg']);
+												$this->total_kills++;
+												$kills++;
+											} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
+												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+
+												$dsvalue = $last_num[$ds_num];
+												$this->total_kills++;
+												$kills++;
+											} elseif ($this->avgnan == 'nan') {
+												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with NaN", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+
+												$dsvalue = 'NaN';
+											}
+										}
+									}
+								} elseif (strtolower($dsvalue) !== 'nan' && $dsvalue != 0) {
 									$last_num[$ds_num] = $dsvalue;
 								}
-							} else {
+
+								break;
+							case SPIKE_METHOD_STDDEV:
 								if (($dsvalue > $rra[$rra_num][$ds_num]['max_cutoff']) ||
 									($dsvalue < $rra[$rra_num][$ds_num]['min_cutoff'])) {
-									if ($kills < $this->numspike) {
-										if ($this->avgnan == 'avg') {
-											cacti_log("DEBUG: replacing dsvalue {$dsvalue} with average {$rra[$rra_num][$ds_num]['average']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-											$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['average']);
-											$kills++;
-											$this->total_kills++;
-										} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
-											cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-											$dsvalue = $last_num[$ds_num];
-											$kills++;
-											$this->total_kills++;
-										} else {
-											cacti_log("DEBUG: replacing dsvalue {$dsvalue} with NaN", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
-											$dsvalue = 'NaN';
+									if (empty($this->out_start) || ($timestamp >= $this->out_start && $timestamp <= $out_end)) {
+										if ($kills < $this->numspike) {
+											if ($this->avgnan == 'avg') {
+												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with average {$rra[$rra_num][$ds_num]['average']}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+
+												$dsvalue = sprintf('%1.10e', $rra[$rra_num][$ds_num]['average']);
+												$this->total_kills++;
+												$kills++;
+											} elseif ($this->avgnan == 'last' && isset($last_num[$ds_num])) {
+												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with last value {$last_num[$ds_num]}", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+
+												$dsvalue = $last_num[$ds_num];
+												$this->total_kills++;
+												$kills++;
+											} elseif ($this->avgnan == 'nan') {
+												cacti_log("DEBUG: replacing dsvalue {$dsvalue} with NaN", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
+
+												$dsvalue = 'NaN';
+											}
 										}
 									}
-								} else {
+								} elseif (strtolower($dsvalue) !== 'nan' && $dsvalue != 0) {
 									$last_num[$ds_num] = $dsvalue;
 								}
-							}
+
+								break;
 						}
 
 						$out_row .= '<v> ' . $dsvalue . '</v>';

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -612,7 +612,9 @@ class spikekill {
 						if ($timestamp > 0) {
 							if ($this->method == SPIKE_METHOD_FILL || $this->method == SPIKE_METHOD_FLOAT || $this->method == SPIKE_METHOD_ABSOLUTE) {
 								if ($timestamp < $this->out_start) {
-									$rra[$rra_num][$ds_num]['last'] = $dsvalue;
+									if (is_numeric($dsvalue)) {
+										$rra[$rra_num][$ds_num]['last'] = $dsvalue;
+									}
 
 									$process = true;
 								} elseif ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
@@ -625,7 +627,7 @@ class spikekill {
 									}
 
 									if ($this->method == SPIKE_METHOD_FILL) {
-										if (strtolower($dsvalue) == 'nan') {
+										if (!is_numeric($dsvalue)) {
 											$this->debug(sprintf('Fill Found, RRA:%s, DSNum:%s, Date:%s, CurVal:%0.4e NewVal:%0.4e', $rra_num, $ds_num, date('Y-m-d H:i:s', $timestamp), $dsvalue, $newval));
 										}
 									} elseif ($this->method == SPIKE_METHOD_FLOAT) {
@@ -649,7 +651,7 @@ class spikekill {
 							$process = true;
 						}
 
-						if (strtolower($dsvalue) != 'nan' && $process) {
+						if (is_numeric($dsvalue) && $process) {
 							if (!isset($rra[$rra_num][$ds_num]['numsamples'])) {
 								$rra[$rra_num][$ds_num]['numsamples'] = 1;
 							} else {
@@ -967,17 +969,17 @@ class spikekill {
 												$rra[$rra_num][$ds_num]['outwind_killed']++;
 												$this->out_kills = true;
 											} elseif ($this->method == SPIKE_METHOD_FILL) {
-												if (strtolower($sample) == 'nan') { // Gap Fill Means 'NaN's only
+												if (!is_numeric($sample)) { // Gap Fill Means 'NaN's only
 													$this->debug(sprintf('Window GapFill Found, Date:%s, Value:%s', date('Y-m-d H:i', $timestamp), $sample));
 
 													$rra[$rra_num][$ds_num]['outwind_killed']++;
 													$this->out_kills = true;
 												}
-											} elseif (strtolower($sample) !== 'nan') {
+											} elseif (is_numeric($sample)) {
 												$rra[$rra_num][$ds_num]['numnksamples']++;
 												$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 											}
-										} elseif (strtolower($sample) !== 'nan') {
+										} elseif (is_numeric($sample)) {
 											$rra[$rra_num][$ds_num]['numnksamples']++;
 											$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 										}
@@ -995,11 +997,11 @@ class spikekill {
 												}
 
 												$this->out_kills = true;
-											} elseif (strtolower($sample) !== 'nan') {
+											} elseif (is_numeric($sample)) {
 												$rra[$rra_num][$ds_num]['numnksamples']++;
 												$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 											}
-										} elseif (strtolower($sample) !== 'nan') {
+										} elseif (is_numeric($sample)) {
 											$rra[$rra_num][$ds_num]['numnksamples']++;
 											$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 										}
@@ -1019,11 +1021,11 @@ class spikekill {
 												}
 
 												$this->std_kills = true;
-											} elseif (strtolower($sample) !== 'nan') {
+											} elseif (is_numeric($sample)) {
 												$rra[$rra_num][$ds_num]['numnksamples']++;
 												$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 											}
-										} elseif (strtolower($sample) !== 'nan') {
+										} elseif (is_numeric($sample)) {
 											$rra[$rra_num][$ds_num]['numnksamples']++;
 											$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 										}
@@ -1040,15 +1042,15 @@ class spikekill {
 												$rra[$rra_num][$ds_num]['outwind_killed']++;
 
 												$this->var_kills = true;
-											} elseif (strtolower($sample) !== 'nan') {
+											} elseif (is_numeric($sample)) {
 												$rra[$rra_num][$ds_num]['numnksamples']++;
 												$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 											}
-										} elseif (strtolower($sample) !== 'nan') {
+										} elseif (is_numeric($sample)) {
 											$rra[$rra_num][$ds_num]['numnksamples']++;
 											$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 										}
-									} elseif (strtolower($sample) !== 'nan') {
+									} elseif (is_numeric($sample)) {
 										$rra[$rra_num][$ds_num]['numnksamples']++;
 										$rra[$rra_num][$ds_num]['sumnksamples'] += $sample;
 									}
@@ -1243,7 +1245,7 @@ class spikekill {
 							case SPIKE_METHOD_FILL:
 								if ($timestamp >= $this->out_start && $timestamp <= $this->out_end) {
 									if ($this->avgnan == 'avg') {
-										if (strtolower($dsvalue) == 'nan' || $dsvalue == 0) {
+										if (!is_numeric($dsvalue) || $dsvalue == 0) {
 											$message = sprintf('Replacing dsvalue %s with average %s', $dsvalue, $rra[$rra_num][$ds_num]['variance_avg']);
 
 											cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
@@ -1256,7 +1258,7 @@ class spikekill {
 									} elseif ($this->avgnan == 'nan') {
 										// Not supported for fill and float modes
 									} elseif ($this->avgnan == 'last' && isset($rra[$rra_num][$ds_num]['last'])) {
-										if (strtolower($dsvalue) == 'nan' || $dsvalue == 0) {
+										if (!is_numeric($dsvalue) || $dsvalue == 0) {
 											$message = sprintf('Replacing dsvalue %s with last value %s', $dsvalue, $rra[$rra_num][$ds_num]['last']);
 
 											cacti_log("DEBUG: $message", false, 'SPIKEKILL', POLLER_VERBOSITY_DEBUG);
@@ -1304,7 +1306,7 @@ class spikekill {
 											}
 										}
 									}
-								} elseif (strtolower($dsvalue) !== 'nan' && $dsvalue != 0) {
+								} elseif (is_numeric($dsvalue) && $dsvalue != 0) {
 									$last_num[$ds_num] = $dsvalue;
 								}
 
@@ -1342,7 +1344,7 @@ class spikekill {
 											}
 										}
 									}
-								} elseif (strtolower($dsvalue) !== 'nan' && $dsvalue != 0) {
+								} elseif (is_numeric($dsvalue) && $dsvalue != 0) {
 									$last_num[$ds_num] = $dsvalue;
 								}
 
@@ -1494,7 +1496,7 @@ class spikekill {
 		$my_samples = $samples;
 
 		foreach ($samples as $timestamp => $value) {
-			if ((empty($this->out_start) || $timestamp < $this->out_start || $timestamp > $this->out_end) && strtolower($value) != 'nan') {
+			if ((empty($this->out_start) || $timestamp < $this->out_start || $timestamp > $this->out_end) && is_numeric($value)) {
 				$my_samples[] = $value;
 			}
 		}


### PR DESCRIPTION
This change:

* modifies the reporting to report the number of samples in the time window, and the number of corrections in the time window
* Allows standard deviation and variance to work only within the time window

NOTE: A UI change will take place to fix not only the output display, which is currently broken, but the feeding of the time window to the backend.  Right now, the time window for variance and stddev is only available at the CLI level.