### PR TITLE
fix: parameterize SQL in cli/add_device.php

### DIFF
--- a/cli/add_device.php
+++ b/cli/add_device.php
@@ -366,7 +366,7 @@ if (cacti_sizeof($parms)) {
 
 	// process host description
 	if (isset($hosts[$description])) {
-		db_execute_prepared('UPDATE host SET hostname = ? WHERE deleted = "" AND id = ?', array($ip, $hosts[$description]));
+		db_execute_prepared('UPDATE host SET hostname = ? WHERE deleted = "" AND id = ?', [$ip, $hosts[$description]]);
 		print "This host already exists in the database ($description) device-id: (" . $hosts[$description] . ')' . PHP_EOL;
 
 		exit(1);
@@ -474,7 +474,7 @@ if (cacti_sizeof($parms)) {
 		}
 
 		if ($fail) {
-			db_execute_prepared('UPDATE host SET description = ? WHERE deleted = "" AND id = ?', array($description, $addresses[$ip]));
+			db_execute_prepared('UPDATE host SET description = ? WHERE deleted = "" AND id = ?', [$description, $addresses[$ip]]);
 			print "ERROR: This IP already exists in the database ($ip) device-id: (" . $addresses[$ip] . ')' . PHP_EOL;
 
 			exit(1);

--- a/cli/add_device.php
+++ b/cli/add_device.php
@@ -366,7 +366,7 @@ if (cacti_sizeof($parms)) {
 
 	// process host description
 	if (isset($hosts[$description])) {
-		db_execute("UPDATE host SET hostname='$ip' WHERE deleted = '' AND id=" . $hosts[$description]);
+		db_execute_prepared('UPDATE host SET hostname = ? WHERE deleted = "" AND id = ?', array($ip, $hosts[$description]));
 		print "This host already exists in the database ($description) device-id: (" . $hosts[$description] . ')' . PHP_EOL;
 
 		exit(1);
@@ -474,7 +474,7 @@ if (cacti_sizeof($parms)) {
 		}
 
 		if ($fail) {
-			db_execute("UPDATE host SET description = '$description' WHERE deleted = '' AND id = " . $addresses[$ip]);
+			db_execute_prepared('UPDATE host SET description = ? WHERE deleted = "" AND id = ?', array($description, $addresses[$ip]));
 			print "ERROR: This IP already exists in the database ($ip) device-id: (" . $addresses[$ip] . ')' . PHP_EOL;
 
 			exit(1);


### PR DESCRIPTION
Replace string-interpolated db_execute() with db_execute_prepared() for two UPDATE queries that embed user-supplied $ip and $description directly in SQL strings.