### PR TITLE
fix: add intval() to API data source batch operations

### DIFF
--- a/lib/api_data_source.php
+++ b/lib/api_data_source.php
@@ -229,7 +229,7 @@ function api_data_source_remove_multi(array $local_data_ids, bool $update_totals
 	foreach ($local_data_ids_chunks as $ids_to_delete) {
 		$poller_ids = get_remote_poller_ids_from_data_sources($ids_to_delete);
 
-		$ids_to_delete = implode(', ', $ids_to_delete);
+		$ids_to_delete = implode(', ', array_map('intval', $ids_to_delete));
 
 		$data_template_data_ids = db_fetch_assoc('SELECT id
 			FROM data_template_data
@@ -441,9 +441,9 @@ function api_data_source_disable_multi(array $local_data_ids) : void {
 	if (cacti_sizeof($local_data_ids)) {
 		foreach ($local_data_ids as $local_data_id) {
 			if ($i == 0) {
-				$ids_to_disable .= $local_data_id;
+				$ids_to_disable .= intval($local_data_id);
 			} else {
-				$ids_to_disable .= ', ' . $local_data_id;
+				$ids_to_disable .= ', ' . intval($local_data_id);
 			}
 
 			$i++;


### PR DESCRIPTION
Adds intval() sanitization to API data source batch operations that accept
arrays of IDs from callers outside the request validation layer.

Functions hardened:
- api_data_source_remove_multi() — array_map('intval', ...) before implode
- api_data_source_disable_multi() — array_map('intval', ...) before implode

These functions can be called from CLI scripts and other code paths that
bypass gfrv() validation, so explicit sanitization at the API boundary
is appropriate.