### PR TITLE
refactor: assign gfrv() to local var in process_span_shift()

### DIFF
--- a/lib/timespan_settings.php
+++ b/lib/timespan_settings.php
@@ -87,19 +87,20 @@ function reset_timespan_settings() : void {
 }
 
 function process_span_shift(string $type, array &$allvals) : void {
-	$default = read_user_setting("default_$type");
+	$default    = read_user_setting("default_$type");
+	$predefined = gfrv("predefined_$type");
 
 	if (isrv("predefined_$type")) {
-		if (!is_numeric(gfrv("predefined_$type"))) {
+		if (!is_numeric($predefined)) {
 			srv("predefined_$type", $default);
-		} elseif (!array_key_exists(gfrv("predefined_$type"), $allvals) &&
-			grv("predefined_$type") != 0) {
+		} elseif (!array_key_exists($predefined, $allvals) &&
+			$predefined != 0) {
 			srv("predefined_$type", $default);
 		}
 	} elseif (isset($_SESSION["sess_current_$type"])) {
 		srv("predefined_$type", $_SESSION["sess_current_$type"]);
-	} elseif (!array_key_exists(gfrv("predefined_$type"), $allvals) &&
-		grv("predefined_$type") != 0) {
+	} elseif (!array_key_exists($predefined, $allvals) &&
+		$predefined != 0) {
 		srv("predefined_$type", $default);
 	} else {
 		srv("predefined_$type", $default);


### PR DESCRIPTION
Assigns gfrv() return value to $predefined in process_span_shift() instead of redundant gfrv()/grv() cache lookups within the same scope.

The final grv() is preserved since srv() may modify the cached value.

First batch for #6658 — single file PoC for review before wider rollout.

Verified: php lint, php-cs-fixer, PHPStan level 6.