### PR TITLE
fix(auth): backport column-name whitelist to is_view_allowed() for 1.2.x

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -829,6 +829,14 @@ function is_graph_template_allowed($graph_template_id, $user = 0) {
  * @return (bool) True if allowed, else false
  */
 function is_view_allowed($view = 'show_tree') {
+	$allowed_views = array('show_tree', 'show_list', 'show_preview', 'graph_settings');
+
+	if (!in_array($view, $allowed_views, true)) {
+		cacti_log("WARNING: Invalid view parameter '$view' in is_view_allowed()", false, 'AUTH');
+
+		return false;
+	}
+
 	if (read_config_option('auth_method') != 0) {
 		if (!isset($_SESSION['sess_user_id'])) {
 			return false;
@@ -836,10 +844,10 @@ function is_view_allowed($view = 'show_tree') {
 
 		if (db_table_exists('user_auth_group')) {
 			$values = array_rekey(
-				db_fetch_assoc_prepared("SELECT DISTINCT $view
+				db_fetch_assoc_prepared("SELECT DISTINCT `$view`
 					FROM user_auth_group AS uag
 					INNER JOIN user_auth_group_members AS uagm
-					ON uag.id = uagm.user_id
+					ON uag.id = uagm.group_id
 					WHERE uag.enabled = 'on'
 					AND uagm.user_id = ?",
 					array($_SESSION['sess_user_id'])
@@ -854,7 +862,7 @@ function is_view_allowed($view = 'show_tree') {
 				return true;
 			}
 		}
-		$value = db_fetch_cell_prepared("SELECT $view
+		$value = db_fetch_cell_prepared("SELECT `$view`
 			FROM user_auth
 			WHERE id = ?",
 			array($_SESSION['sess_user_id'])


### PR DESCRIPTION
## Summary
- Add `$allowed_views` whitelist to validate the `$view` parameter in `is_view_allowed()` before SQL interpolation
- Backtick-quote `$view` in both SELECT statements for defense in depth
- Fix incorrect JOIN: `uagm.user_id` should be `uagm.group_id` when joining group members

Backport of #6697 for the 1.2.x branch. Single file, 11 lines added.

## Test plan
- [ ] Verify tree/list/preview views still work for authenticated users
- [ ] Verify group-based permissions resolve correctly (JOIN fix)
- [ ] Confirm invalid view names are rejected and logged