### PR TITLE
fix: three one-line typos in spikekill subsystem

### DIFF
--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -318,7 +318,7 @@ class spikekill {
 		}
 
 		// Check a bad range of the window start and end
-		if (empty($this->out_start)) {
+		if (!empty($this->out_start)) {
 			if ($this->out_start >= $this->out_end) {
 				$this->set_error(__('FATAL: Outlier time range requires outlier-start to be less than outlier-end.'));
 			}
@@ -770,7 +770,7 @@ class spikekill {
 			unlink($xmlfile);
 		}
 
-		if (file_exists($xmlfile)) {
+		if (file_exists($bakfile)) {
 			unlink($bakfile);
 		}
 

--- a/poller_spikekill.php
+++ b/poller_spikekill.php
@@ -191,7 +191,7 @@ function timeToRun() : bool {
 		}
 	} elseif ($forcerun) {
 		debug('Force to Run');
-		db_execute_prepared('REPLACE INTO settings (name,value) VALUES ("spikekill_lastrun", ?', [time()]);
+		db_execute_prepared('REPLACE INTO settings (name,value) VALUES ("spikekill_lastrun", ?)', [time()]);
 
 		return true;
 	} else {


### PR DESCRIPTION
Three single-character fixes in the spikekill subsystem.

- `poller_spikekill.php:194`: missing `)` in SQL placeholder on `--force` path — `lastrun` silently fails to update, timed runs may double-fire
- `lib/spikekill.php:773`: `file_exists($xmlfile)` checks the XML (just deleted on line 770) instead of `$bakfile` — `.xml.bak` files accumulate forever
- `lib/spikekill.php:321`: `empty($this->out_start)` inverted — range validation runs when no range is specified, skipped when one is

Ref #6647

Verified: `php -l` on both files.