### PR TITLE
Fix typos in auth, function, and spikekill log messages

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -3907,7 +3907,7 @@ function domains_ldap_auth(string $username, string $password = '', string $dn =
 		$response = $ldap->Authenticate();
 
 		if ($response['error_num'] == 0) {
-			cacti_log(sprintf('LDAP: Login for User \'%s\' Succeded on Server %s', $username, $ldap_server), false, 'AUTH', $debug);
+			cacti_log(sprintf('LDAP: Login for User \'%s\' Succeeded on Server %s', $username, $ldap_server), false, 'AUTH', $debug);
 
 			return $response;
 		}
@@ -3950,7 +3950,7 @@ function domains_ldap_search_dn(string $username, int $realm) : mixed {
 		$response = $ldap->Search();
 
 		if ($response['error_num'] == 0) {
-			cacti_log(sprintf('LDAP: Search for User \'%s\' at Server \'%s\' Suceeded', $username, $ldap_server), false, 'AUTH', $debug);
+			cacti_log(sprintf('LDAP: Search for User \'%s\' at Server \'%s\' Succeeded', $username, $ldap_server), false, 'AUTH', $debug);
 
 			return $response;
 		}
@@ -3992,7 +3992,7 @@ function domains_ldap_search_cn(string $username, array $cn = [], int $realm = 0
 		$response = $ldap->Getcn();
 
 		if ($response['error_num'] == 0) {
-			cacti_log(sprintf('LDAP: Search for User \'%s\' CN at Server \'%s\' Suceeded', $username, $ldap_server), false, 'AUTH', $debug);
+			cacti_log(sprintf('LDAP: Search for User \'%s\' CN at Server \'%s\' Succeeded', $username, $ldap_server), false, 'AUTH', $debug);
 
 			return $response;
 		}

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3489,7 +3489,7 @@ function generate_data_source_path($local_data_id) {
  * the list of available consolidation functions for the consolidation functions and returns
  * the most appropriate.  Typically, this will be the requested value
  *
- * @param mixed $local_data_id This needs to be mixed to accomodate special types that are null
+ * @param mixed $local_data_id This needs to be mixed to accommodate special types that are null
  * @param mixed $requested_cf  The requested CF in the Graph
  *
  * @return string The best cf to use
@@ -3497,7 +3497,7 @@ function generate_data_source_path($local_data_id) {
 function generate_graph_best_cf(mixed $local_data_id, mixed $requested_cf) : string {
 	static $best_cf;
 
-	// Accomodate a special graph type that does not have a local_graph_id
+	// Accommodate a special graph type that does not have a local_graph_id
 	if ($local_data_id === null) {
 		return $requested_cf;
 	}
@@ -6066,7 +6066,7 @@ function email_test() : void {
  *
  * @param string $ip      The IP Address
  * @param string $dns     The DNS Server to use
- * @param int    $timeout The tiemout in milliseconds
+ * @param int    $timeout The timeout in milliseconds
  *
  * @return string
  */
@@ -9517,7 +9517,7 @@ function detect_cpu_cores() : int {
 /**
  * wrapper function to emulate pecl stats if it's not installed
  *
- * @param array $items  A lits of items to calculate the standard deviation for
+ * @param array $items  A list of items to calculate the standard deviation for
  * @param bool  $sample
  *
  * @return mixed False on failure, double otherwise

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -674,7 +674,7 @@ class spikekill {
 			$this->strout .= ($this->html ? "<p class='spikekillNote'>" : '') .
 				__esc('NOTE: Limited to Time Window: %s through %s', date('M j, Y H:i:s', $this->out_start), date('M j, Y H:i:s',$this->out_end)) . ($this->html ? "</p><br>\n" : "\n");
 
-			cacti_log('DEBUG: Limited to Tiem Window: ' . date('M j, Y H:i:s',$this->out_start) . ' thru ' . date('M j, Y H:i:s',$this->out_end), false, 'SPIKE', POLLER_VERBOSITY_DEBUG);
+			cacti_log('DEBUG: Limited to Time Window: ' . date('M j, Y H:i:s',$this->out_start) . ' thru ' . date('M j, Y H:i:s',$this->out_end), false, 'SPIKE', POLLER_VERBOSITY_DEBUG);
 		}
 
 		$this->calculateOverallStatistics($rra, $samples);


### PR DESCRIPTION
Corrected "Suceeded" to "Succeeded" in lib/auth.php and "Tiem" to "Time" in lib/spikekill.php