### PR TITLE
[1.2.x] hardening: remove PHP_EOL from force_https redirect header

### DIFF
--- a/include/global.php
+++ b/include/global.php
@@ -415,8 +415,10 @@ db_cacti_initialized($config['is_web']);
 
 if ($config['is_web']) {
 	if (read_config_option('force_https') == 'on') {
-		if (!isset($_SERVER['HTTPS']) && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
-			header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] . PHP_EOL . PHP_EOL);
+		$is_https = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== '' && strtolower($_SERVER['HTTPS']) !== 'off');
+
+		if (!$is_https && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
+			header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
 			exit;
 		}
 	}


### PR DESCRIPTION
## Summary
- Remove `PHP_EOL` from Location header value
- Tighten HTTPS detection to handle edge cases (`$_SERVER['HTTPS']` set to empty or 'off')

Backport of #6659.

## Test plan
- [ ] Verify force_https redirect works correctly