### PR TITLE
Add Docker-based development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+*.md
+LICENSE
+.phpstan*
+.php-cs-fixer.php
+.pre-commit-config.yaml
+.env
+.env.local
+docker-compose.override.yml
+data/
+cache/
+log/
+rra/*.rrd
+*.log

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Cacti Docker Configuration
+
+# Web
+WEB_PORT=8080
+PHP_MEMORY_LIMIT=512M
+
+# Database
+DB_ROOT_PASSWORD=root
+DB_NAME=cacti
+DB_USER=cacti
+DB_PASSWORD=cacti
+DB_PORT=3306
+
+# Database Tuning
+DB_MAX_CONNECTIONS=200
+DB_BUFFER_POOL_SIZE=1G
+
+# Timezone
+TIMEZONE=UTC

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,73 @@
+# Cacti Development Environment
+#
+# Usage:
+#   cp .env.example .env
+#   docker compose up -d
+#
+# Access Cacti at http://localhost:8080/cacti
+# The cacti.sql schema is auto-imported on first DB startup.
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    container_name: cacti_web
+    ports:
+      - "${WEB_PORT:-8080}:80"
+    volumes:
+      - .:/var/www/html/cacti
+      - cacti_cache:/var/www/html/cacti/cache
+      - cacti_rra:/var/www/html/cacti/rra
+      - cacti_logs:/var/www/html/cacti/log
+    environment:
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_USER: ${DB_USER:-cacti}
+      DB_PASS: ${DB_PASSWORD:-cacti}
+      DB_NAME: ${DB_NAME:-cacti}
+      PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT:-512M}
+      TIMEZONE: ${TIMEZONE:-UTC}
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: mariadb:11.8
+    container_name: cacti_db
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-root}
+      MYSQL_DATABASE: ${DB_NAME:-cacti}
+      MYSQL_USER: ${DB_USER:-cacti}
+      MYSQL_PASSWORD: ${DB_PASSWORD:-cacti}
+      TZ: ${TIMEZONE:-UTC}
+    ports:
+      - "${DB_PORT:-3306}:3306"
+    volumes:
+      - cacti_db:/var/lib/mysql
+      - ./cacti.sql:/docker-entrypoint-initdb.d/cacti.sql:ro
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --max_connections=${DB_MAX_CONNECTIONS:-200}
+      - --max_heap_table_size=128M
+      - --tmp_table_size=128M
+      - --join_buffer_size=128M
+      - --innodb_buffer_pool_size=${DB_BUFFER_POOL_SIZE:-1G}
+      - --innodb_flush_log_at_timeout=3
+      - --innodb_read_io_threads=32
+      - --innodb_write_io_threads=16
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  cacti_db:
+  cacti_cache:
+  cacti_rra:
+  cacti_logs:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,80 @@
+FROM php:8.4-fpm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        apache2 \
+        rrdtool \
+        librrd-dev \
+        snmp \
+        libsnmp-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libgmp-dev \
+        libldap2-dev \
+        libicu-dev \
+        libxml2-dev \
+        libonig-dev \
+        default-mysql-client \
+        cron \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) \
+        gd gmp intl ldap mbstring \
+        pdo pdo_mysql mysqli \
+        snmp pcntl posix sockets xml \
+        opcache \
+    && pecl install apcu && docker-php-ext-enable apcu \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Apache modules for php-fpm proxying
+RUN a2enmod rewrite headers proxy proxy_fcgi setenvif \
+    && a2dismod mpm_prefork \
+    && a2enmod mpm_event
+
+COPY docker/apache.conf /etc/apache2/sites-available/cacti.conf
+RUN a2dissite 000-default && a2ensite cacti
+
+# Static PHP settings (runtime-tunable values are set in entrypoint.sh)
+RUN { \
+        echo 'opcache.enable = 1'; \
+        echo 'opcache.memory_consumption = 128'; \
+        echo 'opcache.interned_strings_buffer = 16'; \
+        echo 'opcache.max_accelerated_files = 10000'; \
+        echo 'opcache.revalidate_freq = 2'; \
+        echo 'opcache.fast_shutdown = 1'; \
+        echo 'apc.enabled = 1'; \
+        echo 'apc.shm_size = 128M'; \
+    } > /usr/local/etc/php/conf.d/cacti-opcache.ini
+
+RUN { \
+        echo '[global]'; \
+        echo 'error_log = /proc/self/fd/2'; \
+        echo '[www]'; \
+        echo 'user = www-data'; \
+        echo 'group = www-data'; \
+        echo 'listen = 127.0.0.1:9000'; \
+        echo 'pm = dynamic'; \
+        echo 'pm.max_children = 50'; \
+        echo 'pm.start_servers = 5'; \
+        echo 'pm.min_spare_servers = 5'; \
+        echo 'pm.max_spare_servers = 35'; \
+        echo 'access.log = /proc/self/fd/2'; \
+        echo 'catch_workers_output = yes'; \
+        echo 'decorate_workers_output = no'; \
+    } > /usr/local/etc/php-fpm.d/zz-docker.conf
+
+RUN mkdir -p /var/www/html/cacti/cache \
+             /var/www/html/cacti/rra \
+             /var/www/html/cacti/log \
+    && chown -R www-data:www-data /var/www/html/cacti
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /var/www/html/cacti
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD php -r 'exit(file_get_contents("http://localhost/cacti/") === false ? 1 : 0);'
+
+EXPOSE 80
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -1,0 +1,24 @@
+<VirtualHost *:80>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+
+    <Directory /var/www/html/cacti>
+        Options -Indexes +FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    # Proxy PHP requests to php-fpm
+    <FilesMatch \.php$>
+        SetHandler "proxy:fcgi://127.0.0.1:9000"
+    </FilesMatch>
+
+    # Logging
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    # Security headers
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set X-XSS-Protection "1; mode=block"
+</VirtualHost>

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Write runtime PHP settings from environment
+cat > /usr/local/etc/php/conf.d/cacti-runtime.ini <<INI
+date.timezone = ${TIMEZONE:-UTC}
+memory_limit = ${PHP_MEMORY_LIMIT:-512M}
+max_execution_time = 60
+INI
+
+# Ensure volume directories have correct ownership
+chown -R www-data:www-data /var/www/html/cacti/cache \
+                           /var/www/html/cacti/rra \
+                           /var/www/html/cacti/log 2>/dev/null || true
+
+# Start php-fpm in background
+php-fpm -D
+
+# Run Apache in foreground
+exec apachectl -D FOREGROUND


### PR DESCRIPTION
Closes #6617

Adds a Docker Compose setup for local Cacti development, per @TheWitness's specs.

### What's included

- `docker/Dockerfile` — PHP 8.4-fpm + Apache (proxy_fcgi), all required PHP extensions, rrdtool, cron
- `docker/apache.conf` — vhost config proxying `.php` requests to fpm
- `docker/entrypoint.sh` — starts php-fpm, sets runtime PHP config from env vars, runs Apache in foreground
- `docker-compose.yml` — web + MariaDB 11.8 services, named volumes for DB/cache/rra/logs, healthchecks on both
- `.env.example` — tunable defaults (ports, credentials, DB buffer pool, timezone, PHP memory limit)
- `.dockerignore` — excludes .git, .env, data dirs, logs

### Usage

```
cp .env.example .env
docker compose up -d
```

Cacti at `http://localhost:8080/cacti`. The `cacti.sql` schema is auto-imported on first DB startup.

### Notes

- RRDtool 1.7.2 is the latest available in Debian repos. RRDtool 1.9 would need to be built from source — happy to add that if preferred.
- Tested locally: both containers come up healthy, 126 tables imported, PHP 8.4.18, MariaDB 11.8.6.

### Volumes

| Volume | Purpose |
|--------|---------|
| `cacti_db` | MariaDB data |
| `cacti_cache` | Cacti cache files |
| `cacti_rra` | RRDtool database files |
| `cacti_logs` | Cacti log files |