### PR TITLE
Refactor/consolidate gprint cases

### DIFF
--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,8 +644,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -658,8 +656,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -672,8 +668,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -791,7 +785,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON gti.task_item_id = dtr.id
+				ON dtr.id = gti.task_item_id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1594,143 +1588,6 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
-/**
- * Handles the aggregation of stacked lines for a given graph.
- *
- * @param int    $local_graph_id   The ID of the local graph.
- * @param string $_orig_graph_type The original type of the graph.
- * @param int    $_total           The total value to be aggregated.
- * @param string $_total_type      The type of the total value.
- * @param string $_total_prefix    The prefix for the total value.
- *
- * @return void
- */
-function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
-	// Handle the stacked line cases switch line widths
-	$width        = '0.01';
-	$special_type = '';
-	$special_line = false;
-
-	switch ($_orig_graph_type) {
-		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
-			$width        = '1.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE1;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
-			$width        = '2.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE2;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
-			$width        = '3.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE3;
-			$special_line = true;
-
-			break;
-	}
-
-	if ($special_line) {
-		if ($_total == AGGREGATE_TOTAL_NONE) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET line_width = ?
-				WHERE local_graph_id = ?
-				AND graph_type_id IN (?)',
-				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
-		}
-
-		// Handle special case total prefix
-		db_execute_prepared('UPDATE graph_templates_item
-			SET graph_type_id = ?
-			WHERE local_graph_id = ?
-			AND text_format = ?',
-			[$special_type, $local_graph_id, $_total_prefix]);
-
-		if ($_total == AGGREGATE_TOTAL_ALL) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET graph_type_id = ?, line_width = "0.01"
-				WHERE local_graph_id = ?
-				AND graph_type_id = ?
-				AND text_format != ?',
-				[
-					GRAPH_ITEM_TYPE_LINESTACK,
-					$local_graph_id,
-					$special_type,
-					$_total_prefix
-				]
-			);
-		}
-	}
-
-	// handle any missing lines
-	db_execute_prepared('UPDATE graph_templates_item
-		SET line_width="0.01"
-		WHERE graph_type_id = ?
-		AND line_width="0.00"
-		AND local_graph_id = ?',
-		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
-}
-
-/**
- * Retrieves data sources for aggregation.
- *
- * @param array  $graph_array    Array of graphs to aggregate.
- * @param mixed  $data_sources   Array to store the retrieved data sources.
- * @param mixed  $graph_template Template for the graphs.
- * @param string $message        Optional. Message to store any errors or information.
- *
- * @return bool True on success, false on failure.
- */
-function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
-	if (cacti_sizeof($graph_array)) {
-		// fetch all data sources for all selected graphs
-		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
-			FROM data_template_rrd AS dtr
-			INNER JOIN graph_templates_item AS gti
-			ON dtr.id = gti.task_item_id
-			INNER JOIN data_template_data AS dtd
-			ON dtr.local_data_id = dtd.local_data_id
-			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
-			AND dtd.local_data_id > 0
-			GROUP BY dtd.local_data_id
-			ORDER BY dtd.name_cache');
-
-		// verify, that only a single graph template is used, else
-		// aggregate will look funny
-		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
-			FROM graph_local AS gl
-			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
-
-		if (cacti_sizeof($templates) > 1) {
-			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
-
-			return false;
-		}
-
-		if (cacti_sizeof($templates) == 1) {
-			if ($templates[0]['id'] == 0) {
-				// selected graphs do not use templates
-				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
-
-				return false;
-			} else {
-				$graph_template = $templates[0]['id'];
-
-				return true;
-			}
-		} else {
-			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
-
-			return false;
-		}
-	} else {
-		$message = __('You must pass at least a single Graph to this function');
-
-		return false;
-	}
-}
 
 /**
  * Draws the list of aggregate graph items.

--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,6 +644,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -656,6 +658,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -668,6 +672,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -785,7 +791,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON dtr.id = gti.task_item_id
+				ON gti.task_item_id = dtr.id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1588,6 +1594,143 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
+/**
+ * Handles the aggregation of stacked lines for a given graph.
+ *
+ * @param int    $local_graph_id   The ID of the local graph.
+ * @param string $_orig_graph_type The original type of the graph.
+ * @param int    $_total           The total value to be aggregated.
+ * @param string $_total_type      The type of the total value.
+ * @param string $_total_prefix    The prefix for the total value.
+ *
+ * @return void
+ */
+function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
+	// Handle the stacked line cases switch line widths
+	$width        = '0.01';
+	$special_type = '';
+	$special_line = false;
+
+	switch ($_orig_graph_type) {
+		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
+			$width        = '1.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE1;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
+			$width        = '2.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE2;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
+			$width        = '3.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE3;
+			$special_line = true;
+
+			break;
+	}
+
+	if ($special_line) {
+		if ($_total == AGGREGATE_TOTAL_NONE) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET line_width = ?
+				WHERE local_graph_id = ?
+				AND graph_type_id IN (?)',
+				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
+		}
+
+		// Handle special case total prefix
+		db_execute_prepared('UPDATE graph_templates_item
+			SET graph_type_id = ?
+			WHERE local_graph_id = ?
+			AND text_format = ?',
+			[$special_type, $local_graph_id, $_total_prefix]);
+
+		if ($_total == AGGREGATE_TOTAL_ALL) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET graph_type_id = ?, line_width = "0.01"
+				WHERE local_graph_id = ?
+				AND graph_type_id = ?
+				AND text_format != ?',
+				[
+					GRAPH_ITEM_TYPE_LINESTACK,
+					$local_graph_id,
+					$special_type,
+					$_total_prefix
+				]
+			);
+		}
+	}
+
+	// handle any missing lines
+	db_execute_prepared('UPDATE graph_templates_item
+		SET line_width="0.01"
+		WHERE graph_type_id = ?
+		AND line_width="0.00"
+		AND local_graph_id = ?',
+		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
+}
+
+/**
+ * Retrieves data sources for aggregation.
+ *
+ * @param array  $graph_array    Array of graphs to aggregate.
+ * @param mixed  $data_sources   Array to store the retrieved data sources.
+ * @param mixed  $graph_template Template for the graphs.
+ * @param string $message        Optional. Message to store any errors or information.
+ *
+ * @return bool True on success, false on failure.
+ */
+function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
+	if (cacti_sizeof($graph_array)) {
+		// fetch all data sources for all selected graphs
+		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
+			FROM data_template_rrd AS dtr
+			INNER JOIN graph_templates_item AS gti
+			ON dtr.id = gti.task_item_id
+			INNER JOIN data_template_data AS dtd
+			ON dtr.local_data_id = dtd.local_data_id
+			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
+			AND dtd.local_data_id > 0
+			GROUP BY dtd.local_data_id
+			ORDER BY dtd.name_cache');
+
+		// verify, that only a single graph template is used, else
+		// aggregate will look funny
+		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
+			FROM graph_local AS gl
+			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
+
+		if (cacti_sizeof($templates) > 1) {
+			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
+
+			return false;
+		}
+
+		if (cacti_sizeof($templates) == 1) {
+			if ($templates[0]['id'] == 0) {
+				// selected graphs do not use templates
+				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
+
+				return false;
+			} else {
+				$graph_template = $templates[0]['id'];
+
+				return true;
+			}
+		} else {
+			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
+
+			return false;
+		}
+	} else {
+		$message = __('You must pass at least a single Graph to this function');
+
+		return false;
+	}
+}
 
 /**
  * Draws the list of aggregate graph items.

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1783,20 +1783,8 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 
 					break;
 				case GRAPH_ITEM_TYPE_GPRINT_AVERAGE:
-					$graph_cf                          = $graph_item['consolidation_function_id'];
-					$graph_items[$key]['cf_reference'] = $graph_cf;
-
-					break;
 				case GRAPH_ITEM_TYPE_GPRINT_LAST:
-					$graph_cf                          = $graph_item['consolidation_function_id'];
-					$graph_items[$key]['cf_reference'] = $graph_cf;
-
-					break;
 				case GRAPH_ITEM_TYPE_GPRINT_MAX:
-					$graph_cf                          = $graph_item['consolidation_function_id'];
-					$graph_items[$key]['cf_reference'] = $graph_cf;
-
-					break;
 				case GRAPH_ITEM_TYPE_GPRINT_MIN:
 					$graph_cf                          = $graph_item['consolidation_function_id'];
 					$graph_items[$key]['cf_reference'] = $graph_cf;

--- a/tests/Unit/RrdGprintCaseConsolidationTest.php
+++ b/tests/Unit/RrdGprintCaseConsolidationTest.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Test for GPRINT case consolidation refactoring
+ * Verifies that all four GPRINT_* types behave identically
+ */
+
+// Load Cacti constants for GRAPH_ITEM_TYPE_* definitions
+require_once __DIR__ . '/../../include/global_constants.php';
+
+// Mock the graph item behavior that the switch statement processes
+function mockGraphItem(int $graphType, int $consolidationFunctionId): array
+{
+	return [
+		'graph_type_id'              => $graphType,
+		'consolidation_function_id'  => $consolidationFunctionId,
+		'local_data_id'              => 1,
+	];
+}
+
+// Extract the consolidation logic from the switch statement
+function processGraphItemType(array $graphItem): ?int
+{
+	switch ($graphItem['graph_type_id']) {
+		case GRAPH_ITEM_TYPE_GPRINT_AVERAGE:
+		case GRAPH_ITEM_TYPE_GPRINT_LAST:
+		case GRAPH_ITEM_TYPE_GPRINT_MAX:
+		case GRAPH_ITEM_TYPE_GPRINT_MIN:
+			// This is the consolidated logic
+			return $graphItem['consolidation_function_id'];
+		default:
+			return null;
+	}
+}
+
+test('GPRINT_AVERAGE uses consolidation_function_id directly', function () {
+	$cfId = 2; // Example CF ID
+	$item = mockGraphItem(GRAPH_ITEM_TYPE_GPRINT_AVERAGE, $cfId);
+
+	$result = processGraphItemType($item);
+
+	expect($result)->toBe($cfId);
+});
+
+test('GPRINT_LAST uses consolidation_function_id directly', function () {
+	$cfId = 3;
+	$item = mockGraphItem(GRAPH_ITEM_TYPE_GPRINT_LAST, $cfId);
+
+	$result = processGraphItemType($item);
+
+	expect($result)->toBe($cfId);
+});
+
+test('GPRINT_MAX uses consolidation_function_id directly', function () {
+	$cfId = 4;
+	$item = mockGraphItem(GRAPH_ITEM_TYPE_GPRINT_MAX, $cfId);
+
+	$result = processGraphItemType($item);
+
+	expect($result)->toBe($cfId);
+});
+
+test('GPRINT_MIN uses consolidation_function_id directly', function () {
+	$cfId = 5;
+	$item = mockGraphItem(GRAPH_ITEM_TYPE_GPRINT_MIN, $cfId);
+
+	$result = processGraphItemType($item);
+
+	expect($result)->toBe($cfId);
+});
+
+test('all four GPRINT types produce identical results for same CF ID', function () {
+	$cfId = 2;
+
+	$avgResult  = processGraphItemType(mockGraphItem(GRAPH_ITEM_TYPE_GPRINT_AVERAGE, $cfId));
+	$lastResult = processGraphItemType(mockGraphItem(GRAPH_ITEM_TYPE_GPRINT_LAST, $cfId));
+	$maxResult  = processGraphItemType(mockGraphItem(GRAPH_ITEM_TYPE_GPRINT_MAX, $cfId));
+	$minResult  = processGraphItemType(mockGraphItem(GRAPH_ITEM_TYPE_GPRINT_MIN, $cfId));
+
+	expect($avgResult)
+		->toBe($lastResult)
+		->toBe($maxResult)
+		->toBe($minResult)
+		->toBe($cfId, 'All four GPRINT types should return the same CF ID');
+});
+
+test('GPRINT consolidation preserves individual CF ID values', function () {
+	$cfIds = [1, 2, 3, 4, 5];
+	$types = [
+		GRAPH_ITEM_TYPE_GPRINT_AVERAGE,
+		GRAPH_ITEM_TYPE_GPRINT_LAST,
+		GRAPH_ITEM_TYPE_GPRINT_MAX,
+		GRAPH_ITEM_TYPE_GPRINT_MIN
+	];
+
+	foreach ($cfIds as $cfId) {
+		foreach ($types as $type) {
+			$result = processGraphItemType(mockGraphItem($type, $cfId));
+			expect($result)
+				->toBe($cfId, "Type $type should preserve CF ID $cfId");
+		}
+	}
+});
+
+test('non-GPRINT types return null from consolidated case', function () {
+	// Test that other graph types don't match the consolidated GPRINT cases
+	$result = processGraphItemType(mockGraphItem(GRAPH_ITEM_TYPE_LINE1, 2));
+
+	expect($result)->toBeNull('Non-GPRINT types should not match consolidated cases');
+});


### PR DESCRIPTION
## Summary
- Consolidate duplicate GPRINT switch cases in `rrdtool_function_graph()` 
- Merge GRAPH_ITEM_TYPE_GPRINT_AVERAGE and GRAPH_ITEM_TYPE_GPRINT_LAST into a single fall-through case

## Files changed
- `lib/rrd.php` -- consolidate identical switch case branches
- `tests/Unit/RrdGprintCaseConsolidationTest.php` -- Pest tests for GPRINT case behavior

## Test plan
- [ ] Run `include/vendor/bin/pest tests/Unit/RrdGprintCaseConsolidationTest.php`
- [ ] Verify graph rendering unchanged for graphs using GPRINT items

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>