### PR TITLE
[1.2.x] fix: strict comparison in replicate_table_to_poller column exclusion

### DIFF
--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2114,8 +2114,8 @@ function replicate_table_to_poller($conn, &$data, $table, $exclude = false) {
 		foreach($columns as $index => $c) {
 			if (!db_column_exists($table, $c, false, $conn)) {
 				$skipcols[$index] = $c;
-			} elseif ($exclude !== false && array_search($c, $exclude) === true) {
-				// Do not update this column
+			} elseif ($exclude !== false && array_search($c, $exclude, true) !== false) {
+				$skipcols[$index] = $c;
 			} else {
 				$prefix .= ($colcnt > 0 ? ', ':'') . $c;
 				$suffix .= ($colcnt > 0 ? ', ':'') . "$c=VALUES($c)";


### PR DESCRIPTION
## Summary
- Use `!== false` for `array_search()` return check instead of `== true`
- Previous check failed when found index was 0 (falsy), causing excluded columns to be replicated
- Correctly add excluded columns to `$skipcols` array so they are skipped during row value construction

Backport of #6680.

## Test plan
- [ ] Verify poller replication correctly excludes specified columns
- [ ] Confirm columns at index 0 in the exclude list are properly skipped