### PR TITLE
fix(graph_view): use CACTI_PATH_URL in preview breadcrumb link

### DIFF
--- a/lib/html_graph.php
+++ b/lib/html_graph.php
@@ -1477,7 +1477,7 @@ function html_graph_list_view() : void {
 
 			loadUrl({url:strURL})
 
-			$('#breadcrumbs').empty().html('<li><a href="graph_view.php?action=preview"><?php print __('Preview Mode'); ?></a></li>');
+			$('#breadcrumbs').empty().html('<li><a href="' + urlPath + 'graph_view.php?action=preview"><?php print __('Preview Mode'); ?></a></li>');
 			$('#listview').removeClass('selected');
 			$('#preview').addClass('selected');
 		}


### PR DESCRIPTION
## Summary
- update the preview-mode breadcrumb link in `lib/html_graph.php` to prepend `urlPath`
- avoid generating plugin-relative `graph_view.php` links that resolve to `plugins/<name>/graph_view.php` and 404
- keep behavior unchanged for normal installs where `urlPath` is already `/`

## Testing
- Not run locally: PHP CLI is not available in this environment (`php: command not found`), so I could not execute lint/tests here.
- Change is a one-line JS URL composition update and mirrors existing `urlPath + "graph_view.php"` usage elsewhere in the same file/theme scripts.

## Related
Fixes #6692