### PR TITLE
fix: sanitize Host header and remove CRLF in HTTPS redirect

### DIFF
--- a/include/global.php
+++ b/include/global.php
@@ -502,7 +502,8 @@ db_cacti_initialized($config['is_web']);
 if ($config['is_web']) {
 	if (read_config_option('force_https') == 'on') {
 		if (!isset($_SERVER['HTTPS']) && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
-			header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . PHP_EOL . PHP_EOL);
+			$host = preg_replace('/[^a-zA-Z0-9.\-:]/', '', $_SERVER['HTTP_HOST']);
+			header('Location: https://' . $host . $_SERVER['REQUEST_URI']);
 
 			exit;
 		}


### PR DESCRIPTION
\$_SERVER['HTTP_HOST'] is user-controlled and passed to header('Location: ...')
in the HTTPS enforcement redirect. Appended PHP_EOL could enable response
splitting. Pre-auth reachable.

Strips invalid hostname characters and removes trailing newlines.

Found via RIPS-style static taint analysis on header() sinks.