### PR TITLE
fix: default proxy_headers to false to prevent remote agent auth bypass

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -8335,21 +8335,23 @@ function get_client_addr() : string|false {
 		$last_time = read_config_option('proxy_alert');
 
 		if (empty($last_time)) {
-			$last_time = date('Y-m-d');
-		}
-
-		$last_date = new DateTime($last_time);
-		$this_date = new Datetime();
-
-		$this_diff = $this_date->diff($last_date);
-		$this_days = $this_diff->format('%a');
-
-		if ($this_days) {
-			cacti_log('WARNING: Configuration option "proxy_headers" will be automatically false in future releases.  Please set if you require proxy IPs to be used', false, 'AUTH');
+			// First run — no record yet; log immediately and record today
+			cacti_log('NOTICE: proxy_headers is not set in config.php; defaulting to false (only REMOTE_ADDR trusted). Set proxy_headers if Cacti is behind a reverse proxy.', false, 'AUTH');
 			set_config_option('proxy_alert', date('Y-m-d'));
+		} else {
+			$last_date = new DateTime($last_time);
+			$this_date = new DateTime();
+
+			$this_diff = $this_date->diff($last_date);
+			$this_days = $this_diff->format('%a');
+
+			if ((int) $this_days >= 1) {
+				cacti_log('NOTICE: proxy_headers is not set in config.php; defaulting to false (only REMOTE_ADDR trusted). Set proxy_headers if Cacti is behind a reverse proxy.', false, 'AUTH');
+				set_config_option('proxy_alert', date('Y-m-d'));
+			}
 		}
 
-		$proxy_headers = true;
+		$proxy_headers = false;
 	}
 
 	/* If proxy_headers is true, allow all known headers -- NOT advised

--- a/oauth2.php
+++ b/oauth2.php
@@ -113,7 +113,7 @@ if (empty($_GET['state']) || (isset($_SESSION['oauth2state']) && ($_GET['state']
 
 	// Use this to interact with an API on the users behalf
 	// Use this to get a new access token if the old one expires
-	print __('Refresh Token: ') . $token->getRefreshToken();
+	print __('Refresh Token: ') . htmle($token->getRefreshToken());
 	print '<br/>' . __('Store this token in Settings -> Mail/Reporting/DNS -> Oauth2 refresh token. ');
 	print '<br/>' . __('If the token is empty, it means it stays the same. The Oatuh2 provider will not resend it in that case. ');
 }


### PR DESCRIPTION
## Summary

- Change `get_client_addr()` to default `proxy_headers` to `false` when not configured
- Previously defaulted to `true`, which trusted all proxy headers (`X-Forwarded-For`, `X-Client-IP`, etc.)
- An attacker could set these headers to a known poller IP and bypass `remote_agent.php` authorization

## Impact

Without this fix, any unauthenticated attacker who can reach `remote_agent.php` and knows a poller IP can access the remote agent API by spoofing proxy headers.

## Migration note

Installations behind a reverse proxy that rely on proxy headers for correct client IP detection should explicitly set `proxy_headers` in their Cacti configuration. The previous implicit trust-all behavior is no longer the default.

## Test plan

- Direct connections: `REMOTE_ADDR` used as before, no change
- Behind proxy with `proxy_headers` explicitly configured: works as before
- Behind proxy without `proxy_headers` set: admin sees log notice to configure it
- Spoofed `X-Forwarded-For` without config: correctly ignored