### PR TITLE
fix(tests): remove duplicate Pest method name causing PHP fatal error

### DIFF
--- a/tests/Unit/CactiIsHttpsTest.php
+++ b/tests/Unit/CactiIsHttpsTest.php
@@ -57,11 +57,6 @@ test('returns false when HTTPS is "off"', function () {
 	expect(cacti_is_https())->toBeFalse();
 });
 
-test('returns false when HTTPS is "Off" (case-insensitive)', function () {
-	$_SERVER['HTTPS'] = 'Off';
-	expect(cacti_is_https())->toBeFalse();
-});
-
 test('returns false when HTTPS is "OFF" (case-insensitive)', function () {
 	$_SERVER['HTTPS'] = 'OFF';
 	expect(cacti_is_https())->toBeFalse();


### PR DESCRIPTION
`CactiIsHttpsTest` has two test cases that Pest collapses to the same internal method name:

```
test('returns false when HTTPS is "Off" (case-insensitive)', ...)
test('returns false when HTTPS is "OFF" (case-insensitive)', ...)
```

Pest uppercases identifier segments in its generated method names, so both map to:

```
__pest_evaluable_returns_false_when_HTTPS_is__OFF___case_insensitive_
```

This produces a PHP fatal error at runtime:

```
PHP Fatal error: Cannot redeclare
P\Var\www\html\cacti\tests\Unit\CactiIsHttpsTest::__pest_evaluable_returns_false_when_HTTPS_is__OFF___case_insensitive_()
```

The `"Off"` test is redundant -- `"OFF"` already proves the strtolower path in `cacti_is_https()`. Remove it.

Reported on develop by TheWitness, Mar 6 2026.
