### PR TITLE
fix: use strict comparison for $db_conn in db_table_exists and db_column_exists

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-issue: Fix loose $db_conn comparison in db_table_exists and db_column_exists
 -issue#6545: Add 30 and 60 second timeout options for Remote Agent and Poller settings
 -issue#6210: Fix Error: You have an error in your SQL syntax due to using table field without backtick.
 -issue#6165: Update billboard.js and billboard.css to resolve servcheck graph legend overlapping issue.

--- a/lib/database.php
+++ b/lib/database.php
@@ -1313,7 +1313,7 @@ function db_index_matches(string $table, string $index, array $columns, bool $lo
 function db_table_exists(string $table, bool $log = true, mixed $db_conn = false) : bool {
 	static $results;
 
-	if ($db_conn == false) {
+	if ($db_conn === false) {
 		$index = '-1';
 	} else {
 		$index = md5(json_encode($db_conn));
@@ -1401,7 +1401,7 @@ function db_cacti_initialized(bool $is_web = true) : bool {
 function db_column_exists(string $table, string $column, bool $log = true, mixed $db_conn = false) : bool {
 	static $results = [];
 
-	if ($db_conn == false) {
+	if ($db_conn === false) {
 		$index = '-1';
 	} else {
 		$index = md5(json_encode($db_conn));


### PR DESCRIPTION
Use \`===\` instead of \`==\` when checking \`\$db_conn\` against \`false\` in \`db_table_exists()\` and \`db_column_exists()\`.

Loose \`==\` can match \`null\`, \`0\`, \`''\`, and other falsy values, producing an incorrect cache index when a non-default connection object evaluates to falsy under loose comparison.

**Files**: \`lib/database.php\` (2 lines changed), \`CHANGELOG\`

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>