### PR TITLE
Fix #6600 - Full Sync Generates Warnings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,6 +41,7 @@ Cacti CHANGELOG
 -issue#6546: Add missing xml and script files for NetSNMP LMSensor
 -issue#6551: Fix paths in audit_database script (FreeBSD)
 -issue#6573: Add hook device_change_javascript, necessarily for thold
+-issue#6600: Plugins wishing to replicate out a table that does not exist generates warnings
 -issue: Correct some PHPStan issues found in audit of Aggregate that can lead to warnings
 -issue: Using the rrd_splice.php cli can result in the loss of data
 -issue: Defect in SpikeKill algorithm was causing a loss of data for Gap Fill and Float methods

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -1812,6 +1812,21 @@ function replicate_out($remote_poller_id = 1, $class = 'all') {
  * @return (void)
  */
 function replicate_out_table($conn, &$data, $table, $remote_poller_id, $truncate = true, $exclude = false, $level = POLLER_VERBOSITY_NONE) {
+	// Get the create table syntax just in case
+	$create_table = db_fetch_row("SHOW CREATE TABLE `$table`");
+
+	if (cacti_sizeof($create_table)) {
+		$create = $create_table['Create Table'];
+	} else {
+		cacti_log("WARNING: Replicate Out Unable to get Table Schema for $table.  Table does not exist!", false, 'POLLER');
+		$create = '';
+		return;
+	}
+
+	if (!db_table_exists($table, false, $conn) && $create != '') {
+		db_execute($create, false, $conn);
+	}
+
 	if (cacti_sizeof($data)) {
 		/* check if the table structure changed, and if so, recreate */
 		$local_columns  = db_fetch_assoc('SHOW COLUMNS FROM ' . $table);


### PR DESCRIPTION
Plugins wishing to replicate out a table that does not exist generates warnings