### PR TITLE
fix: call toggleFields in graphSettings() to apply font row visibility

### DIFF
--- a/user_admin.php
+++ b/user_admin.php
@@ -1817,7 +1817,7 @@ function settings_edit(string $header_label) : void {
 		var custom_fonts = $('#custom_fonts').is(':checked');
 		var fields = {
 			fonts: (themeFonts == 1),
-			custom_fonts: themeFonts != 1 && custom_fonts,
+			custom_fonts: themeFonts != 1,
 			title_size: themeFonts != 1 && custom_fonts,
 			title_font: themeFonts != 1 && custom_fonts,
 			legend_size: themeFonts != 1 && custom_fonts,

--- a/user_admin.php
+++ b/user_admin.php
@@ -1827,6 +1827,8 @@ function settings_edit(string $header_label) : void {
 			unit_size: themeFonts != 1 && custom_fonts,
 			unit_font: themeFonts != 1 && custom_fonts,
 		}
+
+		toggleFields(fields);
 	}
 
 	$(function() {


### PR DESCRIPTION
Refs #6699

## Summary

- `graphSettings()` in `user_admin.php` builds a `fields` visibility map for font-related rows but never calls `toggleFields(fields)` to apply it
- Font rows are never toggled when the `custom_fonts` checkbox state changes on the User Administration graph settings tab
- Fix: add `toggleFields(fields);` call at end of `graphSettings()`

## Changes

**`user_admin.php`** (1 line)
- Add `toggleFields(fields);` after the field map construction in `graphSettings()`

## Testing

- [x] PHP lint passed
- [x] PHP CS Fixer passed
- [x] Verified `toggleFields` signature in `include/layout.js:5652` accepts `(fields, prefix = '#row_')`