### PR TITLE
Some hosts may show as down incorrectly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@ Cacti CHANGELOG
 -issue#6600: When replicating plugins, unexpected errors may appear due to missing tables
 -issue#6605: Prevent Row Data Loss When Rebuilding RRD Files
 -issue#6606: When using SpikeKill, actions would not always lead to expected results
+-issue#6706: Fix false device down status in GUI for device that use empty SNMP OID System
 -feature#6523: When disabling users, ensure that their authentication cookies and sessions cleared
 -feature#6524: When changing your password, log off from all sessions
 -feature#6534: Improve Cacti Session ID security

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -1570,7 +1570,11 @@ function api_device_ping_device($device_id, $from_remote = false) {
 						$snmp_system = str_replace(':', ' ', $snmp_system);
 					}
 
-					if ($snmp_system == '') {
+					/* Some devices (Dell iDRAC, Fortigate, etc.) may have an empty system value. This causes a false down status */
+					$snmp_uptime = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
+
+					if ($snmp_system == '' && empty($snmp_uptime)) {
+
 						print "<span class='hostDown'>" . __('Host') . ' ' .  __('SNMP error');
 						if ($snmp_error != '') {
 							print " - $snmp_error";


### PR DESCRIPTION
Devices like Dell iDrac or Fortigate firewall can return empty SNMP system. It is evaluated as a down device. Adding one more oid for test


