### PR TITLE
fix: use require_once in plugin loader paths

### DIFF
--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -229,10 +229,10 @@ function upgrade_database() : void {
 
 				if ($version != $old) {
 					if (file_exists($plugin . '/setup.php')) {
-						include_once($plugin . '/setup.php');
+						require_once($plugin . '/setup.php');
 
 						if (file_exists($plugin . '/includes/database.php')) {
-							include_once($plugin . '/includes/database.php');
+							require_once($plugin . '/includes/database.php');
 						}
 
 						// Always run the new function if it's there

--- a/include/global.php
+++ b/include/global.php
@@ -136,7 +136,7 @@ if (isset($config['cacti_version'])) { // @phpstan-ignore-line
 }
 
 // Define global paths
-include_once(__DIR__ . '/global_path.php');
+require_once(__DIR__ . '/global_path.php');
 
 // Should we allow proxy ip headers?
 $config['proxy_headers'] = $proxy_headers ?? [];
@@ -270,17 +270,17 @@ if (isset($i18n_text_log)) {
 }
 
 // include base modules
-include_once(CACTI_PATH_LIBRARY . '/database.php');
-include_once(CACTI_PATH_LIBRARY . '/functions.php');
-include_once(CACTI_PATH_INCLUDE . '/global_constants.php');
+require_once(CACTI_PATH_LIBRARY . '/database.php');
+require_once(CACTI_PATH_LIBRARY . '/functions.php');
+require_once(CACTI_PATH_INCLUDE . '/global_constants.php');
 
 define('CACTI_VERSION', format_cacti_version($cacti_version, CACTI_VERSION_FORMAT_SHORT));
 define('CACTI_VERSION_FULL', format_cacti_version($cacti_version, CACTI_VERSION_FORMAT_FULL));
 
-include_once(CACTI_PATH_LIBRARY . '/html.php');
-include_once(CACTI_PATH_LIBRARY . '/html_utility.php');
-include_once(CACTI_PATH_LIBRARY . '/html_validate.php');
-include_once(CACTI_PATH_LIBRARY . '/html_filter.php');
+require_once(CACTI_PATH_LIBRARY . '/html.php');
+require_once(CACTI_PATH_LIBRARY . '/html_utility.php');
+require_once(CACTI_PATH_LIBRARY . '/html_validate.php');
+require_once(CACTI_PATH_LIBRARY . '/html_filter.php');
 
 $filename = get_current_page();
 
@@ -610,7 +610,7 @@ if ((bool)ini_get('register_globals')) {
 
 define('CACTI_DATE_TIME_FORMAT', date_time_format());
 
-include_once(CACTI_PATH_INCLUDE . '/global_languages.php');
+require_once(CACTI_PATH_INCLUDE . '/global_languages.php');
 
 define('CACTI_VERSION_BRIEF', get_cacti_version_text(false, CACTI_VERSION));
 define('CACTI_VERSION_BRIEF_FULL', get_cacti_version_text(false, CACTI_VERSION_FULL));
@@ -618,24 +618,24 @@ define('CACTI_VERSION_TEXT', get_cacti_version_text(true, CACTI_VERSION));
 define('CACTI_VERSION_TEXT_FULL', get_cacti_version_text(true, CACTI_VERSION_FULL));
 define('CACTI_VERSION_TEXT_CLI', get_cacti_cli_version(true, CACTI_VERSION_FULL)); // @phpstan-ignore-line
 
-include_once(CACTI_PATH_LIBRARY . '/auth.php');
-include_once(CACTI_PATH_LIBRARY . '/plugins.php');
-include_once(CACTI_PATH_INCLUDE . '/plugins.php');
-include_once(CACTI_PATH_INCLUDE . '/global_arrays.php');
-include_once(CACTI_PATH_INCLUDE . '/global_settings.php');
-include_once(CACTI_PATH_INCLUDE . '/global_form.php');
-include_once(CACTI_PATH_LIBRARY . '/html_form.php');
-include_once(CACTI_PATH_LIBRARY . '/html_filter.php');
-include_once(CACTI_PATH_LIBRARY . '/variables.php');
-include_once(CACTI_PATH_LIBRARY . '/mib_cache.php');
-include_once(CACTI_PATH_LIBRARY . '/poller.php');
-include_once(CACTI_PATH_LIBRARY . '/snmpagent.php');
-include_once(CACTI_PATH_LIBRARY . '/aggregate.php');
-include_once(CACTI_PATH_LIBRARY . '/api_automation.php');
-include_once(CACTI_PATH_INCLUDE . '/vendor/autoload.php');
+require_once(CACTI_PATH_LIBRARY . '/auth.php');
+require_once(CACTI_PATH_LIBRARY . '/plugins.php');
+require_once(CACTI_PATH_INCLUDE . '/plugins.php');
+require_once(CACTI_PATH_INCLUDE . '/global_arrays.php');
+require_once(CACTI_PATH_INCLUDE . '/global_settings.php');
+require_once(CACTI_PATH_INCLUDE . '/global_form.php');
+require_once(CACTI_PATH_LIBRARY . '/html_form.php');
+require_once(CACTI_PATH_LIBRARY . '/html_filter.php');
+require_once(CACTI_PATH_LIBRARY . '/variables.php');
+require_once(CACTI_PATH_LIBRARY . '/mib_cache.php');
+require_once(CACTI_PATH_LIBRARY . '/poller.php');
+require_once(CACTI_PATH_LIBRARY . '/snmpagent.php');
+require_once(CACTI_PATH_LIBRARY . '/aggregate.php');
+require_once(CACTI_PATH_LIBRARY . '/api_automation.php');
+require_once(CACTI_PATH_INCLUDE . '/vendor/autoload.php');
 
 if ($config['is_web']) {
-	include_once(CACTI_PATH_INCLUDE . '/csrf.php');
+	require_once(CACTI_PATH_INCLUDE . '/csrf.php');
 
 	// raise a message and perform a page refresh if we've changed modes
 	if ($config['poller_id'] > 1) {

--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -706,7 +706,7 @@ function api_plugin_install(string $plugin) : bool {
 	}
 
 	if (!file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")) {
-		cacti_log("ERROR: Plugin '$plugin' setup.php not found, cannot install", false, 'PLUGIN');
+		cacti_log('ERROR: Plugin \'' . preg_replace('/[^a-zA-Z0-9_\-]/', '', $plugin) . '\' setup.php not found, cannot install', false, 'PLUGIN');
 		raise_message('plugin_missing', __('Plugin setup file not found.'), MESSAGE_LEVEL_ERROR);
 		header('Location: plugins.php');
 		exit;
@@ -858,6 +858,7 @@ function api_plugin_uninstall(string $plugin, bool $tables = true) : void {
 	$plugin_found = false;
 
 	if (file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")) {
+		cacti_log(sprintf('NOTE: Loading setup.php for plugin %s (uninstall)', $plugin), false, 'PLUGIN', POLLER_VERBOSITY_DEBUG);
 		require_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
 
 		// Run the Plugin's Uninstall Function first
@@ -901,6 +902,7 @@ function api_plugin_check_config(string $plugin) : bool {
 	clearstatcache();
 
 	if (file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")) {
+		cacti_log(sprintf('NOTE: Loading setup.php for plugin %s (check_config)', $plugin), false, 'PLUGIN', POLLER_VERBOSITY_DEBUG);
 		require_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
 
 		$function = "plugin_{$plugin}_check_config";

--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -705,7 +705,14 @@ function api_plugin_install(string $plugin) : bool {
 		exit;
 	}
 
-	include_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
+	if (!file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")) {
+		cacti_log("ERROR: Plugin '$plugin' setup.php not found, cannot install", false, 'PLUGIN');
+		raise_message('plugin_missing', __('Plugin setup file not found.'), MESSAGE_LEVEL_ERROR);
+		header('Location: plugins.php');
+		exit;
+	}
+
+	require_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
 
 	$exists = db_fetch_assoc_prepared('SELECT id
 		FROM plugin_config
@@ -851,7 +858,7 @@ function api_plugin_uninstall(string $plugin, bool $tables = true) : void {
 	$plugin_found = false;
 
 	if (file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")) {
-		include_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
+		require_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
 
 		// Run the Plugin's Uninstall Function first
 		$function = "plugin_{$plugin}_uninstall";
@@ -894,7 +901,7 @@ function api_plugin_check_config(string $plugin) : bool {
 	clearstatcache();
 
 	if (file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")) {
-		include_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
+		require_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
 
 		$function = "plugin_{$plugin}_check_config";
 

--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -154,7 +154,7 @@ function api_plugin_hook_function(string $name, mixed $parm = null) : mixed {
 					$p[] = $hdata['name'];
 
 					if (file_exists(CACTI_PATH_PLUGINS . '/' . $hdata['name'] . '/' . $hdata['file'])) {
-						include_once(CACTI_PATH_PLUGINS . '/' . $hdata['name'] . '/' . $hdata['file']);
+						require_once(CACTI_PATH_PLUGINS . '/' . $hdata['name'] . '/' . $hdata['file']);
 					}
 
 					$function = $hdata['function'];

--- a/tests/Unit/RequireOncePluginLoaderTest.php
+++ b/tests/Unit/RequireOncePluginLoaderTest.php
@@ -22,6 +22,7 @@ test('include/global.php uses require_once for all core library includes', funct
 	$source = file_get_contents(__DIR__ . '/../../include/global.php');
 
 	expect($source)->not->toContain('include_once(');
+	expect($source)->toContain("require_once(CACTI_PATH_LIBRARY . '/database.php')");
 });
 
 test('lib/plugins.php uses require_once for plugin setup.php in install path', function () {
@@ -30,10 +31,44 @@ test('lib/plugins.php uses require_once for plugin setup.php in install path', f
 	/* The install path now has an explicit file_exists guard followed by
 	 * require_once — verify no bare include_once remains for setup.php. */
 	expect(preg_match('/include_once\s*\(\s*CACTI_PATH_PLUGINS/', $source))->toBe(0);
+	expect(preg_match('/require_once\s*\(\s*CACTI_PATH_PLUGINS/', $source))->toBe(1);
+});
+
+test('lib/plugins.php install path hard-fails with sanitized log when setup.php missing', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	/* Verify the file_exists guard exists before require_once in the install path. */
+	expect($source)->toContain("file_exists(CACTI_PATH_PLUGINS . \"/\$plugin/setup.php\")");
+
+	/* The log message must use preg_replace to strip non-safe chars from $plugin
+	 * before interpolation, preventing pipe/newline injection into structured logs. */
+	expect($source)->toContain("preg_replace('/[^a-zA-Z0-9_\\-]/', '', \$plugin)");
+
+	/* raise_message must accompany the log call so the UI reflects the failure. */
+	expect($source)->toContain("raise_message('plugin_missing'");
+});
+
+test('lib/plugins.php uninstall and check_config silently skip missing setup.php (by design)', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	/* Install hard-fails (file_exists guard + exit) while uninstall/check_config
+	 * use a silent-skip pattern (require_once only inside if (file_exists(...))).
+	 * This asymmetry is intentional: install must be explicit; cleanup is best-effort. */
+	$uninstallGuards  = preg_match_all('/file_exists\(CACTI_PATH_PLUGINS.*setup\.php.*\)/', $source);
+	expect($uninstallGuards)->toBeGreaterThanOrEqual(3);
 });
 
 test('cli/audit_database.php uses require_once inside file_exists guard', function () {
 	$source = file_get_contents(__DIR__ . '/../../cli/audit_database.php');
 
 	expect($source)->not->toContain('include_once(');
+	expect($source)->toContain("require_once(\$plugin . '/setup.php')");
+});
+
+test('cli/audit_database.php inner includes/database.php load is guarded by file_exists', function () {
+	$source = file_get_contents(__DIR__ . '/../../cli/audit_database.php');
+
+	/* Confirm includes/database.php is loaded with require_once and only when present. */
+	expect($source)->toContain("require_once(\$plugin . '/includes/database.php')");
+	expect($source)->toContain("file_exists(\$plugin . '/includes/database.php')");
 });

--- a/tests/Unit/RequireOncePluginLoaderTest.php
+++ b/tests/Unit/RequireOncePluginLoaderTest.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Test for issue #6788: include_once replaced with require_once for core
+ * library files and plugin setup loaders so missing files produce immediate
+ * fatal errors rather than silent undefined-function failures downstream.
+ */
+
+test('include/global.php uses require_once for all core library includes', function () {
+	$source = file_get_contents(__DIR__ . '/../../include/global.php');
+
+	expect($source)->not->toContain('include_once(');
+});
+
+test('lib/plugins.php uses require_once for plugin setup.php in install path', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	/* The install path now has an explicit file_exists guard followed by
+	 * require_once — verify no bare include_once remains for setup.php. */
+	expect(preg_match('/include_once\s*\(\s*CACTI_PATH_PLUGINS/', $source))->toBe(0);
+});
+
+test('cli/audit_database.php uses require_once inside file_exists guard', function () {
+	$source = file_get_contents(__DIR__ . '/../../cli/audit_database.php');
+
+	expect($source)->not->toContain('include_once(');
+});


### PR DESCRIPTION
include_once in global.php, lib/plugins.php, and cli/audit_database.php silently continues on missing files. require_once fails fast and gives a clear error at the include site rather than an undefined-function notice later in the request.

Closes #6784