### PR TITLE
fix: add output_format to ifName and ifDescr in interface.xml

### DIFF
--- a/resource/snmp_queries/interface.xml
+++ b/resource/snmp_queries/interface.xml
@@ -32,6 +32,7 @@
 		<ifDescr>
 			<name>Description</name>
 			<method>walk</method>
+			<output_format>ascii</output_format>
 			<source>value</source>
 			<direction>input</direction>
 			<oid>.1.3.6.1.2.1.2.2.1.2</oid>
@@ -39,6 +40,7 @@
 		<ifName>
 			<name>Name (IF-MIB)</name>
 			<method>walk</method>
+			<output_format>ascii</output_format>
 			<source>value</source>
 			<direction>input</direction>
 			<oid>.1.3.6.1.2.1.31.1.1.1.1</oid>


### PR DESCRIPTION
When PHP's SNMP extension returns interface names as hex-encoded strings, format_snmp_string() with SNMP_STRING_OUTPUT_GUESS misinterprets them and returns empty values. This causes "sort field returned no data" on the data query page.

ifAlias and ifType already have output_format=ascii in the same file. This adds it to ifName and ifDescr for consistency.

Two reporters independently confirmed this fix resolves the issue.

Fixes #6644