### PR TITLE
fix: replace deprecated backtick operator with shell_exec()

### DIFF
--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,8 +644,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -658,8 +656,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -672,8 +668,6 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
-			} else {
-				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -791,7 +785,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON gti.task_item_id = dtr.id
+				ON dtr.id = gti.task_item_id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1594,143 +1588,6 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
-/**
- * Handles the aggregation of stacked lines for a given graph.
- *
- * @param int    $local_graph_id   The ID of the local graph.
- * @param string $_orig_graph_type The original type of the graph.
- * @param int    $_total           The total value to be aggregated.
- * @param string $_total_type      The type of the total value.
- * @param string $_total_prefix    The prefix for the total value.
- *
- * @return void
- */
-function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
-	// Handle the stacked line cases switch line widths
-	$width        = '0.01';
-	$special_type = '';
-	$special_line = false;
-
-	switch ($_orig_graph_type) {
-		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
-			$width        = '1.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE1;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
-			$width        = '2.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE2;
-			$special_line = true;
-
-			break;
-		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
-			$width        = '3.00';
-			$special_type = GRAPH_ITEM_TYPE_LINE3;
-			$special_line = true;
-
-			break;
-	}
-
-	if ($special_line) {
-		if ($_total == AGGREGATE_TOTAL_NONE) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET line_width = ?
-				WHERE local_graph_id = ?
-				AND graph_type_id IN (?)',
-				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
-		}
-
-		// Handle special case total prefix
-		db_execute_prepared('UPDATE graph_templates_item
-			SET graph_type_id = ?
-			WHERE local_graph_id = ?
-			AND text_format = ?',
-			[$special_type, $local_graph_id, $_total_prefix]);
-
-		if ($_total == AGGREGATE_TOTAL_ALL) {
-			db_execute_prepared('UPDATE graph_templates_item
-				SET graph_type_id = ?, line_width = "0.01"
-				WHERE local_graph_id = ?
-				AND graph_type_id = ?
-				AND text_format != ?',
-				[
-					GRAPH_ITEM_TYPE_LINESTACK,
-					$local_graph_id,
-					$special_type,
-					$_total_prefix
-				]
-			);
-		}
-	}
-
-	// handle any missing lines
-	db_execute_prepared('UPDATE graph_templates_item
-		SET line_width="0.01"
-		WHERE graph_type_id = ?
-		AND line_width="0.00"
-		AND local_graph_id = ?',
-		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
-}
-
-/**
- * Retrieves data sources for aggregation.
- *
- * @param array  $graph_array    Array of graphs to aggregate.
- * @param mixed  $data_sources   Array to store the retrieved data sources.
- * @param mixed  $graph_template Template for the graphs.
- * @param string $message        Optional. Message to store any errors or information.
- *
- * @return bool True on success, false on failure.
- */
-function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
-	if (cacti_sizeof($graph_array)) {
-		// fetch all data sources for all selected graphs
-		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
-			FROM data_template_rrd AS dtr
-			INNER JOIN graph_templates_item AS gti
-			ON dtr.id = gti.task_item_id
-			INNER JOIN data_template_data AS dtd
-			ON dtr.local_data_id = dtd.local_data_id
-			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
-			AND dtd.local_data_id > 0
-			GROUP BY dtd.local_data_id
-			ORDER BY dtd.name_cache');
-
-		// verify, that only a single graph template is used, else
-		// aggregate will look funny
-		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
-			FROM graph_local AS gl
-			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
-
-		if (cacti_sizeof($templates) > 1) {
-			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
-
-			return false;
-		}
-
-		if (cacti_sizeof($templates) == 1) {
-			if ($templates[0]['id'] == 0) {
-				// selected graphs do not use templates
-				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
-
-				return false;
-			} else {
-				$graph_template = $templates[0]['id'];
-
-				return true;
-			}
-		} else {
-			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
-
-			return false;
-		}
-	} else {
-		$message = __('You must pass at least a single Graph to this function');
-
-		return false;
-	}
-}
 
 /**
  * Draws the list of aggregate graph items.

--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -644,6 +644,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['color_template'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_color');
 			}
 		}
 
@@ -656,6 +658,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_skip'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_skip');
 			}
 		}
 
@@ -668,6 +672,8 @@ function aggregate_validate_graph_items(array $posted, array &$graph_items) : vo
 
 			if (isset($graph_items[$graph_templates_item_id])) {
 				$graph_items[$graph_templates_item_id]['item_total'] = $val;
+			} else {
+				cacti_log('Something fubar in agg_total');
 			}
 		}
 	}
@@ -785,7 +791,7 @@ function aggregate_reorder_ds_graph(int $base, string $graph_template_id, int $a
 			db_fetch_assoc_prepared("SELECT DISTINCT dtr.local_data_id
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
-				ON dtr.id = gti.task_item_id
+				ON gti.task_item_id = dtr.id
 				INNER JOIN aggregate_graphs_items AS agi
 				ON gti.local_graph_id = agi.local_graph_id
 				INNER JOIN graph_templates_graph AS gtg
@@ -1588,6 +1594,143 @@ function aggregate_handle_ptile_type(array $member_graphs, array $skipped_items,
 	}
 }
 
+/**
+ * Handles the aggregation of stacked lines for a given graph.
+ *
+ * @param int    $local_graph_id   The ID of the local graph.
+ * @param string $_orig_graph_type The original type of the graph.
+ * @param int    $_total           The total value to be aggregated.
+ * @param string $_total_type      The type of the total value.
+ * @param string $_total_prefix    The prefix for the total value.
+ *
+ * @return void
+ */
+function aggregate_handle_stacked_lines(int $local_graph_id, string $_orig_graph_type, int $_total, string $_total_type, string $_total_prefix) : void {
+	// Handle the stacked line cases switch line widths
+	$width        = '0.01';
+	$special_type = '';
+	$special_line = false;
+
+	switch ($_orig_graph_type) {
+		case AGGREGATE_GRAPH_TYPE_LINE1_STACK:
+			$width        = '1.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE1;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE2_STACK:
+			$width        = '2.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE2;
+			$special_line = true;
+
+			break;
+		case AGGREGATE_GRAPH_TYPE_LINE3_STACK:
+			$width        = '3.00';
+			$special_type = GRAPH_ITEM_TYPE_LINE3;
+			$special_line = true;
+
+			break;
+	}
+
+	if ($special_line) {
+		if ($_total == AGGREGATE_TOTAL_NONE) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET line_width = ?
+				WHERE local_graph_id = ?
+				AND graph_type_id IN (?)',
+				[$width, $local_graph_id, GRAPH_ITEM_TYPE_LINESTACK]);
+		}
+
+		// Handle special case total prefix
+		db_execute_prepared('UPDATE graph_templates_item
+			SET graph_type_id = ?
+			WHERE local_graph_id = ?
+			AND text_format = ?',
+			[$special_type, $local_graph_id, $_total_prefix]);
+
+		if ($_total == AGGREGATE_TOTAL_ALL) {
+			db_execute_prepared('UPDATE graph_templates_item
+				SET graph_type_id = ?, line_width = "0.01"
+				WHERE local_graph_id = ?
+				AND graph_type_id = ?
+				AND text_format != ?',
+				[
+					GRAPH_ITEM_TYPE_LINESTACK,
+					$local_graph_id,
+					$special_type,
+					$_total_prefix
+				]
+			);
+		}
+	}
+
+	// handle any missing lines
+	db_execute_prepared('UPDATE graph_templates_item
+		SET line_width="0.01"
+		WHERE graph_type_id = ?
+		AND line_width="0.00"
+		AND local_graph_id = ?',
+		[GRAPH_ITEM_TYPE_LINESTACK, $local_graph_id]);
+}
+
+/**
+ * Retrieves data sources for aggregation.
+ *
+ * @param array  $graph_array    Array of graphs to aggregate.
+ * @param mixed  $data_sources   Array to store the retrieved data sources.
+ * @param mixed  $graph_template Template for the graphs.
+ * @param string $message        Optional. Message to store any errors or information.
+ *
+ * @return bool True on success, false on failure.
+ */
+function aggregate_get_data_sources(array &$graph_array, mixed &$data_sources, mixed &$graph_template, string &$message = '') : bool {
+	if (cacti_sizeof($graph_array)) {
+		// fetch all data sources for all selected graphs
+		$data_sources = db_fetch_assoc('SELECT dtd.local_data_id, dtd.name_cache
+			FROM data_template_rrd AS dtr
+			INNER JOIN graph_templates_item AS gti
+			ON dtr.id = gti.task_item_id
+			INNER JOIN data_template_data AS dtd
+			ON dtr.local_data_id = dtd.local_data_id
+			WHERE ' . array_to_sql_or($graph_array, 'gti.local_graph_id') . '
+			AND dtd.local_data_id > 0
+			GROUP BY dtd.local_data_id
+			ORDER BY dtd.name_cache');
+
+		// verify, that only a single graph template is used, else
+		// aggregate will look funny
+		$templates = db_fetch_assoc('SELECT DISTINCT gl.graph_template_id AS id
+			FROM graph_local AS gl
+			WHERE ' . array_to_sql_or($graph_array, 'gl.id'));
+
+		if (cacti_sizeof($templates) > 1) {
+			$message = __('The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates.');
+
+			return false;
+		}
+
+		if (cacti_sizeof($templates) == 1) {
+			if ($templates[0]['id'] == 0) {
+				// selected graphs do not use templates
+				$message = __('The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs.');
+
+				return false;
+			} else {
+				$graph_template = $templates[0]['id'];
+
+				return true;
+			}
+		} else {
+			$message = __('There was some error in MySQL/MariaDB.  Can not continue.');
+
+			return false;
+		}
+	} else {
+		$message = __('You must pass at least a single Graph to this function');
+
+		return false;
+	}
+}
 
 /**
  * Draws the list of aggregate graph items.

--- a/scripts/sql.php
+++ b/scripts/sql.php
@@ -6,10 +6,14 @@ include(__DIR__ . '/../include/cli_check.php');
 
 global $database_hostname, $database_username, $database_password;
 
-if ($database_password == '') {
-	$sql = `mysqladmin -h $database_hostname -u $database_username status | awk '{print $6 }'`;
-} else {
-	$sql = `mysqladmin -h $database_hostname -u $database_username -p$database_password status | awk '{print $6 }'`;
+$cmd = 'mysqladmin -h ' . escapeshellarg($database_hostname) . ' -u ' . escapeshellarg($database_username);
+
+if ($database_password != '') {
+	$cmd .= ' -p' . escapeshellarg($database_password);
 }
 
-print trim($sql);
+$cmd .= " status | awk '{print \$6 }'";
+
+$sql = shell_exec($cmd);
+
+print trim($sql ?? '');

--- a/scripts/ss_sql.php
+++ b/scripts/ss_sql.php
@@ -36,11 +36,15 @@ function ss_sql() : string {
 	global $database_password;
 	global $database_hostname;
 
+	$cmd = 'mysqladmin --host=' . escapeshellarg($database_hostname) . ' --user=' . escapeshellarg($database_username);
+
 	if ($database_password != '') {
-		$result = `mysqladmin --host=$database_hostname --user=$database_username --password=$database_password status`;
-	} else {
-		$result = `mysqladmin --host=$database_hostname --user=$database_username status`;
+		$cmd .= ' --password=' . escapeshellarg($database_password);
 	}
+
+	$cmd .= ' status';
+
+	$result = shell_exec($cmd) ?? '';
 
 	$result = preg_replace('/: /', ':', $result);
 	$result = preg_replace('/  /', ' ', $result);

--- a/tests/Unit/SqlScriptsTest.php
+++ b/tests/Unit/SqlScriptsTest.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for the backtick-to-shell_exec migration in scripts/sql.php
+ * and scripts/ss_sql.php.
+ *
+ * PHP 8.4 deprecates the backtick operator. These scripts previously
+ * used backticks to invoke mysqladmin, with unescaped variable
+ * interpolation. The fix replaces backticks with shell_exec() and
+ * wraps all user-supplied values in escapeshellarg().
+ */
+
+$sqlPhpPath   = __DIR__ . '/../../scripts/sql.php';
+$ssSqlPhpPath = __DIR__ . '/../../scripts/ss_sql.php';
+
+// --- scripts/sql.php: no backtick operators remain ---
+
+test('sql.php contains no backtick operators', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->not->toMatch('/`[^`]*mysqladmin[^`]*`/');
+});
+
+test('sql.php uses shell_exec for command execution', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain('shell_exec(');
+});
+
+test('sql.php escapes database_hostname with escapeshellarg', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain('escapeshellarg($database_hostname)');
+});
+
+test('sql.php escapes database_username with escapeshellarg', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain('escapeshellarg($database_username)');
+});
+
+test('sql.php escapes database_password with escapeshellarg', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain('escapeshellarg($database_password)');
+});
+
+test('sql.php handles null return from shell_exec', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain("?? ''");
+});
+
+// --- scripts/ss_sql.php: no backtick operators remain ---
+
+test('ss_sql.php contains no backtick operators', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->not->toMatch('/`[^`]*mysqladmin[^`]*`/');
+});
+
+test('ss_sql.php uses shell_exec for command execution', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain('shell_exec(');
+});
+
+test('ss_sql.php escapes database_hostname with escapeshellarg', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain('escapeshellarg($database_hostname)');
+});
+
+test('ss_sql.php escapes database_username with escapeshellarg', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain('escapeshellarg($database_username)');
+});
+
+test('ss_sql.php escapes database_password with escapeshellarg', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain('escapeshellarg($database_password)');
+});
+
+test('ss_sql.php handles null return from shell_exec', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain("?? ''");
+});
+
+// --- no raw variable interpolation in shell commands ---
+
+test('sql.php does not interpolate variables directly in shell strings', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->not->toMatch('/`[^`]*\$database_/');
+});
+
+test('ss_sql.php does not interpolate variables directly in shell strings', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->not->toMatch('/`[^`]*\$database_/');
+});


### PR DESCRIPTION
## Summary
- Replace PHP backtick execution operator with `shell_exec()` in `scripts/sql.php` and `scripts/ss_sql.php`
- PHP 8.5 deprecates the backtick operator; `shell_exec()` is the direct equivalent
- Escape awk `$6` field reference (`\$6`) to prevent PHP variable interpolation in double-quoted strings

## Test plan
- [ ] Verify `scripts/sql.php` returns MySQL thread count when called directly
- [ ] Verify `scripts/ss_sql.php` returns formatted mysqladmin status via script server
- [ ] Confirm no PHP deprecation notices on PHP 8.5