### PR TITLE
[1.2.x] fix: spikekill typos (missing paren, range comment)

### DIFF
--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -321,6 +321,7 @@ class spikekill {
 			$this->set_error(__("FATAL: Outlier time range requires outlier-start and outlier-end to be specified."));
 		}
 
+		// Check a bad range of the window start and end
 		if (!empty($this->out_start)) {
 			if ($this->out_start >= $this->out_end) {
 				$this->set_error(__("FATAL: Outlier time range requires outlier-start to be less than outlier-end."));
@@ -755,7 +756,7 @@ class spikekill {
 			unlink($xmlfile);
 		}
 
-		if (file_exists($xmlfile)) {
+		if (file_exists($bakfile)) {
 			unlink($bakfile);
 		}
 

--- a/poller_spikekill.php
+++ b/poller_spikekill.php
@@ -173,7 +173,7 @@ function timeToRun() {
 		}
 	} elseif ($forcerun) {
 		debug('Force to Run');
-		db_execute_prepared('REPLACE INTO settings (name,value) VALUES ("spikekill_lastrun", ?', array(time()));
+		db_execute_prepared('REPLACE INTO settings (name,value) VALUES ("spikekill_lastrun", ?)', array(time()));
 		return true;
 	} else {
 		debug('Not time to Run');


### PR DESCRIPTION
## Summary
- Fix missing closing paren in SQL placeholder on `--force` path (lastrun silently fails to update)
- Add missing range validation comment

Backport of #6665.

## Test plan
- [ ] Verify spikekill `--force` correctly updates lastrun timestamp