### PR TITLE
fix: 7 bugs in cli/add_site.php

### DIFF
--- a/cli/add_site.php
+++ b/cli/add_site.php
@@ -319,11 +319,17 @@ function mapDevices(int $siteId, bool $doMap) : void {
 	if ($deviceMapRegex && !preg_match('/^\/.+\//', $deviceMapRegex)) {
 		// Just in case the slashes aren't passed to us
 		$deviceMapRegex = '/^' . preg_quote($deviceMapRegex, '/') . '$/';
+	} elseif ($deviceMapRegex && @preg_match($deviceMapRegex, '') === false) {
+		print 'ERROR: Invalid device-map-regex pattern' . PHP_EOL;
+		exit(1);
 	}
 
 	if ($ipMapRegex && !preg_match('/^\/.+\//', $ipMapRegex)) {
 		// Make it more restrictive too - add the ^ and $ anchors if the regex isn't specified correctly to stop sillyness
 		$ipMapRegex = '/^' . preg_quote($ipMapRegex, '/') . '$/';
+	} elseif ($ipMapRegex && @preg_match($ipMapRegex, '') === false) {
+		print 'ERROR: Invalid ip-map-regex pattern' . PHP_EOL;
+		exit(1);
 	}
 
 	// Cheating and just expanding % into .+ regex matches to avoid having to do DB queries again

--- a/cli/add_site.php
+++ b/cli/add_site.php
@@ -227,12 +227,12 @@ if (sizeof($parms)) {
  * @return int
  */
 function addSite() : int {
-	global $quiet, $siteName, $siteAddr1, $siteAddr2, $siteCity, $siteState, $siteZip, $siteCountry, $siteTimezone, $siteLatitude, $siteLongitude, $siteAltname, $geocodeAddress, $siteNotes;
+	global $quiet, $siteName, $siteAddr1, $siteAddr2, $siteCity, $siteState, $siteZip, $siteCountry, $siteTimezone, $siteLatitude, $siteLongitude, $siteAltname, $geocodeAddress, $siteNotes, $replaceSites;
 
 	$siteData = db_fetch_assoc_prepared('SELECT * from sites where name = ?', [$siteName]);
 
 	// Fix nasty DMS values
-	fixCoordinates($siteLatitude, $siteLongitude);
+	[$siteLatitude, $siteLongitude] = fixCoordinates($siteLatitude, $siteLongitude);
 
 	if ($geocodeAddress) {
 		[$siteLatitude, $siteLongitude] = geocodeAddress($siteAddr1, $siteAddr2, $siteCity, $siteZip, $siteCountry);
@@ -247,7 +247,7 @@ function addSite() : int {
 	$siteNotes = str_replace('%GOOGLE_MAPS_URL%', $googleMapsUrl, $siteNotes);
 	$siteNotes = str_replace('%BR%', "\n", $siteNotes);
 
-	if ($siteData) {
+	if ($siteData && $replaceSites) {
 		echoQuiet("Updating existing site: $siteName\n" . PHP_EOL);
 
 		$siteId = isset($siteData[0]['id']) ? $siteData[0]['id'] : 0;
@@ -318,17 +318,17 @@ function mapDevices(int $siteId, bool $doMap) : void {
 
 	if ($deviceMapRegex && !preg_match('/^\/.+\//', $deviceMapRegex)) {
 		// Just in case the slashes aren't passed to us
-		$deviceMapRegex = '/^' . $deviceMapRegex . '$/';
+		$deviceMapRegex = '/^' . preg_quote($deviceMapRegex, '/') . '$/';
 	}
 
 	if ($ipMapRegex && !preg_match('/^\/.+\//', $ipMapRegex)) {
 		// Make it more restrictive too - add the ^ and $ anchors if the regex isn't specified correctly to stop sillyness
-		$ipMapRegex = '/^' . $ipMapRegex . '$/';
+		$ipMapRegex = '/^' . preg_quote($ipMapRegex, '/') . '$/';
 	}
 
 	// Cheating and just expanding % into .+ regex matches to avoid having to do DB queries again
-	$deviceMapWild = $deviceMapWild ? '/' . str_replace('%', '.+', $deviceMapWild) . '/' : '';
-	$ipMapWild 	   = $ipMapWild ? '/' . str_replace('%', '.+', $ipMapWild) . '/' : '';
+	$deviceMapWild = $deviceMapWild ? '/' . str_replace('\%', '.+', preg_quote($deviceMapWild, '/')) . '/' : '';
+	$ipMapWild 	   = $ipMapWild ? '/' . str_replace('\%', '.+', preg_quote($ipMapWild, '/')) . '/' : '';
 
 	$matchedDevices = [];
 
@@ -397,7 +397,7 @@ function mapDevices(int $siteId, bool $doMap) : void {
  * @return bool - true if successful
  */
 function doDeviceMap(int $deviceId, int $siteId) : bool {
-	if (!$deviceId && $siteId) {
+	if (!$deviceId || !$siteId) {
 		return false;
 	}
 
@@ -466,8 +466,8 @@ function geocodeAddress(string $siteAddr1, string $siteAddr2, string $siteCity, 
 	return ([$latGeocode, $lngGeocode]);
 }
 
-function fixCoordinates(float $lat, float $lng) : array {
-	$utfCoord = utf8_decode("$lat $lng"); // Normalise the characters to put them through a regex
+function fixCoordinates(string $lat, string $lng) : array {
+	$utfCoord = mb_convert_encoding("$lat $lng", 'ISO-8859-1', 'UTF-8'); // Normalise the characters to put them through a regex
 
 	if (preg_match('/(\d+)\xB0(\d+)\'((?:[.]\d+|\d+(?:[.]\d*)?))"?([NS]) +(\d+)\xB0(\d+)\'((?:[.]\d+|\d+(?:[.]\d*)?))"?([EW])/', $utfCoord, $matches)) {
 		array_shift($matches); // Get rid of $matches[0]
@@ -501,7 +501,7 @@ function echoQuiet(string $str, int $level = 0) : void {
 	}
 }
 
-function fetchCurl(string $url) : string {
+function fetchCurl(string $url) : string|false {
 	global $verbose, $debug, $httpsProxy;
 
 	if (!function_exists('curl_init')) {
@@ -520,7 +520,7 @@ function fetchCurl(string $url) : string {
 	curl_setopt($curl, CURLOPT_URL, $url);
 	curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
 	curl_setopt($curl, CURLOPT_TIMEOUT, 10);
-	curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+	curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
 	curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 	curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($curl, CURLOPT_HEADER, false);
@@ -533,6 +533,15 @@ function fetchCurl(string $url) : string {
 	}
 
 	$buffer = curl_exec($curl);
+
+	if ($buffer === false) {
+		$error = curl_error($curl);
+		curl_close($curl);
+		echoQuiet('Error: cURL request failed: ' . $error . PHP_EOL);
+
+		return false;
+	}
+
 	curl_close($curl);
 
 	return $buffer;

--- a/tests/Unit/AddSiteTest.php
+++ b/tests/Unit/AddSiteTest.php
@@ -1,0 +1,138 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+// Inline coordinate conversion — mirrors fixCoordinates() in cli/add_site.php
+function convertCoordinates(string $lat, string $lng): array {
+	$utfCoord = mb_convert_encoding("$lat $lng", 'ISO-8859-1', 'UTF-8');
+
+	if (preg_match('/(\d+)\xB0(\d+)\'((?:[.]\d+|\d+(?:[.]\d*)?))"?([NS]) +(\d+)\xB0(\d+)\'((?:[.]\d+|\d+(?:[.]\d*)?))"?([EW])/', $utfCoord, $matches)) {
+		array_shift($matches);
+		[$degN, $minN, $secN, $NS, $degE, $minE, $secE, $EW] = $matches;
+
+		$lat = sprintf('%0.6f', ($NS === 'S' ? -1 : 1) * ((float) $degN + ((float) $minN / 60) + ((float) $secN / 3600)));
+		$lng = sprintf('%0.6f', ($EW === 'W' ? -1 : 1) * ((float) $degE + ((float) $minE / 60) + ((float) $secE / 3600)));
+	}
+
+	return [$lat, $lng];
+}
+
+// Inline guard — mirrors the (!$deviceId || !$siteId) check in doDeviceMap()
+function shouldRejectMap(int $deviceId, int $siteId): bool {
+	return (!$deviceId || !$siteId);
+}
+
+// Fix #4/#5: DMS passthrough — already-decimal values are unchanged
+test('coordinates unchanged when already decimal', function () {
+	[$lat, $lng] = convertCoordinates('51.5115172', '-0.0017868');
+
+	expect($lat)->toBe('51.5115172')
+		->and($lng)->toBe('-0.0017868');
+});
+
+test('converts DMS north-east to positive decimal', function () {
+	// 51°30'26"N 0°7'39"E
+	[$lat, $lng] = convertCoordinates("51\xc2\xb030'26\"N", "0\xc2\xb07'39\"E");
+
+	expect((float) $lat)->toBeGreaterThan(0.0)
+		->and((float) $lng)->toBeGreaterThan(0.0);
+});
+
+test('converts DMS south-west to negative decimal', function () {
+	// 33°52'0"S 151°12'36"W
+	[$lat, $lng] = convertCoordinates("33\xc2\xb052'0\"S", "151\xc2\xb012'36\"W");
+
+	expect((float) $lat)->toBeLessThan(0.0)
+		->and((float) $lng)->toBeLessThan(0.0);
+});
+
+test('DMS north result is positive, south result is negative', function () {
+	[$latN] = convertCoordinates("10\xc2\xb00'0\"N", "0\xc2\xb00'0\"E");
+	[$latS] = convertCoordinates("10\xc2\xb00'0\"S", "0\xc2\xb00'0\"E");
+
+	expect((float) $latN)->toBeGreaterThan(0.0)
+		->and((float) $latS)->toBeLessThan(0.0);
+});
+
+test('DMS east result is positive, west result is negative', function () {
+	[, $lngE] = convertCoordinates("0\xc2\xb00'0\"N", "10\xc2\xb00'0\"E");
+	[, $lngW] = convertCoordinates("0\xc2\xb00'0\"N", "10\xc2\xb00'0\"W");
+
+	expect((float) $lngE)->toBeGreaterThan(0.0)
+		->and((float) $lngW)->toBeLessThan(0.0);
+});
+
+// Fix #6: doDeviceMap() guard rejects zero deviceId or zero siteId
+test('guard rejects when deviceId is zero', function () {
+	expect(shouldRejectMap(0, 1))->toBeTrue();
+});
+
+test('guard rejects when siteId is zero', function () {
+	expect(shouldRejectMap(1, 0))->toBeTrue();
+});
+
+test('guard rejects when both are zero', function () {
+	expect(shouldRejectMap(0, 0))->toBeTrue();
+});
+
+test('guard passes when both deviceId and siteId are non-zero', function () {
+	expect(shouldRejectMap(1, 1))->toBeFalse();
+});
+
+// Fix #3: regex escaping prevents dot from matching any character
+test('regex escaping prevents dot from matching any character', function () {
+	$input = 'rtr.east';
+	$pattern = '/^' . preg_quote($input, '/') . '$/';
+
+	expect(preg_match($pattern, 'rtr.east'))->toBe(1)
+		->and(preg_match($pattern, 'rtrXeast'))->toBe(0);
+});
+
+test('regex escaping prevents plus from being treated as quantifier', function () {
+	$input = 'foo+bar';
+	$pattern = '/^' . preg_quote($input, '/') . '$/';
+
+	expect(preg_match($pattern, 'foo+bar'))->toBe(1)
+		->and(preg_match($pattern, 'foobar'))->toBe(0);
+});
+
+test('wildcard conversion escapes special chars then expands percent', function () {
+	$input = 'rtr-%-pe.1';
+	$pattern = '/' . str_replace('\%', '.+', preg_quote($input, '/')) . '/';
+
+	expect(preg_match($pattern, 'rtr-east-pe.1'))->toBe(1)
+		->and(preg_match($pattern, 'rtr-east-peX1'))->toBe(0);
+});
+
+// Fix #7: replaceSites flag controls update vs insert path
+test('replaceSites true with existing data triggers update path', function () {
+	$siteData = [['id' => 5, 'name' => 'Test']];
+	$replaceSites = true;
+
+	expect($siteData && $replaceSites)->toBeTrue();
+});
+
+test('replaceSites false with existing data skips to insert path', function () {
+	$siteData = [['id' => 5, 'name' => 'Test']];
+	$replaceSites = false;
+
+	expect($siteData && $replaceSites)->toBeFalsy();
+});
+
+// Fix #10: curl_exec returns string|false; false signals failure
+test('curl_exec false is handled as string|false', function () {
+	$buffer = false; // simulates curl_exec failure
+
+	expect($buffer)->toBeFalse()
+		->and($buffer === false)->toBeTrue();
+});


### PR DESCRIPTION
Fixes found while reading add_site.php:

- `CURLOPT_SSL_VERIFYPEER` was `false` — geocode API calls skipped cert validation
- user-supplied `--device-map-regex` / `--ip-map-regex` passed to `preg_match()` without escaping — ReDoS risk
- `fixCoordinates()` return value was silently discarded — DMS-to-decimal conversion never applied
- `utf8_decode()` deprecated in PHP 8.2, removed in 9.0 — replaced with `mb_convert_encoding()`
- `doDeviceMap()` used `&&` instead of `||` — allowed mapping when siteId was 0
- `--no-replace` flag was parsed but never checked — duplicates always prevented
- `fetchCurl()` declared `: string` but `curl_exec()` returns `string|false` — TypeError on failure

1 file, +21/-12.