### PR TITLE
fix: escape reflected user input in auth pages

### DIFF
--- a/auth_profile.php
+++ b/auth_profile.php
@@ -680,7 +680,7 @@ function settings_javascript() : void {
 	?>
 	<script type='text/javascript'>
 		var themeFonts = <?php print read_config_option('font_method'); ?>;
-		var currentTab = '<?php print gnrv('tab'); ?>';
+		var currentTab = <?php print json_encode(gnrv('tab')); ?>;
 		var currentTheme = '<?php print get_selected_theme(); ?>';
 		var currentLang = '<?php print read_config_option('user_language'); ?>';
 		var authMethod = '<?php print read_config_option('auth_method'); ?>';

--- a/auth_resetpassword.php
+++ b/auth_resetpassword.php
@@ -278,7 +278,7 @@ html_auth_header('reset_password', __('Reset Password'), __('Reset Password'), $
 	<tr>
 		<td colspan='2'>
 			<input type='hidden' name='action' value='resetrequest'>
-			<input type='hidden' name='hash' value='<?php print gnrv('hash'); ?>'>
+			<input type='hidden' name='hash' value='<?php print html_escape(gnrv('hash')); ?>'>
 		</td>
 	</tr>
 <?php }
@@ -305,7 +305,7 @@ if ($action == 'formreset') {?>
 	<tr>
 		<td colspan='2'>
 			<input type='hidden' name='action' value='resetpassword'>
-			<input type='hidden' name='hash' value='<?php print gnrv('hash'); ?>'>
+			<input type='hidden' name='hash' value='<?php print html_escape(gnrv('hash')); ?>'>
 		</td>
 	</tr>
 <?php


### PR DESCRIPTION
## Summary

- `auth_resetpassword.php`: escape `hash` parameter in HTML attribute context (unauthenticated page)
- `auth_profile.php`: use `json_encode` for `tab` parameter in JavaScript string context

Both are reflected XSS — user input from query parameters printed directly into HTML/JS without escaping.

## Test plan

- Password reset flow still works with valid hash tokens
- Profile tab switching still works
- XSS payloads in `hash` and `tab` params are neutralized