### PR TITLE
[1.2.x] fix: add output_format to ifName and ifDescr in interface.xml

### DIFF
--- a/resource/snmp_queries/interface.xml
+++ b/resource/snmp_queries/interface.xml
@@ -32,6 +32,7 @@
 		<ifDescr>
 			<name>Description</name>
 			<method>walk</method>
+			<output_format>ascii</output_format>
 			<source>value</source>
 			<direction>input</direction>
 			<oid>.1.3.6.1.2.1.2.2.1.2</oid>
@@ -39,6 +40,7 @@
 		<ifName>
 			<name>Name (IF-MIB)</name>
 			<method>walk</method>
+			<output_format>ascii</output_format>
 			<source>value</source>
 			<direction>input</direction>
 			<oid>.1.3.6.1.2.1.31.1.1.1.1</oid>


### PR DESCRIPTION
## Summary
- Add missing `output_format` field to ifName and ifDescr SNMP query definitions

Backport of #6664.

## Test plan
- [ ] Verify SNMP interface queries return correctly formatted ifName/ifDescr values