### PR TITLE
[1.2.x] hardening: escape values in array_to_sql_or()

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -1750,7 +1750,7 @@ function array_to_sql_or($array, $sql_column) {
 	}
 
 	if (cacti_sizeof($array)) {
-		$sql_or = "($sql_column IN('" . implode("','", $array) . "'))";
+		$sql_or = '(' . $sql_column . ' IN(' . implode(',', array_map('db_qstr', $array)) . '))';
 
 		return $sql_or;
 	}


### PR DESCRIPTION
## Summary
- Escape array values with `db_qstr()` before imploding into SQL `IN()` clause
- Defense-in-depth measure; callers already validate for integers, but this adds a safety net at the function level

Backport of #6648.

## Test plan
- [ ] Verify graph/device filtering still works with special characters in names