### PR TITLE
fix: harden Docker dev environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
 .github
 *.md
+!README.md
 LICENSE
 .phpstan*
 .php-cs-fixer.php

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ WEB_PORT=8080
 PHP_MEMORY_LIMIT=512M
 
 # Database
+# Change these before use; defaults are intentionally weak.
 DB_ROOT_PASSWORD=root
 DB_NAME=cacti
 DB_USER=cacti

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ include/vendor/csrf/csrf-secret.php
 # Ignore vendor folders
 include/vendor/**
 vendor/**
+
+# Docker local config
+.env
+.env.local
+.env.*.local
+docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 #   docker compose up -d
 #
 # Access Cacti at http://localhost:8080/cacti
-# The cacti.sql schema is auto-imported on first DB startup.
+# Schema auto-imported on first DB start; complete the web installer to finish setup.
 
 services:
   web:
@@ -16,6 +16,7 @@ services:
     ports:
       - "${WEB_PORT:-8080}:80"
     volumes:
+      # Source code (ro); named volumes overlay cache/rra/log to keep them out of the tree.
       - .:/var/www/html/cacti
       - cacti_cache:/var/www/html/cacti/cache
       - cacti_rra:/var/www/html/cacti/rra
@@ -43,21 +44,21 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD:-cacti}
       TZ: ${TIMEZONE:-UTC}
     ports:
-      - "${DB_PORT:-3306}:3306"
+      - "127.0.0.1:${DB_PORT:-3306}:3306"
     volumes:
       - cacti_db:/var/lib/mysql
       - ./cacti.sql:/docker-entrypoint-initdb.d/cacti.sql:ro
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
-      - --max_connections=${DB_MAX_CONNECTIONS:-200}
-      - --max_heap_table_size=128M
-      - --tmp_table_size=128M
-      - --join_buffer_size=128M
-      - --innodb_buffer_pool_size=${DB_BUFFER_POOL_SIZE:-1G}
-      - --innodb_flush_log_at_timeout=3
-      - --innodb_read_io_threads=32
-      - --innodb_write_io_threads=16
+      - --max-connections=${DB_MAX_CONNECTIONS:-200}
+      - --max-heap-table-size=128M
+      - --tmp-table-size=128M
+      - --join-buffer-size=128M
+      - --innodb-buffer-pool-size=${DB_BUFFER_POOL_SIZE:-1G}
+      - --innodb-flush-log-at-timeout=3
+      - --innodb-read-io-threads=32
+      - --innodb-write-io-threads=16
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:8.4-fpm
+FROM php:8.4-fpm-bookworm
+
+# rrdtool 1.7.x from Debian; 1.9+ needs source build (hover tooltips only)
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apache2 \
@@ -43,6 +45,7 @@ RUN { \
         echo 'opcache.fast_shutdown = 1'; \
         echo 'apc.enabled = 1'; \
         echo 'apc.shm_size = 128M'; \
+        echo 'expose_php = Off'; \
     } > /usr/local/etc/php/conf.d/cacti-opcache.ini
 
 RUN { \
@@ -53,10 +56,10 @@ RUN { \
         echo 'group = www-data'; \
         echo 'listen = 127.0.0.1:9000'; \
         echo 'pm = dynamic'; \
-        echo 'pm.max_children = 50'; \
-        echo 'pm.start_servers = 5'; \
-        echo 'pm.min_spare_servers = 5'; \
-        echo 'pm.max_spare_servers = 35'; \
+        echo 'pm.max_children = 10'; \
+        echo 'pm.start_servers = 2'; \
+        echo 'pm.min_spare_servers = 1'; \
+        echo 'pm.max_spare_servers = 5'; \
         echo 'access.log = /proc/self/fd/2'; \
         echo 'catch_workers_output = yes'; \
         echo 'decorate_workers_output = no'; \
@@ -70,10 +73,11 @@ RUN mkdir -p /var/www/html/cacti/cache \
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# App code comes from the docker-compose bind mount, not from this image.
 WORKDIR /var/www/html/cacti
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD php -r 'exit(file_get_contents("http://localhost/cacti/") === false ? 1 : 0);'
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+    CMD pgrep -x apache2 > /dev/null && pgrep -x php-fpm > /dev/null
 
 EXPOSE 80
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM php:8.4-fpm-bookworm
 
-# rrdtool 1.7.x from Debian; 1.9+ needs source build (hover tooltips only)
+# rrdtool 1.7.x from Debian meets Cacti's minimum requirement. 1.9+ (source
+# build) enables graph tooltip output via graphv — not worth the image size
+# trade-off for a dev environment.
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apache2 \

--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -20,6 +20,9 @@
     # Security headers
     Header always set X-Content-Type-Options "nosniff"
     Header always set X-Frame-Options "SAMEORIGIN"
+    # X-XSS-Protection is deprecated; kept for legacy browsers only.
+    # Cacti sets its own CSP headers at the application layer.
+    # TODO: remove once minimum-browser support allows dropping it.
     Header always set X-XSS-Protection "1; mode=block"
     Header always set Referrer-Policy "strict-origin-when-cross-origin"
     Header always set Permissions-Policy "geolocation=(), camera=(), microphone=()"

--- a/docker/apache.conf
+++ b/docker/apache.conf
@@ -4,14 +4,14 @@
 
     <Directory /var/www/html/cacti>
         Options -Indexes +FollowSymLinks
-        AllowOverride All
+        AllowOverride FileInfo Options=FollowSymLinks
         Require all granted
-    </Directory>
 
-    # Proxy PHP requests to php-fpm
-    <FilesMatch \.php$>
-        SetHandler "proxy:fcgi://127.0.0.1:9000"
-    </FilesMatch>
+        # Proxy PHP requests to php-fpm
+        <FilesMatch \.php$>
+            SetHandler "proxy:fcgi://127.0.0.1:9000"
+        </FilesMatch>
+    </Directory>
 
     # Logging
     ErrorLog ${APACHE_LOG_DIR}/error.log
@@ -21,4 +21,7 @@
     Header always set X-Content-Type-Options "nosniff"
     Header always set X-Frame-Options "SAMEORIGIN"
     Header always set X-XSS-Protection "1; mode=block"
+    Header always set Referrer-Policy "strict-origin-when-cross-origin"
+    Header always set Permissions-Policy "geolocation=(), camera=(), microphone=()"
+    Header always set X-Permitted-Cross-Domain-Policies "none"
 </VirtualHost>

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,20 +1,84 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Write runtime PHP settings from environment
 cat > /usr/local/etc/php/conf.d/cacti-runtime.ini <<INI
 date.timezone = ${TIMEZONE:-UTC}
 memory_limit = ${PHP_MEMORY_LIMIT:-512M}
 max_execution_time = 60
 INI
 
-# Ensure volume directories have correct ownership
-chown -R www-data:www-data /var/www/html/cacti/cache \
-                           /var/www/html/cacti/rra \
-                           /var/www/html/cacti/log 2>/dev/null || true
+for dir in /var/www/html/cacti/cache \
+           /var/www/html/cacti/rra \
+           /var/www/html/cacti/log; do
+    [ -d "$dir" ] && chown -R www-data:www-data "$dir"
+done
 
-# Start php-fpm in background
+if [ ! -f /var/www/html/cacti/include/config.php ]; then
+    cat > /var/www/html/cacti/include/config.php <<'PHPCONFIG'
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2024 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+$database_type     = 'mysql';
+PHPCONFIG
+
+    # Reject quotes/backslashes that would break the PHP string literals below
+    for _var in DB_NAME DB_HOST DB_USER DB_PASS DB_PORT; do
+        _val="${!_var:-}"
+        if [[ "$_val" =~ [\'\\] ]]; then
+            echo "ERROR: $_var contains unsafe characters (single quote or backslash)" >&2
+            exit 1
+        fi
+    done
+
+    cat >> /var/www/html/cacti/include/config.php <<PHPCONFIG
+\$database_default  = '${DB_NAME:-cacti}';
+\$database_hostname = '${DB_HOST:-localhost}';
+\$database_username = '${DB_USER:-cacti}';
+\$database_password = '${DB_PASS:-cacti}';
+\$database_port     = '${DB_PORT:-3306}';
+PHPCONFIG
+
+    cat >> /var/www/html/cacti/include/config.php <<'PHPCONFIG'
+$database_retries  = 5;
+$database_ssl      = false;
+$database_persist  = false;
+$poller_id         = 1;
+$url_path          = '/cacti/';
+
+$cacti_session_name = 'Cacti';
+PHPCONFIG
+
+    chown www-data:www-data /var/www/html/cacti/include/config.php
+fi
+
+cat > /etc/cron.d/cacti-poller <<CRON
+*/5 * * * * www-data php /var/www/html/cacti/poller.php >> /proc/1/fd/1 2>> /proc/1/fd/2
+CRON
+
+chmod 0644 /etc/cron.d/cacti-poller
+cron
+
 php-fpm -D
 
