### PR TITLE
[1.2.x] hardening: parameterize SQL in cli/add_device.php

### DIFF
--- a/cli/add_device.php
+++ b/cli/add_device.php
@@ -335,7 +335,7 @@ if (cacti_sizeof($parms)) {
 
 	/* process host description */
 	if (isset($hosts[$description])) {
-		db_execute("UPDATE host SET hostname='$ip' WHERE deleted = '' AND id=" . $hosts[$description]);
+		db_execute_prepared("UPDATE host SET hostname = ? WHERE deleted = '' AND id = ?", array($ip, $hosts[$description]));
 		print "This host already exists in the database ($description) device-id: (" . $hosts[$description] . ")\n";
 		exit(1);
 	}
@@ -399,7 +399,7 @@ if (cacti_sizeof($parms)) {
 		}
 
 		if ($fail) {
-			db_execute("UPDATE host SET description = '$description' WHERE deleted = '' AND id = " . $addresses[$ip]);
+			db_execute_prepared("UPDATE host SET description = ? WHERE deleted = '' AND id = ?", array($description, $addresses[$ip]));
 			print "ERROR: This IP already exists in the database ($ip) device-id: (" . $addresses[$ip] . ")\n";
 			exit(1);
 		}


### PR DESCRIPTION
## Summary
- Replace raw variable interpolation with `db_execute_prepared()` and bound parameters
- Defensive hardening for CLI input handling

Backport of #6656.

## Test plan
- [ ] Verify `cli/add_device.php` handles duplicate hosts/IPs correctly