### PR TITLE
fix: extend remote_agent_timeout dropdown to 30 and 60 seconds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-issue#6545: Add 30 and 60 second timeout options for Remote Agent and Poller settings
 -issue#6210: Fix Error: You have an error in your SQL syntax due to using table field without backtick.
 -issue#6165: Update billboard.js and billboard.css to resolve servcheck graph legend overlapping issue.
 -issue#2205: Allow admins to disable RRDtool watermark

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -742,7 +742,9 @@ $settings['general'] = [
 			5  => __('%d Seconds', 5),
 			10 => __('%d Seconds', 10),
 			15 => __('%d Seconds', 15),
-			20 => __('%d Seconds', 20)
+			20 => __('%d Seconds', 20),
+			30 => __('%d Seconds', 30),
+			60 => __('%d Seconds', 60)
 		]
 	],
 	'automation_header' => [
@@ -1560,7 +1562,9 @@ $settings['poller'] = [
 			5  => __('%d Seconds', 5),
 			10 => __('%d Seconds', 10),
 			15 => __('%d Seconds', 15),
-			20 => __('%d Seconds', 20)
+			20 => __('%d Seconds', 20),
+			30 => __('%d Seconds', 30),
+			60 => __('%d Seconds', 60)
 			]
 	],
 	'poller_refresh_output_table' => [

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -1565,7 +1565,7 @@ $settings['poller'] = [
 			20 => __('%d Seconds', 20),
 			30 => __('%d Seconds', 30),
 			60 => __('%d Seconds', 60)
-			]
+		]
 	],
 	'poller_refresh_output_table' => [
 		'friendly_name' => __('Refresh Poller Table Per Cycle'),


### PR DESCRIPTION
Large environments with slow remote pollers or heavy reindex operations can exceed the current 20-second maximum timeout. This adds 30 and 60 second options to the dropdown.

Default remains 5 seconds — no behavior change for existing deployments.

Ref #6545