-# Run Apache in foreground
 exec apachectl -D FOREGROUND

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,7 +18,7 @@ if [ ! -f /var/www/html/cacti/include/config.php ]; then
 <?php
 /*
  +-------------------------------------------------------------------------+
- | Copyright (C) 2004-2024 The Cacti Group                                 |
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
  |                                                                         |
  | This program is free software; you can redistribute it and/or           |
  | modify it under the terms of the GNU General Public License             |

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 cat > /usr/local/etc/php/conf.d/cacti-runtime.ini <<INI

--- a/tests/tools/check_docker.sh
+++ b/tests/tools/check_docker.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+set -euo pipefail
+
+# Smoke test for Docker dev environment.
+# Builds, starts, validates, tears down. Exit 0 = pass, 1 = fail.
+
+COMPOSE_PROJECT="cacti_test_$$"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WEB_PORT=18080
+PASS=0
+FAIL=0
+
+cleanup() {
+    cd "$REPO_DIR"
+    docker compose -p "$COMPOSE_PROJECT" down -v --remove-orphans 2>/dev/null || true
+    rm -f "$REPO_DIR/.env.test" "$REPO_DIR/include/config.php"
+}
+trap cleanup EXIT
+
+log_pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+log_fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+check() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        log_pass "$desc"
+    else
+        log_fail "$desc"
+    fi
+}
+
+cd "$REPO_DIR"
+
+# Generate test env
+cat > .env.test <<EOF
+WEB_PORT=$WEB_PORT
+DB_ROOT_PASSWORD=testroot
+DB_NAME=cacti
+DB_USER=cacti
+DB_PASSWORD=testpass
+DB_PORT=13306
+TIMEZONE=UTC
+PHP_MEMORY_LIMIT=256M
+DB_MAX_CONNECTIONS=50
+DB_BUFFER_POOL_SIZE=256M
+EOF
+
+echo "=== Docker smoke test ==="
+
+# 1. Build
+echo "Building image..."
+if docker compose -p "$COMPOSE_PROJECT" --env-file .env.test build --quiet 2>&1; then
+    log_pass "Image builds"
+else
+    log_fail "Image builds"
+    echo "Build failed, aborting."
+    exit 1
+fi
+
+# 2. Start
+echo "Starting containers..."
+docker compose -p "$COMPOSE_PROJECT" --env-file .env.test up -d 2>&1
+
+# 3. Wait for healthy (up to 120s)
+echo "Waiting for containers..."
+TRIES=0
+while [ $TRIES -lt 24 ]; do
+    DB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | head -1 | cut -d'"' -f4)
+    WEB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | tail -1 | cut -d'"' -f4)
+    if [ "$DB_HEALTH" = "healthy" ] && [ "$WEB_HEALTH" = "healthy" ]; then
+        break
+    fi
+    sleep 5
+    TRIES=$((TRIES + 1))
+done
+
+WEB_CONTAINER=$(docker compose -p "$COMPOSE_PROJECT" ps -q web 2>/dev/null)
+
+check "DB container healthy" [ "$DB_HEALTH" = "healthy" ]
+check "Web container healthy" [ "$WEB_HEALTH" = "healthy" ]
+
+# 4. PHP extensions
+REQUIRED_EXTS="gd gmp intl ldap mbstring mysqli pdo_mysql snmp pcntl posix sockets xml dom sqlite3 pdo_sqlite"
+LOADED=$(docker exec "$WEB_CONTAINER" php -m 2>/dev/null)
+for ext in $REQUIRED_EXTS; do
+    if echo "$LOADED" | grep -qi "^${ext}$"; then
+        log_pass "PHP ext: $ext"
+    else
+        log_fail "PHP ext: $ext"
+    fi
+done
+
+# 5. config.php generated
+check "config.php exists" docker exec "$WEB_CONTAINER" test -f /var/www/html/cacti/include/config.php
+check "config.php has DB host" docker exec "$WEB_CONTAINER" grep -q "database_hostname" /var/www/html/cacti/include/config.php
+
+# 6. Cron
+check "Cron job installed" docker exec "$WEB_CONTAINER" test -f /etc/cron.d/cacti-poller
+check "Cron daemon running" docker exec "$WEB_CONTAINER" pgrep cron
+
+# 7. HTTP response
+HTTP_CODE=$(curl -so /dev/null -w "%{http_code}" "http://localhost:${WEB_PORT}/cacti/" 2>/dev/null || echo "000")
+check "HTTP 200 on /cacti/" [ "$HTTP_CODE" = "200" ]
+
+# 8. Security headers
+HEADERS=$(curl -sI "http://localhost:${WEB_PORT}/cacti/" 2>/dev/null)
+check "Header: X-Content-Type-Options" grep -qi "X-Content-Type-Options" <<<"$HEADERS"
+check "Header: X-Frame-Options" grep -qi "X-Frame-Options" <<<"$HEADERS"
+check "Header: Referrer-Policy" grep -qi "Referrer-Policy" <<<"$HEADERS"
+check "Header: Permissions-Policy" grep -qi "Permissions-Policy" <<<"$HEADERS"
+if grep -qi "X-Powered-By" <<<"$HEADERS"; then
+    log_fail "No X-Powered-By leak"
+else
+    log_pass "No X-Powered-By leak"
+fi
+
+# 9. DB accessible from web
+check "DB connection from web" docker exec "$WEB_CONTAINER" php -r "new PDO('mysql:host=db;dbname=cacti', 'cacti', 'testpass');"
+
+echo ""
+echo "=== Results ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tests/tools/check_docker.sh
+++ b/tests/tools/check_docker.sh
@@ -1,4 +1,24 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# +-------------------------------------------------------------------------+
+# | Copyright (C) 2004-2026 The Cacti Group                                 |
+# |                                                                         |
+# | This program is free software; you can redistribute it and/or           |
+# | modify it under the terms of the GNU General Public License             |
+# | as published by the Free Software Foundation; either version 2          |
+# | of the License, or (at your option) any later version.                  |
+# |                                                                         |
+# | This program is distributed in the hope that it will be useful,         |
+# | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+# | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+# | GNU General Public License for more details.                            |
+# +-------------------------------------------------------------------------+
+# | Cacti: The Complete RRDtool-based Graphing Solution                     |
+# +-------------------------------------------------------------------------+
+# | This code is designed, written, and maintained by the Cacti Group. See  |
+# | about.php and/or the AUTHORS file for specific developer information.   |
+# +-------------------------------------------------------------------------+
+# | http://www.cacti.net/                                                   |
+# +-------------------------------------------------------------------------+
 set -euo pipefail
 
 # Smoke test for Docker dev environment.
@@ -81,7 +101,7 @@ check "DB container healthy" [ "$DB_HEALTH" = "healthy" ]
 check "Web container healthy" [ "$WEB_HEALTH" = "healthy" ]
 
 # 4. PHP extensions
-REQUIRED_EXTS="gd gmp intl ldap mbstring mysqli pdo_mysql snmp pcntl posix sockets xml dom sqlite3 pdo_sqlite"
+REQUIRED_EXTS="gd gmp intl ldap mbstring mysqli opcache pdo_mysql snmp pcntl posix sockets xml dom sqlite3 pdo_sqlite"
 LOADED=$(docker exec "$WEB_CONTAINER" php -m 2>/dev/null)
 for ext in $REQUIRED_EXTS; do
     if echo "$LOADED" | grep -qi "^${ext}$"; then


### PR DESCRIPTION
## Summary

Follow-up to #6618 addressing Copilot review feedback and adding security hardening:

- **entrypoint.sh**: `set -euo pipefail`, input validation on DB env vars (reject `'` and `\`), config.php generated only on first run, cron output to container stdout
- **apache.conf**: `AllowOverride` scoped to `FileInfo Options=FollowSymLinks`, added `Referrer-Policy`, `Permissions-Policy`, `X-Permitted-Cross-Domain-Policies` headers, `FilesMatch` moved inside `Directory` block
- **docker-compose.yml**: DB port bound to `127.0.0.1` only, dash-separated MariaDB options
- **Dockerfile**: removed bundled extensions from install list (`dom`, `sqlite3`, `pdo_sqlite`), `expose_php = Off`, reduced `pm.max_children` 50→10
- **.gitignore**: exclude `.env`, `.env.local`, `.env.*.local`, `docker-compose.override.yml`
- **.env.example**: credential warning
- **.dockerignore**: `!README.md` exception

Adds `tests/tools/check_docker.sh` — a 29-point smoke test that builds, starts, validates (extensions, config, cron, HTTP, security headers, DB), and tears down in an isolated compose project.

## Test plan

- [x] `bash -n` syntax check on entrypoint.sh and check_docker.sh
- [x] `docker compose config --quiet` validates compose file
- [x] `docker build` succeeds
- [x] Both containers reach healthy state
- [x] All 24 PHP extensions loaded (including bundled dom, sqlite3, pdo_sqlite)
- [x] config.php generated with correct DB credentials
- [x] Cron job installed and daemon running
- [x] HTTP 200 on /cacti/
- [x] All 5 security headers present, no X-Powered-By leak
- [x] DB connection from web container
- [x] Full smoke test: 29/29 pass