### PR TITLE
Guard replicate_out_table against missing local tables

### DIFF
--- a/lib/poller.php
+++ b/lib/poller.php
@@ -1836,6 +1836,12 @@ function replicate_out(int $remote_poller_id = 1, string $class = 'all') : bool 
 function replicate_out_table(mixed $db_conn, array &$data, string $table, int $remote_poller_id, bool $truncate = true,
 	mixed $exclude = false, int $level = POLLER_VERBOSITY_NONE) : void {
 	if (cacti_sizeof($data)) {
+		if (!db_table_exists($table)) {
+			cacti_log('WARNING: Unable to replicate table ' . $table . ' because it does not exist locally', false, 'REPLICATE');
+
+			return;
+		}
+
 		// check if the table structure changed, and if so, recreate
 		$local_columns  = db_fetch_assoc('SHOW COLUMNS FROM ' . $table);
 		$remote_columns = db_fetch_assoc('SHOW COLUMNS FROM ' . $table, false, $db_conn);


### PR DESCRIPTION
## Summary

When a plugin calls `replicate_out_table()` for a table that doesn't exist
on the local database, the `SHOW COLUMNS FROM` query at line 1840 generates
PHP warnings. The empty-data path already handles missing *remote* tables
(line 1951), but the data-present path never checks the local side.

Adds a `db_table_exists()` check before the `SHOW COLUMNS` queries and logs
a WARNING so the admin can see which table was skipped. Uses the same
function that's already used in the else branch at line 1951.

Fixes #6600

## Changes

- `lib/poller.php`: add table existence guard in `replicate_out_table()`

## Test plan

- Verified the `db_table_exists()` function signature accepts a single
  table name argument for local checks (lib/database.php:1313)
- Confirmed the existing empty-data path uses the same pattern
- Reviewed that early return won't leave replication in an inconsistent
  state since no remote writes have happened yet at that point