### PR TITLE
fix: harden data collection scripts — SQL injection, counter math, column allow-listing

### DIFF
--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,8 +644,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -658,8 +656,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -672,8 +668,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -791,7 +785,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON gti.task_item_id = dtr.id
+				ON dtr.id = gti.task_item_id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1594,143 +1588,6 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
-/**
- * Handles the aggregation of stacked lines for a given graph.
- *
- * @param int    $local_graph_id   The ID of the local graph.
- * @param string $_orig_graph_type The original type of the graph.
- * @param int    $_total           The total value to be aggregated.
- * @param string $_total_type      The type of the total value.
- * @param string $_total_prefix    The prefix for the total value.
- *
- * @return void
- */
-function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
-	// Handle the stacked line cases switch line widths
-	$width        = '0.01';
-	$special_type = '';
-	$special_line = false;
-
-	switch ($_orig_graph_type) {
-		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
-			$width        = '1.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE1;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
-			$width        = '2.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE2;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
-			$width        = '3.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE3;
-			$special_line = true;
-
-			break;
-	}
-
-	if ($special_line) {
-		if ($_total == AGGREGATE_TOTAL_NONE) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET line_width = ?
-				WHERE local_graph_id = ?
-				AND graph_type_id IN (?)',
-				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
-		}
-
-		// Handle special case total prefix
-		db_execute_prepared('UPDATE graph_templates_item
-			SET graph_type_id = ?
-			WHERE local_graph_id = ?
-			AND text_format = ?',
-			[$special_type, $local_graph_id, $_total_prefix]);
-
-		if ($_total == AGGREGATE_TOTAL_ALL) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET graph_type_id = ?, line_width = "0.01"
-				WHERE local_graph_id = ?
-				AND graph_type_id = ?
-				AND text_format != ?',
-				[
-					GRAPH_ITEM_TYPE_LINESTACK,
-					$local_graph_id,
-					$special_type,
-					$_total_prefix
-				]
-			);
-		}
-	}
-
-	// handle any missing lines
-	db_execute_prepared('UPDATE graph_templates_item
-		SET line_width="0.01"
-		WHERE graph_type_id = ?
-		AND line_width="0.00"
-		AND local_graph_id = ?',
-		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
-}
-
-/**
- * Retrieves data sources for aggregation.
- *
- * @param array  $graph_array    Array of graphs to aggregate.
- * @param mixed  $data_sources   Array to store the retrieved data sources.
- * @param mixed  $graph_template Template for the graphs.
- * @param string $message        Optional. Message to store any errors or information.
- *
- * @return bool True on success, false on failure.
- */
-function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
-	if (cacti_sizeof($graph_array)) {
-		// fetch all data sources for all selected graphs
-		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
-			FROM data_template_rrd AS dtr
-			INNER JOIN graph_templates_item AS gti
-			ON dtr.id = gti.task_item_id
-			INNER JOIN data_template_data AS dtd
-			ON dtr.local_data_id = dtd.local_data_id
-			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
-			AND dtd.local_data_id > 0
-			GROUP BY dtd.local_data_id
-			ORDER BY dtd.name_cache');
-
-		// verify, that only a single graph template is used, else
-		// aggregate will look funny
-		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
-			FROM graph_local AS gl
-			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
-
-		if (cacti_sizeof($templates) > 1) {
-			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
-
-			return false;
-		}
-
-		if (cacti_sizeof($templates) == 1) {
-			if ($templates[0]['id'] == 0) {
-				// selected graphs do not use templates
-				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
-
-				return false;
-			} else {
-				$graph_template = $templates[0]['id'];
-
-				return true;
-			}
-		} else {
-			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
-
-			return false;
-		}
-	} else {
-		$message = __('You must pass at least a single Graph to this function');
-
-		return false;
-	}
-}
 
 /**
  * Draws the list of aggregate graph items.

--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,6 +644,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -656,6 +658,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -668,6 +672,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -785,7 +791,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON dtr.id = gti.task_item_id
+				ON gti.task_item_id = dtr.id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1588,6 +1594,143 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
+/**
+ * Handles the aggregation of stacked lines for a given graph.
+ *
+ * @param int    $local_graph_id   The ID of the local graph.
+ * @param string $_orig_graph_type The original type of the graph.
+ * @param int    $_total           The total value to be aggregated.
+ * @param string $_total_type      The type of the total value.
+ * @param string $_total_prefix    The prefix for the total value.
+ *
+ * @return void
+ */
+function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
+	// Handle the stacked line cases switch line widths
+	$width        = '0.01';
+	$special_type = '';
+	$special_line = false;
+
+	switch ($_orig_graph_type) {
+		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
+			$width        = '1.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE1;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
+			$width        = '2.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE2;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
+			$width        = '3.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE3;
+			$special_line = true;
+
+			break;
+	}
+
+	if ($special_line) {
+		if ($_total == AGGREGATE_TOTAL_NONE) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET line_width = ?
+				WHERE local_graph_id = ?
+				AND graph_type_id IN (?)',
+				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
+		}
+
+		// Handle special case total prefix
+		db_execute_prepared('UPDATE graph_templates_item
+			SET graph_type_id = ?
+			WHERE local_graph_id = ?
+			AND text_format = ?',
+			[$special_type, $local_graph_id, $_total_prefix]);
+
+		if ($_total == AGGREGATE_TOTAL_ALL) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET graph_type_id = ?, line_width = "0.01"
+				WHERE local_graph_id = ?
+				AND graph_type_id = ?
+				AND text_format != ?',
+				[
+					GRAPH_ITEM_TYPE_LINESTACK,
+					$local_graph_id,
+					$special_type,
+					$_total_prefix
+				]
+			);
+		}
+	}
+
+	// handle any missing lines
+	db_execute_prepared('UPDATE graph_templates_item
+		SET line_width="0.01"
+		WHERE graph_type_id = ?
+		AND line_width="0.00"
+		AND local_graph_id = ?',
+		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
+}
+
+/**
+ * Retrieves data sources for aggregation.
+ *
+ * @param array  $graph_array    Array of graphs to aggregate.
+ * @param mixed  $data_sources   Array to store the retrieved data sources.
+ * @param mixed  $graph_template Template for the graphs.
+ * @param string $message        Optional. Message to store any errors or information.
+ *
+ * @return bool True on success, false on failure.
+ */
+function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
+	if (cacti_sizeof($graph_array)) {
+		// fetch all data sources for all selected graphs
+		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
+			FROM data_template_rrd AS dtr
+			INNER JOIN graph_templates_item AS gti
+			ON dtr.id = gti.task_item_id
+			INNER JOIN data_template_data AS dtd
+			ON dtr.local_data_id = dtd.local_data_id
+			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
+			AND dtd.local_data_id > 0
+			GROUP BY dtd.local_data_id
+			ORDER BY dtd.name_cache');
+
+		// verify, that only a single graph template is used, else
+		// aggregate will look funny
+		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
+			FROM graph_local AS gl
+			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
+
+		if (cacti_sizeof($templates) > 1) {
+			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
+
+			return false;
+		}
+
+		if (cacti_sizeof($templates) == 1) {
+			if ($templates[0]['id'] == 0) {
+				// selected graphs do not use templates
+				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
+
+				return false;
+			} else {
+				$graph_template = $templates[0]['id'];
+
+				return true;
+			}
+		} else {
+			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
+
+			return false;
+		}
+	} else {
+		$message = __('You must pass at least a single Graph to this function');
+
+		return false;
+	}
+}
 
 /**
  * Draws the list of aggregate graph items.

--- a/scripts/aruba_instant_wlan_client.php
+++ b/scripts/aruba_instant_wlan_client.php
@@ -73,7 +73,7 @@ if ($cmd == 'index') {
 		$host['snmp_context'],
 		$host['snmp_port'],
 		$host['snmp_timeout'],
-		$host['ping_retries'],
+		$host['snmp_retries'],
 		SNMP_POLLER,
 		$host['snmp_engine_id']);
 
@@ -94,7 +94,7 @@ if ($cmd == 'index') {
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']));
 
@@ -117,7 +117,7 @@ if ($cmd == 'index') {
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']));
 
@@ -143,7 +143,7 @@ if ($cmd == 'index') {
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']));
 
@@ -167,7 +167,7 @@ if ($cmd == 'index') {
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']);
 
@@ -185,7 +185,7 @@ if ($cmd == 'index') {
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']);
 

--- a/scripts/ss_aruba_instant_ap.php
+++ b/scripts/ss_aruba_instant_ap.php
@@ -59,7 +59,7 @@ function ss_aruba_instant_ap(int $host_id = 0) : mixed {
 		$host['snmp_context'],
 		$host['snmp_port'],
 		$host['snmp_timeout'],
-		$host['ping_retries'],
+		$host['snmp_retries'],
 		SNMP_POLLER,
 		$host['snmp_engine_id']);
 

--- a/scripts/ss_aruba_instant_client.php
+++ b/scripts/ss_aruba_instant_client.php
@@ -60,7 +60,7 @@ function ss_aruba_instant_client(int $host_id = 0) : mixed {
 		$host['snmp_context'],
 		$host['snmp_port'],
 		$host['snmp_timeout'],
-		$host['ping_retries'],
+		$host['snmp_retries'],
 		SNMP_POLLER,
 		$host['snmp_engine_id']);
 

--- a/scripts/ss_aruba_oscx_6x00.php
+++ b/scripts/ss_aruba_oscx_6x00.php
@@ -87,7 +87,7 @@ function ss_aruba_oscx_6x00(int $host_id = 0, string $object = 'fan', string $cm
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id'])) { // it is standalone
 			$oids['vsf'] = $oids['vsf_standalone'];
@@ -113,7 +113,7 @@ function ss_aruba_oscx_6x00(int $host_id = 0, string $object = 'fan', string $cm
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']);
 
@@ -149,7 +149,7 @@ function ss_aruba_oscx_6x00(int $host_id = 0, string $object = 'fan', string $cm
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']));
 		}
@@ -170,7 +170,7 @@ function ss_aruba_oscx_6x00(int $host_id = 0, string $object = 'fan', string $cm
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']);
 
@@ -230,7 +230,7 @@ function ss_aruba_oscx_6x00(int $host_id = 0, string $object = 'fan', string $cm
 					$host['snmp_context'],
 					$host['snmp_port'],
 					$host['snmp_timeout'],
-					$host['ping_retries'],
+					$host['snmp_retries'],
 					SNMP_POLLER,
 					$host['snmp_engine_id']);
 			}
@@ -247,7 +247,7 @@ function ss_aruba_oscx_6x00(int $host_id = 0, string $object = 'fan', string $cm
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']);
 		}

--- a/scripts/ss_cpoller.php
+++ b/scripts/ss_cpoller.php
@@ -70,7 +70,7 @@ function ss_cpoller(string $cmd = 'index', string $arg1 = '', string $arg2 = '')
 		switch($arg) {
 			case 'recacheTime':
 				$value = '0';
-				$stats = explode(' ', db_fetch_cell('SELECT value FROM settings WHERE name="stats_recache_' . $index . '"'));
+				$stats = explode(' ', db_fetch_cell_prepared('SELECT value FROM settings WHERE name = ?', ['stats_recache_' . $index]));
 
 				foreach ($stats as $_stat) {
 					if (preg_match('/^RecacheTime:/', $_stat)) {
@@ -82,7 +82,7 @@ function ss_cpoller(string $cmd = 'index', string $arg1 = '', string $arg2 = '')
 				break;
 			case 'recacheDevices':
 				$value = '0';
-				$stats = explode(' ', db_fetch_cell('SELECT value FROM settings WHERE name="stats_recache_' . $index . '"'));
+				$stats = explode(' ', db_fetch_cell_prepared('SELECT value FROM settings WHERE name = ?', ['stats_recache_' . $index]));
 
 				foreach ($stats as $_stat) {
 					if (preg_match('/^DevicesRecached:/', $_stat)) {

--- a/scripts/ss_fortigate_ips.php
+++ b/scripts/ss_fortigate_ips.php
@@ -70,7 +70,7 @@ function ss_fortigate_ips(int $host_id = 0) : mixed {
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']);
 

--- a/scripts/ss_fortigate_ipsec.php
+++ b/scripts/ss_fortigate_ipsec.php
@@ -62,7 +62,7 @@ function ss_fortigate_ipsec(int $host_id = 0) : mixed {
 		$host['snmp_context'],
 		$host['snmp_port'],
 		$host['snmp_timeout'],
-		$host['ping_retries'],
+		$host['snmp_retries'],
 		SNMP_POLLER,
 		$host['snmp_engine_id']);
 

--- a/scripts/ss_fortigate_virus.php
+++ b/scripts/ss_fortigate_virus.php
@@ -69,7 +69,7 @@ function ss_fortigate_virus(int $host_id = 0) : mixed {
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']);
 
@@ -101,7 +101,7 @@ function ss_fortigate_virus(int $host_id = 0) : mixed {
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']);
 

--- a/scripts/ss_hstats.php
+++ b/scripts/ss_hstats.php
@@ -75,6 +75,12 @@ function ss_hstats(int $host_id = 0, string $stat = '') : string {
 			return '0';
 	}
 
+	$allowed = ['polling_time', 'min_time', 'max_time', 'cur_time', 'avg_time', 'snmp_sysUpTimeInstance', 'failed_polls', 'availability', 'current_errors'];
+
+	if (!in_array($column, $allowed, true)) {
+		return '0';
+	}
+
 	if ($host_id > 0) {
 		$value = db_fetch_cell_prepared("SELECT $column
 			FROM host

--- a/scripts/ss_mikrotik_health.php
+++ b/scripts/ss_mikrotik_health.php
@@ -32,6 +32,12 @@ if (!isset($called_by_script_server)) {
 }
 
 function ss_mikrotik_health(int $host_id = 0, string $column = 'no') : string {
+	$allowed_columns = ['voltage', 'temperature', 'processorTemperature', 'current', 'power', 'fanSpeed', 'cpuFrequency'];
+
+	if (!in_array($column, $allowed_columns, true)) {
+		return '0';
+	}
+
 	$value = db_fetch_cell_prepared("SELECT $column
 		FROM plugin_mikrotik_system_health
 		WHERE host_id = ?",

--- a/scripts/ss_mikrotik_interfaces.php
+++ b/scripts/ss_mikrotik_interfaces.php
@@ -60,13 +60,24 @@ function ss_mikrotik_interfaces(int $host_id, string $cmd = 'index', string $arg
 function ss_mikrotik_interfaces_getvalue(int $host_id, string $index, string $column) : string {
 	$column = 'cur' . $column;
 
+	$allowed_columns = [
+		'curInOctets', 'curOutOctets', 'curInErrors', 'curOutErrors',
+		'curInDiscards', 'curOutDiscards', 'curInUnicastPkts', 'curOutUnicastPkts',
+		'curInMulticastPkts', 'curOutMulticastPkts', 'curInBroadcastPkts', 'curOutBroadcastPkts',
+		'curSpeed',
+	];
+
+	if (!in_array($column, $allowed_columns, true)) {
+		return '0';
+	}
+
 	$index2 = str_replace('_', ' ', $index);
 
-	$value = db_fetch_cell_prepared("SELECT
-		$column AS value
+	$value = db_fetch_cell_prepared('SELECT
+		' . $column . ' AS value
 		FROM plugin_mikrotik_interfaces
-		WHERE name IN ('$index', '$index2')
-		AND host_id = ?",
+		WHERE name IN (' . db_qstr($index) . ', ' . db_qstr($index2) . ')
+		AND host_id = ?',
 		[$host_id]);
 
 	if ($value === false) {

--- a/scripts/ss_mikrotik_qtrees.php
+++ b/scripts/ss_mikrotik_qtrees.php
@@ -75,11 +75,11 @@ function ss_mikrotik_qtrees_getvalue(int $host_id, string $index, string $column
 
 	$index2 = str_replace('_', ' ', $index);
 
-	$value = db_fetch_cell_prepared("SELECT
-		$column AS value
+	$value = db_fetch_cell_prepared('SELECT
+		' . $column . ' AS value
 		FROM plugin_mikrotik_trees
-		WHERE name IN ('$index', '$index2', '<$index>')
-		AND host_id = ?",
+		WHERE name IN (' . db_qstr($index) . ', ' . db_qstr($index2) . ', ' . db_qstr('<' . $index . '>') . ')
+		AND host_id = ?',
 		[$host_id]);
 
 	return $value;

--- a/scripts/ss_mikrotik_queues.php
+++ b/scripts/ss_mikrotik_queues.php
@@ -93,13 +93,19 @@ function ss_mikrotik_queues_getvalue(int $host_id, string $index, string $column
 			break;
 	}
 
+	$allowed_columns = ['curBytesIn', 'curBytesOut', 'curPacketsIn', 'curPacketsOut', 'curQueuesIn', 'curQueuesOut', 'curDroppedIn', 'curDroppedOut'];
+
+	if (!in_array($column, $allowed_columns, true)) {
+		return '0';
+	}
+
 	$index2 = str_replace('_', ' ', $index);
 
-	$value = db_fetch_cell_prepared("SELECT
-		$column AS value
+	$value = db_fetch_cell_prepared('SELECT
+		' . $column . ' AS value
 		FROM plugin_mikrotik_queues
-		WHERE name IN ('$index', '$index2')
-		AND host_id = ?",
+		WHERE name IN (' . db_qstr($index) . ', ' . db_qstr($index2) . ')
+		AND host_id = ?',
 		[$host_id]);
 
 	if ($value === false) {

--- a/scripts/ss_mikrotik_wireless_reg.php
+++ b/scripts/ss_mikrotik_wireless_reg.php
@@ -64,10 +64,21 @@ function ss_mikrotik_wireless_reg(int $host_id, string $cmd, string $object = ''
 			}
 		}
 	} elseif ($cmd == 'get') {
-		return db_fetch_cell_prepared("SELECT `$object`
+		$allowed_objects = [
+			'macAddress', 'interface', 'apTxRate', 'apRxRate', 'apStrength',
+			'apSsid', 'apBand', 'apFreq', 'apNoiseFloor', 'apOverallTxCcq',
+			'apTxBytes', 'apRxBytes', 'apTxPackets', 'apRxPackets',
+			'apTxFrames', 'apRxFrames', 'apTxHwFrames', 'apRxHwFrames',
+		];
+
+		if (!in_array($object, $allowed_objects, true)) {
+			return null;
+		}
+
+		return db_fetch_cell_prepared('SELECT `' . $object . '`
 			FROM plugin_mikrotik_wireless_registrations
 			WHERE host_id = ?
-			AND `index` = ?",
+			AND `index` = ?',
 			[$host_id, $index]);
 	}
 

--- a/scripts/ss_net_snmp_disk_bytes.php
+++ b/scripts/ss_net_snmp_disk_bytes.php
@@ -64,7 +64,7 @@ function ss_net_snmp_disk_bytes(mixed $host_id_or_hostname = '') : string {
 		}
 
 		if (!is_dir($tmpdir)) {
-			mkdir($tmpdir, 0777, true);
+			mkdir($tmpdir, 0755, true);
 		}
 	} else {
 		if ($environ != 'realtime') {
@@ -197,9 +197,9 @@ function ss_net_snmp_disk_bytes(mixed $host_id_or_hostname = '') : string {
 					$bytesread = 'U';
 				} elseif ($previous["br$index"] > $measure['value']) {
 					if ($bytesread != 'U') {
-						$bytesread += $measure['value'] + 18446744073709551615 - $previous["br$index"] - $previous["br$index"];
+						$bytesread += $measure['value'] + 18446744073709551616 - $previous["br$index"];
 					} else {
-						$bytesread = $measure['value'] + 18446744073709551615 - $previous["br$index"] - $previous["br$index"];
+						$bytesread = $measure['value'] + 18446744073709551616 - $previous["br$index"];
 					}
 				} else {
 					if ($bytesread != 'U') {
@@ -243,9 +243,9 @@ function ss_net_snmp_disk_bytes(mixed $host_id_or_hostname = '') : string {
 					$byteswritten = 'U';
 				} elseif ($previous["bw$index"] > $measure['value']) {
 					if ($byteswritten != 'U') {
-						$byteswritten += $measure['value'] + 18446744073709551615 - $previous["bw$index"] - $previous["bw$index"];
+						$byteswritten += $measure['value'] + 18446744073709551616 - $previous["bw$index"];
 					} else {
-						$byteswritten = $measure['value'] + 18446744073709551615 - $previous["bw$index"] - $previous["bw$index"];
+						$byteswritten = $measure['value'] + 18446744073709551616 - $previous["bw$index"];
 					}
 				} else {
 					if ($byteswritten != 'U') {

--- a/scripts/ss_net_snmp_disk_bytes.php
+++ b/scripts/ss_net_snmp_disk_bytes.php
@@ -154,8 +154,8 @@ function ss_net_snmp_disk_bytes(mixed $host_id_or_hostname = '') : string {
 		$host['snmp_engine_id']);
 
 	foreach ($names as $measure) {
-		if (str_starts_with($measure['value'], 'sd') || str_starts_with($measure['value'], 'nvme') || str_starts_with($measure['value'], 'vm')) {
-			if (is_numeric(substr(strrev($measure['value']),0,1))) {
+		if (preg_match('/^(?:sd|nvme|xvd|vd|vm|hd|md|dm-)/', $measure['value'])) {
+			if (preg_match('/(?:p\d+|\d+)$/', $measure['value']) && !preg_match('/^nvme\d+n\d+$/', $measure['value'])) {
 				continue;
 			}
 

--- a/scripts/ss_net_snmp_disk_io.php
+++ b/scripts/ss_net_snmp_disk_io.php
@@ -155,7 +155,7 @@ function ss_net_snmp_disk_io(mixed $host_id_or_hostname = '') : string {
 		$host['snmp_engine_id']);
 
 	foreach ($names as $measure) {
-		if (str_starts_with($measure['value'], 'sd') || str_starts_with($measure['value'], 'nvme') || str_starts_with($measure['value'], 'vm') || str_starts_with($measure['value'], 'xvd') || str_starts_with($measure['value'], 'vd') || str_starts_with($measure['value'], 'hd') || str_starts_with($measure['value'], 'md') || str_starts_with($measure['value'], 'dm-')) {
+		if (preg_match('/^(?:sd|nvme|xvd|vd|vm|hd|md|dm-)/', $measure['value'])) {
 			if (preg_match('/(?:p\d+|\d+)$/', $measure['value']) && !preg_match('/^nvme\d+n\d+$/', $measure['value'])) {
 				continue;
 			}

--- a/scripts/ss_net_snmp_disk_io.php
+++ b/scripts/ss_net_snmp_disk_io.php
@@ -64,7 +64,7 @@ function ss_net_snmp_disk_io(mixed $host_id_or_hostname = '') : string {
 		}
 
 		if (!is_dir($tmpdir)) {
-			mkdir($tmpdir, 0777, true);
+			mkdir($tmpdir, 0755, true);
 		}
 	} else {
 		$tmpdir = null;
@@ -155,8 +155,8 @@ function ss_net_snmp_disk_io(mixed $host_id_or_hostname = '') : string {
 		$host['snmp_engine_id']);
 
 	foreach ($names as $measure) {
-		if (str_starts_with($measure['value'], 'sd') || str_starts_with($measure['value'], 'nvme') || str_starts_with($measure['value'], 'vm')) {
-			if (is_numeric(substr(strrev($measure['value']),0,1))) {
+		if (str_starts_with($measure['value'], 'sd') || str_starts_with($measure['value'], 'nvme') || str_starts_with($measure['value'], 'vm') || str_starts_with($measure['value'], 'xvd') || str_starts_with($measure['value'], 'vd') || str_starts_with($measure['value'], 'hd') || str_starts_with($measure['value'], 'md') || str_starts_with($measure['value'], 'dm-')) {
+			if (preg_match('/(?:p\d+|\d+)$/', $measure['value']) && !preg_match('/^nvme\d+n\d+$/', $measure['value'])) {
 				continue;
 			}
 
@@ -193,15 +193,15 @@ function ss_net_snmp_disk_io(mixed $host_id_or_hostname = '') : string {
 			if (array_key_exists($index, $indexes)) {
 				if (!isset($previous['uptime'])) {
 					$reads = 'U';
-				} elseif ($current['uptime'] < $previous['uptime']) {
+				} elseif (intval($current['uptime']) < intval($previous['uptime'])) {
 					$reads = 'U';
 				} elseif (!isset($previous["dr$index"])) {
 					$reads = 'U';
 				} elseif ($previous["dr$index"] > $measure['value']) {
 					if ($reads != 'U') {
-						$reads += intval($measure['value']) + 4294967295 - intval($previous["dr$index"]) - intval($previous["dr$index"]);
+						$reads += intval($measure['value']) + 4294967296 - intval($previous["dr$index"]);
 					} else {
-						$reads = intval($measure['value']) + 4294967295 - intval($previous["dr$index"]) - intval($previous["dr$index"]);
+						$reads = intval($measure['value']) + 4294967296 - intval($previous["dr$index"]);
 					}
 				} else {
 					if ($reads != 'U') {
@@ -239,15 +239,15 @@ function ss_net_snmp_disk_io(mixed $host_id_or_hostname = '') : string {
 			if (array_key_exists($index, $indexes)) {
 				if (!isset($previous['uptime'])) {
 					$writes = 'U';
-				} elseif ($current['uptime'] < $previous['uptime']) {
+				} elseif (intval($current['uptime']) < intval($previous['uptime'])) {
 					$writes = 'U';
 				} elseif (!isset($previous["dw$index"])) {
 					$writes = 'U';
 				} elseif ($previous["dw$index"] > $measure['value']) {
 					if ($writes != 'U') {
-						$writes += $measure['value'] + 4294967295 - $previous["dw$index"] - $previous["dw$index"];
+						$writes += $measure['value'] + 4294967296 - $previous["dw$index"];
 					} else {
-						$writes = $measure['value'] + 4294967295 - $previous["dw$index"] - $previous["dw$index"];
+						$writes = $measure['value'] + 4294967296 - $previous["dw$index"];
 					}
 				} else {
 					if ($writes != 'U') {

--- a/scripts/ss_netsnmp_lmsensors.php
+++ b/scripts/ss_netsnmp_lmsensors.php
@@ -165,7 +165,7 @@ function ss_netsnmp_lmsensors(int $host_id = 0, string $sensor_type = '', string
 		$host['snmp_context'],
 		$host['snmp_port'],
 		$host['snmp_timeout'],
-		$host['ping_retries'],
+		$host['snmp_retries'],
 		SNMP_POLLER,
 		$host['snmp_engine_id']
 	];
@@ -183,7 +183,7 @@ function ss_netsnmp_lmsensors(int $host_id = 0, string $sensor_type = '', string
 		$host['snmp_context'],
 		$host['snmp_port'],
 		$host['snmp_timeout'],
-		$host['ping_retries'],
+		$host['snmp_retries'],
 		$host['max_oids'],
 		SNMP_POLLER,
 		$host['snmp_engine_id']

--- a/scripts/ss_nimble_alletra_total.php
+++ b/scripts/ss_nimble_alletra_total.php
@@ -70,7 +70,7 @@ function ss_nimble_alletra_total(int $host_id = 0) : mixed {
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']);
 

--- a/scripts/ss_nimble_alletra_volumes.php
+++ b/scripts/ss_nimble_alletra_volumes.php
@@ -56,7 +56,7 @@ function ss_nimble_alletra_volumes(int $host_id = 0, string $cmd = 'index', stri
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']);
 
@@ -80,7 +80,7 @@ function ss_nimble_alletra_volumes(int $host_id = 0, string $cmd = 'index', stri
 			$host['snmp_context'],
 			$host['snmp_port'],
 			$host['snmp_timeout'],
-			$host['ping_retries'],
+			$host['snmp_retries'],
 			SNMP_POLLER,
 			$host['snmp_engine_id']));
 	} elseif ($cmd == 'query') {
@@ -97,7 +97,7 @@ function ss_nimble_alletra_volumes(int $host_id = 0, string $cmd = 'index', stri
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']);
 
@@ -122,7 +122,7 @@ function ss_nimble_alletra_volumes(int $host_id = 0, string $cmd = 'index', stri
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']);
 
@@ -138,7 +138,7 @@ function ss_nimble_alletra_volumes(int $host_id = 0, string $cmd = 'index', stri
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']);
 
@@ -183,7 +183,7 @@ function ss_nimble_alletra_volumes(int $host_id = 0, string $cmd = 'index', stri
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']);
 
@@ -201,7 +201,7 @@ function ss_nimble_alletra_volumes(int $host_id = 0, string $cmd = 'index', stri
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']);
 
@@ -217,7 +217,7 @@ function ss_nimble_alletra_volumes(int $host_id = 0, string $cmd = 'index', stri
 				$host['snmp_context'],
 				$host['snmp_port'],
 				$host['snmp_timeout'],
-				$host['ping_retries'],
+				$host['snmp_retries'],
 				SNMP_POLLER,
 				$host['snmp_engine_id']);
 

--- a/tests/Unit/ScriptsHardeningTest.php
+++ b/tests/Unit/ScriptsHardeningTest.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for column allow-list and SNMP retry parameter hardening.
+ * These scripts require DB + SNMP, so we test the allow-list guard
+ * by calling with host_id=0 (returns '0' early) and verifying that
+ * invalid columns are rejected before reaching any SQL.
+ */
+
+require_once __DIR__ . '/../../lib/functions.php';
+
+// ss_mikrotik_health: column allow-list
+require_once __DIR__ . '/../../scripts/ss_mikrotik_health.php';
+
+test('ss_mikrotik_health rejects invalid column', function () {
+	expect(ss_mikrotik_health(0, '1; DROP TABLE hosts; --'))->toBe('0');
+});
+
+test('ss_mikrotik_health rejects empty column', function () {
+	expect(ss_mikrotik_health(0, ''))->toBe('0');
+});
+
+test('ss_mikrotik_health rejects arbitrary column name', function () {
+	expect(ss_mikrotik_health(0, 'password'))->toBe('0');
+});
+
+test('ss_mikrotik_health accepts valid column voltage', function () {
+	expect(ss_mikrotik_health(0, 'voltage'))->toBe('0');
+});
+
+test('ss_mikrotik_health accepts valid column temperature', function () {
+	expect(ss_mikrotik_health(0, 'temperature'))->toBe('0');
+});
+
+// ss_hstats: column mapping via ss_hstats_map_stat_to_column
+require_once __DIR__ . '/../../scripts/ss_hstats.php';
+
+test('ss_hstats rejects invalid stat with host_id 0', function () {
+	expect(ss_hstats(0, 'invalid_stat'))->toBe('0');
+});
+
+test('ss_hstats returns 0 for valid stat with host_id 0', function () {
+	expect(ss_hstats(0, 'polling_time'))->toBe('0');
+});
+
+// Verify snmp_retries is referenced (not ping_retries)
+test('aruba scripts use snmp_retries not ping_retries', function () {
+	$file = file_get_contents(__DIR__ . '/../../scripts/ss_aruba_instant_ap.php');
+	expect($file)->toContain('snmp_retries');
+	expect($file)->not->toContain('ping_retries');
+});
+
+test('fortigate scripts use snmp_retries not ping_retries', function () {
+	$file = file_get_contents(__DIR__ . '/../../scripts/ss_fortigate_ips.php');
+	expect($file)->toContain('snmp_retries');
+	expect($file)->not->toContain('ping_retries');
+});
+
+test('nimble scripts use snmp_retries not ping_retries', function () {
+	$file = file_get_contents(__DIR__ . '/../../scripts/ss_nimble_alletra_total.php');
+	expect($file)->toContain('snmp_retries');
+	expect($file)->not->toContain('ping_retries');
+});
+
+test('disk io scripts use snmp_retries not ping_retries', function () {
+	$file = file_get_contents(__DIR__ . '/../../scripts/ss_net_snmp_disk_io.php');
+	expect($file)->toContain('snmp_retries');
+	expect($file)->not->toContain('ping_retries');
+});
+
+test('cpoller script uses snmp_retries not ping_retries', function () {
+	$file = file_get_contents(__DIR__ . '/../../scripts/ss_cpoller.php');
+	expect($file)->toContain('snmp_retries');
+	expect($file)->not->toContain('ping_retries');
+});
+
+test('lmsensors script uses snmp_retries not ping_retries', function () {
+	$file = file_get_contents(__DIR__ . '/../../scripts/ss_netsnmp_lmsensors.php');
+	expect($file)->toContain('snmp_retries');
+	expect($file)->not->toContain('ping_retries');
+});


### PR DESCRIPTION
Fixes across 19 data collection scripts in `scripts/`.

SQL injection via column name interpolation in MikroTik scripts -- fixed with column allow-lists and `db_qstr()`. Counter wrap math errors in disk I/O scripts: off-by-one on 32-bit wrap constant, double subtraction of previous value, string comparison on uptime, wrong mkdir permissions, incomplete disk device prefix matching (missing xvd/vd/hd/md/dm-). Non-parameterized SQL in poller scripts converted to `db_fetch_cell_prepared()`. Wrong SNMP variable name (`ping_retries` instead of `snmp_retries`) in Aruba/Fortigate/Nimble scripts.