### PR TITLE
fix: correct JOIN condition in is_view_allowed() group membership lookup

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -853,7 +853,7 @@ function is_view_allowed(string $view = 'show_tree') : bool {
 			db_fetch_assoc_prepared("SELECT DISTINCT $view
 				FROM user_auth_group AS uag
 				INNER JOIN user_auth_group_members AS uagm
-				ON uag.id = uagm.user_id
+				ON uag.id = uagm.group_id
 				WHERE uag.enabled = 'on'
 				AND uagm.user_id = ?",
 				[$_SESSION[SESS_USER_ID]]


### PR DESCRIPTION
Refs #6698

## Summary

- `is_view_allowed()` in `lib/auth.php` joins `user_auth_group` (alias `uag`) to `user_auth_group_members` (alias `uagm`) with `ON uag.id = uagm.user_id`
- `uag.id` is the group ID, so it should match `uagm.group_id`, not `uagm.user_id`
- This causes group-based view permissions to silently fail for all group members
- The `WHERE uagm.user_id = ?` clause (filtering by session user) is correct and unchanged

## Changes

**`lib/auth.php`** (1 line)
- `ON uag.id = uagm.user_id` changed to `ON uag.id = uagm.group_id`

## Testing

- [x] PHP lint passed
- [x] Verified `user_auth_group.id` is the group primary key
- [x] Verified `user_auth_group_members.group_id` references the group
- [x] The `WHERE uagm.user_id = ?` remains correct for session user filtering