### PR TITLE
fix: replace strtolower/strtoupper with locale-independent wrappers

### DIFF
--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -1846,9 +1846,9 @@ function aggregate_make_sql_where(string $sql_where, array $items, string $field
 			}
 
 			if ($i != '') {
-				if (strtolower($i) == 'and') {
+				if (cacti_strtolower($i) == 'and') {
 					$sql_where .= ' AND ';
-				} elseif (strtolower($i) == 'or') {
+				} elseif (cacti_strtolower($i) == 'or') {
 					$sql_where .= ' OR ';
 				} else {
 					$sql_where .= ($termcount > 0 ? ' OR ' : '') . $field . " LIKE '%" . trim($i) . "%'";
@@ -1881,7 +1881,7 @@ function aggregate_format_text(string $text, string $filter) : string {
 		$i = str_replace('(', '', $i);
 		$i = str_replace(')', '', $i);
 
-		if (strtolower($i) == 'and' || strtolower($i) == 'or') {
+		if (cacti_strtolower($i) == 'and' || cacti_strtolower($i) == 'or') {
 			continue;
 		}
 

--- a/changelog.php
+++ b/changelog.php
@@ -126,7 +126,7 @@ function changelog_view() : void {
 			$type = 'unknown';
 
 			if (isset($parts[1])) {
-				$type = strtolower($parts[1]);
+				$type = cacti_strtolower($parts[1]);
 
 				if ($type == 'security') {
 					$type = ' security';

--- a/cli/add_data_query.php
+++ b/cli/add_data_query.php
@@ -95,7 +95,7 @@ if (cacti_sizeof($parms)) {
 					($value <= DATA_QUERY_AUTOINDEX_FIELD_VERIFICATION)) {
 					$reindex_method = $value;
 				} else {
-					switch (strtolower($value)) {
+					switch (cacti_strtolower($value)) {
 						case 'none':
 							$reindex_method = DATA_QUERY_AUTOINDEX_NONE;
 

--- a/cli/add_device.php
+++ b/cli/add_device.php
@@ -153,7 +153,7 @@ if (cacti_sizeof($parms)) {
 
 				break;
 			case '--security-level':
-				$snmp_security_level = strtolower(trim($value));
+				$snmp_security_level = cacti_strtolower(trim($value));
 
 				break;
 			case '--username':
@@ -243,7 +243,7 @@ if (cacti_sizeof($parms)) {
 
 				break;
 			case '--ping_method':
-				switch(strtolower($value)) {
+				switch(cacti_strtolower($value)) {
 					case 'icmp':
 						$ping_method = PING_ICMP;
 

--- a/cli/add_graphs.php
+++ b/cli/add_graphs.php
@@ -227,7 +227,7 @@ if (cacti_sizeof($parms)) {
 					($value <= DATA_QUERY_AUTOINDEX_FIELD_VERIFICATION)) {
 					$dsGraph['reindex_method'] = intval($value);
 				} else {
-					switch (strtolower($value)) {
+					switch (cacti_strtolower($value)) {
 						case 'none':
 							$dsGraph['reindex_method'] = DATA_QUERY_AUTOINDEX_NONE;
 

--- a/cli/change_device.php
+++ b/cli/change_device.php
@@ -218,7 +218,7 @@ foreach ($parms as $parameter) {
 
 			break;
 		case '--ping_method':
-			switch(strtolower($value)) {
+			switch(cacti_strtolower($value)) {
 				case 'icmp':
 					$overrides['ping_method'] = PING_ICMP;
 

--- a/cli/clone_device_template.php
+++ b/cli/clone_device_template.php
@@ -263,7 +263,7 @@ if (cacti_sizeof($parms)) {
 		while (true) {
 			printf(PHP_EOL . 'Precheck completed with no Errors.  Do you want to continue [Y|N]? ');
 
-			$line = strtolower(trim(fgets($fin)));
+			$line = cacti_strtolower(trim(fgets($fin)));
 
 			if ($line == 'y') {
 				fclose($fin);

--- a/cli/convert_tables.php
+++ b/cli/convert_tables.php
@@ -184,7 +184,7 @@ if ($innodb) {
 
 	if (cacti_sizeof($engines)) {
 		foreach ($engines as $engine) {
-			if (strtolower($engine['Engine']) == 'innodb' && strtolower($engine['Support']) == 'off') {
+			if (cacti_strtolower($engine['Engine']) == 'innodb' && cacti_strtolower($engine['Support']) == 'off') {
 				print_or_log($installer,  'InnoDB Engine is not enabled' . PHP_EOL);
 
 				exit;
@@ -194,7 +194,7 @@ if ($innodb) {
 
 	$file_per_table = db_fetch_row("SHOW GLOBAL VARIABLES LIKE 'innodb_file_per_table'");
 
-	if (strtolower($file_per_table['Value']) != 'on') {
+	if (cacti_strtolower($file_per_table['Value']) != 'on') {
 		print_or_log($installer,  'innodb_file_per_table not enabled');
 
 		exit;

--- a/cli/copy_user.php
+++ b/cli/copy_user.php
@@ -157,7 +157,7 @@ function validate_field(string $field, string $value) : string {
 }
 
 function validate_boolean(string $field, string $value) : string {
-	$value = empty($value) ? '' : strtolower($value);
+	$value = empty($value) ? '' : cacti_strtolower($value);
 
 	if ($value == 'on' || $value == 'yes') {
 		$result = true;

--- a/cli/fix_mediumint.php
+++ b/cli/fix_mediumint.php
@@ -153,7 +153,7 @@ function database_fix_mediumint_columns() : int {
 					}
 				}
 
-				if (strtolower($attribs['Extra']) == 'auto_increment') {
+				if (cacti_strtolower($attribs['Extra']) == 'auto_increment') {
 					$sql .= ($i == 0 ? '' : ', ') . ' MODIFY COLUMN ' . $c . ' int(10) unsigned NOT NULL AUTO_INCREMENT';
 				} else {
 					if ($c != 'id') {
@@ -206,7 +206,7 @@ function database_fix_mediumint_columns() : int {
 						}
 					}
 
-					if (strtolower($attribs['Extra']) == 'auto_increment') {
+					if (cacti_strtolower($attribs['Extra']) == 'auto_increment') {
 						$sql .= ($i == 0 ? '' : ', ') . ' MODIFY COLUMN ' . $field . ' int(10) unsigned NOT NULL AUTO_INCREMENT';
 					} else {
 						if ($attribs['Default'] != '') {

--- a/cli/host_update_template.php
+++ b/cli/host_update_template.php
@@ -111,7 +111,7 @@ if (cacti_sizeof($parms)) {
 }
 
 // determine the hosts to reindex
-if (strtolower($host_id) == 'all') {
+if (cacti_strtolower($host_id) == 'all') {
 	$sql_where = '';
 } elseif ($host_id > 0) {
 	$sql_where = ' WHERE id = ?';

--- a/cli/install_cacti.php
+++ b/cli/install_cacti.php
@@ -175,7 +175,7 @@ if (cacti_sizeof($parms)) {
 				break;
 			case '--notifyadmin':
 			case '-n':
-				$value = strtolower($value) == 'true' ? 'on' : '';
+				$value = cacti_strtolower($value) == 'true' ? 'on' : '';
 				set_install_option($options, 'notify_admin', 'Notify Admin', $value);
 
 				break;

--- a/cli/migrate_poller.php
+++ b/cli/migrate_poller.php
@@ -339,7 +339,7 @@ function migrate_all_devices(int $source_poller, int $dest_poller, bool $quietMo
 		print 'Are you sure you want to continue? (y/N): ';
 		$confirmation = trim(fgets(STDIN));
 
-		if (strtolower($confirmation) !== 'y') {
+		if (cacti_strtolower($confirmation) !== 'y') {
 			print 'Migration cancelled by user' . PHP_EOL;
 
 			return false;
@@ -434,7 +434,7 @@ function migrate_from_host_ids(string $host_ids_string, int $source_poller, int 
 		print 'Are you sure you want to continue? (y/N): ';
 		$confirmation = trim(fgets(STDIN));
 
-		if (strtolower($confirmation) !== 'y') {
+		if (cacti_strtolower($confirmation) !== 'y') {
 			print 'Migration cancelled by user' . PHP_EOL;
 
 			return false;

--- a/cli/poller_data_sources_reapply_names.php
+++ b/cli/poller_data_sources_reapply_names.php
@@ -109,7 +109,7 @@ if ($filter != '') {
 	$sql_where = '';
 }
 
-if (strtolower($host_id) == 'all') {
+if (cacti_strtolower($host_id) == 'all') {
 	// Act on all graphs
 } elseif (substr_count($host_id, ',')) {
 	$hosts    = explode(',', $host_id);

--- a/cli/poller_graphs_reapply_names.php
+++ b/cli/poller_graphs_reapply_names.php
@@ -101,7 +101,7 @@ if ($filter != '') {
 	$sql_where = '';
 }
 
-if (strtolower($host_id) == 'all') {
+if (cacti_strtolower($host_id) == 'all') {
 	// Act on all graphs
 } elseif (substr_count($host_id, ',')) {
 	$hosts    = explode(',', $host_id);

--- a/cli/poller_reindex_hosts.php
+++ b/cli/poller_reindex_hosts.php
@@ -90,7 +90,7 @@ foreach ($parms as $parameter) {
 	switch ($arg) {
 		case '-id':
 		case '--id':
-			if (strtolower($value) == 'all') {
+			if (cacti_strtolower($value) == 'all') {
 				$host_id = -1;
 			} elseif (is_numeric($value) && $value > 0) {
 				$host_id = intval($value);
@@ -102,7 +102,7 @@ foreach ($parms as $parameter) {
 
 			break;
 		case '--qid':
-			if (strtolower($value) == 'all') {
+			if (cacti_strtolower($value) == 'all') {
 				$query_id = -1;
 			} elseif (is_numeric($value) && $value > 0) {
 				$query_id = intval($value);

--- a/cli/removespikes.php
+++ b/cli/removespikes.php
@@ -104,7 +104,7 @@ if (cacti_sizeof($parms)) {
 				break;
 			case '--avgnan':
 			case '-A':
-				$avgnan = strtolower($value);
+				$avgnan = cacti_strtolower($value);
 
 				break;
 			case '--rrdfile':

--- a/cli/reorder_data_query.php
+++ b/cli/reorder_data_query.php
@@ -100,7 +100,7 @@ if (cacti_sizeof($parms)) {
 $sql_where = "WHERE data_input_fields.type_code='output_type'";
 
 // determine the hosts to reindex
-if (strtolower($host_id) == 'all') {
+if (cacti_strtolower($host_id) == 'all') {
 	// NOP
 } elseif (is_numeric($host_id)) {
 	$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . 'data_local.host_id = ' . $host_id;
@@ -112,7 +112,7 @@ if (strtolower($host_id) == 'all') {
 }
 
 // determine data queries to rerun
-if (strtolower($query_id) == 'all') {
+if (cacti_strtolower($query_id) == 'all') {
 	// do nothing
 } elseif (is_numeric($query_id)) {
 	$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . 'data_local.snmp_query_id= ' . $query_id;

--- a/cli/show_perms.php
+++ b/cli/show_perms.php
@@ -84,7 +84,7 @@ $perms = db_get_permissions(true);
 $count = 0;
 
 if ($output_json) {
-	print strtolower(json_encode($perms, JSON_PRETTY_PRINT));
+	print cacti_strtolower(json_encode($perms, JSON_PRETTY_PRINT));
 } else {
 	if ($output_grants) {
 		$pad = str_repeat('-', 20);

--- a/cli/sqltable_to_php.php
+++ b/cli/sqltable_to_php.php
@@ -122,13 +122,13 @@ function sqltable_to_php(string $table, bool $create, string $plugin = '') : str
 				$text .= "\$data['columns'][] = array(";
 				$text .= "'name' => '" . $r['Field'] . "'";
 
-				if (str_contains(strtolower($r['Type']), ' unsigned')) {
+				if (str_contains(cacti_strtolower($r['Type']), ' unsigned')) {
 					$r['Type'] = str_ireplace(' unsigned', '', $r['Type']);
 					$text .= ", 'unsigned' => true";
 				}
 
 				$text .= ", 'type' => " . db_qstr($r['Type']);
-				$text .= ", 'NULL' => " . (strtolower($r['Null']) == 'no' ? 'false' : 'true');
+				$text .= ", 'NULL' => " . (cacti_strtolower($r['Null']) == 'no' ? 'false' : 'true');
 
 				if ($r['Default'] != '' && trim($r['Default']) != '') {
 					if ($r['Default'] == "''") {
@@ -143,11 +143,11 @@ function sqltable_to_php(string $table, bool $create, string $plugin = '') : str
 				}
 
 				if (trim($r['Extra']) != '') {
-					if (strtolower($r['Extra']) == 'on update current_timestamp') {
+					if (cacti_strtolower($r['Extra']) == 'on update current_timestamp') {
 						$text .= ", 'on_update' => 'CURRENT_TIMESTAMP'";
 					}
 
-					if (strtolower($r['Extra']) == 'auto_increment') {
+					if (cacti_strtolower($r['Extra']) == 'auto_increment') {
 						$text .= ", 'auto_increment' => true";
 					}
 				}

--- a/cli/structure_rra_paths.php
+++ b/cli/structure_rra_paths.php
@@ -246,7 +246,7 @@ foreach ($data_sources as $info) {
 			LIMIT 1',
 			[$local_data_id]);
 
-		$data_source_path1 = $base_rra_path . '/' . strtolower(clean_up_file_name($info['description'])) . '_' . $local_data_id . '.rrd';
+		$data_source_path1 = $base_rra_path . '/' . cacti_strtolower(clean_up_file_name($info['description'])) . '_' . $local_data_id . '.rrd';
 		$data_source_path2 = '';
 
 		if ($pattern == '' || $pattern == 'device') {

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -508,7 +508,7 @@ function profile_export_execute(mixed $profile_ids) : array {
 
 	$json_array = [];
 
-	$json_array['name']        = clean_up_name(strtolower($export_name));
+	$json_array['name']        = clean_up_name(cacti_strtolower($export_name));
 	$json_array['export_name'] = $json_array['name'] . '.json';
 
 	if (cacti_sizeof($profile_ids)) {

--- a/graph_image.php
+++ b/graph_image.php
@@ -68,7 +68,7 @@ if (!isrv('image_format')) {
 			break;
 	}
 } else {
-	switch(strtolower(gnrv('image_format'))) {
+	switch(cacti_strtolower(gnrv('image_format'))) {
 		case 'png':
 			$gtype = 'png';
 

--- a/graph_json.php
+++ b/graph_json.php
@@ -128,7 +128,7 @@ if (!isrv('image_format')) {
 			break;
 	}
 } else {
-	switch(strtolower(gnrv('image_format'))) {
+	switch(cacti_strtolower(gnrv('image_format'))) {
 		case 'png':
 			$graph_data_array['image_format'] = 'png';
 

--- a/graph_realtime.php
+++ b/graph_realtime.php
@@ -197,7 +197,7 @@ switch (grv('action')) {
 					break;
 			}
 		} else {
-			switch(strtolower(gnrv('image_format'))) {
+			switch(cacti_strtolower(gnrv('image_format'))) {
 				case 'png':
 					$graph_data_array['image_format'] = 'png';
 

--- a/include/global.php
+++ b/include/global.php
@@ -247,7 +247,7 @@ if (isset($input_whitelist)) {
 foreach ($config as $key => $value) {
 	if (str_ends_with($key, '_path')) {
 		$path_name     = substr($key, 0, -5);
-		$constant_name = 'CACTI_PATH_' . strtoupper($path_name);
+		$constant_name = 'CACTI_PATH_' . cacti_strtoupper($path_name);
 
 		if (!defined($constant_name)) {
 			define($constant_name, $value);
@@ -501,7 +501,7 @@ db_cacti_initialized($config['is_web']);
 
 if ($config['is_web']) {
 	if (read_config_option('force_https') == 'on') {
-		$is_https = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== '' && strtolower($_SERVER['HTTPS']) !== 'off');
+		$is_https = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== '' && cacti_strtolower($_SERVER['HTTPS']) !== 'off');
 
 		if (!$is_https && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
 			header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);

--- a/include/global_languages.php
+++ b/include/global_languages.php
@@ -638,7 +638,7 @@ function load_fallback_procedure() : void {
  */
 function set_language_constants(array $constants) : void {
 	foreach ($constants as $key => $value) {
-		$upperKey = strtoupper($key);
+		$upperKey = cacti_strtoupper($key);
 
 		switch ($upperKey) {
 			case 'LOCALE':
@@ -1068,7 +1068,7 @@ function number_format_i18n(mixed $number, mixed $decimals = null, mixed $baseu 
 		return '0';
 	}
 
-	$country = strtoupper($cacti_country);
+	$country = cacti_strtoupper($cacti_country);
 
 	if (function_exists('numfmt_create')) {
 		$fmt_key = $cacti_locale . '_' . $country;

--- a/include/themes/midwinter/update_hash.php
+++ b/include/themes/midwinter/update_hash.php
@@ -32,7 +32,7 @@ function file_search(string $folder, array $pattern_array) : array {
 	foreach (new RecursiveIteratorIterator($iti) as $file) {
 		$fileParts = explode('.', $file);
 
-		if (in_array(strtolower(array_pop($fileParts)), $pattern_array, true)) {
+		if (in_array(cacti_strtolower(array_pop($fileParts)), $pattern_array, true)) {
 			$return[] = $file;
 		}
 	}

--- a/install/cli_check.php
+++ b/install/cli_check.php
@@ -32,7 +32,7 @@ include(__DIR__ . '/../include/cli_check.php');
 include(__DIR__ . '/../lib/utility.php');
 
 if (is_array($argv) && $argc > 1) {
-	$value = strtolower($argv[1]);
+	$value = cacti_strtolower($argv[1]);
 
 	if ($value == 'extensions') {
 		$ext = false;

--- a/install/functions.php
+++ b/install/functions.php
@@ -611,7 +611,7 @@ function db_install_add_key(string $table, string $type, string $key, mixed $col
 		$columns = [$columns];
 	}
 
-	$type = strtoupper($type);
+	$type = cacti_strtoupper($type);
 
 	if ($type == 'KEY' && $key == 'PRIMARY') {
 		$sql = 'ALTER TABLE `' . $table . '` ADD ' . $key . ' ' . $type . '(' . implode(',', $columns) . ')';
@@ -641,7 +641,7 @@ function db_install_add_key(string $table, string $type, string $key, mixed $col
 }
 
 function db_install_drop_key(string $table, string $type, string $key) : int {
-	$type = strtoupper(str_ireplace('UNIQUE ', '', $type));
+	$type = cacti_strtoupper(str_ireplace('UNIQUE ', '', $type));
 
 	if ($type == 'KEY' && $key == 'PRIMARY') {
 		$sql = "ALTER TABLE $table DROP $key $type;";
@@ -1405,7 +1405,7 @@ function log_install_and_file(int $level, string $text, string $section = '', bo
 	$name  = 'INSTALL:';
 
 	if (!empty($section)) {
-		$name = 'INSTALL-' . strtoupper($section) . ':';
+		$name = 'INSTALL-' . cacti_strtoupper($section) . ':';
 	}
 
 	cacti_log(log_install_level_name($level) . ': ' . $text, false, $name, $level);

--- a/install/upgrades/1_2_17.php
+++ b/install/upgrades/1_2_17.php
@@ -142,7 +142,7 @@ function database_fix_mediumint_columns() : int {
 					}
 				}
 
-				if (strtolower($attribs['Extra']) == 'auto_increment') {
+				if (cacti_strtolower($attribs['Extra']) == 'auto_increment') {
 					$sql .= ($i == 0 ? '' : ', ') . ' MODIFY COLUMN ' . $c . ' int(10) unsigned NOT NULL AUTO_INCREMENT';
 				} else {
 					if ($c != 'id') {
@@ -191,7 +191,7 @@ function database_fix_mediumint_columns() : int {
 						}
 					}
 
-					if (strtolower($attribs['Extra']) == 'auto_increment') {
+					if (cacti_strtolower($attribs['Extra']) == 'auto_increment') {
 						$sql .= ($i == 0 ? '' : ', ') . ' MODIFY COLUMN ' . $field . ' int(10) unsigned NOT NULL AUTO_INCREMENT';
 					} else {
 						if ($attribs['Default'] != '') {

--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,8 +644,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -658,8 +656,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -672,8 +668,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -791,7 +785,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON gti.task_item_id = dtr.id
+				ON dtr.id = gti.task_item_id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1594,143 +1588,6 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
-/**
- * Handles the aggregation of stacked lines for a given graph.
- *
- * @param int    $local_graph_id   The ID of the local graph.
- * @param string $_orig_graph_type The original type of the graph.
- * @param int    $_total           The total value to be aggregated.
- * @param string $_total_type      The type of the total value.
- * @param string $_total_prefix    The prefix for the total value.
- *
- * @return void
- */
-function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
-	// Handle the stacked line cases switch line widths
-	$width        = '0.01';
-	$special_type = '';
-	$special_line = false;
-
-	switch ($_orig_graph_type) {
-		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
-			$width        = '1.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE1;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
-			$width        = '2.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE2;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
-			$width        = '3.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE3;
-			$special_line = true;
-
-			break;
-	}
-
-	if ($special_line) {
-		if ($_total == AGGREGATE_TOTAL_NONE) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET line_width = ?
-				WHERE local_graph_id = ?
-				AND graph_type_id IN (?)',
-				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
-		}
-
-		// Handle special case total prefix
-		db_execute_prepared('UPDATE graph_templates_item
-			SET graph_type_id = ?
-			WHERE local_graph_id = ?
-			AND text_format = ?',
-			[$special_type, $local_graph_id, $_total_prefix]);
-
-		if ($_total == AGGREGATE_TOTAL_ALL) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET graph_type_id = ?, line_width = "0.01"
-				WHERE local_graph_id = ?
-				AND graph_type_id = ?
-				AND text_format != ?',
-				[
-					GRAPH_ITEM_TYPE_LINESTACK,
-					$local_graph_id,
-					$special_type,
-					$_total_prefix
-				]
-			);
-		}
-	}
-
-	// handle any missing lines
-	db_execute_prepared('UPDATE graph_templates_item
-		SET line_width="0.01"
-		WHERE graph_type_id = ?
-		AND line_width="0.00"
-		AND local_graph_id = ?',
-		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
-}
-
-/**
- * Retrieves data sources for aggregation.
- *
- * @param array  $graph_array    Array of graphs to aggregate.
- * @param mixed  $data_sources   Array to store the retrieved data sources.
- * @param mixed  $graph_template Template for the graphs.
- * @param string $message        Optional. Message to store any errors or information.
- *
- * @return bool True on success, false on failure.
- */
-function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
-	if (cacti_sizeof($graph_array)) {
-		// fetch all data sources for all selected graphs
-		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
-			FROM data_template_rrd AS dtr
-			INNER JOIN graph_templates_item AS gti
-			ON dtr.id = gti.task_item_id
-			INNER JOIN data_template_data AS dtd
-			ON dtr.local_data_id = dtd.local_data_id
-			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
-			AND dtd.local_data_id > 0
-			GROUP BY dtd.local_data_id
-			ORDER BY dtd.name_cache');
-
-		// verify, that only a single graph template is used, else
-		// aggregate will look funny
-		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
-			FROM graph_local AS gl
-			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
-
-		if (cacti_sizeof($templates) > 1) {
-			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
-
-			return false;
-		}
-
-		if (cacti_sizeof($templates) == 1) {
-			if ($templates[0]['id'] == 0) {
-				// selected graphs do not use templates
-				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
-
-				return false;
-			} else {
-				$graph_template = $templates[0]['id'];
-
-				return true;
-			}
-		} else {
-			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
-
-			return false;
-		}
-	} else {
-		$message = __('You must pass at least a single Graph to this function');
-
-		return false;
-	}
-}
 
 /**
  * Draws the list of aggregate graph items.

--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,6 +644,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -656,6 +658,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -668,6 +672,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -785,7 +791,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON dtr.id = gti.task_item_id
+				ON gti.task_item_id = dtr.id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1588,6 +1594,143 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
+/**
+ * Handles the aggregation of stacked lines for a given graph.
+ *
+ * @param int    $local_graph_id   The ID of the local graph.
+ * @param string $_orig_graph_type The original type of the graph.
+ * @param int    $_total           The total value to be aggregated.
+ * @param string $_total_type      The type of the total value.
+ * @param string $_total_prefix    The prefix for the total value.
+ *
+ * @return void
+ */
+function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
+	// Handle the stacked line cases switch line widths
+	$width        = '0.01';
+	$special_type = '';
+	$special_line = false;
+
+	switch ($_orig_graph_type) {
+		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
+			$width        = '1.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE1;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
+			$width        = '2.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE2;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
+			$width        = '3.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE3;
+			$special_line = true;
+
+			break;
+	}
+
+	if ($special_line) {
+		if ($_total == AGGREGATE_TOTAL_NONE) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET line_width = ?
+				WHERE local_graph_id = ?
+				AND graph_type_id IN (?)',
+				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
+		}
+
+		// Handle special case total prefix
+		db_execute_prepared('UPDATE graph_templates_item
+			SET graph_type_id = ?
+			WHERE local_graph_id = ?
+			AND text_format = ?',
+			[$special_type, $local_graph_id, $_total_prefix]);
+
+		if ($_total == AGGREGATE_TOTAL_ALL) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET graph_type_id = ?, line_width = "0.01"
+				WHERE local_graph_id = ?
+				AND graph_type_id = ?
+				AND text_format != ?',
+				[
+					GRAPH_ITEM_TYPE_LINESTACK,
+					$local_graph_id,
+					$special_type,
+					$_total_prefix
+				]
+			);
+		}
+	}
+
+	// handle any missing lines
+	db_execute_prepared('UPDATE graph_templates_item
+		SET line_width="0.01"
+		WHERE graph_type_id = ?
+		AND line_width="0.00"
+		AND local_graph_id = ?',
+		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
+}
+
+/**
+ * Retrieves data sources for aggregation.
+ *
+ * @param array  $graph_array    Array of graphs to aggregate.
+ * @param mixed  $data_sources   Array to store the retrieved data sources.
+ * @param mixed  $graph_template Template for the graphs.
+ * @param string $message        Optional. Message to store any errors or information.
+ *
+ * @return bool True on success, false on failure.
+ */
+function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
+	if (cacti_sizeof($graph_array)) {
+		// fetch all data sources for all selected graphs
+		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
+			FROM data_template_rrd AS dtr
+			INNER JOIN graph_templates_item AS gti
+			ON dtr.id = gti.task_item_id
+			INNER JOIN data_template_data AS dtd
+			ON dtr.local_data_id = dtd.local_data_id
+			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
+			AND dtd.local_data_id > 0
+			GROUP BY dtd.local_data_id
+			ORDER BY dtd.name_cache');
+
+		// verify, that only a single graph template is used, else
+		// aggregate will look funny
+		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
+			FROM graph_local AS gl
+			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
+
+		if (cacti_sizeof($templates) > 1) {
+			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
+
+			return false;
+		}
+
+		if (cacti_sizeof($templates) == 1) {
+			if ($templates[0]['id'] == 0) {
+				// selected graphs do not use templates
+				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
+
+				return false;
+			} else {
+				$graph_template = $templates[0]['id'];
+
+				return true;
+			}
+		} else {
+			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
+
+			return false;
+		}
+	} else {
+		$message = __('You must pass at least a single Graph to this function');
+
+		return false;
+	}
+}
 
 /**
  * Draws the list of aggregate graph items.

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -2260,7 +2260,7 @@ function get_query_fields(string $table, array $excluded_fields) : array {
 			// we want to know later which table was selected
 			$new_key = $table . '.' . $key;
 			// give the user a hint about the data type of the column
-			$new_fields[$new_key] = strtoupper($table) . ': ' . $key . ' - ' . $value;
+			$new_fields[$new_key] = cacti_strtoupper($table) . ': ' . $key . ' - ' . $value;
 		}
 	}
 
@@ -2521,11 +2521,11 @@ function global_item_edit(int $rule_id, int $rule_item_id, int $rule_type) : voi
 				$missing_array = explode('.',$missing_key);
 
 				if (cacti_sizeof($missing_array) > 1) {
-					$missing_table = strtoupper($missing_array[0]);
-					$missing_value = strtolower($missing_array[1]);
+					$missing_table = cacti_strtoupper($missing_array[0]);
+					$missing_value = cacti_strtolower($missing_array[1]);
 				} else {
 					$missing_table = '';
-					$missing_value = strtolower($missing_array[0]);
+					$missing_value = cacti_strtolower($missing_array[0]);
 				}
 
 				$_fields_rule_item_edit['field']['array'] = array_merge(
@@ -4317,7 +4317,7 @@ function automation_get_dns_from_ip(string $ip, string $dns, int $timeout = 1000
 			// null terminated string, so length 0 = finished
 			if ($len[1] == 0) {
 				// return the hostname, without the trailing '.'
-				return strtoupper(substr($host, 0, strlen($host) - 1));
+				return cacti_strtoupper(substr($host, 0, strlen($host) - 1));
 			}
 
 			// add the next segment to our host
@@ -4329,7 +4329,7 @@ function automation_get_dns_from_ip(string $ip, string $dns, int $timeout = 1000
 	}
 
 	// error - return the hostname
-	return strtoupper($ip);
+	return cacti_strtoupper($ip);
 }
 
 /**
@@ -4382,7 +4382,7 @@ function ping_netbios_name(string $ip, int $timeout_ms = 1000) : mixed {
 				$host .= $response[$i];
 			}
 
-			return trim(strtolower($host));
+			return trim(cacti_strtolower($host));
 		} else {
 			return false;
 		}
@@ -4677,7 +4677,7 @@ function automation_network_export(mixed $network_ids) : array {
 
 	$json_array = [];
 
-	$json_array['name']        = clean_up_name(strtolower($export_name));
+	$json_array['name']        = clean_up_name(cacti_strtolower($export_name));
 	$json_array['export_name'] = $json_array['name'] . '.json';
 
 	if (cacti_sizeof($network_ids)) {
@@ -4779,7 +4779,7 @@ function automation_device_rule_export(mixed $template_ids) : array {
 
 	$json_array = [];
 
-	$json_array['name']        = clean_up_name(strtolower($export_name));
+	$json_array['name']        = clean_up_name(cacti_strtolower($export_name));
 	$json_array['export_name'] = $json_array['name'] . '.json';
 
 	if (cacti_sizeof($template_ids)) {
@@ -5133,7 +5133,7 @@ function automation_graph_rule_export(mixed $graph_rule_ids) : array {
 
 	$json_array = [];
 
-	$json_array['name']        = clean_up_name(strtolower($export_name));
+	$json_array['name']        = clean_up_name(cacti_strtolower($export_name));
 	$json_array['export_name'] = $json_array['name'] . '.json';
 
 	if (cacti_sizeof($graph_rule_ids)) {
@@ -5219,7 +5219,7 @@ function automation_tree_rule_export(mixed $tree_rule_ids) : array {
 
 	$json_array = [];
 
-	$json_array['name']        = clean_up_name(strtolower($export_name));
+	$json_array['name']        = clean_up_name(cacti_strtolower($export_name));
 	$json_array['export_name'] = $json_array['name'] . '.json';
 
 	if (cacti_sizeof($tree_rule_ids)) {
@@ -5305,7 +5305,7 @@ function automation_snmp_option_export(mixed $snmp_option_ids) : array {
 
 	$json_array = [];
 
-	$json_array['name']        = clean_up_name(strtolower($export_name));
+	$json_array['name']        = clean_up_name(cacti_strtolower($export_name));
 	$json_array['export_name'] = $json_array['name'] . '.json';
 
 	if (cacti_sizeof($snmp_option_ids)) {

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -1889,12 +1889,12 @@ string $include_dq, string $clone_dq, string $include_dt, string $clone_dt, stri
 
 	$errors     = 0;
 	$warnings   = 0;
-	$include_gt = strtolower($include_gt);
-	$include_dq = strtolower($include_dq);
-	$include_dt = strtolower($include_dt);
-	$clone_gt   = strtolower($clone_gt);
-	$clone_dq   = strtolower($clone_dq);
-	$clone_dt   = strtolower($clone_dt);
+	$include_gt = cacti_strtolower($include_gt);
+	$include_dq = cacti_strtolower($include_dq);
+	$include_dt = cacti_strtolower($include_dt);
+	$clone_gt   = cacti_strtolower($clone_gt);
+	$clone_dq   = cacti_strtolower($clone_dq);
+	$clone_dt   = cacti_strtolower($clone_dt);
 
 	printf('Cloning Criteria for Device Template are:' . PHP_EOL);
 	printf('---------------------------------------------------------------------------' . PHP_EOL);
@@ -2958,7 +2958,7 @@ function api_device_template_download(string $type, array $ids) : void {
 			$name = clean_up_name(db_fetch_cell_prepared('SELECT name FROM host_template_archive WHERE id = ?', $ids));
 		}
 
-		$filename = 'device_package_' . strtolower($name) . '_download.tar';
+		$filename = 'device_package_' . cacti_strtolower($name) . '_download.tar';
 	} else {
 		$filename = 'device_package_multiple_download.tar';
 	}

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4149,7 +4149,7 @@ function secpass_check_pass(string $password) : string {
 		return __('Your password must contain at least 1 numerical character!');
 	}
 
-	if (read_config_option('secpass_reqmixcase') == 'on' && strtolower($password) == $password) {
+	if (read_config_option('secpass_reqmixcase') == 'on' && cacti_strtolower($password) == $password) {
 		return __('Your password must contain a mix of lower case and upper case characters!');
 	}
 
@@ -4160,7 +4160,7 @@ function secpass_check_pass(string $password) : string {
 	}
 
 	if (read_config_option('secpass_pwnedcheck') == 'on') {
-		$sha1    = strtoupper(sha1($password));
+		$sha1    = cacti_strtoupper(sha1($password));
 		$suffix  = substr($sha1,5);
 		$options = [
 			CURLOPT_RETURNTRANSFER => true,   // return web page

--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -1253,9 +1253,9 @@ function query_snmp_host(int $host_id, int $snmp_query_id) : bool {
 
 						foreach ($parts as $idx => $part) {
 							if (is_numeric($part)) {
-								$parts[$idx] = substr(strtoupper('00' . dechex(intval($part))), -2);
+								$parts[$idx] = substr(cacti_strtoupper('00' . dechex(intval($part))), -2);
 							} else {
-								$parts[$idx] = substr(strtoupper('00' . $part), -2);
+								$parts[$idx] = substr(cacti_strtoupper('00' . $part), -2);
 							}
 
 							if ($idx % 2 == 0 && $idx > 0) {
@@ -1565,9 +1565,9 @@ function query_snmp_host(int $host_id, int $snmp_query_id) : bool {
 
 						foreach ($parts as $idx => $part) {
 							if (is_numeric($part)) {
-								$parts[$idx] = substr(strtoupper('00' . dechex(intval($part))), -2);
+								$parts[$idx] = substr(cacti_strtoupper('00' . dechex(intval($part))), -2);
 							} else {
-								$parts[$idx] = substr(strtoupper('00' . $part), -2);
+								$parts[$idx] = substr(cacti_strtoupper('00' . $part), -2);
 							}
 
 							if ($idx % 2 == 0 && $idx > 0) {

--- a/lib/database.php
+++ b/lib/database.php
@@ -397,7 +397,7 @@ function db_binlog_enabled() : bool {
 	$enabled = db_fetch_row('SHOW GLOBAL VARIABLES LIKE "log_bin"');
 
 	if (cacti_sizeof($enabled)) {
-		if (strtolower($enabled['Value']) == 'on' || $enabled['Value'] == 1) {
+		if (cacti_strtolower($enabled['Value']) == 'on' || $enabled['Value'] == 1) {
 			return true;
 		}
 	}
@@ -1005,7 +1005,7 @@ function db_add_column(string $table, array $column, bool $log = true, mixed $db
 			}
 
 			if (isset($column['default'])) {
-				if (in_array(strtolower($column['type']), ['timestamp', 'datetime', 'date'], true) && str_contains($column['default'], 'CURRENT_TIMESTAMP')) {
+				if (in_array(cacti_strtolower($column['type']), ['timestamp', 'datetime', 'date'], true) && str_contains($column['default'], 'CURRENT_TIMESTAMP')) {
 					$sql .= ' default ' . $column['default'];
 				} else {
 					$sql .= ' default ' . (is_numeric($column['default']) ? $column['default'] : "'" . $column['default'] . "'");
@@ -1101,7 +1101,7 @@ function db_change_column(string $table, array $column, bool $log = true, mixed 
 				}
 
 				if (isset($column['default'])) {
-					if (strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
+					if (cacti_strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
 						$sql .= ' default CURRENT_TIMESTAMP';
 					} else {
 						$sql .= ' default ' . (is_numeric($column['default']) ? $column['default'] : "'" . $column['default'] . "'");
@@ -1493,13 +1493,13 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 		WHERE TABLE_SCHEMA = SCHEMA()
 		AND TABLE_NAME = '$table'", $log, $db_conn);
 
-	if (isset($info['ENGINE']) && isset($data['type']) && strtolower($info['ENGINE']) != strtolower($data['type'])) {
+	if (isset($info['ENGINE']) && isset($data['type']) && cacti_strtolower($info['ENGINE']) != cacti_strtolower($data['type'])) {
 		if (!db_execute("ALTER TABLE `$table` ENGINE = " . $data['type'], $log, $db_conn)) {
 			return false;
 		}
 	}
 
-	if (isset($data['row_format']) && strtolower(db_get_global_variable('innodb_file_format', $db_conn)) == 'barracuda') {
+	if (isset($data['row_format']) && cacti_strtolower(db_get_global_variable('innodb_file_format', $db_conn)) == 'barracuda') {
 		db_execute("ALTER TABLE `$table` ROW_FORMAT = " . $data['row_format'], $log, $db_conn);
 	}
 
@@ -1524,7 +1524,7 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 			// FIXME: Need to still check default value
 			$arr = db_fetch_row("SHOW columns FROM `$table` LIKE '" . $column['name'] . "'", $log, $db_conn);
 
-			if (str_contains(strtolower($arr['Type']), ' unsigned')) {
+			if (str_contains(cacti_strtolower($arr['Type']), ' unsigned')) {
 				$arr['Type']     = str_ireplace(' unsigned', '', $arr['Type']);
 				$arr['unsigned'] = true;
 			}
@@ -1552,7 +1552,7 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 				}
 
 				if (isset($column['default'])) {
-					if (strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
+					if (cacti_strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
 						$sql .= ' default CURRENT_TIMESTAMP';
 					} else {
 						$sql .= ' default ' . (is_numeric($column['default']) ? $column['default'] : "'" . $column['default'] . "'");
@@ -1770,7 +1770,7 @@ function db_table_create(string $table, array $data, bool $log = true, mixed $db
 				}
 
 				if (isset($column['default'])) {
-					if (strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
+					if (cacti_strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
 						$sql .= ' default CURRENT_TIMESTAMP';
 					} else {
 						$sql .= ' default ' . (is_numeric($column['default']) ? $column['default'] : "'" . $column['default'] . "'");
@@ -1818,7 +1818,7 @@ function db_table_create(string $table, array $data, bool $log = true, mixed $db
 			$sql .= " COMMENT = '" . $data['comment'] . "'";
 		}
 
-		if (isset($data['row_format']) && strtolower(db_get_global_variable('innodb_file_format', $db_conn)) == 'barracuda') {
+		if (isset($data['row_format']) && cacti_strtolower(db_get_global_variable('innodb_file_format', $db_conn)) == 'barracuda') {
 			$sql .= ' ROW_FORMAT = ' . $data['row_format'];
 		}
 
@@ -2594,7 +2594,7 @@ function db_get_permissions(bool $include_unknown = false, bool $log = false, mi
 
 							if (cacti_sizeof($db_grant_perms)) {
 								foreach ($db_grant_perms as $db_grant_perm) {
-									$db_grant_perm = strtoupper($db_grant_perm);
+									$db_grant_perm = cacti_strtoupper($db_grant_perm);
 
 									if ($db_grant_perm == 'ALL' ||
 										$db_grant_perm == 'ALL PRIVILEGES') {

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -734,7 +734,7 @@ function dsstats_log_child_stats(string $type, int $thread_id, float $total_time
 		WHERE name LIKE ?',
 		['dsstats_total_dsses_%' . $type . '_' . $thread_id . '%']);
 
-	$cacti_stats = sprintf('Time:%01.2f Type:%s ProcessNumber:%s RRDfiles:%s DSSes:%s RRDUser:%01.2f RRDSystem:%01.2f RRDReal:%01.2f', $total_time, strtoupper($type), $thread_id, $rrd_files, $dsses, $rrd_user, $rrd_system, $rrd_real);
+	$cacti_stats = sprintf('Time:%01.2f Type:%s ProcessNumber:%s RRDfiles:%s DSSes:%s RRDUser:%01.2f RRDSystem:%01.2f RRDReal:%01.2f', $total_time, cacti_strtoupper($type), $thread_id, $rrd_files, $dsses, $rrd_user, $rrd_system, $rrd_real);
 
 	cacti_log('DSSTATS CHILD STATS: ' . $cacti_stats, true, 'SYSTEM');
 }
@@ -906,7 +906,7 @@ function dsstats_poller_output(mixed &$rrd_update_array) : void {
 
 							if (is_numeric($value)) {
 								$result['output'] = $value;
-							} elseif ($value == 'U' || strtolower($value) == 'nan') {
+							} elseif ($value == 'U' || cacti_strtolower($value) == 'nan') {
 								$result['output'] = 'NULL';
 							} else {
 								$result['output'] = 'NULL';
@@ -1012,7 +1012,7 @@ function dsstats_poller_output(mixed &$rrd_update_array) : void {
 								case 4:	// ABSOLUTE
 									if ($result['output']          != 'NULL' &&
 										$result['output']             != 'U' &&
-										strtolower($result['output']) != 'nan') {
+										cacti_strtolower($result['output']) != 'nan') {
 										$currentval = abs($result['output']);
 										$lastval    = $currentval;
 									} else {
@@ -1024,7 +1024,7 @@ function dsstats_poller_output(mixed &$rrd_update_array) : void {
 								case 1:	// GAUGE
 									if ($result['output']          != 'NULL' &&
 										$result['output']             != 'U' &&
-										strtolower($result['output']) != 'nan') {
+										cacti_strtolower($result['output']) != 'nan') {
 										$currentval = $result['output'];
 										$lastval    = $result['output'];
 									} else {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1677,7 +1677,7 @@ function tail_file(string $file_name, int $line_cnt, mixed $message_type = -1, m
 		return [__('Error %s is not readable', $file_name)];
 	}
 
-	$filter = strtolower($filter);
+	$filter = cacti_strtolower($filter);
 
 	$fp = fopen($file_name, 'r');
 
@@ -2241,7 +2241,7 @@ function is_hex_string(string &$result) : bool {
 		return false;
 	}
 
-	$compare = strtolower($result);
+	$compare = cacti_strtolower($result);
 
 	/* strip off the 'Hex:, Hex-, and Hex-STRING:'
 	 * Hex- is considered due to the stripping of 'String:' in
@@ -3013,7 +3013,7 @@ function get_data_source_item_name(int $data_template_rrd_id) : mixed {
 	if (empty($data_source['data_source_name'])) {
 		// limit input to 19 characters
 		$data_source_name = clean_up_name($data_source['name']);
-		$data_source_name = substr(strtolower($data_source_name), 0, (19 - strlen('' . $data_template_rrd_id))) . $data_template_rrd_id;
+		$data_source_name = substr(cacti_strtolower($data_source_name), 0, (19 - strlen('' . $data_template_rrd_id))) . $data_template_rrd_id;
 
 		return $data_source_name;
 	} else {
@@ -3078,7 +3078,7 @@ function get_data_source_path(int $local_data_id, bool $expand_paths) : string {
  * @return string The original string with '$find' replaced by '$replace'
  */
 function stri_replace(string $find, string $replace, string $string) : string {
-	$parts = explode(strtolower($find), strtolower($string));
+	$parts = explode(cacti_strtolower($find), cacti_strtolower($string));
 
 	$pos = 0;
 
@@ -3458,7 +3458,7 @@ function generate_data_source_path($local_data_id) {
 			$new_path = "<path_rra>/$local_data_id.rrd";
 		}
 	} else {
-		$host_part = strtolower(clean_up_file_name($host_name)) . '_';
+		$host_part = cacti_strtolower(clean_up_file_name($host_name)) . '_';
 
 		// then try and use the internal DS name to identify it
 		$data_source_rrd_name = db_fetch_cell_prepared('SELECT data_source_name
@@ -3470,7 +3470,7 @@ function generate_data_source_path($local_data_id) {
 		);
 
 		if (!empty($data_source_rrd_name)) {
-			$ds_part = strtolower(clean_up_file_name($data_source_rrd_name));
+			$ds_part = cacti_strtolower(clean_up_file_name($data_source_rrd_name));
 		} else {
 			$ds_part = 'ds';
 		}
@@ -5440,7 +5440,7 @@ function mailer(array|string $from, array|string $to, null|array|string $cc = nu
 		$secure = read_config_option('settings_oauth2_secure');
 
 		if (!empty($secure) && $secure != 'none') {
-			$mail->SMTPSecure = strtolower($secure);
+			$mail->SMTPSecure = cacti_strtolower($secure);
 		} else {
 			$mail->SMTPAutoTLS = false;
 		}
@@ -6159,7 +6159,7 @@ function get_dns_from_ip(string $ip, string $dns, int $timeout = 1000) : string 
 			// null terminated string, so length 0 = finished
 			if ($len[1] == 0) {
 				// return the hostname, without the trailing '.'
-				return strtoupper(substr($host, 0, strlen($host) - 1));
+				return cacti_strtoupper(substr($host, 0, strlen($host) - 1));
 			}
 
 			// add the next segment to our host
@@ -6171,7 +6171,7 @@ function get_dns_from_ip(string $ip, string $dns, int $timeout = 1000) : string 
 	}
 
 	// error - return the hostname
-	return strtoupper($ip);
+	return cacti_strtoupper($ip);
 }
 
 function poller_maintenance() : void {
@@ -6469,7 +6469,7 @@ function get_classic_tabimage(string $text, bool $down = false) : mixed {
 	if ($text == '') {
 		return false;
 	}
-	$text = strtolower($text);
+	$text = cacti_strtolower($text);
 
 	$possibles = [
 		['DejaVuSans-Bold.ttf', 9, true],
@@ -7083,7 +7083,7 @@ function repair_system_data_input_methods(string $step = 'import') : void {
 				[$data_input_id]);
 
 			if (cacti_sizeof($bad_hashes)) {
-				cacti_log(strtoupper($step) . ' NOTE: Repairing ' . cacti_sizeof($bad_hashes) . ' Damaged data_input_fields', false);
+				cacti_log(cacti_strtoupper($step) . ' NOTE: Repairing ' . cacti_sizeof($bad_hashes) . ' Damaged data_input_fields', false);
 
 				foreach ($bad_hashes as $bhash) {
 					$good_field_id = db_fetch_cell_prepared('SELECT id
@@ -7105,7 +7105,7 @@ function repair_system_data_input_methods(string $step = 'import') : void {
 							[$bhash['id']]);
 
 						if (cacti_sizeof($bad_mappings)) {
-							cacti_log(strtoupper($step) . ' NOTE: Found ' . cacti_sizeof($bad_mappings) . ' Damaged data_input_fields', false);
+							cacti_log(cacti_strtoupper($step) . ' NOTE: Found ' . cacti_sizeof($bad_mappings) . ' Damaged data_input_fields', false);
 
 							foreach ($bad_mappings as $mfid) {
 								$good_found = db_fetch_cell_prepared('SELECT COUNT(*)
@@ -7144,7 +7144,7 @@ function repair_system_data_input_methods(string $step = 'import') : void {
 							[$bhash['id']]);
 
 						if (cacti_sizeof($bad_mappings)) {
-							cacti_log(strtoupper($step) . ' NOTE: Found ' . cacti_sizeof($bad_mappings) . ' Damaged data_template_rrd', false);
+							cacti_log(cacti_strtoupper($step) . ' NOTE: Found ' . cacti_sizeof($bad_mappings) . ' Damaged data_template_rrd', false);
 
 							foreach ($bad_mappings as $mfid) {
 								$good_found = db_fetch_cell_prepared('SELECT COUNT(*)
@@ -7201,7 +7201,7 @@ function repair_system_data_input_methods(string $step = 'import') : void {
 	}
 }
 
-if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && !function_exists('posix_kill')) {
+if (cacti_strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' && !function_exists('posix_kill')) {
 	if (!defined('SIGTERM')) {
 		define('SIGTERM', 15);
 	}
@@ -7792,7 +7792,7 @@ function char_to_dec(string $part) : int {
 		$part = substr($part, -1);
 	}
 
-	return ord(strtoupper($part)) - ord('0');
+	return ord(cacti_strtoupper($part)) - ord('0');
 }
 
 /**
@@ -8532,14 +8532,45 @@ function cacti_count(mixed $array) : int {
 	return ($array === false || !is_array($array)) ? 0 : count($array);
 }
 
+/**
+ * cacti_strtolower - Locale-independent lowercase conversion
+ *
+ * PHP 8.5 deprecates locale-sensitive cacti_strtolower(). This wrapper
+ * uses mb_strtolower with explicit UTF-8 encoding to avoid
+ * locale-dependent behavior. All Cacti string comparisons are
+ * ASCII or UTF-8, never locale-sensitive.
+ *
+ * @param string $string The string to convert
+ *
+ * @return string The lowercased string
+ */
+function cacti_strtolower(string $string) : string {
+	return mb_strtolower($string, 'UTF-8');
+}
+
+/**
+ * cacti_strtoupper - Locale-independent uppercase conversion
+ *
+ * PHP 8.5 deprecates locale-sensitive cacti_strtoupper(). This wrapper
+ * uses mb_strtoupper with explicit UTF-8 encoding to avoid
+ * locale-dependent behavior.
+ *
+ * @param string $string The string to convert
+ *
+ * @return string The uppercased string
+ */
+function cacti_strtoupper(string $string) : string {
+	return mb_strtoupper($string, 'UTF-8');
+}
+
 function is_function_enabled(string $name) : bool {
 	return function_exists($name) &&
 		!in_array($name, array_map('trim', explode(', ', ini_get('disable_functions'))), true) &&
-		strtolower(ini_get('safe_mode')) != 1;
+		cacti_strtolower(ini_get('safe_mode')) != 1;
 }
 
 function is_page_ajax() : bool {
-	if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') {
+	if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && cacti_strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') {
 		return true;
 	}
 
@@ -9488,14 +9519,14 @@ function cacti_unserialize(string $strobj) : mixed {
 function detect_cpu_cores() : int {
 	$cpu_cores = 0;
 
-	if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+	if (str_starts_with(cacti_strtoupper(PHP_OS), 'WIN')) {
 		$output = shell_exec('powershell -Command "Get-WmiObject Win32_Processor | Select-Object NumberOfLogicalProcessors"');
 
 		if (!is_null($output) && $output !== false) {
 			preg_match_all('/\d+/', $output, $matches);
 			$cpu_cores = array_sum($matches[0]);
 		}
-	} elseif (substr_count(strtolower(PHP_OS), 'darwin')) {
+	} elseif (substr_count(cacti_strtolower(PHP_OS), 'darwin')) {
 		$cpu_cores = shell_exec('sysctl -n hw.ncpu');
 	} else {
 		if (file_exists('/usr/bin/nproc')) {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -8535,7 +8535,7 @@ function cacti_count(mixed $array) : int {
 /**
  * cacti_strtolower - Locale-independent lowercase conversion
  *
- * PHP 8.5 deprecates locale-sensitive cacti_strtolower(). This wrapper
+ * PHP 8.5 deprecates locale-sensitive strtolower(). This wrapper
  * uses mb_strtolower with explicit UTF-8 encoding to avoid
  * locale-dependent behavior. All Cacti string comparisons are
  * ASCII or UTF-8, never locale-sensitive.
@@ -8551,7 +8551,7 @@ function cacti_strtolower(string $string) : string {
 /**
  * cacti_strtoupper - Locale-independent uppercase conversion
  *
- * PHP 8.5 deprecates locale-sensitive cacti_strtoupper(). This wrapper
+ * PHP 8.5 deprecates locale-sensitive strtoupper(). This wrapper
  * uses mb_strtoupper with explicit UTF-8 encoding to avoid
  * locale-dependent behavior.
  *

--- a/lib/html.php
+++ b/lib/html.php
@@ -219,7 +219,7 @@ function html_filter_start_box(string $title, mixed $url_or_buttons = '', bool $
  *
  * @param array  $tabs        An associative array of tab variables and names
  *                            Alternatively an array of names that can be converted
- *                            using the strtoupper() function to titles.
+ *                            using the cacti_strtoupper() function to titles.
  * @param string $uri         A string of URL parameters like 'action=edit&id=x'
  * @param string $session_var An option session variable to use to store
  *                            the current tab status.  Defaults to the page
@@ -267,7 +267,7 @@ function html_sub_tabs(array $tabs, string $uri = '', string $session_var = '') 
 			if (is_numeric($id)) {
 				print "<li class='subTab'>
 					<a class='pic" . ($name == $current_tab ? ' selected' : '') . "'
-					href='" . htmle($page_name . 'tab=' . $name) . "'>" . strtoupper($name) . '</a>
+					href='" . htmle($page_name . 'tab=' . $name) . "'>" . cacti_strtoupper($name) . '</a>
 				</li>';
 			} else {
 				print "<li class='subTab'>
@@ -857,9 +857,9 @@ function html_header_sort(array $header_items, string $sort_column, string $sort
 			$tip   = '';
 		}
 
-		if (strtolower($icon) == 'asc') {
+		if (cacti_strtolower($icon) == 'asc') {
 			$icon = 'ti ti-caret-up-filled';
-		} elseif (strtolower($icon) == 'desc') {
+		} elseif (cacti_strtolower($icon) == 'desc') {
 			$icon = 'ti ti-caret-down-filled';
 		} else {
 			$icon = 'ti ti-caret-up-down-filled';
@@ -1055,9 +1055,9 @@ function html_header_sort_checkbox(array $header_items, string $sort_column, str
 			$tip   = '';
 		}
 
-		if (strtolower($icon) == 'asc') {
+		if (cacti_strtolower($icon) == 'asc') {
 			$icon = 'ti ti-caret-up-filled';
-		} elseif (strtolower($icon) == 'desc') {
+		} elseif (cacti_strtolower($icon) == 'desc') {
 			$icon = 'ti ti-caret-down-filled';
 		} else {
 			$icon = 'ti ti-caret-down-filled';
@@ -1843,7 +1843,7 @@ function draw_menu(mixed $user_menu = '') : void {
 
 		if ($show_header_items == true) {
 			// Let's give our menu li's a unique id
-			$id = 'menu_' . strtolower(clean_up_name($header_name));
+			$id = 'menu_' . cacti_strtolower(clean_up_name($header_name));
 
 			if (isset($headers[$id])) {
 				$id .= '_' . $i++;

--- a/lib/html_form.php
+++ b/lib/html_form.php
@@ -1007,9 +1007,9 @@ function form_droplanguage(string $form_name, string $column_display, string $co
 		$flags = explode('-', $key);
 
 		if (cacti_count($flags) > 1) {
-			$flagName = strtolower($flags[1]);
+			$flagName = cacti_strtolower($flags[1]);
 		} else {
-			$flagName = strtolower($flags[0]);
+			$flagName = cacti_strtolower($flags[0]);
 		}
 
 		print '<option value=\'' . $key . '\'' . $selected . ' data-class=\'fi-' . $flagName . '\'><span class="fi fis fi-' . $flagName . '"></span>' . __($value) . '</option>';

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -2097,9 +2097,9 @@ class Installer implements JsonSerializable {
 			$flags = explode('-', $key);
 
 			if (cacti_count($flags) > 1) {
-				$flagName = strtolower($flags[1]);
+				$flagName = cacti_strtolower($flags[1]);
 			} else {
-				$flagName = strtolower($flags[0]);
+				$flagName = cacti_strtolower($flags[0]);
 			}
 			$langOutput .= '<option value=\'' . $key . '\'' . $selected . ' data-class=\'fi-' . $flagName . '\'><span class="fi fis fi-' . $flagName . '"></span>' . $value . '</option>';
 		}

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -182,25 +182,25 @@ class Net_Ping {
 				 * but this field has already been verified. The other fields are
 				 * numerical fields only and thus not vulnerable for command injection.
 				 */
-				if (substr_count(strtolower(PHP_OS), 'sun')) {
+				if (substr_count(cacti_strtolower(PHP_OS), 'sun')) {
 					$result = shell_exec('ping ' . $this->host['hostname']);
-				} elseif (substr_count(strtolower(PHP_OS), 'hpux')) {
+				} elseif (substr_count(cacti_strtolower(PHP_OS), 'hpux')) {
 					$result = shell_exec('ping -m ' . ceil($this->timeout / 1000) . ' -n ' . $this->retries . ' ' . $this->host['hostname']);
-				} elseif (substr_count(strtolower(PHP_OS), 'mac')) {
+				} elseif (substr_count(cacti_strtolower(PHP_OS), 'mac')) {
 					$result = shell_exec('ping -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
-				} elseif (substr_count(strtolower(PHP_OS), 'freebsd')) {
+				} elseif (substr_count(cacti_strtolower(PHP_OS), 'freebsd')) {
 					if (str_contains($this->host['hostname'], ':')) {
 						$result = shell_exec('ping6 -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
 					} else {
 						$result = shell_exec('ping -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
 					}
-				} elseif (substr_count(strtolower(PHP_OS), 'darwin')) {
+				} elseif (substr_count(cacti_strtolower(PHP_OS), 'darwin')) {
 					$result = shell_exec('ping -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
-				} elseif (substr_count(strtolower(PHP_OS), 'bsd')) {
+				} elseif (substr_count(cacti_strtolower(PHP_OS), 'bsd')) {
 					$result = shell_exec('ping -w ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
-				} elseif (substr_count(strtolower(PHP_OS), 'aix')) {
+				} elseif (substr_count(cacti_strtolower(PHP_OS), 'aix')) {
 					$result = shell_exec('ping -i ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
-				} elseif (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+				} elseif (cacti_strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 					$result = shell_exec('chcp 437 && ping -w ' . $this->timeout . ' -n ' . $this->retries . ' ' . $this->host['hostname']);
 				} else {
 					/**
@@ -764,23 +764,23 @@ class Net_Ping {
 	function strip_ip_address(string $ip_address) : string {
 		// clean up hostname if specifying snmp_transport
 		if (str_contains($ip_address, 'tcp6:')) {
-			$ip_address = str_replace('tcp6:', '', strtolower($ip_address));
+			$ip_address = str_replace('tcp6:', '', cacti_strtolower($ip_address));
 
 			if (str_contains($ip_address, '[')) {
 				$parts      = explode(']', $ip_address);
 				$ip_address = trim($parts[0], '[');
 			}
 		} elseif (str_contains($ip_address, 'udp6:')) {
-			$ip_address = str_replace('udp6:', '', strtolower($ip_address));
+			$ip_address = str_replace('udp6:', '', cacti_strtolower($ip_address));
 
 			if (str_contains($ip_address, '[')) {
 				$parts      = explode(']', $ip_address);
 				$ip_address = trim($parts[0], '[');
 			}
 		} elseif (str_contains($ip_address, 'tcp:')) {
-			$ip_address = str_replace('tcp:', '', strtolower($ip_address));
+			$ip_address = str_replace('tcp:', '', cacti_strtolower($ip_address));
 		} elseif (str_contains($ip_address, 'udp:')) {
-			$ip_address = str_replace('udp:', '', strtolower($ip_address));
+			$ip_address = str_replace('udp:', '', cacti_strtolower($ip_address));
 		}
 
 		return $ip_address;

--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -494,7 +494,7 @@ function api_plugin_db_table_create(string $plugin, string $table, array $data) 
 				}
 
 				if (isset($column['default'])) {
-					if (strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
+					if (cacti_strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
 						$sql .= ' default CURRENT_TIMESTAMP';
 					} else {
 						$sql .= ' default ' . (is_numeric($column['default']) ? $column['default'] : "'" . $column['default'] . "'");
@@ -535,7 +535,7 @@ function api_plugin_db_table_create(string $plugin, string $table, array $data) 
 			$sql .= ' DEFAULT CHARSET = ' . $data['charset'];
 		}
 
-		if (isset($data['row_format']) && strtolower(db_get_global_variable('innodb_file_format')) == 'barracuda') {
+		if (isset($data['row_format']) && cacti_strtolower(db_get_global_variable('innodb_file_format')) == 'barracuda') {
 			$sql .= ' ROW_FORMAT = ' . $data['row_format'];
 		}
 
@@ -637,7 +637,7 @@ function api_plugin_db_add_column(string $plugin, string $table, array $column) 
 		}
 
 		if (isset($column['default'])) {
-			if (strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
+			if (cacti_strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
 				$sql .= ' default CURRENT_TIMESTAMP';
 			} else {
 				$sql .= ' default ' . (is_numeric($column['default']) ? $column['default'] : "'" . $column['default'] . "'");
@@ -1872,7 +1872,7 @@ function plugin_load_info_defaults(string $file, mixed $info, array $defaults = 
 	if ($info_fields['status'] == 0) {
 		if (str_contains($dir, ' ')) {
 			$result['status'] = -3;
-		} elseif (strtolower($dir) != strtolower($result['name'])) {
+		} elseif (cacti_strtolower($dir) != cacti_strtolower($result['name'])) {
 			$result['status'] = -2;
 		} elseif (!isset($result['compat']) || cacti_version_compare(CACTI_VERSION, $result['compat'], '<')) {
 			$result['status'] = -1;

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -898,7 +898,7 @@ function update_resource_cache($poller_id = 1) : bool {
 				$pathinfo = pathinfo($path['path']);
 
 				if (isset($pathinfo['extension'])) {
-					$extension = strtolower($pathinfo['extension']);
+					$extension = cacti_strtolower($pathinfo['extension']);
 				} else {
 					$extension = '';
 				}
@@ -959,7 +959,7 @@ function update_resource_cache($poller_id = 1) : bool {
 									$pathinfo = pathinfo($fpath);
 
 									if (isset($pathinfo['extension'])) {
-										$extension = strtolower($pathinfo['extension']);
+										$extension = cacti_strtolower($pathinfo['extension']);
 									} else {
 										$extension = '';
 									}
@@ -1063,7 +1063,7 @@ function cache_in_path(string $path, string $type, bool $recursive = true) : voi
 		$pathinfo            = pathinfo($path);
 
 		if (isset($pathinfo['extension'])) {
-			$extension = strtolower($pathinfo['extension']);
+			$extension = cacti_strtolower($pathinfo['extension']);
 		} else {
 			$extension = '';
 		}
@@ -1140,7 +1140,7 @@ function update_db_from_path(string $path, string $type, bool $recursive = true)
 					$pathinfo = pathinfo($entry);
 
 					if (isset($pathinfo['extension'])) {
-						$extension = strtolower($pathinfo['extension']);
+						$extension = cacti_strtolower($pathinfo['extension']);
 					} else {
 						$extension = '';
 					}
@@ -1178,7 +1178,7 @@ function update_db_from_path(string $path, string $type, bool $recursive = true)
 			$pathinfo = pathinfo($path);
 
 			if (isset($pathinfo['extension'])) {
-				$extension = strtolower($pathinfo['extension']);
+				$extension = cacti_strtolower($pathinfo['extension']);
 			} else {
 				$extension = '';
 			}
@@ -1362,7 +1362,7 @@ function md5sum_path(string $path, bool $recursive = true) : mixed {
 			$pathinfo = pathinfo($entry);
 
 			if (isset($pathinfo['extension'])) {
-				$extension = strtolower($pathinfo['extension']);
+				$extension = cacti_strtolower($pathinfo['extension']);
 			} else {
 				$extension = '';
 			}

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -2391,7 +2391,7 @@ function reports_run(int $id) : bool {
 	$output      = [];
 	$command     = $report['run_command'] . ' --report-id=' . $report['source_id'] . ' --queue-id=' . $id;
 	$timeout     = $report['run_timeout'];
-	$source      = strtoupper($report['source']);
+	$source      = cacti_strtoupper($report['source']);
 
 	if ($timeout == 0) {
 		$timeout = read_config_option('scheduler_timeout');

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1146,7 +1146,7 @@ function rrdtool_function_fetch(int $local_data_id, int $start_time, int $end_ti
 
 				// process out bad data
 				foreach ($data as $index => $number) {
-					if (strtolower($number) == 'nan' || strtolower($number) == '-nan') {
+					if (cacti_strtolower($number) == 'nan' || cacti_strtolower($number) == '-nan') {
 						if ($show_unknown) {
 							$fetch_array['values'][$index][$timestamp] = 'U';
 						}
@@ -2963,7 +2963,7 @@ function rrdtool_function_theme_font_options(array &$graph_data_array) : string 
 
 		if (isset(${$themecolors}) && is_array(${$themecolors})) { // @phpstan-ignore-line
 			foreach (${$themecolors} as $colortag => $color) { // @phpstan-ignore-line
-				$graph_opts .= '--color ' . strtoupper($colortag) . '#' . strtoupper($color) . RRD_NL;
+				$graph_opts .= '--color ' . cacti_strtoupper($colortag) . '#' . cacti_strtoupper($color) . RRD_NL;
 			}
 		}
 
@@ -3033,7 +3033,7 @@ function rrdtool_function_set_font(string $type, string $no_legend, array $theme
 		$size = 8;
 	}
 
-	return '--font ' . strtoupper($type) . ':' . floatval($size) . ':' . $font . RRD_NL;
+	return '--font ' . cacti_strtoupper($type) . ':' . floatval($size) . ':' . $font . RRD_NL;
 }
 
 function rrd_substitute_host_query_data(string $txt_graph_item, array $graph, array $graph_item) : string {
@@ -3696,7 +3696,7 @@ function rrdtool_info2html(array $info_array, array $diff = []) : void {
 			form_selectable_cell(($value['cur_row'] ?? ''), 'cur_row', '', 'text-align:right');
 			form_selectable_cell(($value['pdp_per_row'] ?? ''), 'pdp_per_row', '', 'text-align:right');
 			form_selectable_cell((isset($value['xff']) ? floatval($value['xff']) : ''), 'xff', '', (isset($diff['rra'][$key]['xff']) ? 'color:red;text-align:right' : 'text-align:right'));
-			form_selectable_cell((isset($value['cdp_prep'][0]['value']) ? ((strtolower($value['cdp_prep'][0]['value']) == 'nan') ? $value['cdp_prep'][0]['value'] : floatval($value['cdp_prep'][0]['value'])) : ''), 'value', '', 'text-align:right');
+			form_selectable_cell((isset($value['cdp_prep'][0]['value']) ? ((cacti_strtolower($value['cdp_prep'][0]['value']) == 'nan') ? $value['cdp_prep'][0]['value'] : floatval($value['cdp_prep'][0]['value'])) : ''), 'value', '', 'text-align:right');
 			form_selectable_cell(($value['cdp_prep'][0]['unknown_datapoints'] ?? ''), 	'unknown_datapoints', '', 'text-align:right');
 
 			form_end_row();

--- a/lib/rrdcheck.php
+++ b/lib/rrdcheck.php
@@ -417,7 +417,7 @@ function do_rrdcheck(int $thread_id = 1) : void {
 									}
 								}
 
-								if (strtolower($number) == 'nan' || strtolower($number) == '-nan') {
+								if (cacti_strtolower($number) == 'nan' || cacti_strtolower($number) == '-nan') {
 									$nan_24[$index]++;
 
 									if ($lines_24 > $one_hour_limit) {
@@ -650,7 +650,7 @@ function rrdcheck_log_child_stats(string $type, int $thread_id, float $total_tim
 		WHERE name LIKE ?',
 		['rrdcheck_total_dsses_%' . $type . '_' . $thread_id . '%']);
 
-	$cacti_stats = sprintf('Time:%01.2f Type:%s ProcessNumber:%s RRDfiles:%s DSSes:%s RRDUser:%01.2f RRDSystem:%01.2f RRDReal:%01.2f', $total_time, strtoupper($type), $thread_id, $rrd_files, $dsses, $rrd_user, $rrd_system, $rrd_real);
+	$cacti_stats = sprintf('Time:%01.2f Type:%s ProcessNumber:%s RRDfiles:%s DSSes:%s RRDUser:%01.2f RRDSystem:%01.2f RRDReal:%01.2f', $total_time, cacti_strtoupper($type), $thread_id, $rrd_files, $dsses, $rrd_user, $rrd_system, $rrd_real);
 
 	cacti_log('RRDCHECK CHILD STATS: ' . $cacti_stats, true, 'SYSTEM');
 }

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -964,7 +964,7 @@ function format_snmp_string(string $string, bool $snmp_oid_included, int $value_
 		} else {
 			$possible_ip = false;
 		}
-	} elseif (str_starts_with(strtolower($string), 'hex:')) {
+	} elseif (str_starts_with(cacti_strtolower($string), 'hex:')) {
 		// strip off the 'Hex:'
 		$string = trim(str_ireplace('hex:', '', $string));
 

--- a/lib/snmpagent.php
+++ b/lib/snmpagent.php
@@ -914,7 +914,7 @@ function snmpagent_notification(string $notification, string $mib, array $varbin
 			foreach ($notification_managers as $notification_manager) {
 				if (!$snmp_notification_varbinds) {
 					foreach ($registered_var_binds as $name => $attributes) {
-						$snmp_notification_varbinds .= ' ' . $attributes['oid'] . ' ' . $smi2netsnmp_datatypes[strtolower($attributes['type'])] . ' "' . str_replace('"', "'", $varbinds[$name]) . '"';
+						$snmp_notification_varbinds .= ' ' . $attributes['oid'] . ' ' . $smi2netsnmp_datatypes[cacti_strtolower($attributes['type'])] . ' "' . str_replace('"', "'", $varbinds[$name]) . '"';
 						$log_notification_varbinds .= $name . ':"' . str_replace('"', "'", $varbinds[$name]) . '" ';
 					}
 				}

--- a/lib/time.php
+++ b/lib/time.php
@@ -193,7 +193,7 @@ function get_timespan(array &$span, int $curr_time, int $timespan_given, int $fi
  */
 function month_shift(string $shift_size) : bool {
 	// is monthly shifting required?
-	return (strpos(cacti_strtolower($shift_size), 'month') > 0);
+	return (strpos(cacti_strtolower($shift_size), 'month') !== false);
 }
 
 /**

--- a/lib/time.php
+++ b/lib/time.php
@@ -193,7 +193,7 @@ function get_timespan(array &$span, int $curr_time, int $timespan_given, int $fi
  */
 function month_shift(string $shift_size) : bool {
 	// is monthly shifting required?
-	return (strpos(strtolower($shift_size), 'month') > 0);
+	return (strpos(cacti_strtolower($shift_size), 'month') > 0);
 }
 
 /**

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -1683,7 +1683,7 @@ function utilities_php_modules() : string {
 
 function memory_bytes(mixed $val) : mixed {
 	$val  = trim($val);
-	$last = strtolower($val[strlen($val) - 1]);
+	$last = cacti_strtolower($val[strlen($val) - 1]);
 	$val  = (float) trim($val, 'GMKgmk');
 
 	switch($last) {
@@ -1876,7 +1876,7 @@ function utility_php_recommends() : array {
 }
 
 function utility_get_formatted_bytes(mixed $input_value, string $wanted_type, mixed &$output_value, string $default_type = 'B') : mixed {
-	$default_type = strtoupper($default_type);
+	$default_type = cacti_strtoupper($default_type);
 	$multiplier   = [
 		'B' => 1,
 		'K' => 1024,

--- a/plugins.php
+++ b/plugins.php
@@ -1380,7 +1380,7 @@ function format_plugin_row(array $plugin, bool $last_plugin, bool $include_order
 
 	$row = plugin_actions($plugin, $table);
 
-	$uname = strtoupper($plugin['plugin']);
+	$uname = cacti_strtoupper($plugin['plugin']);
 
 	if ($uname == $plugin['plugin']) {
 		$plugin_name = $uname;
@@ -1555,7 +1555,7 @@ function format_available_plugin_row(array $plugin, string $table) : string {
 
 	$row .= '</td>';
 
-	$uname = strtoupper($plugin['plugin']);
+	$uname = cacti_strtoupper($plugin['plugin']);
 
 	if ($uname == $plugin['plugin']) {
 		$plugin_name = $uname;
@@ -1664,7 +1664,7 @@ function format_archive_plugin_row(array $plugin, string $table) : string {
 	$row .= "<a class='pirmarchive' href='" . htmle(CACTI_PATH_URL . 'plugins.php?action=delete&plugin=' . $plugin['plugin'] . '&id=' . $plugin['id']) . "' title='" . __esc('Delete this Plugin archive') . "' class='linkEditMain'><i class='ti ti-trash deviceRecovering'></i></a>";
 	$row .= '</td>';
 
-	$uname = strtoupper($plugin['plugin']);
+	$uname = cacti_strtoupper($plugin['plugin']);
 
 	if ($uname == $plugin['plugin']) {
 		$plugin_name = $uname;
@@ -1923,7 +1923,7 @@ function plugin_actions(array $plugin, string $table) : string {
 
 			break;
 		case '-2': // Naming issues
-			$link .= "<a class='pierror' href='#' title='" . __esc('Plugin directory is not correct.  Should be \'%s\' but is \'%s\'', strtolower($plugin['plugin']), $plugin['plugin']) . "' class='linkEditMain'><i class='ti ti-settings-filled deviceUnknown'></i></a>";
+			$link .= "<a class='pierror' href='#' title='" . __esc('Plugin directory is not correct.  Should be \'%s\' but is \'%s\'', cacti_strtolower($plugin['plugin']), $plugin['plugin']) . "' class='linkEditMain'><i class='ti ti-settings-filled deviceUnknown'></i></a>";
 
 			break;
 		default: // Old PIA

--- a/poller.php
+++ b/poller.php
@@ -562,7 +562,7 @@ while ($poller_runs_completed < $poller_runs) {
 	$first_host        = 0;
 	$last_host         = 0;
 	$rrds_processed    = 0;
-	$webroot           = addslashes((CACTI_SERVER_OS == 'win32') ? strtr(strtolower(substr(__DIR__, 0, 1)) . substr(__DIR__, 1),'\\', '/') : __DIR__);
+	$webroot           = addslashes((CACTI_SERVER_OS == 'win32') ? strtr(cacti_strtolower(substr(__DIR__, 0, 1)) . substr(__DIR__, 1),'\\', '/') : __DIR__);
 
 	// update web paths for the poller
 	set_config_option('path_webroot', $webroot);
@@ -715,7 +715,7 @@ while ($poller_runs_completed < $poller_runs) {
 			$total_procs    = $concurrent_processes;
 		} else {
 			$command_string = cacti_escapeshellcmd(read_config_option('path_php_binary'));
-			$extra_args     = '-q ' . cacti_escapeshellarg(strtolower(CACTI_PATH_BASE . '/cmd.php'));
+			$extra_args     = '-q ' . cacti_escapeshellarg(cacti_strtolower(CACTI_PATH_BASE . '/cmd.php'));
 			$method         = 'cmd.php';
 			$total_procs    = $concurrent_processes;
 		}

--- a/poller_automation.php
+++ b/poller_automation.php
@@ -493,7 +493,7 @@ function discoverDevices(int $network_id, int $thread) : bool {
 
 					$device['hostname']      = $dnsname;
 					$device['dnsname']       = $dnsname;
-					$device['dnsname_short'] = explode('.', strtolower($dnsname))[0];
+					$device['dnsname_short'] = explode('.', cacti_strtolower($dnsname))[0];
 				} elseif ($network['enable_netbios'] == 'on') {
 					automation_debug('Device: ' . $device['ip_address'] . ', Checking DNS: Not found, Checking NetBIOS:');
 
@@ -535,7 +535,7 @@ function discoverDevices(int $network_id, int $thread) : bool {
 						[$dnsname, $device['ip_address']]);
 
 					$device['dnsname']       = $dnsname;
-					$device['dnsname_short'] = explode('.', strtolower($dnsname))[0];
+					$device['dnsname_short'] = explode('.', cacti_strtolower($dnsname))[0];
 				} elseif ($network['enable_netbios'] == 'on') {
 					automation_debug('Device: ' . $device['ip_address'] . ', Checking DNS: Not found, Checking NetBIOS:');
 

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -1430,8 +1430,8 @@ function boost_purge_cached_png_files(bool $forcerun) : void {
 
 						if ($modify_time < $remove_time) {
 							// only remove jpeg's and png's
-							if ((substr_count(strtolower($file), '.png')) ||
-								(substr_count(strtolower($file), '.jpg'))) {
+							if ((substr_count(cacti_strtolower($file), '.png')) ||
+								(substr_count(cacti_strtolower($file), '.jpg'))) {
 								unlink($file);
 							}
 						}

--- a/poller_maintenance.php
+++ b/poller_maintenance.php
@@ -799,7 +799,7 @@ function remove_files(array $file_array) : void {
 		if (read_config_option('storage_location') == 0) {
 			switch ($file['action']) {
 				case '1':
-					if (file_exists($real_file) && strtolower(pathinfo($real_file, PATHINFO_EXTENSION)) === 'rrd') {
+					if (file_exists($real_file) && cacti_strtolower(pathinfo($real_file, PATHINFO_EXTENSION)) === 'rrd') {
 						if (unlink($real_file)) {
 							maint_debug('Deleted: ' . $real_file);
 							$purged++;

--- a/script_server.php
+++ b/script_server.php
@@ -147,8 +147,8 @@ $start = microtime(true);
 $include_file = '';
 
 if (CACTI_SERVER_OS == 'win32') {
-	cacti_log('DEBUG: GETCWD: ' . strtolower(strtr(getcwd(),'\\','/')), false, 'PHPSVR', POLLER_VERBOSITY_DEBUG);
-	cacti_log('DEBUG: DIRNAM: ' . strtolower(strtr(__DIR__,'\\','/')), false, 'PHPSVR', POLLER_VERBOSITY_DEBUG);
+	cacti_log('DEBUG: GETCWD: ' . cacti_strtolower(strtr(getcwd(),'\\','/')), false, 'PHPSVR', POLLER_VERBOSITY_DEBUG);
+	cacti_log('DEBUG: DIRNAM: ' . cacti_strtolower(strtr(__DIR__,'\\','/')), false, 'PHPSVR', POLLER_VERBOSITY_DEBUG);
 } else {
 	cacti_log('DEBUG: GETCWD: ' . strtr(getcwd(),'\\','/'), false, 'PHPSVR', POLLER_VERBOSITY_DEBUG);
 	cacti_log('DEBUG: DIRNAM: ' . strtr(__DIR__,'\\','/'), false, 'PHPSVR', POLLER_VERBOSITY_DEBUG);
@@ -188,7 +188,7 @@ while (1) {
 
 	if (empty($input_string)) {
 		if (!empty($parent_pid)) {
-			if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+			if (cacti_strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 				$out = [];
 				exec("TASKLIST /FO LIST /FI \"PID eq $parent_pid\"", $out);
 
@@ -278,7 +278,7 @@ while (1) {
 					 * path must be lower case
 					 */
 					if (CACTI_SERVER_OS == 'win32') {
-						$include_file = strtolower($include_file);
+						$include_file = cacti_strtolower($include_file);
 					}
 
 					/**

--- a/scripts/ss_aruba_oscx_6x00.php
+++ b/scripts/ss_aruba_oscx_6x00.php
@@ -195,9 +195,9 @@ function ss_aruba_oscx_6x00(int $host_id = 0, string $object = 'fan', string $cm
 				// ok = fan, normal = tempsensor
 				if ($what == 'state') {
 					if ($object == 'fan' || $object == 'power') {
-						print $index . ':' . (strtolower($value['value']) == 'ok' ? '1' : '0') . PHP_EOL;
+						print $index . ':' . (cacti_strtolower($value['value']) == 'ok' ? '1' : '0') . PHP_EOL;
 					} elseif ($object == 'temp') {
-						print $index . ':' . (strtolower($value['value']) == 'normal' ? '1' : '0') . PHP_EOL;
+						print $index . ':' . (cacti_strtolower($value['value']) == 'normal' ? '1' : '0') . PHP_EOL;
 					} elseif ($object == 'vsf') {
 						print $index . ':' . $state_table[$value['value']] . PHP_EOL;
 					}
@@ -254,11 +254,11 @@ function ss_aruba_oscx_6x00(int $host_id = 0, string $object = 'fan', string $cm
 
 		if ($what == 'state') {
 			if ($object == 'fan' || $object == 'power') {
-				return (strtolower($return_val) == 'ok' ? '1' : '0');
+				return (cacti_strtolower($return_val) == 'ok' ? '1' : '0');
 			}
 
 			if ($object == 'temp') {
-				return (strtolower($return_val) == 'normal' ? '1' : '0');
+				return (cacti_strtolower($return_val) == 'normal' ? '1' : '0');
 			}
 
 			if ($object == 'vsf') {

--- a/scripts/ss_esxi_vhosts.php
+++ b/scripts/ss_esxi_vhosts.php
@@ -42,7 +42,7 @@ function ss_esxi_vhosts(int $device_id) : string {
 
 	if (cacti_sizeof($array)) {
 		foreach ($array as $key => $value) {
-			if (strtolower(trim($value['value'])) == 'powered on' || strtolower(trim($value['value'])) == 'poweredon') {
+			if (cacti_strtolower(trim($value['value'])) == 'powered on' || cacti_strtolower(trim($value['value'])) == 'poweredon') {
 				$vh_state++;
 			}
 		}

--- a/scripts/ss_fping.php
+++ b/scripts/ss_fping.php
@@ -69,7 +69,7 @@ function ss_fping(string $hostname = '', int $ping_sweeps = 6, string $ping_type
 		$ping_timeout = read_config_option('ping_timeout');
 	}
 
-	switch (strtoupper($ping_type)) {
+	switch (cacti_strtoupper($ping_type)) {
 		case 'ICMP':
 			$method = PING_ICMP;
 

--- a/scripts/ss_netsnmp_lmsensors.php
+++ b/scripts/ss_netsnmp_lmsensors.php
@@ -61,7 +61,7 @@ function ss_netsnmp_lmsensors(int $host_id = 0, string $sensor_type = '', string
 		return 'U';
 	}
 
-	$sensor_type = strtolower(trim($sensor_type));
+	$sensor_type = cacti_strtolower(trim($sensor_type));
 
 	if (($sensor_type != 'fan') && ($sensor_type != 'temperature') && ($sensor_type != 'voltage')) {
 		cacti_log(sprintf('ERROR: Device with ID %s has an invalid Sensor Type of %s', $host_id, $sensor_type), false, 'LMSENSORS');
@@ -69,7 +69,7 @@ function ss_netsnmp_lmsensors(int $host_id = 0, string $sensor_type = '', string
 		return 'U';
 	}
 
-	$cacti_request = strtolower(trim($cacti_request));
+	$cacti_request = cacti_strtolower(trim($cacti_request));
 
 	if ($cacti_request == '') {
 		cacti_log(sprintf('ERROR: Device with ID %s has an empty request type', $host_id), false, 'LMSENSORS');
@@ -87,7 +87,7 @@ function ss_netsnmp_lmsensors(int $host_id = 0, string $sensor_type = '', string
 	// remaining function arguments are $data_request and $data_request_key
 	// ------------------------------------------------------------------------------------
 	if ($cacti_request == 'query' || $cacti_request == 'get') {
-		$data_request = strtolower(trim($data_request));
+		$data_request = cacti_strtolower(trim($data_request));
 
 		if ($data_request == '') {
 			cacti_log(sprintf('ERROR: Device with ID %s has an empty get or query data request.', $host_id), false, 'LMSENSORS');
@@ -105,7 +105,7 @@ function ss_netsnmp_lmsensors(int $host_id = 0, string $sensor_type = '', string
 		// get the index variable
 		// ------------------------------------------------------------------------------------
 		if ($cacti_request == 'get') {
-			$data_request_key = strtolower(trim($data_request_key));
+			$data_request_key = cacti_strtolower(trim($data_request_key));
 
 			if ($data_request_key == '') {
 				cacti_log(sprintf('ERROR: Device with ID %s has an empty get or query data request.', $host_id), false, 'LMSENSORS');

--- a/snmpagent_mibcache.php
+++ b/snmpagent_mibcache.php
@@ -50,7 +50,7 @@ $php        = cacti_escapeshellcmd(read_config_option('path_php_binary'));
 $extra_args = ' ' . cacti_escapeshellarg('./snmpagent_mibcachechild.php');
 
 while (true) {
-	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+	if (cacti_strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 		popen('start "CactiSNMPCacheChild" /I ' . $php . ' ' . $extra_args, 'r');
 	} else {
 		exec($php . ' ' . $extra_args . ' > /dev/null &');

--- a/snmpagent_persist.php
+++ b/snmpagent_persist.php
@@ -78,7 +78,7 @@ get_options();
 $php            = cacti_escapeshellcmd(read_config_option('path_php_binary'));
 $extra_args     = '-q ' . cacti_escapeshellarg('./snmpagent_mibcache.php');
 
-if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+if (cacti_strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 	// windows part missing
 	pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 } else {

--- a/support.php
+++ b/support.php
@@ -808,7 +808,7 @@ function show_cacti_processes() : void {
 			}
 
 			form_selectable_cell($p['tasktype'], $p['pid']);
-			form_selectable_cell(filter_value(strtoupper($p['taskname']), ''), $p['pid']);
+			form_selectable_cell(filter_value(cacti_strtoupper($p['taskname']), ''), $p['pid']);
 			form_selectable_cell($p['taskid'], $p['pid'], '', 'right');
 			form_selectable_cell($p['runtime'], $p['pid'], '', 'right');
 			form_selectable_cell($p['pid'], $p['pid'], '', 'right');

--- a/templates_export.php
+++ b/templates_export.php
@@ -72,7 +72,7 @@ function form_save() : void {
 				header('Location: templates_export.php');
 			} else {
 				header('Content-type: application/xml');
-				header('Content-Disposition: attachment; filename=cacti_' . gnrv('export_type') . '_' . strtolower(clean_up_file_name(db_fetch_cell(str_replace('|id|', gnrv('export_item_id'), $export_types[gnrv('export_type')]['title_sql'])))) . '.xml');
+				header('Content-Disposition: attachment; filename=cacti_' . gnrv('export_type') . '_' . cacti_strtolower(clean_up_file_name(db_fetch_cell(str_replace('|id|', gnrv('export_item_id'), $export_types[gnrv('export_type')]['title_sql'])))) . '.xml');
 				print $xml_data;
 			}
 		}

--- a/tests/Unit/CactiStrtolowerTest.php
+++ b/tests/Unit/CactiStrtolowerTest.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once __DIR__ . '/../../lib/functions.php';
+
+// cacti_strtolower tests
+
+test('cacti_strtolower converts ASCII uppercase', function () {
+	expect(cacti_strtolower('HELLO'))->toBe('hello');
+});
+
+test('cacti_strtolower preserves lowercase', function () {
+	expect(cacti_strtolower('hello'))->toBe('hello');
+});
+
+test('cacti_strtolower handles mixed case', function () {
+	expect(cacti_strtolower('HeLLo WoRLd'))->toBe('hello world');
+});
+
+test('cacti_strtolower handles empty string', function () {
+	expect(cacti_strtolower(''))->toBe('');
+});
+
+test('cacti_strtolower handles protocol names', function () {
+	expect(cacti_strtolower('TCP'))->toBe('tcp');
+	expect(cacti_strtolower('UDP6'))->toBe('udp6');
+	expect(cacti_strtolower('HTTPS'))->toBe('https');
+});
+
+test('cacti_strtolower handles config values', function () {
+	expect(cacti_strtolower('ON'))->toBe('on');
+	expect(cacti_strtolower('Off'))->toBe('off');
+});
+
+test('cacti_strtolower handles UTF-8 characters', function () {
+	expect(cacti_strtolower('ÜBER'))->toBe('über');
+});
+
+test('cacti_strtolower handles numeric strings', function () {
+	expect(cacti_strtolower('123ABC'))->toBe('123abc');
+});
+
+test('cacti_strtolower handles NaN detection pattern', function () {
+	expect(cacti_strtolower('NaN'))->toBe('nan');
+	expect(cacti_strtolower('-NaN'))->toBe('-nan');
+});
+
+test('cacti_strtolower handles file extensions', function () {
+	expect(cacti_strtolower('RRD'))->toBe('rrd');
+	expect(cacti_strtolower('PNG'))->toBe('png');
+});
+
+// cacti_strtoupper tests
+
+test('cacti_strtoupper converts ASCII lowercase', function () {
+	expect(cacti_strtoupper('hello'))->toBe('HELLO');
+});
+
+test('cacti_strtoupper preserves uppercase', function () {
+	expect(cacti_strtoupper('HELLO'))->toBe('HELLO');
+});
+
+test('cacti_strtoupper handles empty string', function () {
+	expect(cacti_strtoupper(''))->toBe('');
+});
+
+test('cacti_strtoupper handles hex strings', function () {
+	expect(cacti_strtoupper('0a1b2c'))->toBe('0A1B2C');
+	expect(cacti_strtoupper('ff'))->toBe('FF');
+});
+
+test('cacti_strtoupper handles PHP_OS pattern', function () {
+	expect(cacti_strtoupper('win'))->toBe('WIN');
+	expect(cacti_strtoupper('Lin'))->toBe('LIN');
+});
+
+test('cacti_strtoupper handles plugin names', function () {
+	expect(cacti_strtoupper('thold'))->toBe('THOLD');
+});
+
+test('cacti_strtoupper handles UTF-8 characters', function () {
+	expect(cacti_strtoupper('über'))->toBe('ÜBER');
+});
+
+test('cacti_strtoupper handles path constants pattern', function () {
+	expect(cacti_strtoupper('base'))->toBe('BASE');
+	expect(cacti_strtoupper('library'))->toBe('LIBRARY');
+});

--- a/utilities.php
+++ b/utilities.php
@@ -1204,8 +1204,8 @@ function boost_display_run_status() : void {
 				// check and fry as applicable
 				foreach ($directory_contents as $file) {
 					// only remove jpeg's and png's
-					if ((substr_count(strtolower($file), '.png')) ||
-						(substr_count(strtolower($file), '.jpg'))) {
+					if ((substr_count(cacti_strtolower($file), '.png')) ||
+						(substr_count(cacti_strtolower($file), '.jpg'))) {
 						$cache_files++;
 						$directory_size += filesize($file);
 					}


### PR DESCRIPTION
## Summary
- Add `cacti_strtolower()` and `cacti_strtoupper()` wrappers using `mb_strtolower`/`mb_strtoupper` with explicit UTF-8 encoding
- Replace all 185 `strtolower()`/`strtoupper()` call sites across 65 files
- PHP 8.5 deprecates locale-sensitive `strtolower()` and `strtoupper()`; these wrappers ensure locale-independent behavior

## Details
The wrappers are placed in `lib/functions.php` alongside `cacti_sizeof()` and `cacti_count()`. Existing `mb_strtolower()` calls (2 instances for email normalization) are left unchanged since they already specify encoding explicitly.

## Test plan
- [x] 18 Pest tests in `tests/Unit/CactiStrtolowerTest.php` covering ASCII, UTF-8, protocol names, config values, hex strings, NaN detection, and file extension patterns
- [ ] Verify no locale-dependent behavior regressions in SNMP, ping, and data query paths
- [ ] Confirm no remaining raw `strtolower()`/`strtoupper()` calls outside `include/vendor/`