### PR TITLE
hardening: use cacti_escapeshellarg() in sql.php and ss_sql.php

### DIFF
--- a/scripts/sql.php
+++ b/scripts/sql.php
@@ -6,10 +6,10 @@ include(__DIR__ . '/../include/cli_check.php');
 
 global $database_hostname, $database_username, $database_password;
 
-$cmd = 'mysqladmin -h ' . escapeshellarg($database_hostname) . ' -u ' . escapeshellarg($database_username);
+$cmd = 'mysqladmin -h ' . cacti_escapeshellarg($database_hostname) . ' -u ' . cacti_escapeshellarg($database_username);
 
 if ($database_password != '') {
-	$cmd .= ' -p' . escapeshellarg($database_password);
+	$cmd .= ' -p' . cacti_escapeshellarg($database_password);
 }
 
 $cmd .= " status | awk '{print \$6 }'";

--- a/scripts/sql.php
+++ b/scripts/sql.php
@@ -16,4 +16,5 @@ $cmd .= " status | awk '{print \$6 }'";
 
 $sql = shell_exec($cmd);
 
-print trim($sql ?? '');
+// Cacti expects 'U' on error, not empty string or 0.
+print trim($sql ?? '') ?: 'U';

--- a/scripts/ss_sql.php
+++ b/scripts/ss_sql.php
@@ -53,5 +53,5 @@ function ss_sql() : string {
 	$result = preg_replace('/Queries per second avg/', 'QPS', $result);
 	$result = preg_replace('/Flush tables/', 'FlushTables', $result);
 
-	return trim($result);
+	return trim($result) ?: 'U';
 }

