### PR TITLE
fix: strict comparison in replicate_table_to_poller column exclusion

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 Cacti CHANGELOG
 
 1.3.0-dev
--issue: Fix column exclusion silently skipping first element due to loose array_search comparison
 -issue#6545: Add 30 and 60 second timeout options for Remote Agent and Poller settings
+-issue#6682: Fix column exclusion silently skipping first element due to loose array_search comparison
 -issue#6210: Fix Error: You have an error in your SQL syntax due to using table field without backtick.
 -issue#6165: Update billboard.js and billboard.css to resolve servcheck graph legend overlapping issue.
 -issue#2205: Allow admins to disable RRDtool watermark

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-issue: Fix column exclusion silently skipping first element due to loose array_search comparison
 -issue#6545: Add 30 and 60 second timeout options for Remote Agent and Poller settings
 -issue#6210: Fix Error: You have an error in your SQL syntax due to using table field without backtick.
 -issue#6165: Update billboard.js and billboard.css to resolve servcheck graph legend overlapping issue.

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2135,7 +2135,7 @@ function replicate_table_to_poller(mixed $db_conn, array &$data, string $table, 
 			if (!db_column_exists($table, $c, false, $db_conn)) {
 				$skipcols[$index] = $c;
 			} elseif ($exclude !== false && array_search($c, $exclude, true) !== false) {
-				// Do not update this column
+				$skipcols[$index] = $c;
 			} else {
 				$prefix .= ($colcnt > 0 ? ', ' : '') . $c;
 				$suffix .= ($colcnt > 0 ? ', ' : '') . "$c=VALUES($c)";

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2134,7 +2134,7 @@ function replicate_table_to_poller(mixed $db_conn, array &$data, string $table, 
 		foreach ($columns as $index => $c) {
 			if (!db_column_exists($table, $c, false, $db_conn)) {
 				$skipcols[$index] = $c;
-			} elseif ($exclude != false && array_search($c, $exclude, true) == true) {
+			} elseif ($exclude !== false && array_search($c, $exclude, true) !== false) {
 				// Do not update this column
 			} else {
 				$prefix .= ($colcnt > 0 ? ', ' : '') . $c;


### PR DESCRIPTION
Fix two bugs in `replicate_table_to_poller()`:

1. `array_search()` returns `0` for the first match; `== true` evaluates `0` as falsy so the first excluded column was never actually excluded. Changed to `!== false` with strict comparison.

2. Excluded columns were omitted from the INSERT column list but still included in the VALUES tuples, causing a column count mismatch. Now adds excluded columns to `$skipcols` so the row-building loop skips them consistently.

Also tightened `$exclude != false` to `$exclude !== false`.

CHANGELOG updated.

**Files**: `lib/poller.php` (2 lines changed)