### PR TITLE
fix: correct wildcard-to-regex conversion in AddSiteTest

### DIFF
--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,8 +644,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -658,8 +656,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -672,8 +668,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -791,7 +785,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON gti.task_item_id = dtr.id
+				ON dtr.id = gti.task_item_id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1594,143 +1588,6 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
-/**
- * Handles the aggregation of stacked lines for a given graph.
- *
- * @param int    $local_graph_id   The ID of the local graph.
- * @param string $_orig_graph_type The original type of the graph.
- * @param int    $_total           The total value to be aggregated.
- * @param string $_total_type      The type of the total value.
- * @param string $_total_prefix    The prefix for the total value.
- *
- * @return void
- */
-function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
-	// Handle the stacked line cases switch line widths
-	$width        = '0.01';
-	$special_type = '';
-	$special_line = false;
-
-	switch ($_orig_graph_type) {
-		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
-			$width        = '1.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE1;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
-			$width        = '2.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE2;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
-			$width        = '3.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE3;
-			$special_line = true;
-
-			break;
-	}
-
-	if ($special_line) {
-		if ($_total == AGGREGATE_TOTAL_NONE) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET line_width = ?
-				WHERE local_graph_id = ?
-				AND graph_type_id IN (?)',
-				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
-		}
-
-		// Handle special case total prefix
-		db_execute_prepared('UPDATE graph_templates_item
-			SET graph_type_id = ?
-			WHERE local_graph_id = ?
-			AND text_format = ?',
-			[$special_type, $local_graph_id, $_total_prefix]);
-
-		if ($_total == AGGREGATE_TOTAL_ALL) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET graph_type_id = ?, line_width = "0.01"
-				WHERE local_graph_id = ?
-				AND graph_type_id = ?
-				AND text_format != ?',
-				[
-					GRAPH_ITEM_TYPE_LINESTACK,
-					$local_graph_id,
-					$special_type,
-					$_total_prefix
-				]
-			);
-		}
-	}
-
-	// handle any missing lines
-	db_execute_prepared('UPDATE graph_templates_item
-		SET line_width="0.01"
-		WHERE graph_type_id = ?
-		AND line_width="0.00"
-		AND local_graph_id = ?',
-		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
-}
-
-/**
- * Retrieves data sources for aggregation.
- *
- * @param array  $graph_array    Array of graphs to aggregate.
- * @param mixed  $data_sources   Array to store the retrieved data sources.
- * @param mixed  $graph_template Template for the graphs.
- * @param string $message        Optional. Message to store any errors or information.
- *
- * @return bool True on success, false on failure.
- */
-function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
-	if (cacti_sizeof($graph_array)) {
-		// fetch all data sources for all selected graphs
-		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
-			FROM data_template_rrd AS dtr
-			INNER JOIN graph_templates_item AS gti
-			ON dtr.id = gti.task_item_id
-			INNER JOIN data_template_data AS dtd
-			ON dtr.local_data_id = dtd.local_data_id
-			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
-			AND dtd.local_data_id > 0
-			GROUP BY dtd.local_data_id
-			ORDER BY dtd.name_cache');
-
-		// verify, that only a single graph template is used, else
-		// aggregate will look funny
-		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
-			FROM graph_local AS gl
-			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
-
-		if (cacti_sizeof($templates) > 1) {
-			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
-
-			return false;
-		}
-
-		if (cacti_sizeof($templates) == 1) {
-			if ($templates[0]['id'] == 0) {
-				// selected graphs do not use templates
-				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
-
-				return false;
-			} else {
-				$graph_template = $templates[0]['id'];
-
-				return true;
-			}
-		} else {
-			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
-
-			return false;
-		}
-	} else {
-		$message = __('You must pass at least a single Graph to this function');
-
-		return false;
-	}
-}
 
 /**
  * Draws the list of aggregate graph items.

--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,6 +644,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -656,6 +658,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -668,6 +672,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -785,7 +791,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON dtr.id = gti.task_item_id
+				ON gti.task_item_id = dtr.id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1588,6 +1594,143 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
+/**
+ * Handles the aggregation of stacked lines for a given graph.
+ *
+ * @param int    $local_graph_id   The ID of the local graph.
+ * @param string $_orig_graph_type The original type of the graph.
+ * @param int    $_total           The total value to be aggregated.
+ * @param string $_total_type      The type of the total value.
+ * @param string $_total_prefix    The prefix for the total value.
+ *
+ * @return void
+ */
+function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
+	// Handle the stacked line cases switch line widths
+	$width        = '0.01';
+	$special_type = '';
+	$special_line = false;
+
+	switch ($_orig_graph_type) {
+		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
+			$width        = '1.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE1;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
+			$width        = '2.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE2;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
+			$width        = '3.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE3;
+			$special_line = true;
+
+			break;
+	}
+
+	if ($special_line) {
+		if ($_total == AGGREGATE_TOTAL_NONE) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET line_width = ?
+				WHERE local_graph_id = ?
+				AND graph_type_id IN (?)',
+				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
+		}
+
+		// Handle special case total prefix
+		db_execute_prepared('UPDATE graph_templates_item
+			SET graph_type_id = ?
+			WHERE local_graph_id = ?
+			AND text_format = ?',
+			[$special_type, $local_graph_id, $_total_prefix]);
+
+		if ($_total == AGGREGATE_TOTAL_ALL) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET graph_type_id = ?, line_width = "0.01"
+				WHERE local_graph_id = ?
+				AND graph_type_id = ?
+				AND text_format != ?',
+				[
+					GRAPH_ITEM_TYPE_LINESTACK,
+					$local_graph_id,
+					$special_type,
+					$_total_prefix
+				]
+			);
+		}
+	}
+
+	// handle any missing lines
+	db_execute_prepared('UPDATE graph_templates_item
+		SET line_width="0.01"
+		WHERE graph_type_id = ?
+		AND line_width="0.00"
+		AND local_graph_id = ?',
+		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
+}
+
+/**
+ * Retrieves data sources for aggregation.
+ *
+ * @param array  $graph_array    Array of graphs to aggregate.
+ * @param mixed  $data_sources   Array to store the retrieved data sources.
+ * @param mixed  $graph_template Template for the graphs.
+ * @param string $message        Optional. Message to store any errors or information.
+ *
+ * @return bool True on success, false on failure.
+ */
+function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
+	if (cacti_sizeof($graph_array)) {
+		// fetch all data sources for all selected graphs
+		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
+			FROM data_template_rrd AS dtr
+			INNER JOIN graph_templates_item AS gti
+			ON dtr.id = gti.task_item_id
+			INNER JOIN data_template_data AS dtd
+			ON dtr.local_data_id = dtd.local_data_id
+			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
+			AND dtd.local_data_id > 0
+			GROUP BY dtd.local_data_id
+			ORDER BY dtd.name_cache');
+
+		// verify, that only a single graph template is used, else
+		// aggregate will look funny
+		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
+			FROM graph_local AS gl
+			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
+
+		if (cacti_sizeof($templates) > 1) {
+			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
+
+			return false;
+		}
+
+		if (cacti_sizeof($templates) == 1) {
+			if ($templates[0]['id'] == 0) {
+				// selected graphs do not use templates
+				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
+
+				return false;
+			} else {
+				$graph_template = $templates[0]['id'];
+
+				return true;
+			}
+		} else {
+			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
+
+			return false;
+		}
+	} else {
+		$message = __('You must pass at least a single Graph to this function');
+
+		return false;
+	}
+}
 
 /**
  * Draws the list of aggregate graph items.

--- a/tests/Unit/AddSiteTest.php
+++ b/tests/Unit/AddSiteTest.php
@@ -108,7 +108,8 @@ test('regex escaping prevents plus from being treated as quantifier', function (
 
 test('wildcard conversion escapes special chars then expands percent', function () {
 	$input = 'rtr-%-pe.1';
-	$pattern = '/' . str_replace('\%', '.+', preg_quote($input, '/')) . '/';
+	$parts = explode('%', $input);
+	$pattern = '/^' . implode('.*', array_map(fn($p) => preg_quote($p, '/'), $parts)) . '$/';
 
 	expect(preg_match($pattern, 'rtr-east-pe.1'))->toBe(1)
 		->and(preg_match($pattern, 'rtr-east-peX1'))->toBe(0);


### PR DESCRIPTION
## Summary
- Fix wildcard-to-regex conversion in AddSiteTest to match MySQL LIKE semantics
- Use `.*` (not `.+`) for `%` wildcard and add `^...$` anchors

## Files changed
- `tests/Unit/AddSiteTest.php` -- regex pattern fix

## Test plan
- [ ] Run `include/vendor/bin/pest tests/Unit/AddSiteTest.php`

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>