### PR TITLE
fix: remove deprecated curl_close() and imagedestroy() for PHP 8.5

### DIFF
--- a/cli/add_site.php
+++ b/cli/add_site.php
@@ -542,13 +542,10 @@ function fetchCurl(string $url) : string|false {
 
 	if ($buffer === false) {
 		$error = curl_error($curl);
-		curl_close($curl);
 		echoQuiet('Error: cURL request failed: ' . $error . PHP_EOL);
 
 		return false;
 	}
-
-	curl_close($curl);
 
 	return $buffer;
 }

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4187,7 +4187,6 @@ function secpass_check_pass(string $password) : string {
 
 		$content  = curl_exec($ch);
 
-		curl_close($ch);
 		$lines = explode("\r\n", $content);
 		$count = 0;
 

--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -2317,8 +2317,6 @@ function plugin_make_github_request(string $url, string $type = 'json') : mixed 
 		$errno = curl_errno($ch);
 		$error = curl_error($ch);
 
-		curl_close($ch);
-
 		if ($info['http_code'] == 403 || $info['http_code'] == 429) {
 			$json_data = json_decode($data, true);
 

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -1879,7 +1879,6 @@ function png2jpeg(string $png_data) : string {
 		$ImageData       = ob_get_contents(); // fetch image from buffer
 		$ImageDataLength = ob_get_length();
 		ob_end_clean(); // stop this output buffer
-		imagedestroy($im); // clean up
 
 		unlink($fn); // delete scratch file
 	}
@@ -1922,7 +1921,6 @@ function png2gif(string $png_data) : string {
 		$ImageData       = ob_get_contents(); // fetch image from buffer
 		$ImageDataLength = ob_get_length();
 		ob_end_clean(); // stop this output buffer
-		imagedestroy($im); // clean up
 
 		unlink($fn); // delete scratch file
 	}

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -4573,14 +4573,6 @@ function rrdtool_create_error_image(string $string, mixed $width = '', mixed $he
 	// get the image from the buffer
 	$image_data = ob_get_contents();
 
-	// destroy the image object
-	imagedestroy($image);
-	imagedestroy($logo);
-
-	if (isset($nimage)) {
-		imagedestroy($nimage);
-	}
-
 	// flush the buffer
 	ob_end_clean();
 

--- a/tests/Unit/Php85DeprecationsTest.php
+++ b/tests/Unit/Php85DeprecationsTest.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ |
+ | Tests for PHP 8.5 deprecation removals: curl_close(), imagedestroy().
+ | PR #6772 removes explicit calls; resources are freed when out of scope.
+ +-------------------------------------------------------------------------+
+*/
+
+$basePath = dirname(__DIR__, 2);
+
+// --- Static analysis: no deprecated calls in changed files ---
+
+test('cli/add_site.php contains no curl_close calls', function () use ($basePath) {
+	$path = $basePath . '/cli/add_site.php';
+	$contents = file_get_contents($path);
+
+	expect($contents)->not->toContain('curl_close(');
+});
+
+test('lib/auth.php contains no curl_close calls', function () use ($basePath) {
+	$path = $basePath . '/lib/auth.php';
+	$contents = file_get_contents($path);
+
+	expect($contents)->not->toContain('curl_close(');
+});
+
+test('lib/plugins.php contains no curl_close calls', function () use ($basePath) {
+	$path = $basePath . '/lib/plugins.php';
+	$contents = file_get_contents($path);
+
+	expect($contents)->not->toContain('curl_close(');
+});
+
+test('lib/reports.php contains no imagedestroy calls', function () use ($basePath) {
+	$path = $basePath . '/lib/reports.php';
+	$contents = file_get_contents($path);
+
+	expect($contents)->not->toContain('imagedestroy(');
+});
+
+test('lib/rrd.php contains no imagedestroy calls', function () use ($basePath) {
+	$path = $basePath . '/lib/rrd.php';
+	$contents = file_get_contents($path);
+
+	expect($contents)->not->toContain('imagedestroy(');
+});

--- a/tests/Unit/ReportsImageConversionTest.php
+++ b/tests/Unit/ReportsImageConversionTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ |
+ | Tests for png2jpeg() and png2gif() in lib/reports.php.
+ | Verifies image conversion works without explicit imagedestroy() (PHP 8.5).
+ +-------------------------------------------------------------------------+
+*/
+
+$basePath = dirname(__DIR__, 2);
+
+beforeEach(function () use ($basePath) {
+	$config = [
+		'base_path'         => $basePath,
+		'cacti_server_os'   => str_starts_with(PHP_OS, 'WIN') ? 'win32' : 'unix',
+	];
+	$GLOBALS['config'] = $config;
+	require_once $basePath . '/include/global_path.php';
+	require_once $basePath . '/lib/functions.php';
+	require_once $basePath . '/lib/reports.php';
+});
+
+// Create minimal 1x1 PNG using GD
+function createMinimalPng() : string {
+	$im = imagecreate(1, 1);
+	if ($im === false) {
+		throw new RuntimeException('imagecreate failed');
+	}
+	imagecolorallocate($im, 255, 0, 0);
+	ob_start();
+	imagepng($im);
+	$png = ob_get_clean();
+
+	return $png;
+}
+
+test('png2jpeg returns non-empty string for valid PNG', function () {
+	$png = createMinimalPng();
+	$jpeg = png2jpeg($png);
+
+	expect($jpeg)->toBeString()
+		->and($jpeg)->not->toBe('')
+		->and(substr($jpeg, 0, 2))->toBe("\xFF\xD8");
+});
+
+test('png2jpeg returns empty string for empty input', function () {
+	$jpeg = png2jpeg('');
+
+	expect($jpeg)->toBe('')
+		->and($jpeg)->toBeString();
+});
+
+test('png2gif returns non-empty string for valid PNG', function () {
+	$png = createMinimalPng();
+	$gif = png2gif($png);
+
+	expect($gif)->toBeString()
+		->and($gif)->not->toBe('')
+		->and(substr($gif, 0, 6))->toMatch('/^GIF8[79]a/');
+});
+
+test('png2gif returns empty string for empty input', function () {
+	$gif = png2gif('');
+
+	expect($gif)->toBe('')
+		->and($gif)->toBeString();
+});


### PR DESCRIPTION
## Summary

PHP 8.5 deprecates `curl_close()`, `imagedestroy()`, and `xml_parser_free()`. Handles are automatically freed when they go out of scope.

## Changes

- **cli/add_site.php**: remove 2 `curl_close()` calls
- **lib/auth.php**: remove `curl_close()` in `secpass_check_pwned()`
- **lib/plugins.php**: remove `curl_close()` in plugin fetch
- **lib/reports.php**: remove 2 `imagedestroy()` calls in jpeg2png/png2gif
- **lib/rrd.php**: remove 3 `imagedestroy()` calls in graph rendering

## Why

No behavioral change; resources are freed implicitly when variables go out of scope. Removing explicit calls silences PHP 8.5 deprecation notices.

## Test plan

- [ ] Geocoding in add_site.php still works
- [ ] Plugin fetch from marketplace still works
- [ ] Pwned password check still works
- [ ] Report image conversion (jpeg2png, png2gif) still works
- [ ] RRD graph rendering still works

Made with [Cursor](https://cursor.com)