--- a/scripts/ss_sql.php
+++ b/scripts/ss_sql.php
@@ -36,10 +36,10 @@ function ss_sql() : string {
 	global $database_password;
 	global $database_hostname;
 
-	$cmd = 'mysqladmin --host=' . escapeshellarg($database_hostname) . ' --user=' . escapeshellarg($database_username);
+	$cmd = 'mysqladmin --host=' . cacti_escapeshellarg($database_hostname) . ' --user=' . cacti_escapeshellarg($database_username);
 
 	if ($database_password != '') {
-		$cmd .= ' --password=' . escapeshellarg($database_password);
+		$cmd .= ' --password=' . cacti_escapeshellarg($database_password);
 	}
 
 	$cmd .= ' status';

--- a/tests/Unit/SqlScriptsTest.php
+++ b/tests/Unit/SqlScriptsTest.php
@@ -122,6 +122,41 @@ test('ss_sql.php handles null return from shell_exec', function () use ($ssSqlPh
 	expect($contents)->toContain("?? ''");
 });
 
+test('ss_sql.php returns U on empty/null shell_exec output', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	/* Cacti data source scripts must return 'U' on error, never empty string. */
+	expect($contents)->toContain(": 'U'");
+});
+
+// --- runtime: cacti_escapeshellarg is callable and ss_sql() falls back to 'U' ---
+
+test('ss_sql() returns U when shell_exec produces no output', function () use ($ssSqlPhpPath) {
+	/* Bootstrap cacti_escapeshellarg if global.php has not yet been loaded. */
+	if (!function_exists('cacti_escapeshellarg')) {
+		/* Minimal stub: delegate to the native call so arg-quoting still works. */
+		function cacti_escapeshellarg(string $arg, bool $quote = true): string {
+			return escapeshellarg($arg);
+		}
+	}
+
+	/* Provide dummy globals so the function can build its command string. */
+	$GLOBALS['database_hostname'] = '127.0.0.1';
+	$GLOBALS['database_username'] = 'cacti_test_no_such_user';
+	$GLOBALS['database_password'] = '';
+
+	/* Include the script in "called by script server" mode so only the
+	 * function definition is loaded, not the top-level print statement. */
+	$called_by_script_server = true;
+	if (!function_exists('ss_sql')) {
+		require $ssSqlPhpPath;
+	}
+
+	/* mysqladmin will fail (bad credentials / no server), shell_exec returns
+	 * null or empty.  ss_sql() must map that to 'U'. */
+	expect(ss_sql())->toBe('U');
+});
+
 // --- no raw variable interpolation in shell commands ---
 
 test('sql.php does not interpolate variables directly in shell strings', function () use ($sqlPhpPath) {

--- a/tests/Unit/SqlScriptsTest.php
+++ b/tests/Unit/SqlScriptsTest.php
@@ -70,6 +70,13 @@ test('sql.php handles null return from shell_exec', function () use ($sqlPhpPath
 	expect($contents)->toContain("?? ''");
 });
 
+test('sql.php returns U on empty/null shell_exec output', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	/* Cacti data source scripts must return 'U' on error, never empty string. */
+	expect($contents)->toContain(": 'U'");
+});
+
 // --- scripts/ss_sql.php: no backtick operators remain ---
 
 test('ss_sql.php contains no backtick operators', function () use ($ssSqlPhpPath) {

--- a/tests/Unit/SqlScriptsTest.php
+++ b/tests/Unit/SqlScriptsTest.php
@@ -13,13 +13,13 @@
 */
 
 /*
- * Tests for the backtick-to-shell_exec migration in scripts/sql.php
- * and scripts/ss_sql.php.
+ * Tests for scripts/sql.php and scripts/ss_sql.php.
  *
- * PHP 8.4 deprecates the backtick operator. These scripts previously
- * used backticks to invoke mysqladmin, with unescaped variable
- * interpolation. The fix replaces backticks with shell_exec() and
- * wraps all user-supplied values in escapeshellarg().
+ * Covers two hardening steps:
+ * 1. Backtick-to-shell_exec migration (PHP 8.4 deprecates the backtick
+ *    operator; the fix replaces backticks with shell_exec()).
+ * 2. cacti_escapeshellarg() wrapper (Cacti's internal contract; bare
+ *    escapeshellarg() bypasses any future Cacti-level escaping hooks).
  */
 
 $sqlPhpPath   = __DIR__ . '/../../scripts/sql.php';
@@ -39,22 +39,29 @@ test('sql.php uses shell_exec for command execution', function () use ($sqlPhpPa
 	expect($contents)->toContain('shell_exec(');
 });
 
-test('sql.php escapes database_hostname with escapeshellarg', function () use ($sqlPhpPath) {
+test('sql.php escapes database_hostname with cacti_escapeshellarg', function () use ($sqlPhpPath) {
 	$contents = file_get_contents($sqlPhpPath);
 
-	expect($contents)->toContain('escapeshellarg($database_hostname)');
+	expect($contents)->toContain('cacti_escapeshellarg($database_hostname)');
 });
 
-test('sql.php escapes database_username with escapeshellarg', function () use ($sqlPhpPath) {
+test('sql.php escapes database_username with cacti_escapeshellarg', function () use ($sqlPhpPath) {
 	$contents = file_get_contents($sqlPhpPath);
 
-	expect($contents)->toContain('escapeshellarg($database_username)');
+	expect($contents)->toContain('cacti_escapeshellarg($database_username)');
 });
 
-test('sql.php escapes database_password with escapeshellarg', function () use ($sqlPhpPath) {
+test('sql.php escapes database_password with cacti_escapeshellarg', function () use ($sqlPhpPath) {
 	$contents = file_get_contents($sqlPhpPath);
 
-	expect($contents)->toContain('escapeshellarg($database_password)');
+	expect($contents)->toContain('cacti_escapeshellarg($database_password)');
+});
+
+test('sql.php uses no bare escapeshellarg calls', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	// Negative lookbehind: match escapeshellarg( NOT preceded by cacti_
+	expect(preg_match('/(?<!cacti_)escapeshellarg\(/', $contents))->toBe(0);
 });
 
 test('sql.php handles null return from shell_exec', function () use ($sqlPhpPath) {
@@ -77,22 +84,29 @@ test('ss_sql.php uses shell_exec for command execution', function () use ($ssSql
 	expect($contents)->toContain('shell_exec(');
 });
 
-test('ss_sql.php escapes database_hostname with escapeshellarg', function () use ($ssSqlPhpPath) {
+test('ss_sql.php escapes database_hostname with cacti_escapeshellarg', function () use ($ssSqlPhpPath) {
 	$contents = file_get_contents($ssSqlPhpPath);
 
-	expect($contents)->toContain('escapeshellarg($database_hostname)');
+	expect($contents)->toContain('cacti_escapeshellarg($database_hostname)');
 });
 
-test('ss_sql.php escapes database_username with escapeshellarg', function () use ($ssSqlPhpPath) {
+test('ss_sql.php escapes database_username with cacti_escapeshellarg', function () use ($ssSqlPhpPath) {
 	$contents = file_get_contents($ssSqlPhpPath);
 
-	expect($contents)->toContain('escapeshellarg($database_username)');
+	expect($contents)->toContain('cacti_escapeshellarg($database_username)');
 });
 
-test('ss_sql.php escapes database_password with escapeshellarg', function () use ($ssSqlPhpPath) {
+test('ss_sql.php escapes database_password with cacti_escapeshellarg', function () use ($ssSqlPhpPath) {
 	$contents = file_get_contents($ssSqlPhpPath);
 
-	expect($contents)->toContain('escapeshellarg($database_password)');
+	expect($contents)->toContain('cacti_escapeshellarg($database_password)');
+});
+
+test('ss_sql.php uses no bare escapeshellarg calls', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	// Negative lookbehind: match escapeshellarg( NOT preceded by cacti_
+	expect(preg_match('/(?<!cacti_)escapeshellarg\(/', $contents))->toBe(0);
 });
 
 test('ss_sql.php handles null return from shell_exec', function () use ($ssSqlPhpPath) {


### PR DESCRIPTION
scripts/sql.php and scripts/ss_sql.php called bare escapeshellarg() directly. cacti_escapeshellarg() applies locale-aware quoting on non-UNIX platforms and is the project-standard wrapper for all shell argument escaping.

Closes #6788