### PR TITLE
fix: correct codespell-detected spelling errors in PHP source files

### DIFF
--- a/cactid.php
+++ b/cactid.php
@@ -70,7 +70,7 @@ if (isset($options['foreground'])) {
 }
 
 // Set the frequency of data collection dynamically
-// before loosing our database connection after fork.
+// before losing our database connection after fork.
 // We would not have to do this is PDO supported
 // connection cloning as does Perl.
 $frequency = read_config_option('cron_interval', true);

--- a/cli/splice_rrd.php
+++ b/cli/splice_rrd.php
@@ -248,7 +248,7 @@ debug('Entering Mainline');
 // let's see if we can find rrdtool
 global $rrdtool, $use_db, $db;
 
-// see if sqlLite is available
+// see if SQLite is available
 if (class_exists('SQLite3')) {
 	print 'NOTE: Using SQLite Database for performance.' . PHP_EOL;
 	$use_db = true;

--- a/data_queries.php
+++ b/data_queries.php
@@ -498,7 +498,7 @@ function data_query_sv_check_sequences(string $type, int $snmp_query_graph_id, s
 
 	if ($bad_seq > 0 || $dup_seq > 0) {
 		// resequence the list so it has no gaps, and 0 values will appear at the top
-		// since thats where they would have been displayed
+		// since that's where they would have been displayed
 		db_execute_prepared("SET @seq = 0;
 			UPDATE $table
 			SET sequence = (@seq:=@seq+1)

--- a/graphs.php
+++ b/graphs.php
@@ -1403,7 +1403,7 @@ function form_actions() : void {
 					update_graph_title_cache($selected_items[$i]);
 				}
 			} elseif (grv('drp_action') == '9' || grv('drp_action') == '10') {
-				// get common info - not dependant on template/no template
+				// get common info - not dependent on template/no template
 				$local_graph_id = 0; // this will be a new graph
 				$member_graphs  = $selected_items;
 				$graph_title    = form_input_validate(gnrv('title_format'), 'title_format', '', true, 3);

--- a/include/global_arrays.php
+++ b/include/global_arrays.php
@@ -311,7 +311,7 @@ $messages = [
 		'message' => __('Unable to determine size of password field, please check permissions of db user'),
 		'level'   => MESSAGE_LEVEL_ERROR],
 	'nopasswordinc' => [
-		'message' => __('Unable to increase size of password field, pleas check permission of db user'),
+		'message' => __('Unable to increase size of password field, please check permission of db user'),
 		'level'   => MESSAGE_LEVEL_ERROR],
 	'nodomainpassword' => [
 		'message' => __('LDAP/AD based password change not supported.'),
@@ -3101,7 +3101,7 @@ if (CACTI_SERVER_OS == 'unix') {
 		'/usr/share/fonts/truetype/', // SLES
 		'/usr/share/fonts/truetype/dejavu/', // Ubuntu
 		'/usr/local/share/fonts/dejavu/', // FreeBSD
-		__DIR__ . '/fonts'  // Build-in
+		__DIR__ . '/fonts'  // Built-in
 	];
 } else {
 	$dejavu_paths = [

--- a/include/global_form.php
+++ b/include/global_form.php
@@ -22,7 +22,7 @@
  +-------------------------------------------------------------------------+
 */
 
-// Work aorund issue where phpstan is not detecting globals
+// Work around issue where phpstan is not detecting globals
 
 include_once(__DIR__ . '/global_arrays.php');
 

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -24,7 +24,7 @@
 
 $dir = dir(CACTI_PATH_INCLUDE . '/themes/');
 
-// Work aorund issue where phpstan is not detecting globals
+// Work around issue where phpstan is not detecting globals
 
 include_once(__DIR__ . '/global_arrays.php');
 
@@ -1308,7 +1308,7 @@ $settings['visual'] = [
 	],
 	'default_graphs_new_dropdown' => [
 		'friendly_name' => __('Default Graph Type'),
-		'description'   => __('When creating graphs, what Graph Type would you like pre-selected?'),
+		'description'   => __('When creating graphs, what Graph Type would you like preselected?'),
 		'method'        => 'drop_array',
 		'default'       => '-2',
 		'array'         => [
@@ -2092,7 +2092,7 @@ $settings['authentication'] = [
 	],
 	'secpass_history' => [
 		'friendly_name' => __('Password History'),
-		'description'   => __('Remember this number of old passwords and disallow re-using them.'),
+		'description'   => __('Remember this number of old passwords and disallow reusing them.'),
 		'method'        => 'drop_array',
 		'default'       => '0',
 		'array'         => [

--- a/install/upgrades/1_0_0.php
+++ b/install/upgrades/1_0_0.php
@@ -505,7 +505,7 @@ function upgrade_to_1_0_0() : void {
 
 						$pos_array[$parent_id] = $position;
 
-						$postion = $position_result['data'] ?? 0 + 1;
+						$position = $position_result['data'] ?? 0 + 1;
 
 						db_install_execute('UPDATE graph_tree_items
 							SET parent = ?, position = ?
@@ -840,7 +840,7 @@ function upgrade_to_1_0_0() : void {
 		$data['comment']    = 'Aggregate Graph Graph Items';
 		db_table_create('plugin_aggregate_graphs_graph_item', $data);
 
-		// TODO should this go in a seperate upgrade function?
+		// TODO should this go in a separate upgrade function?
 		// Create table holding aggregate template graph params
 		$data               = [];
 		$data['columns'][]  = ['name' => 'aggregate_template_id', 'type' => 'int(10)', 'unsigned' => 'unsigned', 'NULL' => false];
@@ -885,7 +885,7 @@ function upgrade_to_1_0_0() : void {
 		$data['comment']    = 'Aggregate Template Graph Data';
 		db_table_create('plugin_aggregate_graph_templates_graph', $data);
 
-		// TODO should this go in a seperate upgrade function?
+		// TODO should this go in a separate upgrade function?
 		// Add cfed and graph_type override columns to aggregate tables
 		$columns   = [];
 		$columns[] = ['name' => 't_graph_type_id', 'type' => 'char(2)', 'default' => '', 'after' => 'color_template'];

--- a/install/upgrades/1_0_0.php
+++ b/install/upgrades/1_0_0.php
@@ -505,8 +505,6 @@ function upgrade_to_1_0_0() : void {
 
 						$pos_array[$parent_id] = $position;
 
-						$position = $position_result['data'] ?? 0 + 1;
-
 						db_install_execute('UPDATE graph_tree_items
 							SET parent = ?, position = ?
 							WHERE id = ?',

--- a/install/upgrades/1_1_11.php
+++ b/install/upgrades/1_1_11.php
@@ -27,7 +27,7 @@ function upgrade_to_1_1_11() : void {
 		MODIFY COLUMN data_name VARCHAR(40) NOT NULL DEFAULT "",
 		MODIFY COLUMN data_source_names VARCHAR(125) NOT NULL DEFAULT ""');
 
-	// required for tne new plugin structure
+	// required for the new plugin structure
 	db_install_execute('DELETE FROM settings WHERE name LIKE "md5%_plugins"');
 	db_install_execute('DELETE FROM poller_resource_cache WHERE `path` LIKE "plugins/%"');
 }

--- a/install/upgrades/1_1_20.php
+++ b/install/upgrades/1_1_20.php
@@ -53,7 +53,7 @@ function upgrade_to_1_1_20() : void {
 
 	db_install_add_key('snmpagent_cache_textual_conventions', 'key', 'PRIMARY', ['name', 'mib', 'type']);
 
-	// correct dumplicate notifications
+	// correct duplicate notifications
 	$notifications_results = db_install_fetch_assoc('SELECT *, COUNT(*) AS totals
 		FROM snmpagent_managers_notifications
 		GROUP BY manager_id, notification, mib

--- a/install/upgrades/1_2_19.php
+++ b/install/upgrades/1_2_19.php
@@ -25,7 +25,7 @@
 function upgrade_to_1_2_19() : void {
 	// Correct name values in data input fields
 	db_install_execute("UPDATE data_input_fields
-		SET name='SNMP Authenticaion Protocol (v3)'
+		SET name='SNMP Authentication Protocol (v3)'
 		WHERE hash IN ('20832ce12f099c8e54140793a091af90', '2cf7129ad3ff819a7a7ac189bee48ce8')");
 
 	if (!db_column_exists('graph_templates', 'test_source')) {

--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -142,7 +142,7 @@ function aggregate_graph_templates_graph_save(int $local_graph_id, int $graph_te
 		$graph_data['title_cache'] = $existing_data['title_cache'];
 	} else {
 		/* this is an existing graph and not templated from aggregate,
-		 * re-use its old data */
+		 * reuse its old data */
 		$graph_data = $existing_data;
 	}
 

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4259,7 +4259,7 @@ function secpass_check_history(int $id, string $password) : bool {
 
 		$passes = explode('|', is_string($user['password_history']) ? $user['password_history'] : '');
 
-		// Double check this incase the password history setting was changed
+		// Double check this in case the password history setting was changed
 		while (cacti_count($passes) > $history) {
 			array_shift($passes);
 		}
@@ -4630,7 +4630,7 @@ function auth_login_redirect(string $login_opts = '') : void {
 }
 
 /**
- * Provides a URL knowledgable basename function
+ * Provides a URL-knowledgeable basename function
  *
  * @param string $referer The referer URL or file path to extract the base name from.
  *

--- a/lib/dbparallel.php
+++ b/lib/dbparallel.php
@@ -370,7 +370,7 @@ function db_query_parallelize(string $sql, bool $log = true, mixed $db_conn = fa
 	 * ORDER BY
 	 * LIMIT
 	 *
-	 * Knowning this information, we can tokenize the SQL
+	 * Knowing this information, we can tokenize the SQL
 	 * statement and prepare for parallelization.  The MySQL/MariaDB language
 	 * syntax has a very many modifiers that we hope not to have to cover
 	 * in this exercise.  They include, but are not limited to the items included

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -8978,7 +8978,7 @@ function cacti_browser_zone_enabled() : bool {
 }
 
 /**
- * cacti_time_zone_set - Givin an offset in minutes, attempt
+ * cacti_time_zone_set - Given an offset in minutes, attempt
  * to set a PHP date.timezone.  There are some oddballs that
  * we have to accommodate.
  *

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -248,7 +248,7 @@ class Installer implements JsonSerializable {
 
 	/**
 	 * jsonSerialize() - provides JSON object of return data with optional
-	 * values output dependant on Runtime mode.
+	 * values output dependent on Runtime mode.
 	 *
 	 * @return array - An array of options data
 	 */

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -323,7 +323,7 @@ function reports_interval_start(int $interval, int $count, int $offset, int $tim
 		case REPORTS_SCHED_INTVL_MONTH_WEEKDAY:
 			// add $count months to current mailtime, but if this is the nth weekday, it must be the same nth weekday in the new month
 			// e.g. if this is currently the 3rd Monday of current month
-			// ist must be the 3rd Monday of the new month as well
+			// it must be the 3rd Monday of the new month as well
 			$weekday      = date('l', $timestamp);
 			$day_of_month = date('j', $timestamp);
 			$nth_weekday  = ceil($day_of_month / 7);
@@ -392,7 +392,7 @@ function utime_add(int $timestamp, int $yr = 0, int $mon = 0,
  * @param string $string  The string to append to the log file
  * @param bool   $output  Whether to output the log line to the browser using pring() or not
  * @param string $environ Tell's from where the script was called from
- * @param int    $level   The loging verbosity to use
+ * @param int    $level   The logging verbosity to use
  *
  * @return void
  */

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -648,7 +648,7 @@ function generate_report(int $schedule_id, array $report, bool $force = false) :
 }
 
 /**
- * reports_load_format_file  read the format file from disk and determines it's formatting
+ * reports_load_format_file  read the format file from disk and determines its formatting
  *
  * @param string $format_file The file to read from the formats directory
  * @param string $output      The html and css output from that file

--- a/lib/rrdcheck.php
+++ b/lib/rrdcheck.php
@@ -547,7 +547,7 @@ function do_rrdcheck(int $thread_id = 1) : void {
 
 /**
  * rrdcheck_log_statistics - provides generic timing message to both the Cacti log and the settings
- * table so that the statistcs can be graphed as well.
+ * table so that the statistics can be graphed as well.
  *
  * @param string $type The type of statistics to log, either 'HOURLY', 'BOOST'.
  *

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -2032,7 +2032,7 @@ function utility_php_set_installed(array &$extensions) : void {
 }
 
 /**
- * object_cache_get_totals - This function get's the count of objects
+ * object_cache_get_totals - This function gets the count of objects
  *   for a set of object types.  The object types include:
  *
  *   - device_state  - Load the object database with the current state

--- a/locales/po/cacti.pot
+++ b/locales/po/cacti.pot
@@ -1,14 +1,20 @@
-#: about.php:29 include/global_arrays.php:2813 lib/html.php:3214
+#: about.php:29 include/global_arrays.php:2813 lib/html.php:3155
 msgid "About Cacti"
 msgstr ""
 
 #: about.php:44
-msgid "Cacti is designed to be a complete graphing solution based on the RRDtool Time Series Database (TSDB) and Graphing solution. Its goal is to make the Network Administrator's job easier by taking care of all the important details necessary to create meaningful Graphs."
+msgid ""
+"Cacti is designed to be a complete graphing solution based on the RRDtool "
+"Time Series Database (TSDB) and Graphing solution. Its goal is to make the "
+"Network Administrator's job easier by taking care of all the important "
+"details necessary to create meaningful Graphs."
 msgstr ""
 
 #: about.php:46
 #, php-format
-msgid "Please see the official %sCacti website%s for information on how to use Cacti, get support, and updates."
+msgid ""
+"Please see the official %sCacti website%s for information on how to use "
+"Cacti, get support, and updates."
 msgstr ""
 
 #: about.php:50
@@ -16,7 +22,9 @@ msgid "Active Developers"
 msgstr ""
 
 #: about.php:51
-msgid "Developers working on Cacti, its Architecture, Documentation and Future Releases."
+msgid ""
+"Developers working on Cacti, its Architecture, Documentation and Future "
+"Releases."
 msgstr ""
 
 #: about.php:63
@@ -24,7 +32,9 @@ msgid "Honorable Mentions"
 msgstr ""
 
 #: about.php:64
-msgid "Contributors to Documentation, QA, Packaging, the Forums and our YouTube page."
+msgid ""
+"Contributors to Documentation, QA, Packaging, the Forums and our YouTube "
+"page."
 msgstr ""
 
 #: about.php:74
@@ -32,7 +42,9 @@ msgid "Emeritus Members"
 msgstr ""
 
 #: about.php:75
-msgid "Members of the original Cacti Group that have since moved on in their careers.  We continue to wish them the best."
+msgid ""
+"Members of the original Cacti Group that have since moved on in their "
+"careers.  We continue to wish them the best."
 msgstr ""
 
 #: about.php:85
@@ -41,7 +53,9 @@ msgstr ""
 
 #: about.php:88
 #, php-format
-msgid "A very special thanks to %sTobi Oetiker%s, the creator of %sRRDtool%s and the very popular %sMRTG%s."
+msgid ""
+"A very special thanks to %sTobi Oetiker%s, the creator of %sRRDtool%s and "
+"the very popular %sMRTG%s."
 msgstr ""
 
 #: about.php:91
@@ -49,7 +63,10 @@ msgid "The users of Cacti"
 msgstr ""
 
 #: about.php:92
-msgid "Especially anyone who has taken the time to create an issue report, or otherwise help fix a Cacti related problems. Also to anyone who has contributed to supporting Cacti."
+msgid ""
+"Especially anyone who has taken the time to create an issue report, or "
+"otherwise help fix a Cacti related problems. Also to anyone who has "
+"contributed to supporting Cacti."
 msgstr ""
 
 #: about.php:97
@@ -61,11 +78,19 @@ msgid "Cacti is licensed under the GNU GPL:"
 msgstr ""
 
 #: about.php:101 lib/installer.php:2083
-msgid "This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version."
+msgid ""
+"This program is free software; you can redistribute it and/or modify it "
+"under the terms of the GNU General Public License as published by the Free "
+"Software Foundation; either version 2 of the License, or (at your option) "
+"any later version."
 msgstr ""
 
 #: about.php:103
-msgid "This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details."
+msgid ""
+"This program is distributed in the hope that it will be useful, but WITHOUT "
+"ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
+"FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for "
+"more details."
 msgstr ""
 
 #: aggregate_graphs.php:42 aggregate_templates.php:30
@@ -77,13 +102,13 @@ msgstr ""
 #: data_input.php:32 data_input.php:631 data_input.php:679 data_queries.php:31
 #: data_queries.php:816 data_queries.php:924 data_queries.php:1205
 #: data_source_profiles.php:30 data_source_profiles.php:1149
-#: data_sources.php:37 data_sources.php:1139 data_templates.php:34
+#: data_sources.php:37 data_sources.php:1256 data_templates.php:34
 #: data_templates.php:796 gprint_presets.php:28 graph_templates.php:37
 #: graph_templates.php:1423 graphs.php:46 host.php:41 host_templates.php:41
 #: host_templates.php:54 host_templates.php:620 host_templates.php:678
 #: include/global_arrays.php:1800 include/global_settings.php:308
-#: lib/api_automation.php:1418 lib/api_automation.php:1516
-#: lib/api_automation.php:1625 lib/html.php:1697 lib/html_form.php:1780
+#: lib/api_automation.php:1422 lib/api_automation.php:1520
+#: lib/api_automation.php:1629 lib/html.php:1697 lib/html_form.php:1780
 #: lib/html_reports.php:1813 lib/html_reports.php:1917 links.php:28
 #: managers.php:28 package_keys.php:30 package_repos.php:30 pollers.php:38
 #: pollers.php:814 sites.php:28 tree.php:1601 tree.php:1754 tree.php:1814
@@ -96,7 +121,7 @@ msgstr ""
 msgid "Convert to Normal Graph"
 msgstr ""
 
-#: aggregate_graphs.php:44 graphs.php:81 graphs.php:1973
+#: aggregate_graphs.php:44 graphs.php:81 graphs.php:1975
 msgid "Place Graphs on Report"
 msgstr ""
 
@@ -116,7 +141,7 @@ msgstr ""
 msgid "Disassociate with Aggregate"
 msgstr ""
 
-#: aggregate_graphs.php:114 graphs.php:286 host.php:225
+#: aggregate_graphs.php:114 graphs.php:286 host.php:226
 #, php-format
 msgid "Place on a Tree (%s)"
 msgstr ""
@@ -130,28 +155,40 @@ msgid "Override this Value"
 msgstr ""
 
 #: aggregate_graphs.php:822
-msgid "The selected Aggregate Graphs represent elements from more than one Graph Template."
+msgid ""
+"The selected Aggregate Graphs represent elements from more than one Graph "
+"Template."
 msgstr ""
 
 #: aggregate_graphs.php:823
-msgid "In order to migrate the Aggregate Graphs below to a Template based Aggregate, they must only be using one Graph Template."
+msgid ""
+"In order to migrate the Aggregate Graphs below to a Template based "
+"Aggregate, they must only be using one Graph Template."
 msgstr ""
 
 #: aggregate_graphs.php:833
-msgid "The selected Aggregate Graphs does not appear to have any matching Aggregate Templates."
+msgid ""
+"The selected Aggregate Graphs does not appear to have any matching Aggregate "
+"Templates."
 msgstr ""
 
 #: aggregate_graphs.php:834
-msgid "In order to migrate the Aggregate Graphs below use an Aggregate Template, one must already exist."
+msgid ""
+"In order to migrate the Aggregate Graphs below use an Aggregate Template, "
+"one must already exist."
 msgstr ""
 
 #: aggregate_graphs.php:859
-msgid "There are currently no Aggregate Templates defined for the selected Legacy Aggregates."
+msgid ""
+"There are currently no Aggregate Templates defined for the selected Legacy "
+"Aggregates."
 msgstr ""
 
 #: aggregate_graphs.php:860
 #, php-format
-msgid "In order to migrate the Aggregate Graphs below to a Template based Aggregate, first create an Aggregate Template for the Graph Template '%s'."
+msgid ""
+"In order to migrate the Aggregate Graphs below to a Template based "
+"Aggregate, first create an Aggregate Template for the Graph Template '%s'."
 msgstr ""
 
 #: aggregate_graphs.php:879
@@ -175,11 +212,15 @@ msgid "Delete Aggregate Graphs"
 msgstr ""
 
 #: aggregate_graphs.php:907
-msgid "Click 'Continue' to Migrate the following Legacy Aggregate to a Templated Aggregate Graph."
+msgid ""
+"Click 'Continue' to Migrate the following Legacy Aggregate to a Templated "
+"Aggregate Graph."
 msgstr ""
 
 #: aggregate_graphs.php:908
-msgid "Click 'Continue' to Migrate the following Legacy Aggregates to Templated Aggregate Graphs."
+msgid ""
+"Click 'Continue' to Migrate the following Legacy Aggregates to Templated "
+"Aggregate Graphs."
 msgstr ""
 
 #: aggregate_graphs.php:909
@@ -190,12 +231,13 @@ msgstr ""
 msgid "Migrate to Aggregate Graphs"
 msgstr ""
 
-#: aggregate_graphs.php:915 aggregate_graphs.php:2074 graphs.php:1963
+#: aggregate_graphs.php:915 aggregate_graphs.php:2074 graphs.php:1965
 msgid "Aggregate Template"
 msgstr ""
 
 #: aggregate_graphs.php:921
-msgid "Click 'Continue' to Combine the following Aggregates into an Aggregate Graph."
+msgid ""
+"Click 'Continue' to Combine the following Aggregates into an Aggregate Graph."
 msgstr ""
 
 #: aggregate_graphs.php:922
@@ -226,27 +268,29 @@ msgstr ""
 msgid "Place Aggregate Graphs on Report"
 msgstr ""
 
-#: aggregate_graphs.php:941 graphs.php:1977 host.php:538
+#: aggregate_graphs.php:941 graphs.php:1979 host.php:539
 #: lib/html_graph.php:1396 lib/html_reports.php:38
 msgid "Report Name"
 msgstr ""
 
-#: aggregate_graphs.php:947 graphs.php:1983 host.php:544
+#: aggregate_graphs.php:947 graphs.php:1985 host.php:545
 #: lib/html_graph.php:1405 lib/html_reports.php:1667
 msgid "Timespan"
 msgstr ""
 
-#: aggregate_graphs.php:953 graphs.php:1989 host.php:550
+#: aggregate_graphs.php:953 graphs.php:1991 host.php:551
 #: lib/html_graph.php:1414
 msgid "Align"
 msgstr ""
 
 #: aggregate_graphs.php:960
-msgid "Click 'Continue' to Convert the following Aggregate Graph to a Normal Graph."
+msgid ""
+"Click 'Continue' to Convert the following Aggregate Graph to a Normal Graph."
 msgstr ""
 
 #: aggregate_graphs.php:961
-msgid "Click 'Continue' to Convert the following Aggregate Graphs to Normal Graphs."
+msgid ""
+"Click 'Continue' to Convert the following Aggregate Graphs to Normal Graphs."
 msgstr ""
 
 #: aggregate_graphs.php:962
@@ -258,11 +302,13 @@ msgid "Convert Aggregate Graphs"
 msgstr ""
 
 #: aggregate_graphs.php:966
-msgid "Click 'Continue' to Associate the following Graph with the Aggregate Graph."
+msgid ""
+"Click 'Continue' to Associate the following Graph with the Aggregate Graph."
 msgstr ""
 
 #: aggregate_graphs.php:967
-msgid "Click 'Continue' to Associate the following Graphs with the Aggregate Graph."
+msgid ""
+"Click 'Continue' to Associate the following Graphs with the Aggregate Graph."
 msgstr ""
 
 #: aggregate_graphs.php:968
@@ -274,11 +320,15 @@ msgid "Associate Graphs with  Aggregate"
 msgstr ""
 
 #: aggregate_graphs.php:972
-msgid "Click 'Continue' to Disassociate the following Graph from the Aggregate Graph."
+msgid ""
+"Click 'Continue' to Disassociate the following Graph from the Aggregate "
+"Graph."
 msgstr ""
 
 #: aggregate_graphs.php:973
-msgid "Click 'Continue' to Disassociate the following Graphs from the Aggregate Graph."
+msgid ""
+"Click 'Continue' to Disassociate the following Graphs from the Aggregate "
+"Graph."
 msgstr ""
 
 #: aggregate_graphs.php:974
@@ -311,8 +361,8 @@ msgstr ""
 msgid "Destination Branch:"
 msgstr ""
 
-#: aggregate_graphs.php:1052 data_sources.php:1121 lib/html_reports.php:1521
-#: user_admin.php:1874
+#: aggregate_graphs.php:1052 data_sources.php:1238 lib/html_reports.php:1521
+#: user_admin.php:1876
 #, php-format
 msgid "[edit: %s]"
 msgstr ""
@@ -361,15 +411,15 @@ msgstr ""
 msgid "Aggregate Preview %s"
 msgstr ""
 
-#: aggregate_graphs.php:1193 graphs.php:2540 lib/html_graph.php:2303
+#: aggregate_graphs.php:1193 graphs.php:2542 lib/html_graph.php:2303
 msgid "RRDtool Command:"
 msgstr ""
 
-#: aggregate_graphs.php:1195 graphs.php:2542 lib/html_graph.php:2310
+#: aggregate_graphs.php:1195 graphs.php:2544 lib/html_graph.php:2310
 msgid "RRDtool Says:"
 msgstr ""
 
-#: aggregate_graphs.php:1196 graphs.php:2544 lib/html_graph.php:2316
+#: aggregate_graphs.php:1196 graphs.php:2546 lib/html_graph.php:2316
 msgid "Not Checked"
 msgstr ""
 
@@ -378,24 +428,25 @@ msgstr ""
 msgid "Aggregate Graph %s"
 msgstr ""
 
-#: aggregate_graphs.php:1249 aggregate_templates.php:398 graphs.php:1773
+#: aggregate_graphs.php:1249 aggregate_templates.php:398 graphs.php:1775
 msgid "Prefix Replacement Values"
 msgstr ""
 
-#: aggregate_graphs.php:1250 aggregate_templates.php:399 graphs.php:1774
-msgid "You may use these replacement values for the Prefix in the Aggregate Graph"
+#: aggregate_graphs.php:1250 aggregate_templates.php:399 graphs.php:1776
+msgid ""
+"You may use these replacement values for the Prefix in the Aggregate Graph"
 msgstr ""
 
-#: aggregate_graphs.php:1406 aggregate_templates.php:518 graphs.php:2089
+#: aggregate_graphs.php:1406 aggregate_templates.php:518 graphs.php:2091
 #: lib/api_aggregate.php:1843
 msgid "Total"
 msgstr ""
 
-#: aggregate_graphs.php:1411 aggregate_templates.php:522 graphs.php:2091
+#: aggregate_graphs.php:1411 aggregate_templates.php:522 graphs.php:2093
 msgid "All Items"
 msgstr ""
 
-#: aggregate_graphs.php:1430 graphs.php:2555 lib/api_aggregate.php:2023
+#: aggregate_graphs.php:1430 graphs.php:2557 lib/api_aggregate.php:2023
 msgid "Graph Configuration"
 msgstr ""
 
@@ -414,17 +465,17 @@ msgstr ""
 
 #: aggregate_graphs.php:1698 aggregate_graphs.php:1926
 #: automation_devices.php:533 automation_graph_rules.php:841
-#: automation_tree_rules.php:958 data_debug.php:1125 data_sources.php:1772
-#: data_templates.php:1270 graph_templates.php:1983 graphs.php:3173
-#: graphs_new.php:334 host.php:1970 host_templates.php:893
+#: automation_tree_rules.php:958 data_debug.php:1125 data_sources.php:1889
+#: data_templates.php:1270 graph_templates.php:1983 graphs.php:3175
+#: graphs_new.php:334 host.php:1971 host_templates.php:893
 #: host_templates.php:1294 lib/api_automation.php:67 lib/api_automation.php:536
-#: lib/clog_webapi.php:715 lib/html.php:3284 lib/html_filter.php:126
+#: lib/clog_webapi.php:715 lib/html.php:3225 lib/html_filter.php:126
 #: lib/html_graph.php:303 lib/html_graph.php:1039 lib/html_reports.php:1882
 #: lib/html_reports.php:1968 lib/html_tree.php:153 lib/html_tree.php:1005
 #: managers.php:302 managers.php:495 plugins.php:618 rrdcheck.php:212
 #: rrdcleaner.php:478 settings.php:65 settings.php:343 settings.php:360
 #: settings.php:411 support.php:266 support.php:503 tree.php:862 tree.php:898
-#: tree.php:934 user_admin.php:2065 user_admin.php:2357 user_admin.php:2453
+#: tree.php:934 user_admin.php:2067 user_admin.php:2359 user_admin.php:2455
 #: user_group_admin.php:1991 user_group_admin.php:2073 user_log.php:275
 #: utilities.php:325 utilities.php:779 utilities.php:1506 utilities.php:1697
 msgid "Search"
@@ -432,15 +483,15 @@ msgstr ""
 
 #: aggregate_graphs.php:1704 aggregate_graphs.php:1707
 #: aggregate_graphs.php:1752 aggregate_graphs.php:1946 color_templates.php:829
-#: data_sources.php:1467 data_sources.php:1601 graphs.php:2903 graphs.php:3184
-#: host.php:1631 include/global_arrays.php:1094 include/global_arrays.php:1374
+#: data_sources.php:1584 data_sources.php:1718 graphs.php:2905 graphs.php:3186
+#: host.php:1632 include/global_arrays.php:1094 include/global_arrays.php:1374
 #: include/global_arrays.php:2151 lib/api_automation.php:225
 #: lib/api_automation.php:565 lib/api_automation.php:643 lib/html.php:2168
 #: lib/html_graph.php:267 lib/html_graph.php:381 lib/html_graph.php:912
 #: lib/html_graph.php:1062 lib/html_graph.php:1134 lib/html_graph.php:1268
 #: lib/html_tree.php:1032 lib/html_tree.php:1141 lib/html_tree.php:1534
 #: support.php:1263 tree.php:840 tree.php:2179 user_admin.php:893
-#: user_admin.php:1172 user_admin.php:2377 user_admin.php:2407
+#: user_admin.php:1172 user_admin.php:2379 user_admin.php:2409
 #: user_group_admin.php:869 user_group_admin.php:1039 user_group_admin.php:2011
 #: user_group_admin.php:2041
 msgid "Graphs"
@@ -448,7 +499,7 @@ msgstr ""
 
 #: aggregate_graphs.php:1708 data_source_profiles.php:1392
 #: include/global_arrays.php:1283 include/global_form.php:281
-#: package_repos.php:33 package_repos.php:360 package_repos.php:480
+#: package_repos.php:33 package_repos.php:379 package_repos.php:499
 #: plugins.php:659 user_domains.php:33 user_domains.php:634
 msgid "Default"
 msgstr ""
@@ -459,16 +510,16 @@ msgstr ""
 
 #: aggregate_graphs.php:1731 aggregate_graphs.php:1964
 #: automation_devices.php:594 automation_graph_rules.php:882
-#: automation_tree_rules.php:990 data_debug.php:1148 data_sources.php:1795
-#: data_templates.php:1293 graph_templates.php:2007 graphs.php:3196
-#: graphs_new.php:357 host.php:2011 host_templates.php:916
+#: automation_tree_rules.php:990 data_debug.php:1148 data_sources.php:1912
+#: data_templates.php:1293 graph_templates.php:2007 graphs.php:3198
+#: graphs_new.php:357 host.php:2012 host_templates.php:916
 #: host_templates.php:1317 lib/api_automation.php:108
 #: lib/api_automation.php:577 lib/clog_webapi.php:738 lib/html.php:1985
 #: lib/html_filter.php:149 lib/html_graph.php:346 lib/html_graph.php:1094
 #: lib/html_reports.php:1912 lib/html_reports.php:2009 lib/html_tree.php:1106
 #: managers.php:335 managers.php:527 plugins.php:671 rrdcheck.php:244
-#: rrdcleaner.php:510 support.php:316 support.php:545 user_admin.php:2115
-#: user_admin.php:2389 user_admin.php:2485 user_group_admin.php:2023
+#: rrdcleaner.php:510 support.php:316 support.php:545 user_admin.php:2117
+#: user_admin.php:2391 user_admin.php:2487 user_group_admin.php:2023
 #: user_group_admin.php:2105 user_log.php:316 utilities.php:357
 #: utilities.php:820 utilities.php:1539 utilities.php:1738
 msgid "Go"
@@ -480,16 +531,16 @@ msgstr ""
 
 #: aggregate_graphs.php:1732 aggregate_graphs.php:1969
 #: automation_devices.php:599 automation_graph_rules.php:887
-#: automation_tree_rules.php:995 data_debug.php:1153 data_sources.php:1800
-#: data_templates.php:1298 graph_templates.php:2012 graphs.php:3201
-#: graphs_new.php:362 host.php:2016 host_templates.php:921
+#: automation_tree_rules.php:995 data_debug.php:1153 data_sources.php:1917
+#: data_templates.php:1298 graph_templates.php:2012 graphs.php:3203
+#: graphs_new.php:362 host.php:2017 host_templates.php:921
 #: host_templates.php:1322 lib/api_automation.php:113
 #: lib/api_automation.php:582 lib/clog_webapi.php:743 lib/html_filter.php:154
 #: lib/html_filter.php:590 lib/html_graph.php:352 lib/html_graph.php:1099
 #: lib/html_reports.php:2014 lib/html_tree.php:1112 managers.php:340
 #: managers.php:532 plugins.php:672 rrdcheck.php:249 rrdcleaner.php:515
-#: settings.php:67 support.php:321 support.php:550 user_admin.php:2120
-#: user_admin.php:2394 user_admin.php:2490 user_group_admin.php:2028
+#: settings.php:67 support.php:321 support.php:550 user_admin.php:2122
+#: user_admin.php:2396 user_admin.php:2492 user_group_admin.php:2028
 #: user_group_admin.php:2110 user_log.php:321 utilities.php:362
 #: utilities.php:825 utilities.php:1544 utilities.php:1743
 msgid "Clear"
@@ -507,8 +558,8 @@ msgstr ""
 #: aggregate_graphs.php:1763 aggregate_graphs.php:2068
 #: automation_graph_rules.php:994 automation_tree_rules.php:1100
 #: data_debug.php:398 data_input.php:780 data_queries.php:1321
-#: data_sources.php:1461 data_templates.php:1107 graph_templates.php:1647
-#: graphs.php:2919 host.php:1619 host_templates.php:1074
+#: data_sources.php:1578 data_templates.php:1107 graph_templates.php:1647
+#: graphs.php:2921 host.php:1620 host_templates.php:1074
 #: host_templates.php:1478 lib/api_automation.php:220 package_keys.php:183
 #: pollers.php:964 sites.php:544 support.php:876 support.php:919 tree.php:2119
 #: user_admin.php:901 user_admin.php:1023 user_admin.php:1172
@@ -523,8 +574,8 @@ msgid "Included in Aggregate"
 msgstr ""
 
 #: aggregate_graphs.php:1773 aggregate_graphs.php:2080 graph_templates.php:1688
-#: graphs.php:2943 host_templates.php:1484 lib/html_graph.php:1307
-#: lib/html_graph.php:1320 lib/spikekill.php:1153 plugins.php:1148
+#: graphs.php:2945 host_templates.php:1484 lib/html_graph.php:1307
+#: lib/html_graph.php:1320 lib/spikekill.php:1016 plugins.php:1148
 #: plugins.php:1225
 msgid "Size"
 msgstr ""
@@ -533,13 +584,13 @@ msgstr ""
 #: automation_templates.php:1287 automation_tree_rules.php:884 cdef.php:786
 #: color.php:570 color.php:572 color_templates.php:853 data_input.php:827
 #: data_queries.php:1378 data_source_profiles.php:1474
-#: data_source_profiles.php:1475 data_sources.php:1547 data_sources.php:1548
+#: data_source_profiles.php:1475 data_sources.php:1664 data_sources.php:1665
 #: data_templates.php:1177 gprint_presets.php:281 graph_templates.php:1733
 #: host_templates.php:1129 include/global_settings.php:710
-#: include/global_settings.php:1231 include/global_settings.php:2219
-#: lib/api_automation.php:1596 links.php:348 package_repos.php:504
-#: package_repos.php:505 support.php:249 support.php:1068 tree.php:2214
-#: tree.php:2215 user_admin.php:2286 user_domains.php:693
+#: include/global_settings.php:1233 include/global_settings.php:2223
+#: lib/api_automation.php:1600 links.php:348 package_repos.php:523
+#: package_repos.php:524 support.php:249 support.php:1068 tree.php:2214
+#: tree.php:2215 user_admin.php:2288 user_domains.php:693
 #: user_group_admin.php:1937 vdef.php:789
 msgid "No"
 msgstr ""
@@ -550,39 +601,39 @@ msgstr ""
 #: data_debug.php:653 data_debug.php:659 data_input.php:827
 #: data_queries.php:1378 data_source_profiles.php:1473
 #: data_source_profiles.php:1474 data_source_profiles.php:1475
-#: data_sources.php:1547 data_sources.php:1548 data_templates.php:1177
+#: data_sources.php:1664 data_sources.php:1665 data_templates.php:1177
 #: gprint_presets.php:281 graph_templates.php:1733 host_templates.php:1129
-#: include/global_settings.php:711 include/global_settings.php:1230
-#: include/global_settings.php:2218 lib/api_automation.php:1596
+#: include/global_settings.php:711 include/global_settings.php:1232
+#: include/global_settings.php:2222 lib/api_automation.php:1600
 #: lib/installer.php:2292 lib/installer.php:2320 lib/installer.php:4175
-#: links.php:348 package_repos.php:504 package_repos.php:505 support.php:250
-#: support.php:1068 tree.php:2214 tree.php:2215 user_admin.php:2284
+#: links.php:348 package_repos.php:523 package_repos.php:524 support.php:250
+#: support.php:1068 tree.php:2214 tree.php:2215 user_admin.php:2286
 #: user_domains.php:689 user_domains.php:693 user_group_admin.php:1935
 #: vdef.php:789
 msgid "Yes"
 msgstr ""
 
-#: aggregate_graphs.php:1799 graphs.php:2989 lib/api_automation.php:709
+#: aggregate_graphs.php:1799 graphs.php:2991 lib/api_automation.php:709
 msgid "No Graphs Found"
 msgstr ""
 
 #: aggregate_graphs.php:1907 automation_devices.php:523
 #: automation_graph_rules.php:817 automation_graph_rules.php:829
 #: automation_tree_rules.php:948 data_debug.php:962 data_debug.php:1024
-#: data_sources.php:1619 data_sources.php:1671 data_templates.php:1210
+#: data_sources.php:1736 data_sources.php:1788 data_templates.php:1210
 #: graph_templates.php:909 graph_templates.php:1884 graphs.php:805
-#: graphs.php:830 graphs.php:3011 graphs.php:3094 host.php:1836 host.php:1848
+#: graphs.php:830 graphs.php:3013 graphs.php:3096 host.php:1837 host.php:1849
 #: lib/api_automation.php:39 lib/api_automation.php:52
-#: lib/api_automation.php:487 lib/api_automation.php:521 lib/auth.php:3198
-#: lib/auth.php:3248 lib/clog_webapi.php:598 lib/html.php:2665
+#: lib/api_automation.php:487 lib/api_automation.php:521 lib/auth.php:3218
+#: lib/auth.php:3268 lib/clog_webapi.php:598 lib/html.php:2665
 #: lib/html.php:2689 lib/html.php:2731 lib/html.php:2772 lib/html_graph.php:122
 #: lib/html_graph.php:164 lib/html_graph.php:170 lib/html_graph.php:939
 #: lib/html_graph.php:973 lib/html_graph.php:979 lib/html_reports.php:951
 #: lib/html_reports.php:955 lib/html_reports.php:1077 lib/html_reports.php:1087
 #: lib/html_reports.php:1846 lib/html_reports.php:1948
 #: lib/html_reports.php:1958 lib/html_tree.php:948 managers.php:293
-#: rrdcheck.php:195 support.php:236 user_admin.php:2030 user_admin.php:2338
-#: user_admin.php:2436 user_group_admin.php:1972 user_group_admin.php:2056
+#: rrdcheck.php:195 support.php:236 user_admin.php:2032 user_admin.php:2340
+#: user_admin.php:2438 user_group_admin.php:1972 user_group_admin.php:2056
 #: user_log.php:263 utilities.php:209 utilities.php:222 utilities.php:228
 #: utilities.php:256 utilities.php:666 utilities.php:679 utilities.php:685
 #: utilities.php:713 utilities.php:1497 utilities.php:1681 utilities.php:1684
@@ -592,12 +643,12 @@ msgstr ""
 #: aggregate_graphs.php:1908 aggregate_graphs.php:2105
 #: automation_graph_rules.php:1020 automation_graph_rules.php:1021
 #: automation_networks.php:705 automation_tree_rules.php:1135
-#: data_debug.php:963 data_debug.php:1021 data_sources.php:999
-#: data_sources.php:1518 data_sources.php:1620 data_sources.php:1668
+#: data_debug.php:963 data_debug.php:1021 data_sources.php:1116
+#: data_sources.php:1635 data_sources.php:1737 data_sources.php:1785
 #: data_templates.php:1181 data_templates.php:1211 graph_templates.php:85
 #: graph_templates.php:1885 graphs.php:806 graphs.php:827 graphs.php:1023
-#: graphs.php:2403 graphs.php:2413 graphs.php:3012 graphs.php:3091 host.php:264
-#: host.php:1837 include/global_arrays.php:539 include/global_arrays.php:597
+#: graphs.php:2405 graphs.php:2415 graphs.php:3014 graphs.php:3093 host.php:265
+#: host.php:1838 include/global_arrays.php:539 include/global_arrays.php:597
 #: include/global_arrays.php:700 include/global_arrays.php:975
 #: include/global_arrays.php:1884 include/global_form.php:613
 #: include/global_form.php:919 include/global_form.php:927
@@ -607,13 +658,13 @@ msgstr ""
 #: include/global_form.php:1073 include/global_form.php:1282
 #: include/global_form.php:1301 include/global_form.php:1310
 #: include/global_form.php:2298 include/global_form.php:2340
-#: include/global_settings.php:847 include/global_settings.php:855
-#: include/global_settings.php:863 include/global_settings.php:1607
-#: include/global_settings.php:2293 include/global_settings.php:2381
+#: include/global_settings.php:849 include/global_settings.php:857
+#: include/global_settings.php:865 include/global_settings.php:1611
+#: include/global_settings.php:2297 include/global_settings.php:2385
 #: lib/api_automation.php:40 lib/api_automation.php:488
-#: lib/api_automation.php:692 lib/auth.php:3202 lib/auth.php:3252
-#: lib/auth.php:3299 lib/clog_webapi.php:599 lib/html.php:2666
-#: lib/html.php:2687 lib/html.php:2732 lib/html.php:2773 lib/html.php:3308
+#: lib/api_automation.php:692 lib/auth.php:3222 lib/auth.php:3272
+#: lib/auth.php:3319 lib/clog_webapi.php:599 lib/html.php:2666
+#: lib/html.php:2687 lib/html.php:2732 lib/html.php:2773 lib/html.php:3249
 #: lib/html_form.php:407 lib/html_graph.php:123 lib/html_graph.php:167
 #: lib/html_graph.php:940 lib/html_graph.php:976 lib/html_reports.php:172
 #: lib/html_reports.php:962 lib/html_reports.php:966 lib/html_reports.php:999
@@ -625,34 +676,34 @@ msgstr ""
 #: lib/html_reports.php:1949 lib/html_tree.php:949 lib/installer.php:3177
 #: package_import.php:1193 rrdcheck.php:196 settings.php:336 settings.php:358
 #: settings.php:381 support.php:237 templates_import.php:330
-#: templates_import.php:362 user_admin.php:2031 user_admin.php:2339
-#: user_admin.php:2437 user_group_admin.php:1973 user_group_admin.php:2057
+#: templates_import.php:362 user_admin.php:2033 user_admin.php:2341
+#: user_admin.php:2439 user_group_admin.php:1973 user_group_admin.php:2057
 #: utilities.php:210 utilities.php:259 utilities.php:667 utilities.php:716
 msgid "None"
 msgstr ""
 
 #: aggregate_graphs.php:1928 automation_devices.php:535
 #: automation_graph_rules.php:843 automation_tree_rules.php:960
-#: data_debug.php:1127 data_sources.php:1774 data_templates.php:1272
-#: graph_templates.php:1986 graphs.php:3175 graphs_new.php:336 host.php:1972
+#: data_debug.php:1127 data_sources.php:1891 data_templates.php:1272
+#: graph_templates.php:1986 graphs.php:3177 graphs_new.php:336 host.php:1973
 #: host_templates.php:895 host_templates.php:1296 lib/api_automation.php:69
-#: lib/api_automation.php:538 lib/clog_webapi.php:726 lib/html.php:3281
+#: lib/api_automation.php:538 lib/clog_webapi.php:726 lib/html.php:3222
 #: lib/html_filter.php:128 lib/html_graph.php:305 lib/html_graph.php:1041
 #: lib/html_reports.php:1884 lib/html_reports.php:1970 lib/html_tree.php:1007
 #: managers.php:304 managers.php:497 rrdcheck.php:214 rrdcleaner.php:480
-#: support.php:268 support.php:505 user_admin.php:2067 user_admin.php:2359
-#: user_admin.php:2455 user_group_admin.php:1993 user_group_admin.php:2075
+#: support.php:268 support.php:505 user_admin.php:2069 user_admin.php:2361
+#: user_admin.php:2457 user_group_admin.php:1993 user_group_admin.php:2075
 #: user_log.php:277 utilities.php:327 utilities.php:781 utilities.php:1508
 #: utilities.php:1699
 msgid "Enter a search term"
 msgstr ""
 
-#: aggregate_graphs.php:1937 data_debug.php:1076 data_sources.php:1723
-#: graphs.php:873 graphs.php:3123 host.php:1949 include/global_arrays.php:3085
-#: include/global_settings.php:843 lib/api_automation.php:78
+#: aggregate_graphs.php:1937 data_debug.php:1076 data_sources.php:1840
+#: graphs.php:873 graphs.php:3125 host.php:1950 include/global_arrays.php:3085
+#: include/global_settings.php:845 lib/api_automation.php:78
 #: lib/api_automation.php:556 lib/html_graph.php:253 lib/html_graph.php:1050
 #: lib/html_tree.php:1018 rrdcleaner.php:342 support.php:295
-#: user_admin.php:2368 user_admin.php:2464 user_group_admin.php:2002
+#: user_admin.php:2370 user_admin.php:2466 user_group_admin.php:2002
 #: user_group_admin.php:2084 utilities.php:768
 msgid "Template"
 msgstr ""
@@ -742,14 +793,16 @@ msgstr ""
 
 #: aggregate_templates.php:592 cdef.php:752 color.php:529
 #: color_templates.php:824 data_input.php:786 data_queries.php:1327
-#: data_source_profiles.php:1397 data_sources.php:1479 data_templates.php:1113
+#: data_source_profiles.php:1397 data_sources.php:1596 data_templates.php:1113
 #: gprint_presets.php:239 graph_templates.php:1665 host_templates.php:1080
 #: vdef.php:755
 msgid "Deletable"
 msgstr ""
 
 #: aggregate_templates.php:594
-msgid "Aggregate Templates that are in use can not be Deleted.  In use is defined as being referenced by an Aggregate."
+msgid ""
+"Aggregate Templates that are in use can not be Deleted.  In use is defined "
+"as being referenced by an Aggregate."
 msgstr ""
 
 #: aggregate_templates.php:597 cdef.php:757 color.php:535 data_queries.php:1153
@@ -758,7 +811,7 @@ msgstr ""
 msgid "Graphs Using"
 msgstr ""
 
-#: aggregate_templates.php:602 graphs.php:3043 host_templates.php:1263
+#: aggregate_templates.php:602 graphs.php:3045 host_templates.php:1263
 #: include/global_arrays.php:1047 include/global_arrays.php:1509
 #: include/global_form.php:1569 include/global_form.php:1805
 #: lib/html_reports.php:1111 tree.php:1857
@@ -806,7 +859,8 @@ msgid "Your current password is not correct. Please try again."
 msgstr ""
 
 #: auth_changepassword.php:182 auth_resetpassword.php:149
-msgid "Your new password cannot be the same as the old password. Please try again."
+msgid ""
+"Your new password cannot be the same as the old password. Please try again."
 msgstr ""
 
 #: auth_changepassword.php:268
@@ -840,7 +894,9 @@ msgid "Cannot be reused for %d password changes"
 msgstr ""
 
 #: auth_changepassword.php:367
-msgid "There are problems with the Change Password page.  Contact your Cacti administrator right away."
+msgid ""
+"There are problems with the Change Password page.  Contact your Cacti "
+"administrator right away."
 msgstr ""
 
 #: auth_changepassword.php:376
@@ -852,12 +908,12 @@ msgid "Please enter your new Cacti password."
 msgstr ""
 
 #: auth_changepassword.php:381 include/global_form.php:1722
-#: lib/functions.php:4113 lib/html.php:3238
+#: lib/functions.php:4167 lib/html.php:3179
 msgid "Change Password"
 msgstr ""
 
 #: auth_changepassword.php:393 auth_login.php:294 auth_login.php:297
-#: lib/functions.php:6014 user_admin.php:384
+#: lib/functions.php:6083 user_admin.php:384
 msgid "Username"
 msgstr ""
 
@@ -889,20 +945,28 @@ msgid "Return"
 msgstr ""
 
 #: auth_login.php:74
-msgid "Cacti no longer supports No Authentication mode. Please contact your System Administrator."
+msgid ""
+"Cacti no longer supports No Authentication mode. Please contact your System "
+"Administrator."
 msgstr ""
 
 #: auth_login.php:101
-msgid "Unable to determine user Login Realm or Domain. Please contact your System Administrator."
+msgid ""
+"Unable to determine user Login Realm or Domain. Please contact your System "
+"Administrator."
 msgstr ""
 
 #: auth_login.php:128
-msgid "User was Authenticated, but the Template Account is disabled. Using Guest Account"
+msgid ""
+"User was Authenticated, but the Template Account is disabled. Using Guest "
+"Account"
 msgstr ""
 
 #: auth_login.php:135
 #, php-format
-msgid "Access Denied!  Guest user id %s does not exist.  Please contact your Administrator."
+msgid ""
+"Access Denied!  Guest user id %s does not exist.  Please contact your "
+"Administrator."
 msgstr ""
 
 #: auth_login.php:173
@@ -910,7 +974,8 @@ msgid "Access Denied!  User account disabled."
 msgstr ""
 
 #: auth_login.php:185
-msgid "You do not have access to any area of Cacti.  Contact your administrator."
+msgid ""
+"You do not have access to any area of Cacti.  Contact your administrator."
 msgstr ""
 
 #: auth_login.php:280 lib/html_tree.php:233
@@ -925,35 +990,35 @@ msgstr ""
 msgid "Enter your Username and Password below"
 msgstr ""
 
-#: auth_login.php:302 include/global_form.php:1689 lib/functions.php:6015
+#: auth_login.php:302 include/global_form.php:1689 lib/functions.php:6084
 msgid "Password"
 msgstr ""
 
-#: auth_login.php:321 user_admin.php:396 user_admin.php:2094
-#: user_admin.php:2244 user_group_admin.php:654
+#: auth_login.php:321 user_admin.php:396 user_admin.php:2096
+#: user_admin.php:2246 user_group_admin.php:654
 msgid "Realm"
 msgstr ""
 
-#: auth_login.php:348
+#: auth_login.php:344
 msgid "Keep me signed in"
 msgstr ""
 
-#: auth_login.php:355
+#: auth_login.php:351
 msgid "Login"
 msgstr ""
 
-#: auth_login.php:365
+#: auth_login.php:361
 msgid "Invalid User Name/Password Please Retype"
 msgstr ""
 
-#: auth_login.php:369
+#: auth_login.php:365
 msgid "User Account Disabled"
 msgstr ""
 
 #: auth_profile.php:92 include/global_settings.php:61
-#: include/global_settings.php:1498 include/global_settings.php:1708
-#: include/global_settings.php:1854 lib/html.php:3225 managers.php:39
-#: user_admin.php:1850 user_group_admin.php:1713
+#: include/global_settings.php:1500 include/global_settings.php:1712
+#: include/global_settings.php:1858 lib/html.php:3166 managers.php:39
+#: user_admin.php:1852 user_group_admin.php:1713
 msgid "General"
 msgstr ""
 
@@ -966,21 +1031,21 @@ msgid "User Account Details"
 msgstr ""
 
 #: auth_profile.php:333 include/global_arrays.php:948
-#: include/global_settings.php:3232 lib/html.php:2336 lib/html.php:3300
+#: include/global_settings.php:3190 lib/html.php:2336 lib/html.php:3241
 msgid "Tree View"
 msgstr ""
 
 #: auth_profile.php:337 include/global_arrays.php:949 lib/html.php:2345
-#: lib/html.php:3264
+#: lib/html.php:3205
 msgid "List View"
 msgstr ""
 
-#: auth_profile.php:341 include/global_arrays.php:950 lib/html.php:3277
+#: auth_profile.php:341 include/global_arrays.php:950 lib/html.php:3218
 msgid "Preview View"
 msgstr ""
 
 #: auth_profile.php:354 auth_profile.php:543 include/global_form.php:1664
-#: user_admin.php:2228
+#: user_admin.php:2230
 msgid "User Name"
 msgstr ""
 
@@ -989,17 +1054,19 @@ msgid "The login name for this user."
 msgstr ""
 
 #: auth_profile.php:362 include/global_form.php:1672 user_admin.php:390
-#: user_admin.php:2236 user_domains.php:499 user_group_admin.php:650
+#: user_admin.php:2238 user_domains.php:499 user_group_admin.php:650
 #: user_log.php:111
 msgid "Full Name"
 msgstr ""
 
 #: auth_profile.php:363 include/global_form.php:1673
-msgid "A more descriptive name for this user, that can include spaces or special characters."
+msgid ""
+"A more descriptive name for this user, that can include spaces or special "
+"characters."
 msgstr ""
 
 #: auth_profile.php:371 include/global_form.php:1680
-#: include/global_settings.php:2325 package.php:415
+#: include/global_settings.php:2329 package.php:415
 msgid "Email Address"
 msgstr ""
 
@@ -1028,10 +1095,12 @@ msgid "Logout Everywhere"
 msgstr ""
 
 #: auth_profile.php:398
-msgid "Clear all your Login Session Tokens from all devices that you have logged into using your session cookies."
+msgid ""
+"Clear all your Login Session Tokens from all devices that you have logged "
+"into using your session cookies."
 msgstr ""
 
-#: auth_profile.php:421 user_admin.php:1857 user_group_admin.php:1720
+#: auth_profile.php:421 user_admin.php:1859 user_group_admin.php:1720
 msgid "User Settings"
 msgstr ""
 
@@ -1052,7 +1121,9 @@ msgid "2FA QA Code"
 msgstr ""
 
 #: auth_profile.php:561
-msgid "The 2FA QA Code to be scanned with Google Authenticator, Authy or any compatible 2FA app"
+msgid ""
+"The 2FA QA Code to be scanned with Google Authenticator, Authy or any "
+"compatible 2FA app"
 msgstr ""
 
 #: auth_profile.php:568
@@ -1060,7 +1131,8 @@ msgid "2FA App Token"
 msgstr ""
 
 #: auth_profile.php:569
-msgid "The token generated by Google Authenticator, Auth or any compatible 2FA app"
+msgid ""
+"The token generated by Google Authenticator, Auth or any compatible 2FA app"
 msgstr ""
 
 #: auth_profile.php:576 auth_profile.php:578
@@ -1074,17 +1146,17 @@ msgstr ""
 #: auth_profile.php:606 auth_profile.php:651 automation_graph_rules.php:831
 #: automation_graph_rules.php:1029 automation_networks.php:1119
 #: automation_tree_rules.php:950 automation_tree_rules.php:1147
-#: data_debug.php:986 data_sources.php:1642 data_templates.php:1183
-#: host.php:1850 include/global_arrays.php:1005 include/global_arrays.php:1725
+#: data_debug.php:986 data_sources.php:1759 data_templates.php:1183
+#: host.php:1851 include/global_arrays.php:1005 include/global_arrays.php:1725
 #: include/global_arrays.php:2008 include/global_form.php:1351
 #: include/global_settings.php:471 include/global_settings.php:487
-#: include/global_settings.php:1058 include/global_settings.php:1646
-#: include/global_settings.php:1663 include/global_settings.php:1682
-#: include/global_settings.php:1696 include/global_settings.php:1927
-#: include/global_settings.php:1942 include/global_settings.php:2067
-#: include/global_settings.php:2082 include/global_settings.php:2095
-#: include/global_settings.php:3040 lib/api_automation.php:54
-#: lib/api_automation.php:523 lib/html.php:3317 lib/html_reports.php:1960
+#: include/global_settings.php:1060 include/global_settings.php:1650
+#: include/global_settings.php:1667 include/global_settings.php:1686
+#: include/global_settings.php:1700 include/global_settings.php:1931
+#: include/global_settings.php:1946 include/global_settings.php:2071
+#: include/global_settings.php:2086 include/global_settings.php:2099
+#: include/global_settings.php:2998 lib/api_automation.php:54
+#: lib/api_automation.php:523 lib/html.php:3258 lib/html_reports.php:1960
 #: lib/html_utility.php:1523 links.php:462 managers.php:154 managers.php:461
 #: pollers.php:54 sites.php:593 user_admin.php:1036 user_domains.php:414
 #: user_group_admin.php:688 utilities.php:224 utilities.php:681
@@ -1096,14 +1168,14 @@ msgstr ""
 #: automation_graph_rules.php:1010 automation_graph_rules.php:1029
 #: automation_networks.php:782 automation_tree_rules.php:949
 #: automation_tree_rules.php:1125 automation_tree_rules.php:1147
-#: data_debug.php:985 data_sources.php:1641 host.php:1849
+#: data_debug.php:985 data_sources.php:1758 host.php:1850
 #: include/global_arrays.php:1006 include/global_form.php:1697
 #: include/global_settings.php:472 include/global_settings.php:488
 #: lib/api_automation.php:53 lib/api_automation.php:522
 #: lib/html_reports.php:1959 lib/html_reports.php:2195 links.php:318
-#: links.php:523 managers.php:154 managers.php:461 package_repos.php:353
-#: package_repos.php:475 sites.php:593 user_admin.php:1023 user_admin.php:1036
-#: user_admin.php:2240 user_domains.php:319 user_domains.php:650
+#: links.php:523 managers.php:154 managers.php:461 package_repos.php:372
+#: package_repos.php:494 sites.php:593 user_admin.php:1023 user_admin.php:1036
+#: user_admin.php:2242 user_domains.php:319 user_domains.php:650
 #: user_group_admin.php:87 user_group_admin.php:653 user_group_admin.php:688
 #: user_group_admin.php:1917 utilities.php:223 utilities.php:680
 #: utilities.php:1478
@@ -1162,19 +1234,19 @@ msgstr ""
 msgid "Add Device"
 msgstr ""
 
-#: automation_devices.php:46 host.php:479
+#: automation_devices.php:46 host.php:480
 msgid "Delete Device"
 msgstr ""
 
 #: automation_devices.php:54 automation_devices.php:372
-#: automation_devices.php:674 automation_devices.php:675 host.php:1853
+#: automation_devices.php:674 automation_devices.php:675 host.php:1854
 #: lib/api_automation.php:57 lib/api_automation.php:526
 #: lib/html_utility.php:1532 pollers.php:53
 msgid "Down"
 msgstr ""
 
 #: automation_devices.php:55 automation_devices.php:372
-#: automation_devices.php:674 automation_devices.php:675 host.php:1852
+#: automation_devices.php:674 automation_devices.php:675 host.php:1853
 #: lib/api_automation.php:56 lib/api_automation.php:525
 #: lib/html_utility.php:1534
 msgid "Up"
@@ -1215,7 +1287,7 @@ msgid "Add Discovered Devices"
 msgstr ""
 
 #: automation_devices.php:230 include/global_settings.php:65
-#: include/global_settings.php:859 lib/installer.php:3173
+#: include/global_settings.php:861 lib/installer.php:3173
 msgid "Poller"
 msgstr ""
 
@@ -1247,12 +1319,12 @@ msgid "Remove Discovered Devices"
 msgstr ""
 
 #: automation_devices.php:285 automation_devices.php:582
-#: automation_devices.php:631 host.php:1716 host.php:1999 host.php:2055
-#: host.php:2056 include/global_arrays.php:1091 include/global_arrays.php:1161
+#: automation_devices.php:631 host.php:1717 host.php:2000 host.php:2056
+#: host.php:2057 include/global_arrays.php:1091 include/global_arrays.php:1161
 #: include/global_arrays.php:2501 lib/api_automation.php:36
-#: lib/api_automation.php:187 lib/api_automation.php:1216 pollers.php:1000
+#: lib/api_automation.php:187 lib/api_automation.php:1220 pollers.php:1000
 #: sites.php:556 support.php:1258 tree.php:839 tree.php:2173
-#: user_admin.php:1164 user_admin.php:2473 user_admin.php:2503
+#: user_admin.php:1164 user_admin.php:2475 user_admin.php:2505
 #: user_group_admin.php:1045 user_group_admin.php:2093
 #: user_group_admin.php:2123
 msgid "Devices"
@@ -1278,10 +1350,10 @@ msgstr ""
 msgid "SNMP Name"
 msgstr ""
 
-#: automation_devices.php:320 host.php:1958 include/global_form.php:1280
-#: include/global_settings.php:2777 lib/api_automation.php:207
+#: automation_devices.php:320 host.php:1959 include/global_form.php:1280
+#: include/global_settings.php:2781 lib/api_automation.php:207
 #: lib/api_automation.php:675 lib/html.php:2768 lib/html_graph.php:228
-#: lib/html_graph.php:1014 package_repos.php:329 package_repos.php:466
+#: lib/html_graph.php:1014 package_repos.php:348 package_repos.php:485
 msgid "Location"
 msgstr ""
 
@@ -1292,7 +1364,7 @@ msgstr ""
 #: automation_devices.php:330 include/global_form.php:1229
 #: include/global_form.php:1265 include/global_form.php:1533
 #: include/global_form.php:1909 lib/api_automation.php:195
-#: lib/api_automation.php:1224 lib/installer.php:2204 lib/installer.php:2953
+#: lib/api_automation.php:1228 lib/installer.php:2204 lib/installer.php:2953
 #: managers.php:121 package.php:341 support.php:875 support.php:918
 #: user_admin.php:1023 user_admin.php:1172 user_group_admin.php:1036
 #: user_group_admin.php:1901
@@ -1303,7 +1375,7 @@ msgstr ""
 msgid "OS"
 msgstr ""
 
-#: automation_devices.php:340 host.php:1673 include/global_arrays.php:540
+#: automation_devices.php:340 host.php:1674 include/global_arrays.php:540
 msgid "Uptime"
 msgstr ""
 
@@ -1315,10 +1387,10 @@ msgstr ""
 #: automation_devices.php:350 automation_devices.php:555
 #: automation_graph_rules.php:861 automation_networks.php:1074
 #: automation_tree_rules.php:969 data_debug.php:404 data_debug.php:1096
-#: data_sources.php:1743 data_templates.php:1136 host.php:905 host.php:1033
-#: host.php:1649 host.php:1981 lib/api_automation.php:87
+#: data_sources.php:1860 data_templates.php:1136 host.php:906 host.php:1034
+#: host.php:1650 host.php:1982 lib/api_automation.php:87
 #: lib/api_automation.php:211 lib/api_automation.php:683
-#: lib/api_automation.php:1236 lib/html_reports.php:1988 lib/installer.php:2204
+#: lib/api_automation.php:1240 lib/html_reports.php:1988 lib/installer.php:2204
 #: managers.php:123 package_import.php:359 package_import.php:1024
 #: package_import.php:1103 package_import.php:1118 plugins.php:624
 #: plugins.php:627 plugins.php:1124 plugins.php:1195 plugins.php:1272
@@ -1335,7 +1407,7 @@ msgstr ""
 msgid "Not Detected"
 msgstr ""
 
-#: automation_devices.php:403 host.php:1812
+#: automation_devices.php:403 host.php:1813
 msgid "No Devices Found"
 msgstr ""
 
@@ -1352,23 +1424,23 @@ msgid "Invalid Network"
 msgstr ""
 
 #: automation_devices.php:595 automation_graph_rules.php:883
-#: automation_tree_rules.php:991 data_debug.php:1149 data_sources.php:1796
-#: data_templates.php:1294 graph_templates.php:2008 graphs.php:3197
-#: host.php:2012 lib/clog_webapi.php:739 lib/html_filter.php:150
+#: automation_tree_rules.php:991 data_debug.php:1149 data_sources.php:1913
+#: data_templates.php:1294 graph_templates.php:2008 graphs.php:3199
+#: host.php:2013 lib/clog_webapi.php:739 lib/html_filter.php:150
 #: lib/html_graph.php:347 lib/html_graph.php:1095 lib/html_reports.php:1913
 #: lib/html_tree.php:1107 rrdcheck.php:245 rrdcleaner.php:511
-#: user_admin.php:2116 user_admin.php:2390 user_admin.php:2486
+#: user_admin.php:2118 user_admin.php:2392 user_admin.php:2488
 #: user_group_admin.php:2024 user_group_admin.php:2106 user_log.php:317
 msgid "Apply filter to table"
 msgstr ""
 
 #: automation_devices.php:600 automation_graph_rules.php:888
-#: automation_tree_rules.php:996 data_debug.php:1154 data_sources.php:1801
-#: data_templates.php:1299 graph_templates.php:2013 graphs.php:3202
-#: host.php:2017 lib/clog_webapi.php:744 lib/html_filter.php:155
+#: automation_tree_rules.php:996 data_debug.php:1154 data_sources.php:1918
+#: data_templates.php:1299 graph_templates.php:2013 graphs.php:3204
+#: host.php:2018 lib/clog_webapi.php:744 lib/html_filter.php:155
 #: lib/html_graph.php:353 lib/html_graph.php:1100 lib/html_tree.php:1113
-#: rrdcheck.php:250 rrdcleaner.php:516 user_admin.php:2121 user_admin.php:2395
-#: user_admin.php:2491 user_group_admin.php:2029 user_group_admin.php:2111
+#: rrdcheck.php:250 rrdcleaner.php:516 user_admin.php:2123 user_admin.php:2397
+#: user_admin.php:2493 user_group_admin.php:2029 user_group_admin.php:2111
 #: user_log.php:322
 msgid "Reset filter to default values"
 msgstr ""
@@ -1376,7 +1448,7 @@ msgstr ""
 #: automation_devices.php:604 automation_graph_rules.php:32
 #: automation_networks.php:37 automation_snmp.php:32
 #: automation_templates.php:33 automation_tree_rules.php:33
-#: data_source_profiles.php:32 host.php:2021 lib/html_filter.php:397
+#: data_source_profiles.php:32 host.php:2022 lib/html_filter.php:397
 #: lib/html_form.php:1836 lib/html_form.php:1924
 msgid "Export"
 msgstr ""
@@ -1402,20 +1474,20 @@ msgstr ""
 #: automation_devices.php:696 automation_networks.php:1180
 #: automation_snmp.php:796 automation_snmp.php:797 automation_snmp.php:798
 #: automation_snmp.php:799 automation_snmp.php:800 automation_snmp.php:801
-#: data_debug.php:570 data_source_profiles.php:88 host.php:1744 host.php:1800
-#: host.php:1801 host.php:1802 host.php:1803 host.php:1804
-#: lib/functions.php:6374 lib/functions.php:6390 lib/html_reports.php:1689
+#: data_debug.php:570 data_source_profiles.php:88 host.php:1745 host.php:1801
+#: host.php:1802 host.php:1803 host.php:1804 host.php:1805
+#: lib/functions.php:6451 lib/functions.php:6467 lib/html_reports.php:1689
 #: lib/html_reports.php:1716 lib/html_reports.php:1791
 #: lib/html_reports.php:1792 lib/html_reports.php:1793
-#: lib/html_reports.php:2300 lib/spikekill.php:1181 lib/spikekill.php:1182
-#: lib/spikekill.php:1183 lib/spikekill.php:1184 lib/spikekill.php:1185
-#: lib/spikekill.php:1186 lib/spikekill.php:1187 lib/spikekill.php:1188
-#: lib/spikekill.php:1189 lib/spikekill.php:1190 package_repos.php:503
-#: plugins.php:1438 plugins.php:1457 plugins.php:1461 plugins.php:1596
-#: plugins.php:1731 plugins.php:1735 pollers.php:1086 support.php:1688
-#: user_admin.php:2278 user_log.php:143 utilities.php:1223 utilities.php:1361
-#: utilities.php:1369 utilities.php:1380 utilities.php:1391 utilities.php:1414
-#: utilities.php:1460 utilities.php:1663
+#: lib/html_reports.php:2300 lib/spikekill.php:1043 lib/spikekill.php:1044
+#: lib/spikekill.php:1045 lib/spikekill.php:1046 lib/spikekill.php:1047
+#: lib/spikekill.php:1048 lib/spikekill.php:1049 lib/spikekill.php:1050
+#: lib/spikekill.php:1051 package_repos.php:522 plugins.php:1438
+#: plugins.php:1457 plugins.php:1461 plugins.php:1596 plugins.php:1731
+#: plugins.php:1735 pollers.php:1086 support.php:1688 user_admin.php:2280
+#: user_log.php:143 utilities.php:1223 utilities.php:1361 utilities.php:1369
+#: utilities.php:1380 utilities.php:1391 utilities.php:1414 utilities.php:1460
+#: utilities.php:1663
 msgid "N/A"
 msgstr ""
 
@@ -1450,7 +1522,9 @@ msgid "Import Graph Rules from Local File"
 msgstr ""
 
 #: automation_graph_rules.php:159
-msgid "If the JSON file containing the Graph Rules data is located on your local machine, select it here."
+msgid ""
+"If the JSON file containing the Graph Rules data is located on your local "
+"machine, select it here."
 msgstr ""
 
 #: automation_graph_rules.php:165
@@ -1458,7 +1532,9 @@ msgid "Import Graph Rules from Text"
 msgstr ""
 
 #: automation_graph_rules.php:166
-msgid "If you have the JSON file containing the Graph Rules data as text, you can paste it into this box to import it."
+msgid ""
+"If you have the JSON file containing the Graph Rules data as text, you can "
+"paste it into this box to import it."
 msgstr ""
 
 #: automation_graph_rules.php:178 automation_networks.php:137
@@ -1482,24 +1558,24 @@ msgstr ""
 #: automation_templates.php:259 automation_tree_rules.php:213
 #: automation_tree_rules.php:1000 data_source_profiles.php:207
 #: data_source_profiles.php:356 data_source_profiles.php:358
-#: lib/api_automation.php:5451 lib/api_automation.php:5453
-#: lib/api_automation.php:5488 lib/api_automation.php:5490
-#: lib/api_automation.php:5592 lib/api_automation.php:5594
-#: lib/api_automation.php:5688 lib/api_automation.php:5690
-#: lib/api_automation.php:5715 lib/api_automation.php:5717
-#: lib/api_automation.php:5744 lib/api_automation.php:5746
-#: lib/api_automation.php:5822 lib/api_automation.php:5824
-#: lib/api_automation.php:5847 lib/api_automation.php:5849
-#: lib/api_automation.php:5878 lib/api_automation.php:5880
-#: lib/api_automation.php:5991 lib/api_automation.php:5993
-#: lib/api_automation.php:6049 lib/api_automation.php:6051
-#: lib/api_automation.php:6076 lib/api_automation.php:6078
-#: lib/api_automation.php:6105 lib/api_automation.php:6107
-#: lib/api_automation.php:6158 lib/api_automation.php:6160
-#: lib/api_automation.php:6183 lib/api_automation.php:6185
-#: lib/api_automation.php:6214 lib/api_automation.php:6216
-#: lib/api_automation.php:6270 lib/api_automation.php:6272
-#: lib/api_automation.php:6322 lib/api_automation.php:6324
+#: lib/api_automation.php:5494 lib/api_automation.php:5496
+#: lib/api_automation.php:5531 lib/api_automation.php:5533
+#: lib/api_automation.php:5635 lib/api_automation.php:5637
+#: lib/api_automation.php:5731 lib/api_automation.php:5733
+#: lib/api_automation.php:5758 lib/api_automation.php:5760
+#: lib/api_automation.php:5787 lib/api_automation.php:5789
+#: lib/api_automation.php:5865 lib/api_automation.php:5867
+#: lib/api_automation.php:5890 lib/api_automation.php:5892
+#: lib/api_automation.php:5921 lib/api_automation.php:5923
+#: lib/api_automation.php:6034 lib/api_automation.php:6036
+#: lib/api_automation.php:6092 lib/api_automation.php:6094
+#: lib/api_automation.php:6119 lib/api_automation.php:6121
+#: lib/api_automation.php:6148 lib/api_automation.php:6150
+#: lib/api_automation.php:6201 lib/api_automation.php:6203
+#: lib/api_automation.php:6226 lib/api_automation.php:6228
+#: lib/api_automation.php:6257 lib/api_automation.php:6259
+#: lib/api_automation.php:6313 lib/api_automation.php:6315
+#: lib/api_automation.php:6365 lib/api_automation.php:6367
 #: lib/html_filter.php:389 lib/html_form.php:1833 lib/html_form.php:1922
 #: package_import.php:40
 msgid "Import"
@@ -1608,7 +1684,7 @@ msgstr ""
 
 #: automation_graph_rules.php:519 automation_tree_rules.php:504 cdef.php:276
 #: color_templates.php:333 data_source_profiles.php:782 data_templates.php:509
-#: graph_templates.php:1281 graphs.php:1895 graphs.php:1910
+#: graph_templates.php:1281 graphs.php:1897 graphs.php:1912
 #: host_templates.php:345 vdef.php:270
 msgid "Title Format"
 msgstr ""
@@ -1653,7 +1729,7 @@ msgid "SQL Debug Output"
 msgstr ""
 
 #: automation_graph_rules.php:852 automation_graph_rules.php:1000
-#: graphs.php:3044 include/global_arrays.php:1512
+#: graphs.php:3046 include/global_arrays.php:1512
 #: include/global_arrays.php:3084 include/global_form.php:1815
 #: include/global_form.php:2377 utilities.php:314
 msgid "Data Query"
@@ -1670,7 +1746,9 @@ msgid "The name of this rule."
 msgstr ""
 
 #: automation_graph_rules.php:997
-msgid "The internal database ID for this rule.  Useful in performing debugging and automation."
+msgid ""
+"The internal database ID for this rule.  Useful in performing debugging and "
+"automation."
 msgstr ""
 
 #: automation_graph_rules.php:1005 graphs_new.php:322
@@ -1700,7 +1778,9 @@ msgid "Import Network Discovery Rule from Local File"
 msgstr ""
 
 #: automation_networks.php:118
-msgid "If the JSON file containing the Network Discovery Rule data is located on your local machine, select it here."
+msgid ""
+"If the JSON file containing the Network Discovery Rule data is located on "
+"your local machine, select it here."
 msgstr ""
 
 #: automation_networks.php:124
@@ -1708,7 +1788,9 @@ msgid "Import Network Discovery Rule from Text"
 msgstr ""
 
 #: automation_networks.php:125
-msgid "If you have the JSON file containing the Network Discovery Rule data as text, you can paste it into this box to import it."
+msgid ""
+"If you have the JSON file containing the Network Discovery Rule data as "
+"text, you can paste it into this box to import it."
 msgstr ""
 
 #: automation_networks.php:139 color.php:327 data_source_profiles.php:182
@@ -1735,7 +1817,7 @@ msgstr ""
 msgid "ERROR: Network '%s' is Invalid."
 msgstr ""
 
-#: automation_networks.php:574 host.php:434 lib/html_form.php:1667
+#: automation_networks.php:574 host.php:435 lib/html_form.php:1667
 msgid "Update this Field"
 msgstr ""
 
@@ -1852,11 +1934,15 @@ msgid "Duplicate Networks"
 msgstr ""
 
 #: automation_networks.php:657
-msgid "Click 'Continue' to Change Network options for the following Network.  Check the checkboxes to indicate that this setting should be changed."
+msgid ""
+"Click 'Continue' to Change Network options for the following Network.  Check "
+"the checkboxes to indicate that this setting should be changed."
 msgstr ""
 
 #: automation_networks.php:658
-msgid "Click 'Continue' to Change Network options for the following Networks.  Check the checkboxes to indicate that this setting should be changed."
+msgid ""
+"Click 'Continue' to Change Network options for the following Networks.  "
+"Check the checkboxes to indicate that this setting should be changed."
 msgstr ""
 
 #: automation_networks.php:659
@@ -1893,7 +1979,7 @@ msgstr ""
 #: lib/installer.php:2204 lib/installer.php:2285 lib/installer.php:2315
 #: lib/installer.php:2953 lib/installer.php:3044 lib/vdef.php:86
 #: managers.php:425 package_import.php:358 package_import.php:1575
-#: package_repos.php:314 package_repos.php:458 pollers.php:69 sites.php:43
+#: package_repos.php:333 package_repos.php:477 pollers.php:69 sites.php:43
 #: support.php:964 user_admin.php:1023 user_domains.php:295 utilities.php:1627
 msgid "Name"
 msgstr ""
@@ -1906,12 +1992,14 @@ msgstr ""
 msgid "New Network Discovery Range"
 msgstr ""
 
-#: automation_networks.php:692 automation_networks.php:1059 host.php:1940
+#: automation_networks.php:692 automation_networks.php:1059 host.php:1941
 msgid "Data Collector"
 msgstr ""
 
 #: automation_networks.php:693 include/global_form.php:1291
-msgid "Choose the Cacti Data Collector/Poller to be used to gather data from this Device."
+msgid ""
+"Choose the Cacti Data Collector/Poller to be used to gather data from this "
+"Device."
 msgstr ""
 
 #: automation_networks.php:700
@@ -1919,7 +2007,8 @@ msgid "Associated Site"
 msgstr ""
 
 #: automation_networks.php:701
-msgid "Choose the Cacti Site that you wish to associate discovered Devices with."
+msgid ""
+"Choose the Cacti Site that you wish to associate discovered Devices with."
 msgstr ""
 
 #: automation_networks.php:709
@@ -1927,7 +2016,10 @@ msgid "Subnet Range"
 msgstr ""
 
 #: automation_networks.php:710
-msgid "Enter valid Network Ranges separated by commas.  You may use an IP address, a Network range such as 192.168.1.0/24 or 192.168.1.0/255.255.255.0, or using wildcards such as 192.168.*.*"
+msgid ""
+"Enter valid Network Ranges separated by commas.  You may use an IP address, "
+"a Network range such as 192.168.1.0/24 or 192.168.1.0/255.255.255.0, or "
+"using wildcards such as 192.168.*.*"
 msgstr ""
 
 #: automation_networks.php:719
@@ -1935,7 +2027,9 @@ msgid "IP Addresses to Ignore"
 msgstr ""
 
 #: automation_networks.php:720
-msgid "Enter valid comma separated list command of IP Addresses from this range to ignore."
+msgid ""
+"Enter valid comma separated list command of IP Addresses from this range to "
+"ignore."
 msgstr ""
 
 #: automation_networks.php:725
@@ -1955,7 +2049,9 @@ msgid "Alternate DNS Servers"
 msgstr ""
 
 #: automation_networks.php:736
-msgid "A space delimited list of alternate DNS Servers to use for DNS resolution. If blank, the poller OS will be used to resolve DNS names."
+msgid ""
+"A space delimited list of alternate DNS Servers to use for DNS resolution. "
+"If blank, the poller OS will be used to resolve DNS names."
 msgstr ""
 
 #: automation_networks.php:739
@@ -2005,7 +2101,7 @@ msgstr ""
 
 #: automation_networks.php:769 automation_networks.php:770
 #: automation_networks.php:771 automation_networks.php:772
-#: data_sources.php:1273 include/global_arrays.php:751
+#: data_sources.php:1390 include/global_arrays.php:751
 #: include/global_arrays.php:752 include/global_arrays.php:753
 #: include/global_arrays.php:754 include/global_arrays.php:791
 #: include/global_arrays.php:792 include/global_arrays.php:794
@@ -2017,13 +2113,13 @@ msgstr ""
 #: include/global_arrays.php:1745 include/global_arrays.php:1769
 #: include/global_arrays.php:1770 include/global_arrays.php:1771
 #: include/global_arrays.php:1772 include/global_arrays.php:1773
-#: include/global_arrays.php:1786 include/global_settings.php:1944
-#: include/global_settings.php:1945 include/global_settings.php:1946
-#: include/global_settings.php:1947 include/global_settings.php:1948
-#: include/global_settings.php:2167 include/global_settings.php:2168
-#: include/global_settings.php:2169 include/global_settings.php:2170
-#: include/global_settings.php:3158 include/global_settings.php:3417
-#: include/global_settings.php:3418 include/global_settings.php:3419
+#: include/global_arrays.php:1786 include/global_settings.php:1948
+#: include/global_settings.php:1949 include/global_settings.php:1950
+#: include/global_settings.php:1951 include/global_settings.php:1952
+#: include/global_settings.php:2171 include/global_settings.php:2172
+#: include/global_settings.php:2173 include/global_settings.php:2174
+#: include/global_settings.php:3116 include/global_settings.php:3375
+#: include/global_settings.php:3376 include/global_settings.php:3377
 #: lib/html_filter.php:95 lib/html_filter.php:96
 #, php-format
 msgid "%d Minutes"
@@ -2051,10 +2147,10 @@ msgstr ""
 #: include/global_arrays.php:1698 include/global_arrays.php:1699
 #: include/global_arrays.php:1700 include/global_arrays.php:1701
 #: include/global_arrays.php:1702 include/global_arrays.php:1708
-#: include/global_arrays.php:1709 include/global_settings.php:1950
-#: include/global_settings.php:1951 include/global_settings.php:1952
-#: include/global_settings.php:1953 include/global_settings.php:3421
-#: include/global_settings.php:3422
+#: include/global_arrays.php:1709 include/global_settings.php:1954
+#: include/global_settings.php:1955 include/global_settings.php:1956
+#: include/global_settings.php:1957 include/global_settings.php:3379
+#: include/global_settings.php:3380
 #, php-format
 msgid "%d Hours"
 msgstr ""
@@ -2076,7 +2172,9 @@ msgid "Automatically Add to Cacti"
 msgstr ""
 
 #: automation_networks.php:796
-msgid "For any newly discovered Devices that are reachable using SNMP and who match a Device Rule, add them to Cacti."
+msgid ""
+"For any newly discovered Devices that are reachable using SNMP and who match "
+"a Device Rule, add them to Cacti."
 msgstr ""
 
 #: automation_networks.php:801
@@ -2084,7 +2182,9 @@ msgid "Allow same sysName on different hosts"
 msgstr ""
 
 #: automation_networks.php:802
-msgid "When discovering devices, allow duplicate sysnames to be added on different hosts"
+msgid ""
+"When discovering devices, allow duplicate sysnames to be added on different "
+"hosts"
 msgstr ""
 
 #: automation_networks.php:807
@@ -2104,7 +2204,9 @@ msgid "Notification Enabled"
 msgstr ""
 
 #: automation_networks.php:824
-msgid "If checked, when the Automation Network is scanned, a report will be sent to the Notification Email account.."
+msgid ""
+"If checked, when the Automation Network is scanned, a report will be sent to "
+"the Notification Email account.."
 msgstr ""
 
 #: automation_networks.php:830
@@ -2120,7 +2222,10 @@ msgid "Notification From Name"
 msgstr ""
 
 #: automation_networks.php:839
-msgid "The Email account name to be used as the senders name for the Notification Email.  If left blank, Cacti will use the default Automation Notification Name if specified, otherwise, it will use the Cacti system default Email name"
+msgid ""
+"The Email account name to be used as the senders name for the Notification "
+"Email.  If left blank, Cacti will use the default Automation Notification "
+"Name if specified, otherwise, it will use the Cacti system default Email name"
 msgstr ""
 
 #: automation_networks.php:847
@@ -2128,7 +2233,11 @@ msgid "Notification From Email Address"
 msgstr ""
 
 #: automation_networks.php:848
-msgid "The Email Address to be used as the senders Email for the Notification Email.  If left blank, Cacti will use the default Automation Notification Email Address if specified, otherwise, it will use the Cacti system default Email Address"
+msgid ""
+"The Email Address to be used as the senders Email for the Notification "
+"Email.  If left blank, Cacti will use the default Automation Notification "
+"Email Address if specified, otherwise, it will use the Cacti system default "
+"Email Address"
 msgstr ""
 
 #: automation_networks.php:855
@@ -2154,7 +2263,7 @@ msgid "The type of ping packet to send."
 msgstr ""
 
 #: automation_networks.php:875 include/global_form.php:1364
-#: include/global_settings.php:1075
+#: include/global_settings.php:1077
 msgid "Ping Port"
 msgstr ""
 
@@ -2163,21 +2272,25 @@ msgid "TCP or UDP port to attempt connection."
 msgstr ""
 
 #: automation_networks.php:883 include/global_form.php:1372
-#: include/global_settings.php:1083
+#: include/global_settings.php:1085
 msgid "Ping Timeout Value"
 msgstr ""
 
 #: automation_networks.php:884 include/global_form.php:1373
-msgid "The timeout value to use for host ICMP and UDP pinging.  This host SNMP timeout value applies for SNMP pings."
+msgid ""
+"The timeout value to use for host ICMP and UDP pinging.  This host SNMP "
+"timeout value applies for SNMP pings."
 msgstr ""
 
 #: automation_networks.php:892 include/global_form.php:1381
-#: include/global_settings.php:1091
+#: include/global_settings.php:1093
 msgid "Ping Retry Count"
 msgstr ""
 
 #: automation_networks.php:893 include/global_form.php:1382
-msgid "After an initial failure, the number of ping retries Cacti will attempt before failing."
+msgid ""
+"After an initial failure, the number of ping retries Cacti will attempt "
+"before failing."
 msgstr ""
 
 #: automation_networks.php:966
@@ -2227,7 +2340,7 @@ msgstr ""
 msgid "Up/SNMP Hosts"
 msgstr ""
 
-#: automation_networks.php:1091 host.php:1625 pollers.php:125
+#: automation_networks.php:1091 host.php:1626 pollers.php:125
 msgid "Threads"
 msgstr ""
 
@@ -2252,8 +2365,8 @@ msgid "Idle"
 msgstr ""
 
 #: automation_networks.php:1181 include/global_arrays.php:981
-#: include/global_arrays.php:1355 include/global_settings.php:3066
-#: lib/html_reports.php:2303 user_admin.php:2049
+#: include/global_arrays.php:1355 include/global_settings.php:3024
+#: lib/html_reports.php:2303 user_admin.php:2051
 msgid "Never"
 msgstr ""
 
@@ -2266,7 +2379,9 @@ msgid "Import SNMP Options from Local File"
 msgstr ""
 
 #: automation_snmp.php:161
-msgid "If the JSON file containing the SNMP Options data is located on your local machine, select it here."
+msgid ""
+"If the JSON file containing the SNMP Options data is located on your local "
+"machine, select it here."
 msgstr ""
 
 #: automation_snmp.php:166
@@ -2274,7 +2389,9 @@ msgid "Import SNMP Options from Text"
 msgstr ""
 
 #: automation_snmp.php:167
-msgid "If you have the JSON file containing the SNMP Options data as text, you can paste it into this box to import it."
+msgid ""
+"If you have the JSON file containing the SNMP Options data as text, you can "
+"paste it into this box to import it."
 msgstr ""
 
 #: automation_snmp.php:182
@@ -2368,11 +2485,11 @@ msgstr ""
 #: automation_templates.php:922 cdef.php:318 color_templates.php:496
 #: data_input.php:300 data_queries.php:551 data_source_profiles.php:883
 #: host_templates.php:434 host_templates.php:500 lib/clog_webapi.php:296
-#: lib/html.php:3286 lib/html_form.php:1723 lib/html_form.php:1779
+#: lib/html.php:3227 lib/html_form.php:1723 lib/html_form.php:1779
 #: lib/html_form.php:1805 lib/html_form.php:1819 lib/html_form.php:1891
 #: lib/html_form.php:1912 lib/html_graph.php:1527 package_import.php:367
-#: package_keys.php:104 package_repos.php:212 package_repos.php:222
-#: package_repos.php:232 package_repos.php:242 plugins.php:823 plugins.php:836
+#: package_keys.php:104 package_repos.php:231 package_repos.php:241
+#: package_repos.php:251 package_repos.php:261 plugins.php:823 plugins.php:836
 #: plugins.php:849 plugins.php:862 plugins.php:875 user_log.php:217
 #: vdef.php:312
 msgid "Cancel"
@@ -2382,9 +2499,9 @@ msgstr ""
 #: automation_templates.php:798 cdef.php:319 color_templates.php:497
 #: data_input.php:301 data_queries.php:552 data_source_profiles.php:884
 #: host_templates.php:435 host_templates.php:501 lib/clog_webapi.php:297
-#: lib/html.php:3287 lib/html_form.php:1724 package_import.php:367
-#: package_keys.php:104 package_repos.php:213 package_repos.php:223
-#: package_repos.php:233 package_repos.php:243 user_log.php:218 vdef.php:313
+#: lib/html.php:3228 lib/html_form.php:1724 package_import.php:367
+#: package_keys.php:104 package_repos.php:232 package_repos.php:242
+#: package_repos.php:252 package_repos.php:262 user_log.php:218 vdef.php:313
 msgid "Continue"
 msgstr ""
 
@@ -2404,8 +2521,8 @@ msgstr ""
 #: automation_snmp.php:636 automation_templates.php:1160
 #: automation_templates.php:1262 include/global_form.php:1152
 #: include/global_form.php:2318 include/global_form.php:2360
-#: include/global_form.php:2511 lib/api_automation.php:1343
-#: lib/api_automation.php:1466 lib/api_automation.php:1567
+#: include/global_form.php:2511 lib/api_automation.php:1347
+#: lib/api_automation.php:1470 lib/api_automation.php:1571
 #: lib/html_reports.php:1175 lib/html_reports.php:1664
 msgid "Sequence"
 msgstr ""
@@ -2427,34 +2544,34 @@ msgstr ""
 msgid "Fill in the name of this SNMP Option Set."
 msgstr ""
 
-#: automation_snmp.php:722 cdef.php:584 lib/api_automation.php:1339
-#: lib/api_automation.php:1465 lib/api_automation.php:1566
+#: automation_snmp.php:722 cdef.php:584 lib/api_automation.php:1343
+#: lib/api_automation.php:1469 lib/api_automation.php:1570
 #: lib/html_reports.php:1663 vdef.php:580
 msgid "Item"
 msgstr ""
 
 #: automation_snmp.php:726 graph_templates.php:1659 host_templates.php:1050
 #: host_templates.php:1454 include/auth.php:360 include/global_form.php:1181
-#: include/global_form.php:1446 include/global_settings.php:912 package.php:363
+#: include/global_form.php:1446 include/global_settings.php:914 package.php:363
 #: package_import.php:972 package_import.php:1581 plugins.php:1219
 #: plugins.php:1296
 msgid "Version"
 msgstr ""
 
-#: automation_snmp.php:730 include/global_settings.php:919
+#: automation_snmp.php:730 include/global_settings.php:921
 msgid "Community"
 msgstr ""
 
-#: automation_snmp.php:734 lib/functions.php:6010
+#: automation_snmp.php:734 lib/functions.php:6079
 msgid "Port"
 msgstr ""
 
 #: automation_snmp.php:738 include/global_settings.php:737
-#: include/global_settings.php:997 support.php:768
+#: include/global_settings.php:999 support.php:768
 msgid "Timeout"
 msgstr ""
 
-#: automation_snmp.php:742 include/global_settings.php:1005
+#: automation_snmp.php:742 include/global_settings.php:1007
 msgid "Retries"
 msgstr ""
 
@@ -2492,8 +2609,8 @@ msgstr ""
 
 #: automation_snmp.php:789 cdef.php:604 color_templates.php:139
 #: lib/api_aggregate.php:1935 lib/api_aggregate.php:1938
-#: lib/api_aggregate.php:1942 lib/api_automation.php:1380
-#: lib/api_automation.php:1486 lib/api_automation.php:1592
+#: lib/api_aggregate.php:1942 lib/api_automation.php:1384
+#: lib/api_automation.php:1490 lib/api_automation.php:1596
 #: lib/html_reports.php:1797 vdef.php:599
 #, php-format
 msgid "Item # %d"
@@ -2506,8 +2623,8 @@ msgstr ""
 #: automation_snmp.php:806 automation_templates.php:1188
 #: automation_templates.php:1299 automation_templates.php:1663 cdef.php:614
 #: color_templates.php:156 data_queries.php:802 data_queries.php:910
-#: lib/api_automation.php:1399 lib/api_automation.php:1502
-#: lib/api_automation.php:1606 lib/html.php:1686 lib/html_reports.php:1806
+#: lib/api_automation.php:1403 lib/api_automation.php:1506
+#: lib/api_automation.php:1610 lib/html.php:1686 lib/html_reports.php:1806
 #: lib/html_reports.php:1808 plugins.php:49 tree.php:2199 tree.php:2205
 #: vdef.php:609
 msgid "Move Down"
@@ -2516,8 +2633,8 @@ msgstr ""
 #: automation_snmp.php:812 automation_templates.php:1194
 #: automation_templates.php:1305 automation_templates.php:1669 cdef.php:620
 #: color_templates.php:162 data_queries.php:807 data_queries.php:915
-#: lib/api_automation.php:1408 lib/api_automation.php:1508
-#: lib/api_automation.php:1615 lib/html.php:1692 lib/html_reports.php:1808
+#: lib/api_automation.php:1412 lib/api_automation.php:1512
+#: lib/api_automation.php:1619 lib/html.php:1692 lib/html_reports.php:1808
 #: lib/html_reports.php:1810 plugins.php:48 tree.php:2203 tree.php:2206
 #: vdef.php:615
 msgid "Move Up"
@@ -2572,7 +2689,9 @@ msgid "Import Device Rules from Local File"
 msgstr ""
 
 #: automation_templates.php:206
-msgid "If the JSON file containing the Device Rules data is located on your local machine, select it here."
+msgid ""
+"If the JSON file containing the Device Rules data is located on your local "
+"machine, select it here."
 msgstr ""
 
 #: automation_templates.php:212
@@ -2580,7 +2699,9 @@ msgid "Import Device Rules from Text"
 msgstr ""
 
 #: automation_templates.php:213
-msgid "If you have the JSON file containing the Device Rules data as text, you can paste it into this box to import it."
+msgid ""
+"If you have the JSON file containing the Device Rules data as text, you can "
+"paste it into this box to import it."
 msgstr ""
 
 #: automation_templates.php:221 automation_tree_rules.php:175
@@ -2588,7 +2709,9 @@ msgid "Import Device Rules Trees and Branches"
 msgstr ""
 
 #: automation_templates.php:222 automation_tree_rules.php:176
-msgid "Automatically Recreate the Trees and Branches if they do not exist upon Import."
+msgid ""
+"Automatically Recreate the Trees and Branches if they do not exist upon "
+"Import."
 msgstr ""
 
 #: automation_templates.php:234
@@ -2644,18 +2767,20 @@ msgid "Export Device Rules"
 msgstr ""
 
 #: automation_templates.php:718 automation_templates.php:784
-#: automation_templates.php:908 data_input.php:446 host.php:1807 host.php:1855
-#: lib/api_automation.php:59 lib/api_automation.php:528 lib/auth.php:2439
-#: lib/functions.php:6394 lib/html_utility.php:1536 lib/import.php:360
+#: automation_templates.php:908 data_input.php:446 host.php:1808 host.php:1856
+#: lib/api_automation.php:59 lib/api_automation.php:528 lib/auth.php:2455
+#: lib/functions.php:6471 lib/html_utility.php:1536 lib/import.php:360
 #: lib/installer.php:3181 lib/plugins.php:1856 lib/plugins.php:1857
-#: lib/rrd.php:3648 lib/rrd.php:3660 package_import.php:997
+#: lib/rrd.php:3682 lib/rrd.php:3694 package_import.php:997
 #: package_import.php:1073 package_import.php:1621 support.php:1125
 #: support.php:1126 utilities.php:1219
 msgid "Unknown"
 msgstr ""
 
 #: automation_templates.php:724
-msgid "Click 'Continue' to Delete the following Threshold Template will be disassociated from the Device Rule."
+msgid ""
+"Click 'Continue' to Delete the following Threshold Template will be "
+"disassociated from the Device Rule."
 msgstr ""
 
 #: automation_templates.php:725
@@ -2668,7 +2793,9 @@ msgid "Remove Threshold Template"
 msgstr ""
 
 #: automation_templates.php:790
-msgid "Click 'Continue' to Delete the following Graph Rule will be disassociated from the Device Rule."
+msgid ""
+"Click 'Continue' to Delete the following Graph Rule will be disassociated "
+"from the Device Rule."
 msgstr ""
 
 #: automation_templates.php:791
@@ -2685,7 +2812,9 @@ msgid "The Graph Rule has been removed from the Device Rule"
 msgstr ""
 
 #: automation_templates.php:914
-msgid "Click 'Continue' to Delete the following Tree Rule(s) will be disassociated from the Device Rule."
+msgid ""
+"Click 'Continue' to Delete the following Tree Rule(s) will be disassociated "
+"from the Device Rule."
 msgstr ""
 
 #: automation_templates.php:915
@@ -2710,7 +2839,7 @@ msgid "Matching Settings"
 msgstr ""
 
 #: automation_templates.php:1044 automation_templates.php:1612
-#: data_sources.php:1491 package_import.php:1100 package_import.php:1115
+#: data_sources.php:1608 package_import.php:1100 package_import.php:1115
 #: templates_import.php:260 user_admin.php:1318 user_group_admin.php:1199
 msgid "Template Name"
 msgstr ""
@@ -2728,7 +2857,10 @@ msgid "System Description Match"
 msgstr ""
 
 #: automation_templates.php:1060
-msgid "This is a unique string that will be matched to a devices sysDescr string to pair it to this Device Rule.  Any Perl regular expression can be used in addition to any SQL Where expression."
+msgid ""
+"This is a unique string that will be matched to a devices sysDescr string to "
+"pair it to this Device Rule.  Any Perl regular expression can be used in "
+"addition to any SQL Where expression."
 msgstr ""
 
 #: automation_templates.php:1066 automation_templates.php:1624
@@ -2736,7 +2868,10 @@ msgid "System Name Match"
 msgstr ""
 
 #: automation_templates.php:1067
-msgid "This is a unique string that will be matched to a devices sysName string to pair it to this Device Rule.  Any Perl regular expression can be used in addition to any SQL Where expression."
+msgid ""
+"This is a unique string that will be matched to a devices sysName string to "
+"pair it to this Device Rule.  Any Perl regular expression can be used in "
+"addition to any SQL Where expression."
 msgstr ""
 
 #: automation_templates.php:1073 automation_templates.php:1628
@@ -2744,7 +2879,10 @@ msgid "System OID Match"
 msgstr ""
 
 #: automation_templates.php:1074
-msgid "This is a unique string that will be matched to a devices sysOid string to pair it to this Device Rule.  Any Perl regular expression can be used in addition to any SQL Where expression."
+msgid ""
+"This is a unique string that will be matched to a devices sysOid string to "
+"pair it to this Device Rule.  Any Perl regular expression can be used in "
+"addition to any SQL Where expression."
 msgstr ""
 
 #: automation_templates.php:1080
@@ -2756,7 +2894,15 @@ msgid "Device Description Pattern"
 msgstr ""
 
 #: automation_templates.php:1085
-msgid "Represents the final desired Device description to be used in Cacti.  The following replacement values can be used: |sysName|, |ipAddress|, |dnsName|, |dnsShortName|, |sysLocation|.  The following functions can also be used: CONCAT(), SUBSTRING(), SUBSTRING_INDEX().  See the MySQL/MariaDB documentation for examples on how to use these functions.  An example would be: CONCAT('|sysName|', SUBSTRING('|sysLocation|',1,3)).  Take care to include quoting around the variables names when used in the supported MySQL/MariaDB function examples."
+msgid ""
+"Represents the final desired Device description to be used in Cacti.  The "
+"following replacement values can be used: |sysName|, |ipAddress|, |dnsName|, "
+"|dnsShortName|, |sysLocation|.  The following functions can also be used: "
+"CONCAT(), SUBSTRING(), SUBSTRING_INDEX().  See the MySQL/MariaDB "
+"documentation for examples on how to use these functions.  An example would "
+"be: CONCAT('|sysName|', SUBSTRING('|sysLocation|',1,3)).  Take care to "
+"include quoting around the variables names when used in the supported MySQL/"
+"MariaDB function examples."
 msgstr ""
 
 #: automation_templates.php:1093
@@ -2764,7 +2910,10 @@ msgid "Populate Location with sysLocation"
 msgstr ""
 
 #: automation_templates.php:1094
-msgid "If checked, when the Automation Network is scanned if a Device is found that will be added to Cacti, its Location will be updated to match the Devices sysLocation."
+msgid ""
+"If checked, when the Automation Network is scanned if a Device is found that "
+"will be added to Cacti, its Location will be updated to match the Devices "
+"sysLocation."
 msgstr ""
 
 #: automation_templates.php:1115
@@ -2789,7 +2938,7 @@ msgid "Graph Rule Name"
 msgstr ""
 
 #: automation_templates.php:1164 automation_templates.php:1266
-#: automation_templates.php:1369 host.php:1034 include/global_arrays.php:2267
+#: automation_templates.php:1369 host.php:1035 include/global_arrays.php:2267
 #: include/global_arrays.php:2333 include/global_arrays.php:2423
 #: include/global_arrays.php:2459 include/global_arrays.php:2477
 #: include/global_arrays.php:2495 include/global_arrays.php:2513
@@ -2797,8 +2946,8 @@ msgstr ""
 #: include/global_arrays.php:2609 include/global_arrays.php:2717
 #: include/global_arrays.php:2909 include/global_arrays.php:2933
 #: include/global_arrays.php:2951 include/global_arrays.php:2975
-#: include/global_arrays.php:2999 lib/api_automation.php:1363
-#: lib/api_automation.php:1471 lib/api_automation.php:1573 lib/html.php:1478
+#: include/global_arrays.php:2999 lib/api_automation.php:1367
+#: lib/api_automation.php:1475 lib/api_automation.php:1577 lib/html.php:1478
 #: lib/html_reports.php:1670 links.php:298 plugins.php:1101 plugins.php:1177
 #: plugins.php:1254 utilities.php:799
 msgid "Actions"
@@ -2814,7 +2963,7 @@ msgstr ""
 
 #: automation_templates.php:1231 automation_templates.php:1342
 #: automation_templates.php:1418 data_queries.php:846 data_queries.php:955
-#: host.php:989 host.php:1146 host_templates.php:650 host_templates.php:705
+#: host.php:990 host.php:1147 host_templates.php:650 host_templates.php:705
 #: lib/html.php:72 lib/html_filter.php:113
 msgid "Add"
 msgstr ""
@@ -2893,7 +3042,9 @@ msgid "Import Tree Rules from Local File"
 msgstr ""
 
 #: automation_tree_rules.php:160
-msgid "If the JSON file containing the Tree Rules data is located on your local machine, select it here."
+msgid ""
+"If the JSON file containing the Tree Rules data is located on your local "
+"machine, select it here."
 msgstr ""
 
 #: automation_tree_rules.php:166
@@ -2901,7 +3052,9 @@ msgid "Import Tree Rules from Text"
 msgstr ""
 
 #: automation_tree_rules.php:167
-msgid "If you have the JSON file containing the Tree Rules data as text, you can paste it into this box to import it."
+msgid ""
+"If you have the JSON file containing the Tree Rules data as text, you can "
+"paste it into this box to import it."
 msgstr ""
 
 #: automation_tree_rules.php:188
@@ -3001,7 +3154,7 @@ msgstr ""
 msgid "Rule Item"
 msgstr ""
 
-#: automation_tree_rules.php:589 lib/api_automation.php:1051
+#: automation_tree_rules.php:589 lib/api_automation.php:1055
 msgid "Matching Items"
 msgstr ""
 
@@ -3032,11 +3185,15 @@ msgid "WARNING:"
 msgstr ""
 
 #: automation_tree_rules.php:902
-msgid "You are changing the leaf type to \"Device\" which does not support Graph-based object matching/creation."
+msgid ""
+"You are changing the leaf type to \"Device\" which does not support Graph-"
+"based object matching/creation."
 msgstr ""
 
 #: automation_tree_rules.php:903
-msgid "By changing the leaf type, all invalid rules will be automatically removed and will not be recoverable."
+msgid ""
+"By changing the leaf type, all invalid rules will be automatically removed "
+"and will not be recoverable."
 msgstr ""
 
 #: automation_tree_rules.php:904
@@ -3082,11 +3239,11 @@ msgstr ""
 msgid "Notice: Cacti Daemon PID["
 msgstr ""
 
-#: cactid.php:159 help.php:44 lib/functions.php:6710 lib/functions.php:6803
-#: lib/functions.php:6913 lib/functions.php:6941 lib/functions.php:8036
+#: cactid.php:159 help.php:44 lib/functions.php:6813 lib/functions.php:6906
+#: lib/functions.php:7016 lib/functions.php:7044 lib/functions.php:8154
 #: poller.php:405 poller.php:594 poller.php:652 poller.php:693 poller.php:842
 #: poller.php:991 poller.php:1383 poller.php:1399 poller_automation.php:57
-#: poller_boost.php:396 poller_maintenance.php:1069 poller_maintenance.php:1076
+#: poller_boost.php:395 poller_maintenance.php:1069 poller_maintenance.php:1076
 #: poller_maintenance.php:1080 poller_maintenance.php:1086
 msgid "Cacti System Warning"
 msgstr ""
@@ -3187,7 +3344,7 @@ msgid "Delete CDEF Item"
 msgstr ""
 
 #: cdef.php:700 cdef.php:702 cdef.php:736 graph_templates.php:1954
-#: graphs.php:3153 include/global_arrays.php:1120
+#: graphs.php:3155 include/global_arrays.php:1120
 #: include/global_arrays.php:2309
 msgid "CDEFs"
 msgstr ""
@@ -3201,7 +3358,9 @@ msgid "The name of this CDEF."
 msgstr ""
 
 #: cdef.php:754
-msgid "CDEFs that are in use cannot be Deleted.  In use is defined as being referenced by a Graph or a Graph Template."
+msgid ""
+"CDEFs that are in use cannot be Deleted.  In use is defined as being "
+"referenced by a Graph or a Graph Template."
 msgstr ""
 
 #: cdef.php:760
@@ -3268,7 +3427,9 @@ msgid "Import Colors from Local File"
 msgstr ""
 
 #: color.php:345
-msgid "Please specify the location of the CSV file containing your Color information."
+msgid ""
+"Please specify the location of the CSV file containing your Color "
+"information."
 msgstr ""
 
 #: color.php:349 lib/html_form.php:602
@@ -3280,7 +3441,9 @@ msgid "Overwrite Existing Data?"
 msgstr ""
 
 #: color.php:357
-msgid "Should the import process be allowed to overwrite existing data?  Please note, this does not mean delete old rows, only update duplicate rows."
+msgid ""
+"Should the import process be allowed to overwrite existing data?  Please "
+"note, this does not mean delete old rows, only update duplicate rows."
 msgstr ""
 
 #: color.php:360
@@ -3351,7 +3514,9 @@ msgid "The Color as shown on the screen."
 msgstr ""
 
 #: color.php:532
-msgid "Colors in use cannot be Deleted.  In use is defined as being referenced either by a Graph or a Graph Template."
+msgid ""
+"Colors in use cannot be Deleted.  In use is defined as being referenced "
+"either by a Graph or a Graph Template."
 msgstr ""
 
 #: color.php:538
@@ -3412,11 +3577,15 @@ msgid "Duplicate Color Templates"
 msgstr ""
 
 #: color_templates.php:340
-msgid "Click 'Continue' to Synchronize the following Color Template to its Aggregates."
+msgid ""
+"Click 'Continue' to Synchronize the following Color Template to its "
+"Aggregates."
 msgstr ""
 
 #: color_templates.php:341
-msgid "Click 'Continue' to Synchronize the following Color Templates to its Aggregates."
+msgid ""
+"Click 'Continue' to Synchronize the following Color Templates to its "
+"Aggregates."
 msgstr ""
 
 #: color_templates.php:342
@@ -3477,12 +3646,16 @@ msgstr ""
 
 #: color_templates.php:759
 #, php-format
-msgid "Color Template '%s' had %d Aggregate Templates pushed out and %d Non-Templated Aggregates pushed out"
+msgid ""
+"Color Template '%s' had %d Aggregate Templates pushed out and %d Non-"
+"Templated Aggregates pushed out"
 msgstr ""
 
 #: color_templates.php:761
 #, php-format
-msgid "Color Template '%s' had no Aggregate Templates or Graphs using this Color Template."
+msgid ""
+"Color Template '%s' had no Aggregate Templates or Graphs using this Color "
+"Template."
 msgstr ""
 
 #: color_templates.php:774 color_templates.php:810
@@ -3491,7 +3664,9 @@ msgid "Color Templates"
 msgstr ""
 
 #: color_templates.php:826
-msgid "Color Templates that are in use cannot be Deleted. In use is defined as being referenced by an Aggregate Template."
+msgid ""
+"Color Templates that are in use cannot be Deleted. In use is defined as "
+"being referenced by an Aggregate Template."
 msgstr ""
 
 #: color_templates.php:862
@@ -3531,7 +3706,7 @@ msgid "Data Source repair received an invalid Data Source ID."
 msgstr ""
 
 #: data_debug.php:382 data_debug.php:831 data_queries.php:722
-#: data_sources.php:1060 data_templates.php:726 graphs.php:1019
+#: data_sources.php:1177 data_templates.php:726 graphs.php:1019
 #: include/global_arrays.php:1106 include/global_form.php:1003
 #: lib/api_aggregate.php:1834 lib/html.php:1437 rrdcheck.php:134
 msgid "Data Source"
@@ -3541,7 +3716,7 @@ msgstr ""
 msgid "The Data Source to Debug"
 msgstr ""
 
-#: data_debug.php:387 lib/html.php:3237 support.php:421 user_log.php:110
+#: data_debug.php:387 lib/html.php:3178 support.php:421 user_log.php:110
 #: user_log.php:286
 msgid "User"
 msgstr ""
@@ -3583,7 +3758,7 @@ msgstr ""
 msgid "Determines if the Data Source is located in the Poller Cache."
 msgstr ""
 
-#: data_debug.php:422 data_sources.php:1485 data_templates.php:1183
+#: data_debug.php:422 data_sources.php:1602 data_templates.php:1183
 msgid "Active"
 msgstr ""
 
@@ -3623,8 +3798,8 @@ msgstr ""
 msgid "Summary of issues found for the Data Source."
 msgstr ""
 
-#: data_debug.php:515 data_debug.php:1200 data_sources.php:1445
-#: data_sources.php:1783 data_sources.php:1840 graphs.php:3237 host.php:1637
+#: data_debug.php:515 data_debug.php:1200 data_sources.php:1562
+#: data_sources.php:1900 data_sources.php:1957 graphs.php:3239 host.php:1638
 #: include/global_arrays.php:1095 include/global_arrays.php:1147
 #: include/global_arrays.php:2483 lib/api_automation.php:229 rrdcheck.php:272
 #: support.php:1268 user_admin.php:1172 user_group_admin.php:1040
@@ -3739,7 +3914,7 @@ msgstr ""
 msgid "Check"
 msgstr ""
 
-#: data_debug.php:777 include/global_form.php:1083 lib/rrd.php:3623
+#: data_debug.php:777 include/global_form.php:1083 lib/rrd.php:3657
 #: support.php:1027 support.php:1048 support.php:1049 support.php:1095
 #: utilities.php:1631
 msgid "Value"
@@ -3788,21 +3963,21 @@ msgid "Waiting on Data Source Check to Complete"
 msgstr ""
 
 #: data_debug.php:961 data_debug.php:983 data_debug.php:990
-#: data_sources.php:1618 data_sources.php:1640 data_templates.php:1209
-#: graph_templates.php:1883 graphs.php:804 graphs.php:3010 graphs.php:3041
-#: graphs_new.php:293 host.php:1835 host_templates.php:790
+#: data_sources.php:1735 data_sources.php:1757 data_templates.php:1209
+#: graph_templates.php:1883 graphs.php:804 graphs.php:3012 graphs.php:3043
+#: graphs_new.php:293 host.php:1836 host_templates.php:790
 #: host_templates.php:1160 lib/clog_webapi.php:597 lib/clog_webapi.php:623
-#: lib/html.php:3307 lib/html_graph.php:121 lib/html_graph.php:938
+#: lib/html.php:3248 lib/html_graph.php:121 lib/html_graph.php:938
 #: lib/html_reports.php:1058 lib/html_reports.php:1952
 #: lib/html_reports.php:2430 lib/html_tree.php:947 managers.php:486
 #: package_import.php:1473 plugins.php:644 plugins.php:645 rrdcheck.php:194
 #: settings.php:335 settings.php:357 settings.php:380 support.php:485
-#: tree.php:837 user_admin.php:2029 user_admin.php:2043 user_admin.php:2053
+#: tree.php:837 user_admin.php:2031 user_admin.php:2045 user_admin.php:2055
 #: user_log.php:241 utilities.php:208 utilities.php:665
 msgid "All"
 msgstr ""
 
-#: data_debug.php:964 data_sources.php:1621 lib/clog_webapi.php:600
+#: data_debug.php:964 data_sources.php:1738 lib/clog_webapi.php:600
 #: user_log.php:242 utilities.php:211 utilities.php:668
 msgid "Deleted/Invalid"
 msgstr ""
@@ -3815,27 +3990,27 @@ msgstr ""
 msgid "Debugging"
 msgstr ""
 
-#: data_debug.php:1055 data_sources.php:1702 graphs.php:3102 host.php:1655
-#: host.php:1931 include/global_settings.php:851 lib/api_automation.php:203
+#: data_debug.php:1055 data_sources.php:1819 graphs.php:3104 host.php:1656
+#: host.php:1932 include/global_settings.php:853 lib/api_automation.php:203
 #: lib/api_automation.php:671 lib/html.php:2727 lib/html.php:2730
 #: lib/html_graph.php:219 lib/html_graph.php:1005 lib/html_reports.php:1071
 #: utilities.php:293 utilities.php:747
 msgid "Site"
 msgstr ""
 
-#: data_debug.php:1064 data_sources.php:997 data_sources.php:1711
-#: graphs.php:860 graphs.php:2408 graphs.php:3111 graphs_new.php:310
+#: data_debug.php:1064 data_sources.php:1114 data_sources.php:1828
+#: graphs.php:860 graphs.php:2410 graphs.php:3113 graphs_new.php:310
 #: include/global_arrays.php:1043 include/global_arrays.php:1104
 #: include/global_arrays.php:1831 include/global_arrays.php:2000
-#: lib/api_automation.php:547 lib/functions.php:6009 lib/html.php:2661
+#: lib/api_automation.php:547 lib/functions.php:6078 lib/html.php:2661
 #: lib/html.php:2664 lib/html.php:2694 lib/html_graph.php:238
 #: lib/html_graph.php:1024 lib/html_graph.php:1292 lib/html_reports.php:1100
 #: utilities.php:302 utilities.php:458 utilities.php:756
 msgid "Device"
 msgstr ""
 
-#: data_debug.php:1087 data_sources.php:1734 data_templates.php:1250
-#: lib/html.php:3230
+#: data_debug.php:1087 data_sources.php:1851 data_templates.php:1250
+#: lib/html.php:3171
 msgid "Profile"
 msgstr ""
 
@@ -3927,7 +4102,9 @@ msgid "Remove Data Input Field"
 msgstr ""
 
 #: data_input.php:433
-msgid "This script appears to have no input values, therefore there is nothing to add."
+msgid ""
+"This script appears to have no input values, therefore there is nothing to "
+"add."
 msgstr ""
 
 #: data_input.php:440
@@ -3974,11 +4151,15 @@ msgid "White List Verification Succeeded."
 msgstr ""
 
 #: data_input.php:550
-msgid "White List Verification Failed.  Run CLI script input_whitelist.php to correct."
+msgid ""
+"White List Verification Failed.  Run CLI script input_whitelist.php to "
+"correct."
 msgstr ""
 
 #: data_input.php:552
-msgid "Input String does not exist in White List.  Run CLI script input_whitelist.php to correct."
+msgid ""
+"Input String does not exist in White List.  Run CLI script "
+"input_whitelist.php to correct."
 msgstr ""
 
 #: data_input.php:575 data_input.php:645 include/global_form.php:490
@@ -4039,11 +4220,15 @@ msgid "The name of this Data Input Method."
 msgstr ""
 
 #: data_input.php:783
-msgid "The internal database ID for this Data Input Method.  Useful when performing automation or debugging."
+msgid ""
+"The internal database ID for this Data Input Method.  Useful when performing "
+"automation or debugging."
 msgstr ""
 
 #: data_input.php:788
-msgid "Data Inputs that are in use cannot be Deleted. In use is defined as being referenced either by a Data Source or a Data Template."
+msgid ""
+"Data Inputs that are in use cannot be Deleted. In use is defined as being "
+"referenced either by a Data Source or a Data Template."
 msgstr ""
 
 #: data_input.php:791 data_source_profiles.php:1419 data_templates.php:1118
@@ -4135,7 +4320,10 @@ msgid "Data Template - %s"
 msgstr ""
 
 #: data_queries.php:743
-msgid "If this Graph Template requires the Data Template Data Source to the left, select the correct XML output column and then to enable the mapping either check or toggle here."
+msgid ""
+"If this Graph Template requires the Data Template Data Source to the left, "
+"select the correct XML output column and then to enable the mapping either "
+"check or toggle here."
 msgstr ""
 
 #: data_queries.php:759
@@ -4152,8 +4340,8 @@ msgstr ""
 
 #: data_queries.php:834 data_queries.php:943 include/global_form.php:2294
 #: include/global_form.php:2336 include/global_form.php:2470
-#: lib/api_automation.php:1351 lib/api_automation.php:1468
-#: lib/api_automation.php:1568 utilities.php:461
+#: lib/api_automation.php:1355 lib/api_automation.php:1472
+#: lib/api_automation.php:1572 utilities.php:461
 msgid "Field Name"
 msgstr ""
 
@@ -4175,7 +4363,9 @@ msgstr ""
 
 #: data_queries.php:1102
 #, php-format
-msgid "The Data Query ID [%s] that you are trying to Edit does not exist.  Please run the repair_database.php CLI script to resolve this database issue."
+msgid ""
+"The Data Query ID [%s] that you are trying to Edit does not exist.  Please "
+"run the repair_database.php CLI script to resolve this database issue."
 msgstr ""
 
 #: data_queries.php:1108
@@ -4196,7 +4386,7 @@ msgid "Could not locate XML file."
 msgstr ""
 
 #: data_queries.php:1149 graph_templates.php:1641 graphs_new.php:565
-#: host.php:904 lib/api_automation.php:659
+#: host.php:905 lib/api_automation.php:659
 msgid "Graph Template Name"
 msgstr ""
 
@@ -4204,7 +4394,7 @@ msgstr ""
 msgid "Mapping ID"
 msgstr ""
 
-#: data_queries.php:1166 host.php:900 host_templates.php:602
+#: data_queries.php:1166 host.php:901 host_templates.php:602
 #: include/global_arrays.php:2591
 msgid "Associated Graph Templates"
 msgstr ""
@@ -4227,12 +4417,12 @@ msgstr ""
 
 #: data_queries.php:1277 data_queries.php:1279 data_queries.php:1357
 #: include/global_arrays.php:1100 include/global_arrays.php:1371
-#: include/global_arrays.php:2573 lib/api_automation.php:1049
-#: lib/api_automation.php:1055 lib/package.php:320
+#: include/global_arrays.php:2573 lib/api_automation.php:1053
+#: lib/api_automation.php:1059 lib/package.php:320
 msgid "Data Queries"
 msgstr ""
 
-#: data_queries.php:1315 host.php:1029 utilities.php:459
+#: data_queries.php:1315 host.php:1030 utilities.php:459
 msgid "Data Query Name"
 msgstr ""
 
@@ -4241,11 +4431,15 @@ msgid "The name of this Data Query."
 msgstr ""
 
 #: data_queries.php:1324 graph_templates.php:1650
-msgid "The internal ID for this Graph Template.  Useful when performing automation or debugging."
+msgid ""
+"The internal ID for this Graph Template.  Useful when performing automation "
+"or debugging."
 msgstr ""
 
 #: data_queries.php:1329
-msgid "Data Queries that are in use cannot be Deleted. In use is defined as being referenced by either a Graph or a Graph Template."
+msgid ""
+"Data Queries that are in use cannot be Deleted. In use is defined as being "
+"referenced by either a Graph or a Graph Template."
 msgstr ""
 
 #: data_queries.php:1335
@@ -4257,7 +4451,9 @@ msgid "The number of Graphs Templates using this Data Query."
 msgstr ""
 
 #: data_queries.php:1347
-msgid "The Data Input Method used to collect data for Data Sources associated with this Data Query."
+msgid ""
+"The Data Input Method used to collect data for Data Sources associated with "
+"this Data Query."
 msgstr ""
 
 #: data_queries.php:1350 data_templates.php:1142 graph_templates.php:1700
@@ -4278,7 +4474,9 @@ msgid "Import Data Source Profile from Local File"
 msgstr ""
 
 #: data_source_profiles.php:161
-msgid "If the JSON file containing the Data Source Profile data is located on your local machine, select it here."
+msgid ""
+"If the JSON file containing the Data Source Profile data is located on your "
+"local machine, select it here."
 msgstr ""
 
 #: data_source_profiles.php:167
@@ -4286,7 +4484,9 @@ msgid "Import Data Source Profile from Text"
 msgstr ""
 
 #: data_source_profiles.php:168
-msgid "If you have the JSON file containing the Data Source Profile data as text, you can paste it into this box to import it."
+msgid ""
+"If you have the JSON file containing the Data Source Profile data as text, "
+"you can paste it into this box to import it."
 msgstr ""
 
 #: data_source_profiles.php:193 data_source_profiles.php:207
@@ -4313,46 +4513,46 @@ msgid "Data Source Profile '%s' %s!"
 msgstr ""
 
 #: data_source_profiles.php:350 data_source_profiles.php:352
-#: lib/api_automation.php:5445 lib/api_automation.php:5447
-#: lib/api_automation.php:5482 lib/api_automation.php:5484
-#: lib/api_automation.php:5586 lib/api_automation.php:5588
-#: lib/api_automation.php:5682 lib/api_automation.php:5684
-#: lib/api_automation.php:5709 lib/api_automation.php:5711
-#: lib/api_automation.php:5738 lib/api_automation.php:5740
-#: lib/api_automation.php:5816 lib/api_automation.php:5818
-#: lib/api_automation.php:5841 lib/api_automation.php:5843
-#: lib/api_automation.php:5872 lib/api_automation.php:5874
-#: lib/api_automation.php:5985 lib/api_automation.php:5987
-#: lib/api_automation.php:6043 lib/api_automation.php:6045
-#: lib/api_automation.php:6070 lib/api_automation.php:6072
-#: lib/api_automation.php:6099 lib/api_automation.php:6101
-#: lib/api_automation.php:6152 lib/api_automation.php:6154
-#: lib/api_automation.php:6177 lib/api_automation.php:6179
-#: lib/api_automation.php:6208 lib/api_automation.php:6210
-#: lib/api_automation.php:6264 lib/api_automation.php:6266
-#: lib/api_automation.php:6316 lib/api_automation.php:6318
+#: lib/api_automation.php:5488 lib/api_automation.php:5490
+#: lib/api_automation.php:5525 lib/api_automation.php:5527
+#: lib/api_automation.php:5629 lib/api_automation.php:5631
+#: lib/api_automation.php:5725 lib/api_automation.php:5727
+#: lib/api_automation.php:5752 lib/api_automation.php:5754
+#: lib/api_automation.php:5781 lib/api_automation.php:5783
+#: lib/api_automation.php:5859 lib/api_automation.php:5861
+#: lib/api_automation.php:5884 lib/api_automation.php:5886
+#: lib/api_automation.php:5915 lib/api_automation.php:5917
+#: lib/api_automation.php:6028 lib/api_automation.php:6030
+#: lib/api_automation.php:6086 lib/api_automation.php:6088
+#: lib/api_automation.php:6113 lib/api_automation.php:6115
+#: lib/api_automation.php:6142 lib/api_automation.php:6144
+#: lib/api_automation.php:6195 lib/api_automation.php:6197
+#: lib/api_automation.php:6220 lib/api_automation.php:6222
+#: lib/api_automation.php:6251 lib/api_automation.php:6253
+#: lib/api_automation.php:6307 lib/api_automation.php:6309
+#: lib/api_automation.php:6359 lib/api_automation.php:6361
 msgid "Imported"
 msgstr ""
 
 #: data_source_profiles.php:350 data_source_profiles.php:352
-#: lib/api_automation.php:5445 lib/api_automation.php:5447
-#: lib/api_automation.php:5482 lib/api_automation.php:5484
-#: lib/api_automation.php:5586 lib/api_automation.php:5588
-#: lib/api_automation.php:5682 lib/api_automation.php:5684
-#: lib/api_automation.php:5709 lib/api_automation.php:5711
-#: lib/api_automation.php:5738 lib/api_automation.php:5740
-#: lib/api_automation.php:5816 lib/api_automation.php:5818
-#: lib/api_automation.php:5841 lib/api_automation.php:5843
-#: lib/api_automation.php:5872 lib/api_automation.php:5874
-#: lib/api_automation.php:5985 lib/api_automation.php:5987
-#: lib/api_automation.php:6043 lib/api_automation.php:6045
-#: lib/api_automation.php:6070 lib/api_automation.php:6072
-#: lib/api_automation.php:6099 lib/api_automation.php:6101
-#: lib/api_automation.php:6152 lib/api_automation.php:6154
-#: lib/api_automation.php:6177 lib/api_automation.php:6179
-#: lib/api_automation.php:6208 lib/api_automation.php:6210
-#: lib/api_automation.php:6264 lib/api_automation.php:6266
-#: lib/api_automation.php:6316 lib/api_automation.php:6318
+#: lib/api_automation.php:5488 lib/api_automation.php:5490
+#: lib/api_automation.php:5525 lib/api_automation.php:5527
+#: lib/api_automation.php:5629 lib/api_automation.php:5631
+#: lib/api_automation.php:5725 lib/api_automation.php:5727
+#: lib/api_automation.php:5752 lib/api_automation.php:5754
+#: lib/api_automation.php:5781 lib/api_automation.php:5783
+#: lib/api_automation.php:5859 lib/api_automation.php:5861
+#: lib/api_automation.php:5884 lib/api_automation.php:5886
+#: lib/api_automation.php:5915 lib/api_automation.php:5917
+#: lib/api_automation.php:6028 lib/api_automation.php:6030
+#: lib/api_automation.php:6086 lib/api_automation.php:6088
+#: lib/api_automation.php:6113 lib/api_automation.php:6115
+#: lib/api_automation.php:6142 lib/api_automation.php:6144
+#: lib/api_automation.php:6195 lib/api_automation.php:6197
+#: lib/api_automation.php:6220 lib/api_automation.php:6222
+#: lib/api_automation.php:6251 lib/api_automation.php:6253
+#: lib/api_automation.php:6307 lib/api_automation.php:6309
+#: lib/api_automation.php:6359 lib/api_automation.php:6361
 #: package_import.php:1147 templates_import.php:290
 msgid "Updated"
 msgstr ""
@@ -4363,24 +4563,24 @@ msgid "Data Source Profile '%s' %s Failed!"
 msgstr ""
 
 #: data_source_profiles.php:356 data_source_profiles.php:358
-#: lib/api_automation.php:5451 lib/api_automation.php:5453
-#: lib/api_automation.php:5488 lib/api_automation.php:5490
-#: lib/api_automation.php:5592 lib/api_automation.php:5594
-#: lib/api_automation.php:5688 lib/api_automation.php:5690
-#: lib/api_automation.php:5715 lib/api_automation.php:5717
-#: lib/api_automation.php:5744 lib/api_automation.php:5746
-#: lib/api_automation.php:5822 lib/api_automation.php:5824
-#: lib/api_automation.php:5847 lib/api_automation.php:5849
-#: lib/api_automation.php:5878 lib/api_automation.php:5880
-#: lib/api_automation.php:5991 lib/api_automation.php:5993
-#: lib/api_automation.php:6049 lib/api_automation.php:6051
-#: lib/api_automation.php:6076 lib/api_automation.php:6078
-#: lib/api_automation.php:6105 lib/api_automation.php:6107
-#: lib/api_automation.php:6158 lib/api_automation.php:6160
-#: lib/api_automation.php:6183 lib/api_automation.php:6185
-#: lib/api_automation.php:6214 lib/api_automation.php:6216
-#: lib/api_automation.php:6270 lib/api_automation.php:6272
-#: lib/api_automation.php:6322 lib/api_automation.php:6324 user_admin.php:797
+#: lib/api_automation.php:5494 lib/api_automation.php:5496
+#: lib/api_automation.php:5531 lib/api_automation.php:5533
+#: lib/api_automation.php:5635 lib/api_automation.php:5637
+#: lib/api_automation.php:5731 lib/api_automation.php:5733
+#: lib/api_automation.php:5758 lib/api_automation.php:5760
+#: lib/api_automation.php:5787 lib/api_automation.php:5789
+#: lib/api_automation.php:5865 lib/api_automation.php:5867
+#: lib/api_automation.php:5890 lib/api_automation.php:5892
+#: lib/api_automation.php:5921 lib/api_automation.php:5923
+#: lib/api_automation.php:6034 lib/api_automation.php:6036
+#: lib/api_automation.php:6092 lib/api_automation.php:6094
+#: lib/api_automation.php:6119 lib/api_automation.php:6121
+#: lib/api_automation.php:6148 lib/api_automation.php:6150
+#: lib/api_automation.php:6201 lib/api_automation.php:6203
+#: lib/api_automation.php:6226 lib/api_automation.php:6228
+#: lib/api_automation.php:6257 lib/api_automation.php:6259
+#: lib/api_automation.php:6313 lib/api_automation.php:6315
+#: lib/api_automation.php:6365 lib/api_automation.php:6367 user_admin.php:797
 #: user_admin.php:1086 user_admin.php:1256 user_admin.php:1412
 #: user_group_admin.php:770 user_group_admin.php:954 user_group_admin.php:1132
 #: user_group_admin.php:1277
@@ -4388,45 +4588,51 @@ msgid "Update"
 msgstr ""
 
 #: data_source_profiles.php:363
-msgid "Data Source Profile Import data is either for another object type or not JSON formatted."
+msgid ""
+"Data Source Profile Import data is either for another object type or not "
+"JSON formatted."
 msgstr ""
 
-#: data_source_profiles.php:373 lib/api_automation.php:6358
+#: data_source_profiles.php:373 lib/api_automation.php:6401
 msgid "Template column '"
 msgstr ""
 
 #: data_source_profiles.php:435 data_source_profiles.php:439
-#: lib/api_automation.php:5372 lib/api_automation.php:5376
+#: lib/api_automation.php:5409 lib/api_automation.php:5413
 msgid "The file is too big."
 msgstr ""
 
-#: data_source_profiles.php:443 lib/api_automation.php:5380
+#: data_source_profiles.php:443 lib/api_automation.php:5417
 msgid "Incomplete file transfer."
 msgstr ""
 
 #: data_source_profiles.php:447 data_source_profiles.php:479
-#: lib/api_automation.php:5384 lib/api_automation.php:5416
+#: lib/api_automation.php:5421 lib/api_automation.php:5459
 msgid "No file uploaded."
 msgstr ""
 
-#: data_source_profiles.php:451 lib/api_automation.php:5388
+#: data_source_profiles.php:451 lib/api_automation.php:5425
 msgid "Temporary folder missing."
 msgstr ""
 
-#: data_source_profiles.php:455 lib/api_automation.php:5392
+#: data_source_profiles.php:455 lib/api_automation.php:5429
 msgid "Failed to write file to disk"
 msgstr ""
 
-#: data_source_profiles.php:459 lib/api_automation.php:5396
+#: data_source_profiles.php:459 lib/api_automation.php:5433
 msgid "File upload stopped by extension"
 msgstr ""
 
-#: data_source_profiles.php:471 lib/api_automation.php:5408
+#: data_source_profiles.php:471 lib/api_automation.php:5445
 msgid "Invalid file extension."
 msgstr ""
 
 #: data_source_profiles.php:637
-msgid "Changing the Heartbeat from this page, does not change the Heartbeat for your existing Data Sources.  Use RRDtool's 'tune' function to make that change to your existing RRDfiles heartbeats, or run the CLI utility update_heartbeat.php to correct.<br>"
+msgid ""
+"Changing the Heartbeat from this page, does not change the Heartbeat for "
+"your existing Data Sources.  Use RRDtool's 'tune' function to make that "
+"change to your existing RRDfiles heartbeats, or run the CLI utility "
+"update_heartbeat.php to correct.<br>"
 msgstr ""
 
 #: data_source_profiles.php:769
@@ -4528,7 +4734,7 @@ msgstr ""
 msgid "Data Retention"
 msgstr ""
 
-#: data_source_profiles.php:1120 include/global_settings.php:1369
+#: data_source_profiles.php:1120 include/global_settings.php:1371
 #: lib/html_reports.php:1142
 msgid "Graph Timespan"
 msgstr ""
@@ -4539,7 +4745,7 @@ msgstr ""
 
 #: data_source_profiles.php:1122 graphs_new.php:345 include/global_form.php:323
 #: lib/html.php:608 lib/html_filter.php:86 lib/installer.php:3044
-#: lib/rrd.php:3677 support.php:966
+#: lib/rrd.php:3711 support.php:966
 msgid "Rows"
 msgstr ""
 
@@ -4575,7 +4781,7 @@ msgstr ""
 #: include/global_arrays.php:881 include/global_arrays.php:882
 #: include/global_arrays.php:883 include/global_arrays.php:884
 #: include/global_arrays.php:885 include/global_arrays.php:1623
-#: include/global_settings.php:2073
+#: include/global_settings.php:2077
 #, php-format
 msgid "%d Years"
 msgstr ""
@@ -4610,7 +4816,7 @@ msgstr ""
 #: data_source_profiles.php:1318 include/global_arrays.php:762
 #: include/global_arrays.php:818 include/global_arrays.php:839
 #: include/global_arrays.php:850 include/global_arrays.php:1615
-#: include/global_settings.php:1999 rrdcleaner.php:462 rrdcleaner.php:463
+#: include/global_settings.php:2003 rrdcleaner.php:462 rrdcleaner.php:463
 #, php-format
 msgid "%d Week"
 msgstr ""
@@ -4619,15 +4825,15 @@ msgstr ""
 #: include/global_arrays.php:820 include/global_arrays.php:840
 #: include/global_arrays.php:841 include/global_arrays.php:851
 #: include/global_arrays.php:852 include/global_arrays.php:1616
-#: include/global_settings.php:3425 include/global_settings.php:3426
-#: include/global_settings.php:3427 rrdcleaner.php:464 rrdcleaner.php:465
+#: include/global_settings.php:3383 include/global_settings.php:3384
+#: include/global_settings.php:3385 rrdcleaner.php:464 rrdcleaner.php:465
 #, php-format
 msgid "%d Weeks"
 msgstr ""
 
 #: data_source_profiles.php:1327 include/global_arrays.php:761
 #: include/global_arrays.php:805 include/global_arrays.php:815
-#: include/global_arrays.php:1611 include/global_settings.php:1993
+#: include/global_arrays.php:1611 include/global_settings.php:1997
 #, php-format
 msgid "%d Day"
 msgstr ""
@@ -4635,13 +4841,13 @@ msgstr ""
 #: data_source_profiles.php:1327 include/global_arrays.php:806
 #: include/global_arrays.php:816 include/global_arrays.php:817
 #: include/global_arrays.php:1612 include/global_arrays.php:1613
-#: include/global_arrays.php:1614 include/global_settings.php:1994
-#: include/global_settings.php:1995 include/global_settings.php:1996
-#: include/global_settings.php:1997 include/global_settings.php:1998
-#: include/global_settings.php:2068 include/global_settings.php:2069
-#: include/global_settings.php:2070 include/global_settings.php:2071
-#: include/global_settings.php:2083 include/global_settings.php:2084
-#: include/global_settings.php:2085 include/global_settings.php:2086
+#: include/global_arrays.php:1614 include/global_settings.php:1998
+#: include/global_settings.php:1999 include/global_settings.php:2000
+#: include/global_settings.php:2001 include/global_settings.php:2002
+#: include/global_settings.php:2072 include/global_settings.php:2073
+#: include/global_settings.php:2074 include/global_settings.php:2075
+#: include/global_settings.php:2087 include/global_settings.php:2088
+#: include/global_settings.php:2089 include/global_settings.php:2090
 #, php-format
 msgid "%d Days"
 msgstr ""
@@ -4650,8 +4856,8 @@ msgstr ""
 #: include/global_arrays.php:1676 include/global_arrays.php:1697
 #: include/global_arrays.php:1707 include/global_arrays.php:1737
 #: include/global_arrays.php:1746 include/global_arrays.php:1774
-#: include/global_settings.php:1762 include/global_settings.php:1949
-#: include/global_settings.php:3420
+#: include/global_settings.php:1766 include/global_settings.php:1953
+#: include/global_settings.php:3378
 msgid "1 Hour"
 msgstr ""
 
@@ -4672,7 +4878,9 @@ msgid "Is this the default Profile for all new Data Templates?"
 msgstr ""
 
 #: data_source_profiles.php:1399
-msgid "Profiles that are in use cannot be Deleted. In use is defined as being referenced by a Data Source or a Data Template."
+msgid ""
+"Profiles that are in use cannot be Deleted. In use is defined as being "
+"referenced by a Data Source or a Data Template."
 msgstr ""
 
 #: data_source_profiles.php:1402 include/global_form.php:399
@@ -4683,8 +4891,8 @@ msgstr ""
 msgid "Profiles that are in use by Data Sources become read only for now."
 msgstr ""
 
-#: data_source_profiles.php:1407 data_sources.php:1473
-#: include/global_settings.php:1523
+#: data_source_profiles.php:1407 data_sources.php:1590
+#: include/global_settings.php:1525
 msgid "Poller Interval"
 msgstr ""
 
@@ -4698,7 +4906,9 @@ msgid "Heartbeat"
 msgstr ""
 
 #: data_source_profiles.php:1416
-msgid "The Amount of Time, in seconds, without good data before Data is stored as Unknown"
+msgid ""
+"The Amount of Time, in seconds, without good data before Data is stored as "
+"Unknown"
 msgstr ""
 
 #: data_source_profiles.php:1422
@@ -4713,7 +4923,7 @@ msgstr ""
 msgid "No Data Source Profiles Found"
 msgstr ""
 
-#: data_sources.php:40 graphs.php:65 host.php:514
+#: data_sources.php:40 graphs.php:65 host.php:515
 msgid "Change Device"
 msgstr ""
 
@@ -4721,254 +4931,289 @@ msgstr ""
 msgid "Reapply Suggested Names"
 msgstr ""
 
-#: data_sources.php:531
+#: data_sources.php:42 data_sources.php:696
+msgid "Change Data Source Profile"
+msgstr ""
+
+#: data_sources.php:551
+#, php-format
+msgid ""
+"%d RRD files were backed up and will be recreated with new step value at "
+"next polling."
+msgstr ""
+
+#: data_sources.php:634
 msgid "Click 'Continue' to Delete the following Data Source."
 msgstr ""
 
-#: data_sources.php:532
+#: data_sources.php:635
 msgid "Click 'Continue' to Delete following Data Sources."
 msgstr ""
 
-#: data_sources.php:533
+#: data_sources.php:636
 msgid "Delete Data Source"
 msgstr ""
 
-#: data_sources.php:534
+#: data_sources.php:637
 msgid "Delete Data Sources"
 msgstr ""
 
-#: data_sources.php:536
+#: data_sources.php:639
 msgid "The following Graph is using this Data Source."
 msgid_plural "The following Graphs are using this Data Source."
 msgstr[0] ""
 msgstr[1] ""
 
-#: data_sources.php:537
+#: data_sources.php:640
 msgid "The following Graph is using these Data Sources."
 msgid_plural "The following Graphs are using these Data Sources."
 msgstr[0] ""
 msgstr[1] ""
 
-#: data_sources.php:544
+#: data_sources.php:647
 msgid "Leave the Graph Untouched"
 msgid_plural "Leave all Graphs untouched."
 msgstr[0] ""
 msgstr[1] ""
 
-#: data_sources.php:548
+#: data_sources.php:651
 msgid "Delete all Graph Items that reference this Data Source."
 msgid_plural "Delete all Graph Items that reference these Data Sources"
 msgstr[0] ""
 msgstr[1] ""
 
-#: data_sources.php:552
+#: data_sources.php:655
 msgid "Delete all Graphs that reference this Data Source."
 msgid_plural "Delete all Graphs that reference these Data Sources"
 msgstr[0] ""
 msgstr[1] ""
 
-#: data_sources.php:559
+#: data_sources.php:662
 msgid "Click 'Continue' to Disable the following Data Source."
 msgstr ""
 
-#: data_sources.php:560
+#: data_sources.php:663
 msgid "Click 'Continue' to Disable following Data Sources."
 msgstr ""
 
-#: data_sources.php:561 data_sources.php:967
+#: data_sources.php:664 data_sources.php:1084
 msgid "Disable Data Source"
 msgstr ""
 
-#: data_sources.php:562
+#: data_sources.php:665
 msgid "Disable Data Sources"
 msgstr ""
 
-#: data_sources.php:565
+#: data_sources.php:668
 msgid "Click 'Continue' to Enable the following Data Source."
 msgstr ""
 
-#: data_sources.php:566
+#: data_sources.php:669
 msgid "Click 'Continue' to Enable following Data Sources."
 msgstr ""
 
-#: data_sources.php:567 data_sources.php:967
+#: data_sources.php:670 data_sources.php:1084
 msgid "Enable Data Source"
 msgstr ""
 
-#: data_sources.php:568
+#: data_sources.php:671
 msgid "Enable Data Sources"
 msgstr ""
 
-#: data_sources.php:571
+#: data_sources.php:674
 msgid "Click 'Continue' to Change the Device for the following Data Source."
 msgstr ""
 
-#: data_sources.php:572
+#: data_sources.php:675
 msgid "Click 'Continue' to Change the Device for the following Data Sources."
 msgstr ""
 
-#: data_sources.php:573
+#: data_sources.php:676
 msgid "Change Device for Data Source"
 msgstr ""
 
-#: data_sources.php:574
+#: data_sources.php:677
 msgid "Change Device for Data Sources"
 msgstr ""
 
-#: data_sources.php:578 graphs.php:1925 host.php:856
+#: data_sources.php:681 graphs.php:1927 host.php:857
 #: include/global_arrays.php:1088
 msgid "New Device"
 msgstr ""
 
-#: data_sources.php:585
+#: data_sources.php:688
 msgid "Click 'Continue' to Reapply Suggested Names the following Data Source."
 msgstr ""
 
-#: data_sources.php:586
-msgid "Click 'Continue' to Reapply Suggested Names for the following Data Sources."
+#: data_sources.php:689
+msgid ""
+"Click 'Continue' to Reapply Suggested Names for the following Data Sources."
 msgstr ""
 
-#: data_sources.php:587
+#: data_sources.php:690
 msgid "Reapply Suggested Names for Data Source"
 msgstr ""
 
-#: data_sources.php:588
+#: data_sources.php:691
 msgid "Reapply Suggested Names for Data Sources"
 msgstr ""
 
-#: data_sources.php:648 data_templates.php:888
+#: data_sources.php:694
+msgid ""
+"Click 'Continue' to Change the Data Source Profile for the following Data "
+"Source."
+msgstr ""
+
+#: data_sources.php:695
+msgid ""
+"Click 'Continue' to Change the Data Source Profile for the following Data "
+"Sources."
+msgstr ""
+
+#: data_sources.php:697
+msgid "Change Data Source Profiles"
+msgstr ""
+
+#: data_sources.php:701 data_templates.php:524
+msgid "New Data Source Profile"
+msgstr ""
+
+#: data_sources.php:765 data_templates.php:888
 #, php-format
 msgid "Custom Data [data input: %s]"
 msgstr ""
 
-#: data_sources.php:681
+#: data_sources.php:798
 #, php-format
 msgid "(From Device: %s)"
 msgstr ""
 
-#: data_sources.php:684
+#: data_sources.php:801
 msgid "(From Data Template)"
 msgstr ""
 
-#: data_sources.php:685
+#: data_sources.php:802
 msgid "Nothing Entered"
 msgstr ""
 
-#: data_sources.php:700 data_templates.php:970
+#: data_sources.php:817 data_templates.php:970
 msgid "No Input Fields for the Selected Data Input Source"
 msgstr ""
 
-#: data_sources.php:806
+#: data_sources.php:923
 #, php-format
 msgid "Data Template Selection [edit: %s]"
 msgstr ""
 
-#: data_sources.php:812
+#: data_sources.php:929
 msgid "Data Template Selection [new]"
 msgstr ""
 
-#: data_sources.php:894
+#: data_sources.php:1011
 msgid "Turn Off Data Source Debug Mode"
 msgstr ""
 
-#: data_sources.php:897
+#: data_sources.php:1014
 msgid "Turn On Data Source Debug Mode"
 msgstr ""
 
-#: data_sources.php:904
+#: data_sources.php:1021
 msgid "Turn Off Data Source Info Mode"
 msgstr ""
 
-#: data_sources.php:907
+#: data_sources.php:1024
 msgid "Turn On Data Source Info Mode"
 msgstr ""
 
-#: data_sources.php:936
+#: data_sources.php:1053
 #, php-format
 msgid "Edit Graph: '%s'"
 msgstr ""
 
-#: data_sources.php:945 graphs.php:2388 lib/html.php:549
+#: data_sources.php:1062 graphs.php:2390 lib/html.php:549
 msgid "Edit Device"
 msgstr ""
 
-#: data_sources.php:953
+#: data_sources.php:1070
 msgid "Edit Data Template"
 msgstr ""
 
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR The Cacti Group
-# This file is distributed under the same license as the Cacti package.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#: data_sources.php:984
+#: data_sources.php:1101
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Cacti 1.3.0.-1\n"
-"Report-Msgid-Bugs-To: developers@cacti.net\n"
-"POT-Creation-Date: 2026-02-01 13:20-0500\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-08 23:42-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Cacti Developers <developers@cacti.net>>\n"
-"Language-Team: Cacti Developers <developers@cacti.net>\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: data_sources.php:989 include/global_arrays.php:1504
+#: data_sources.php:1106 include/global_arrays.php:1504
 #: include/global_form.php:1810
 msgid "Data Template"
 msgstr ""
 
-#: data_sources.php:990
-msgid "The name given to this data template.  Please note that you may only change Graph Templates to a 100%$ compatible Graph Template, which means that it includes identical Data Sources."
+#: data_sources.php:1107
+msgid ""
+"The name given to this data template.  Please note that you may only change "
+"Graph Templates to a 100%$ compatible Graph Template, which means that it "
+"includes identical Data Sources."
 msgstr ""
 
-#: data_sources.php:998
+#: data_sources.php:1115
 msgid "Choose the Device that this Data Source belongs to."
 msgstr ""
 
-#: data_sources.php:1048
+#: data_sources.php:1165
 msgid "Supplemental Data Template Data"
 msgstr ""
 
-#: data_sources.php:1050
+#: data_sources.php:1167
 msgid "Data Source Fields"
 msgstr ""
 
-#: data_sources.php:1051
+#: data_sources.php:1168
 msgid "Data Source Item Fields"
 msgstr ""
 
-#: data_sources.php:1052
+#: data_sources.php:1169
 msgid "Custom Data"
 msgstr ""
 
-#: data_sources.php:1154
+#: data_sources.php:1271
 #, php-format
 msgid "Data Source Item %s"
 msgstr ""
 
-#: data_sources.php:1157 data_templates.php:818 package_import.php:1071
+#: data_sources.php:1274 data_templates.php:818 package_import.php:1071
 #: package_import.php:1149 templates_import.php:292
 msgid "New"
 msgstr ""
 
-#: data_sources.php:1215
+#: data_sources.php:1332
 msgid "Data Source Debug"
 msgstr ""
 
-#: data_sources.php:1237
+#: data_sources.php:1354
 msgid "RRDtool Tune Info"
 msgstr ""
 
-#: data_sources.php:1263 data_templates.php:1182 include/global_form.php:621
+#: data_sources.php:1380 data_templates.php:1182 include/global_form.php:621
 msgid "External"
 msgstr ""
 
-#: data_sources.php:1267 include/global_arrays.php:749
+#: data_sources.php:1384 include/global_arrays.php:749
 #: include/global_arrays.php:785 include/global_arrays.php:786
 #: include/global_arrays.php:787 include/global_arrays.php:788
 #: include/global_arrays.php:789 include/global_arrays.php:790
@@ -4983,10 +5228,12 @@ msgstr ""
 #: include/global_arrays.php:1783 include/global_arrays.php:1784
 #: include/global_settings.php:742 include/global_settings.php:743
 #: include/global_settings.php:744 include/global_settings.php:745
-#: include/global_settings.php:1560 include/global_settings.php:1561
+#: include/global_settings.php:746 include/global_settings.php:747
 #: include/global_settings.php:1562 include/global_settings.php:1563
-#: include/global_settings.php:3154 include/global_settings.php:3155
-#: include/global_settings.php:3156 lib/html_filter.php:89
+#: include/global_settings.php:1564 include/global_settings.php:1565
+#: include/global_settings.php:1566 include/global_settings.php:1567
+#: include/global_settings.php:3112 include/global_settings.php:3113
+#: include/global_settings.php:3114 lib/html_filter.php:89
 #: lib/html_filter.php:90 lib/html_filter.php:91 lib/html_filter.php:92
 #: lib/html_filter.php:93 support.php:240 support.php:241 support.php:242
 #: support.php:243 support.php:244 support.php:245 support.php:488
@@ -4996,86 +5243,93 @@ msgstr ""
 msgid "%d Seconds"
 msgstr ""
 
-#: data_sources.php:1271 include/global_arrays.php:750
+#: data_sources.php:1388 include/global_arrays.php:750
 #: include/global_arrays.php:1352 include/global_arrays.php:1731
 #: include/global_arrays.php:1767 include/global_arrays.php:1785
-#: include/global_settings.php:1943 include/global_settings.php:3157
+#: include/global_settings.php:1947 include/global_settings.php:3115
 msgid "1 Minute"
 msgstr ""
 
-#: data_sources.php:1455 utilities.php:602
+#: data_sources.php:1572 utilities.php:602
 msgid "Data Source Name"
 msgstr ""
 
-#: data_sources.php:1458
-msgid "The name of this Data Source. Generally programmatically generated from the Data Template definition."
+#: data_sources.php:1575
+msgid ""
+"The name of this Data Source. Generally programmatically generated from the "
+"Data Template definition."
 msgstr ""
 
-#: data_sources.php:1464
-msgid "The internal database ID for this Data Source. Useful when performing automation or debugging."
+#: data_sources.php:1581
+msgid ""
+"The internal database ID for this Data Source. Useful when performing "
+"automation or debugging."
 msgstr ""
 
-#: data_sources.php:1470
-msgid "The number of Graphs and Aggregate Graphs that are using the Data Source."
+#: data_sources.php:1587
+msgid ""
+"The number of Graphs and Aggregate Graphs that are using the Data Source."
 msgstr ""
 
-#: data_sources.php:1476
+#: data_sources.php:1593
 msgid "The frequency that data is collected for this Data Source."
 msgstr ""
 
-#: data_sources.php:1482
+#: data_sources.php:1599
 msgid "If this Data Source is no long in use by Graphs, it can be Deleted."
 msgstr ""
 
-#: data_sources.php:1488
-msgid "Whether or not data will be collected for this Data Source. Controlled at the Data Template level."
+#: data_sources.php:1605
+msgid ""
+"Whether or not data will be collected for this Data Source. Controlled at "
+"the Data Template level."
 msgstr ""
 
-#: data_sources.php:1494
+#: data_sources.php:1611
 msgid "The Data Template that this Data Source was based upon."
 msgstr ""
 
-#: data_sources.php:1531
+#: data_sources.php:1648
 msgid "Damaged Data Source Name"
 msgstr ""
 
-#: data_sources.php:1555
+#: data_sources.php:1672
 msgid "No Data Sources Found"
 msgstr ""
 
-#: data_sources.php:1603
+#: data_sources.php:1720
 msgid "No Graphs"
 msgstr ""
 
-#: data_sources.php:1607 include/global_arrays.php:1096
+#: data_sources.php:1724 include/global_arrays.php:1096
 msgid "Aggregates"
 msgstr ""
 
-#: data_sources.php:1609
+#: data_sources.php:1726
 msgid "No Aggregates"
 msgstr ""
 
-#: data_sources.php:1643
+#: data_sources.php:1760
 msgid "Bad Indexes"
 msgstr ""
 
-#: data_sources.php:1752 graphs.php:3133
+#: data_sources.php:1869 graphs.php:3135
 msgid "Orphaned"
 msgstr ""
 
-#: data_sources.php:1761
+#: data_sources.php:1878
 msgid "Errored"
 msgstr ""
 
-#: data_sources.php:1827 data_sources.php:1834
+#: data_sources.php:1944 data_sources.php:1951
 msgid "Data Sources [ All Devices ]"
 msgstr ""
 
-#: data_sources.php:1829
+#: data_sources.php:1946
 msgid "Data Sources [ Non Device Based ]"
 msgstr ""
 
-#: data_sources.php:1832
+#: data_sources.php:1949
 #, php-format
 msgid "Data Sources [ %s ]"
 msgstr ""
@@ -5086,12 +5340,16 @@ msgstr ""
 
 #: data_templates.php:264
 #, php-format
-msgid "Field \"%s\" is missing an Output Field.  Select the Output Field associated with this Data Source, and press Save again."
+msgid ""
+"Field \"%s\" is missing an Output Field.  Select the Output Field associated "
+"with this Data Source, and press Save again."
 msgstr ""
 
 #: data_templates.php:453
 #, php-format
-msgid "The Poller Cache operation has been launched in background for Data Template ID %d."
+msgid ""
+"The Poller Cache operation has been launched in background for Data Template "
+"ID %d."
 msgstr ""
 
 #: data_templates.php:496
@@ -5143,11 +5401,9 @@ msgid "Change Profile for Data Templates"
 msgstr ""
 
 #: data_templates.php:520
-msgid "NOTE: This change only will affect future Data Sources and does not alter existing Data Sources."
-msgstr ""
-
-#: data_templates.php:524
-msgid "New Data Source Profile"
+msgid ""
+"NOTE: This change only will affect future Data Sources and does not alter "
+"existing Data Sources."
 msgstr ""
 
 #: data_templates.php:530
@@ -5155,7 +5411,16 @@ msgid "Update database for existing Data Sources?"
 msgstr ""
 
 #: data_templates.php:531
-msgid "WARNING: This change will not change either the step or the heartbeat of existing RRDfiles.  After this change, a Rebuild Poller Cache operation will take place in background to update the data collection cycle for the impacted Data Sources.  It is strongly suggested that you either delete all the impacted RRDfiles afterwards, or use the splice_rrd.php CLI script to preserve old data and repopulate the new RRDfiles with the legacy data.  Otherwise, this change will have no on the data and may in fact lead to a loss of fidelity if you are increasing the time between data collection cycles."
+msgid ""
+"WARNING: This change will not change either the step or the heartbeat of "
+"existing RRDfiles.  After this change, a Rebuild Poller Cache operation will "
+"take place in background to update the data collection cycle for the "
+"impacted Data Sources.  It is strongly suggested that you either delete all "
+"the impacted RRDfiles afterwards, or use the splice_rrd.php CLI script to "
+"preserve old data and repopulate the new RRDfiles with the legacy data.  "
+"Otherwise, this change will have no on the data and may in fact lead to a "
+"loss of fidelity if you are increasing the time between data collection "
+"cycles."
 msgstr ""
 
 #: data_templates.php:676
@@ -5176,7 +5441,9 @@ msgid "This field is always templated."
 msgstr ""
 
 #: data_templates.php:747 data_templates.php:853 data_templates.php:921
-msgid "Check this checkbox if you wish to allow the user to override the value on the right during Data Source creation."
+msgid ""
+"Check this checkbox if you wish to allow the user to override the value on "
+"the right during Data Source creation."
 msgstr ""
 
 #: data_templates.php:796
@@ -5189,11 +5456,15 @@ msgid "Data Source Item [%s]"
 msgstr ""
 
 #: data_templates.php:903
-msgid "This value is disabled due to it either it value being derived from the Device or special Data Query object that keeps track of critical data Data Query associations."
+msgid ""
+"This value is disabled due to it either it value being derived from the "
+"Device or special Data Query object that keeps track of critical data Data "
+"Query associations."
 msgstr ""
 
 #: data_templates.php:915
-msgid "This value is disabled due to it being derived from the Device and read only."
+msgid ""
+"This value is disabled due to it being derived from the Device and read only."
 msgstr ""
 
 #: data_templates.php:951
@@ -5209,7 +5480,10 @@ msgid "WARNING: Data Loss can Occur"
 msgstr ""
 
 #: data_templates.php:1022
-msgid "After you uncheck this checkbox and then Save the Data Template, any existing Data Sources based on this Data Template will lose their Custom Data.  This can result in broken Data Collection and Graphs"
+msgid ""
+"After you uncheck this checkbox and then Save the Data Template, any "
+"existing Data Sources based on this Data Template will lose their Custom "
+"Data.  This can result in broken Data Collection and Graphs"
 msgstr ""
 
 #: data_templates.php:1101
@@ -5221,11 +5495,15 @@ msgid "The name of this Data Template."
 msgstr ""
 
 #: data_templates.php:1110
-msgid "The internal database ID for this Data Template.  Useful when performing automation or debugging."
+msgid ""
+"The internal database ID for this Data Template.  Useful when performing "
+"automation or debugging."
 msgstr ""
 
 #: data_templates.php:1115
-msgid "Data Templates that are in use cannot be Deleted.  In use is defined as being referenced by a Data Source."
+msgid ""
+"Data Templates that are in use cannot be Deleted.  In use is defined as "
+"being referenced by a Data Source."
 msgstr ""
 
 #: data_templates.php:1121
@@ -5249,7 +5527,9 @@ msgid "The default Data Source Profile for this Data Template."
 msgstr ""
 
 #: data_templates.php:1139
-msgid "Data Sources based on Inactive Data Templates will not be updated when the poller runs."
+msgid ""
+"Data Sources based on Inactive Data Templates will not be updated when the "
+"poller runs."
 msgstr ""
 
 #: data_templates.php:1149 data_templates.php:1281 data_templates.php:1313
@@ -5262,7 +5542,7 @@ msgstr ""
 msgid "No Data Templates Found"
 msgstr ""
 
-#: data_templates.php:1241 lib/functions.php:5981
+#: data_templates.php:1241 lib/functions.php:6050
 msgid "Method"
 msgstr ""
 
@@ -5320,7 +5600,9 @@ msgid "The GPRINT format string."
 msgstr ""
 
 #: gprint_presets.php:241
-msgid "GPRINTs that are in use cannot be Deleted.  In use is defined as being referenced by either a Graph or a Graph Template."
+msgid ""
+"GPRINTs that are in use cannot be Deleted.  In use is defined as being "
+"referenced by either a Graph or a Graph Template."
 msgstr ""
 
 #: gprint_presets.php:247
@@ -5335,37 +5617,42 @@ msgstr ""
 msgid "No GPRINT Presets"
 msgstr ""
 
-#: graph_image.php:188 graph_json.php:287 graph_realtime.php:251
+#: graph_image.php:188 graph_json.php:287 graph_realtime.php:253
+#: lib/rrd.php:1850
 msgid "The Cacti Poller has not run yet."
 msgstr ""
 
-#: graph_realtime.php:351
+#: graph_realtime.php:353
 msgid "Real-time has been disabled by your administrator."
 msgstr ""
 
-#: graph_realtime.php:361
-msgid "The Image Cache Directory does not exist.  Please first create it and set permissions and then attempt to open another Real-time graph."
+#: graph_realtime.php:363
+msgid ""
+"The Image Cache Directory does not exist.  Please first create it and set "
+"permissions and then attempt to open another Real-time graph."
 msgstr ""
 
-#: graph_realtime.php:371
-msgid "The Image Cache Directory is not writable.  Please set permissions and then attempt to open another Real-time graph."
+#: graph_realtime.php:373
+msgid ""
+"The Image Cache Directory is not writable.  Please set permissions and then "
+"attempt to open another Real-time graph."
 msgstr ""
 
-#: graph_realtime.php:393
+#: graph_realtime.php:395
 msgid "Cacti Real-time Graphing"
 msgstr ""
 
-#: graph_realtime.php:430 lib/html.php:2620 lib/html_graph.php:285
+#: graph_realtime.php:432 lib/html.php:2620 lib/html_graph.php:285
 #: lib/html_reports.php:127 lib/html_tree.php:1050
 msgid "Thumbnails"
 msgstr ""
 
-#: graph_realtime.php:434
+#: graph_realtime.php:436
 #, php-format
 msgid "%d seconds left."
 msgstr ""
 
-#: graph_realtime.php:450
+#: graph_realtime.php:452
 msgid " seconds left."
 msgstr ""
 
@@ -5407,7 +5694,8 @@ msgid "Data Template Filter"
 msgstr ""
 
 #: graph_templates.php:910
-msgid "This filter will limit the Data Sources visible in the Data Source dropdown."
+msgid ""
+"This filter will limit the Data Sources visible in the Data Source dropdown."
 msgstr ""
 
 #: graph_templates.php:1216 graph_templates.php:1231
@@ -5480,16 +5768,28 @@ msgstr ""
 msgid "Graph Width"
 msgstr ""
 
-#: graph_templates.php:1318 graph_templates.php:1682 graphs.php:2937
+#: graph_templates.php:1318 graph_templates.php:1682 graphs.php:2939
 msgid "Image Format"
 msgstr ""
 
 #: graph_templates.php:1326
-msgid "Click 'Continue' to perform a Full Synchronization between your Graphs and the chosen Graph Template. If you simply have a situation where the Graph Items don't match the Graph Template, try the Quick Sync Graphs option first as it will take much less time.  This function is important if you have Graphs that exist with multiple versions of a Graph Template and wish to make them all common in appearance."
+msgid ""
+"Click 'Continue' to perform a Full Synchronization between your Graphs and "
+"the chosen Graph Template. If you simply have a situation where the Graph "
+"Items don't match the Graph Template, try the Quick Sync Graphs option first "
+"as it will take much less time.  This function is important if you have "
+"Graphs that exist with multiple versions of a Graph Template and wish to "
+"make them all common in appearance."
 msgstr ""
 
 #: graph_templates.php:1327
-msgid "Click 'Continue' to perform a Full Synchronization between your Graphs and the chosen Graph Templates. If you simply have a situation where the Graph Items don't match the Graph Template, try the Quick Sync Graphs option first as it will take much less time.  This function is important if you have Graphs that exist with multiple versions of a Graph Template and wish to make them all common in appearance."
+msgid ""
+"Click 'Continue' to perform a Full Synchronization between your Graphs and "
+"the chosen Graph Templates. If you simply have a situation where the Graph "
+"Items don't match the Graph Template, try the Quick Sync Graphs option first "
+"as it will take much less time.  This function is important if you have "
+"Graphs that exist with multiple versions of a Graph Template and wish to "
+"make them all common in appearance."
 msgstr ""
 
 #: graph_templates.php:1328 graph_templates.php:1334
@@ -5501,11 +5801,19 @@ msgid "Synchronize Graphs to Graph Templates"
 msgstr ""
 
 #: graph_templates.php:1332
-msgid "Click 'Continue' to perform a Quick Synchronization of your Graphs for the following Graph Template. Use this option if your Graphs have Graph Items that do not match your Graph Template.  If this option does not work, use the Full Sync Graphs option, which will take more time to complete."
+msgid ""
+"Click 'Continue' to perform a Quick Synchronization of your Graphs for the "
+"following Graph Template. Use this option if your Graphs have Graph Items "
+"that do not match your Graph Template.  If this option does not work, use "
+"the Full Sync Graphs option, which will take more time to complete."
 msgstr ""
 
 #: graph_templates.php:1333
-msgid "Click 'Continue' to perform a Quick Synchronization of your Graphs for the following Graph Templates. Use this option if your Graphs have Graph Items that do not match your Graph Template.  If this option does not work, use the Full Sync Graphs option, which will take more time to complete."
+msgid ""
+"Click 'Continue' to perform a Quick Synchronization of your Graphs for the "
+"following Graph Templates. Use this option if your Graphs have Graph Items "
+"that do not match your Graph Template.  If this option does not work, use "
+"the Full Sync Graphs option, which will take more time to complete."
 msgstr ""
 
 #: graph_templates.php:1384
@@ -5535,7 +5843,9 @@ msgid "Graph Template Options"
 msgstr ""
 
 #: graph_templates.php:1516
-msgid "Check this checkbox if you wish to allow the user to override the value on the right during Graph creation."
+msgid ""
+"Check this checkbox if you wish to allow the user to override the value on "
+"the right during Graph creation."
 msgstr ""
 
 #: graph_templates.php:1644
@@ -5557,7 +5867,9 @@ msgid "The Version of this Graph Template"
 msgstr ""
 
 #: graph_templates.php:1667
-msgid "Graph Templates that are in use cannot be Deleted.  In use is defined as being referenced by a Graph."
+msgid ""
+"Graph Templates that are in use cannot be Deleted.  In use is defined as "
+"being referenced by a Graph."
 msgstr ""
 
 #: graph_templates.php:1670 include/global_arrays.php:2273
@@ -5581,7 +5893,7 @@ msgstr ""
 msgid "The default size of the resulting Graphs."
 msgstr ""
 
-#: graph_templates.php:1694 graph_xport.php:123 graph_xport.php:188
+#: graph_templates.php:1694 graph_xport.php:132 graph_xport.php:197
 msgid "Vertical Label"
 msgstr ""
 
@@ -5615,7 +5927,7 @@ msgstr ""
 msgid "Item #%s"
 msgstr ""
 
-#: graph_templates.php:1963 graphs.php:3162 include/global_arrays.php:1121
+#: graph_templates.php:1963 graphs.php:3164 include/global_arrays.php:1121
 #: include/global_arrays.php:2711 vdef.php:722 vdef.php:724 vdef.php:739
 msgid "VDEFs"
 msgstr ""
@@ -5624,57 +5936,62 @@ msgstr ""
 msgid "Has Graphs"
 msgstr ""
 
-#: graph_xport.php:122 graph_xport.php:186 include/global_form.php:1979
+#: graph_xport.php:99
+msgid ""
+"Error: Graph export returned no data. Check the Cacti log for RRDtool errors."
+msgstr ""
+
+#: graph_xport.php:131 graph_xport.php:195 include/global_form.php:1979
 #: include/global_form.php:2247 lib/html.php:2232 links.php:308
 msgid "Title"
 msgstr ""
 
-#: graph_xport.php:125 graph_xport.php:193
+#: graph_xport.php:134 graph_xport.php:202
 msgid "Start Date"
 msgstr ""
 
-#: graph_xport.php:126 graph_xport.php:195
+#: graph_xport.php:135 graph_xport.php:204
 msgid "End Date"
 msgstr ""
 
-#: graph_xport.php:127 graph_xport.php:200 include/global_form.php:626
+#: graph_xport.php:136 graph_xport.php:209 include/global_form.php:626
 msgid "Step"
 msgstr ""
 
-#: graph_xport.php:128 graph_xport.php:202
+#: graph_xport.php:137 graph_xport.php:211
 msgid "Total Rows"
 msgstr ""
 
-#: graph_xport.php:129 graph_xport.php:207 lib/api_automation.php:655
+#: graph_xport.php:138 graph_xport.php:216 lib/api_automation.php:655
 msgid "Graph ID"
 msgstr ""
 
-#: graph_xport.php:130 graph_xport.php:209
+#: graph_xport.php:139 graph_xport.php:218
 msgid "Host ID"
 msgstr ""
 
-#: graph_xport.php:134 graph_xport.php:232
+#: graph_xport.php:143 graph_xport.php:241
 msgid "Nth Percentile"
 msgstr ""
 
-#: graph_xport.php:140 graph_xport.php:259
+#: graph_xport.php:149 graph_xport.php:268
 msgid "Summation"
 msgstr ""
 
-#: graph_xport.php:146 graph_xport.php:279 rrdcheck.php:147 support.php:1207
+#: graph_xport.php:155 graph_xport.php:288 rrdcheck.php:147 support.php:1207
 #: user_log.php:113
 msgid "Date"
 msgstr ""
 
-#: graph_xport.php:176
+#: graph_xport.php:185
 msgid "Summary Details"
 msgstr ""
 
-#: graph_xport.php:178
+#: graph_xport.php:187
 msgid "Download as CSV"
 msgstr ""
 
-#: graphs.php:53 graphs.php:1877 include/global_arrays.php:2261
+#: graphs.php:53 graphs.php:1879 include/global_arrays.php:2261
 msgid "Change Graph Template"
 msgstr ""
 
@@ -5686,7 +6003,7 @@ msgstr ""
 msgid "Apply Automation Rules"
 msgstr ""
 
-#: graphs.php:68 graphs.php:1946 graphs.php:1957
+#: graphs.php:68 graphs.php:1948 graphs.php:1959
 msgid "Create Aggregate Graph"
 msgstr ""
 
@@ -5725,343 +6042,363 @@ msgstr ""
 msgid "Choose the Data Source to associate with this Graph Item."
 msgstr ""
 
-#: graphs.php:1815
+#: graphs.php:1817
 msgid "There were not Aggregate Templates found for the selected Graphs"
 msgstr ""
 
-#: graphs.php:1849
+#: graphs.php:1851
 msgid "Click 'Continue' to Delete the following Graph."
 msgstr ""
 
-#: graphs.php:1850
+#: graphs.php:1852
 msgid "Click 'Continue' to Delete following Graphs."
 msgstr ""
 
-#: graphs.php:1851
+#: graphs.php:1853
 msgid "Delete Graph"
 msgstr ""
 
-#: graphs.php:1852
+#: graphs.php:1854
 msgid "Delete Graphs"
 msgstr ""
 
-#: graphs.php:1854
+#: graphs.php:1856
 msgid "The following Data Source is used by this Graph."
 msgid_plural "The following Data Sources are used by this Graph."
 msgstr[0] ""
 msgstr[1] ""
 
-#: graphs.php:1855
+#: graphs.php:1857
 msgid "The following Data Source is used by these Graphs."
 msgid_plural "The following Data Sources are used by these Graphs."
 msgstr[0] ""
 msgstr[1] ""
 
-#: graphs.php:1859 host.php:484
+#: graphs.php:1861 host.php:485
 msgid "Delete Method"
 msgstr ""
 
-#: graphs.php:1864
+#: graphs.php:1866
 msgid "Delete the Data Sources referenced by this Graph"
 msgid_plural "Delete the Data Sources reference by these Graphs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: graphs.php:1868
+#: graphs.php:1870
 msgid "Leave the Data Source Untouched"
 msgid_plural "Leave the Data Sources Untouched"
 msgstr[0] ""
 msgstr[1] ""
 
-#: graphs.php:1875
-msgid "Choose a Graph Template and click 'Continue' to Change the Graph Template for the following Graph.  Note that only compatible Graph Templates will be displayed.  Compatible is identified by those having identical Data Sources."
+#: graphs.php:1877
+msgid ""
+"Choose a Graph Template and click 'Continue' to Change the Graph Template "
+"for the following Graph.  Note that only compatible Graph Templates will be "
+"displayed.  Compatible is identified by those having identical Data Sources."
 msgstr ""
 
-#: graphs.php:1876
-msgid "Choose a Graph Template and click 'Continue' to Change the Graph Template for the following Graphs.  Note that only compatible Graph Templates will be displayed.  Compatible is identified by those having identical Data Sources."
+#: graphs.php:1878
+msgid ""
+"Choose a Graph Template and click 'Continue' to Change the Graph Template "
+"for the following Graphs.  Note that only compatible Graph Templates will be "
+"displayed.  Compatible is identified by those having identical Data Sources."
 msgstr ""
 
-#: graphs.php:1881 graphs_new.php:531
+#: graphs.php:1883 graphs_new.php:531
 msgid "New Graph Template"
 msgstr ""
 
-#: graphs.php:1888
+#: graphs.php:1890
 msgid "Click 'Continue' to Duplicate the following Graph."
 msgstr ""
 
-#: graphs.php:1889
+#: graphs.php:1891
 msgid "Click 'Continue' to Duplicate following Graphs."
 msgstr ""
 
-#: graphs.php:1890
+#: graphs.php:1892
 msgid "Duplicate Graph"
 msgstr ""
 
-#: graphs.php:1891
+#: graphs.php:1893
 msgid "Duplicate Graphs"
 msgstr ""
 
-#: graphs.php:1903
+#: graphs.php:1905
 msgid "Click 'Continue' to Convert the following Graph to a Graph Template."
 msgstr ""
 
-#: graphs.php:1904
+#: graphs.php:1906
 msgid "Click 'Continue' to Convert the following Graphs to Graph Templates."
 msgstr ""
 
-#: graphs.php:1905
+#: graphs.php:1907
 msgid "Convert Graph to Template"
 msgstr ""
 
-#: graphs.php:1906
+#: graphs.php:1908
 msgid "Convert Graphs to Templates"
 msgstr ""
 
-#: graphs.php:1918
-msgid "Choose a Device and click 'Continue' to Change the Graph to the new Device."
-msgstr ""
-
-#: graphs.php:1919
-msgid "Choose a Device and click 'Continue' to Change the Graphs to the new Device."
-msgstr ""
-
 #: graphs.php:1920
-msgid "Change Graph to new Device"
+msgid ""
+"Choose a Device and click 'Continue' to Change the Graph to the new Device."
 msgstr ""
 
 #: graphs.php:1921
+msgid ""
+"Choose a Device and click 'Continue' to Change the Graphs to the new Device."
+msgstr ""
+
+#: graphs.php:1922
+msgid "Change Graph to new Device"
+msgstr ""
+
+#: graphs.php:1923
 msgid "Change Graphs to new Device"
 msgstr ""
 
-#: graphs.php:1932
+#: graphs.php:1934
 msgid "Click 'Continue' to Reapply Suggested Names the following Graph."
 msgstr ""
 
-#: graphs.php:1933
+#: graphs.php:1935
 msgid "Click 'Continue' to Reapply Suggested Names for the following Graphs."
 msgstr ""
 
-#: graphs.php:1934
+#: graphs.php:1936
 msgid "Reapply Suggested Names for Graph"
 msgstr ""
 
-#: graphs.php:1935
+#: graphs.php:1937
 msgid "Reapply Suggested Names for Graphs"
 msgstr ""
 
-#: graphs.php:1938
+#: graphs.php:1940
 msgid "Click 'Continue' to apply Automation Rules to the following Graph."
 msgstr ""
 
-#: graphs.php:1939
+#: graphs.php:1941
 msgid "Click 'Continue' to apply Automation Rules to the following Graphs."
 msgstr ""
 
-#: graphs.php:1940
+#: graphs.php:1942
 msgid "Apply Automation Rules to Graph"
 msgstr ""
 
-#: graphs.php:1941
+#: graphs.php:1943
 msgid "Apply Automation Rules to Graphs"
 msgstr ""
 
-#: graphs.php:1944
+#: graphs.php:1946
 msgid "Click 'Continue' to Create an Aggregate Graph from the selected Graph."
 msgstr ""
 
-#: graphs.php:1945
+#: graphs.php:1947
 msgid "Click 'Continue' to Create an Aggregate Graph from the selected Graphs."
 msgstr ""
 
-#: graphs.php:1951
+#: graphs.php:1953
 msgid "The following Data Source is in use by this Graph."
 msgid_plural "The following Data Sources are in use by these Graphs."
 msgstr[0] ""
 msgstr[1] ""
 
-#: graphs.php:1952
+#: graphs.php:1954
 msgid "The following Data Source is in use by these Graphs."
 msgid_plural "The following Data Sources are in use by these Graphs."
 msgstr[0] ""
 msgstr[1] ""
 
-#: graphs.php:1955
-msgid "Choose an Aggregate Template and click 'Continue' to Create the Aggregate Graph from the following Graph."
+#: graphs.php:1957
+msgid ""
+"Choose an Aggregate Template and click 'Continue' to Create the Aggregate "
+"Graph from the following Graph."
 msgstr ""
 
-#: graphs.php:1956
-msgid "Choose an Aggregate Template and click 'Continue' to Create the Aggregate Graph from the following Graphs."
-msgstr ""
-
-#: graphs.php:1970
-msgid "Click 'Continue' to Place the following Graph on a Report."
-msgstr ""
-
-#: graphs.php:1971
-msgid "Click 'Continue' to Place the following Graphs on a Report."
+#: graphs.php:1958
+msgid ""
+"Choose an Aggregate Template and click 'Continue' to Create the Aggregate "
+"Graph from the following Graphs."
 msgstr ""
 
 #: graphs.php:1972
+msgid "Click 'Continue' to Place the following Graph on a Report."
+msgstr ""
+
+#: graphs.php:1973
+msgid "Click 'Continue' to Place the following Graphs on a Report."
+msgstr ""
+
+#: graphs.php:1974
 msgid "Place Graph on Report"
 msgstr ""
 
-#: graphs.php:2003
+#: graphs.php:2005
 #, php-format
 msgid "Click 'Continue' to Place the following Graph on Tree %s."
 msgstr ""
 
-#: graphs.php:2004
+#: graphs.php:2006
 #, php-format
 msgid "Click 'Continue' to Duplicate following Graphs on Tree %s."
 msgstr ""
 
-#: graphs.php:2005
+#: graphs.php:2007
 msgid "Place Graph on Tree"
 msgstr ""
 
-#: graphs.php:2006
+#: graphs.php:2008
 msgid "Place Graphs on Tree"
 msgstr ""
 
-#: graphs.php:2010 host.php:586
+#: graphs.php:2012 host.php:587
 msgid "Destination Branch"
 msgstr ""
 
-#: graphs.php:2151
+#: graphs.php:2153
 msgid "Graph Items [new]"
 msgstr ""
 
-#: graphs.php:2193
+#: graphs.php:2195
 #, php-format
 msgid "Graph Items [edit: %s]"
 msgstr ""
 
-#: graphs.php:2305
+#: graphs.php:2307
 #, php-format
 msgid "Graph [edit: %s]"
 msgstr ""
 
-#: graphs.php:2311
+#: graphs.php:2313
 msgid "Graph [new]"
 msgstr ""
 
-#: graphs.php:2336
+#: graphs.php:2338
 msgid "Turn Off Graph Debug Mode."
 msgstr ""
 
-#: graphs.php:2339
+#: graphs.php:2341
 msgid "Turn On Graph Debug Mode."
 msgstr ""
 
-#: graphs.php:2379
+#: graphs.php:2381
 #, php-format
 msgid "Edit Data Source: '%s'."
 msgstr ""
 
-#: graphs.php:2399
+#: graphs.php:2401
 msgid "Selected Graph Template"
 msgstr ""
 
-#: graphs.php:2400
+#: graphs.php:2402
 #, php-format
-msgid "Choose a Graph Template to apply to this Graph. Please note that you may only change Graph Templates to a 100%% compatible Graph Template, which means that it includes identical Data Sources."
+msgid ""
+"Choose a Graph Template to apply to this Graph. Please note that you may "
+"only change Graph Templates to a 100%% compatible Graph Template, which "
+"means that it includes identical Data Sources."
 msgstr ""
 
-#: graphs.php:2409
+#: graphs.php:2411
 msgid "Choose the Device that this Graph belongs to."
 msgstr ""
 
-#: graphs.php:2456 lib/html.php:556 lib/html_graph.php:1788
+#: graphs.php:2458 lib/html.php:556 lib/html_graph.php:1788
 #: lib/html_graph.php:2083
 msgid "Edit Graph Template"
 msgstr ""
 
-#: graphs.php:2470
+#: graphs.php:2472
 msgid "Lock Graph"
 msgstr ""
 
-#: graphs.php:2470
+#: graphs.php:2472
 msgid "Unlock Graph"
 msgstr ""
 
-#: graphs.php:2476
+#: graphs.php:2478
 msgid "View Timespan Graphs"
 msgstr ""
 
-#: graphs.php:2506
+#: graphs.php:2508
 msgid "Supplemental Graph Template Data"
 msgstr ""
 
-#: graphs.php:2508
+#: graphs.php:2510
 msgid "Graph Fields"
 msgstr ""
 
-#: graphs.php:2509
+#: graphs.php:2511
 msgid "Graph Item Fields"
 msgstr ""
 
-#: graphs.php:2913 include/global_form.php:2054 lib/html_graph.php:1277
+#: graphs.php:2915 include/global_form.php:2054 lib/html_graph.php:1277
 #: lib/html_graph.php:1315 lib/html_reports.php:1131 tree.php:947
 msgid "Graph Name"
 msgstr ""
 
-#: graphs.php:2916 lib/html_graph.php:1279 lib/html_graph.php:1317
-msgid "The Title of this Graph.  Generally programmatically generated from the Graph Template definition or Suggested Naming rules.  The max length of the Title is controlled under Settings->Visual."
+#: graphs.php:2918 lib/html_graph.php:1279 lib/html_graph.php:1317
+msgid ""
+"The Title of this Graph.  Generally programmatically generated from the "
+"Graph Template definition or Suggested Naming rules.  The max length of the "
+"Title is controlled under Settings->Visual."
 msgstr ""
 
-#: graphs.php:2922
-msgid "The internal database ID for this Graph.  Useful when performing automation or debugging."
+#: graphs.php:2924
+msgid ""
+"The internal database ID for this Graph.  Useful when performing automation "
+"or debugging."
 msgstr ""
 
-#: graphs.php:2925 lib/html_graph.php:1297
+#: graphs.php:2927 lib/html_graph.php:1297
 msgid "Source Type"
 msgstr ""
 
-#: graphs.php:2928 lib/html_graph.php:1299
+#: graphs.php:2930 lib/html_graph.php:1299
 msgid "The underlying source that this Graph was based upon."
 msgstr ""
 
-#: graphs.php:2931 lib/html_graph.php:1302
+#: graphs.php:2933 lib/html_graph.php:1302
 msgid "Source Name"
 msgstr ""
 
-#: graphs.php:2934 lib/html_graph.php:1304
+#: graphs.php:2936 lib/html_graph.php:1304
 msgid "The Graph Template or Data Query that this Graph was based upon."
 msgstr ""
 
-#: graphs.php:2940
+#: graphs.php:2942
 msgid "The image format of the Graph."
 msgstr ""
 
-#: graphs.php:2946 lib/html_graph.php:1309 lib/html_graph.php:1322
+#: graphs.php:2948 lib/html_graph.php:1309 lib/html_graph.php:1322
 msgid "The size of this Graph when not in Preview mode."
 msgstr ""
 
-#: graphs.php:2972
+#: graphs.php:2974
 msgid "Empty Graph"
 msgstr ""
 
-#: graphs.php:3042
+#: graphs.php:3044
 msgid "Non Templated"
 msgstr ""
 
-#: graphs.php:3144 lib/html.php:2479 lib/html.php:2524 lib/html.php:2606
+#: graphs.php:3146 lib/html.php:2479 lib/html.php:2524 lib/html.php:2606
 msgid "Source"
 msgstr ""
 
-#: graphs.php:3222
+#: graphs.php:3224
 msgid "Graph Management [ Custom Graphs List Applied - Clear to Reset ]"
 msgstr ""
 
-#: graphs.php:3224 graphs.php:3231
+#: graphs.php:3226 graphs.php:3233
 msgid "Graph Management [ All Devices ]"
 msgstr ""
 
-#: graphs.php:3226
+#: graphs.php:3228
 msgid "Graph Management [ Non Device Based ]"
 msgstr ""
 
-#: graphs.php:3229
+#: graphs.php:3231
 #, php-format
 msgid "Graph Management [ %s ]"
 msgstr ""
@@ -6082,7 +6419,7 @@ msgstr ""
 msgid "Save the Filter for the User"
 msgstr ""
 
-#: graphs_new.php:370 lib/html.php:3258
+#: graphs_new.php:370 lib/html.php:3199
 msgid "Filter Settings Saved"
 msgstr ""
 
@@ -6090,7 +6427,7 @@ msgstr ""
 msgid "Edit this Device"
 msgstr ""
 
-#: graphs_new.php:380 host.php:746
+#: graphs_new.php:380 host.php:747
 msgid "Create New Device"
 msgstr ""
 
@@ -6124,17 +6461,22 @@ msgstr ""
 
 #: graphs_new.php:681
 #, php-format
-msgid "Error Parsing Data Query Resource XML file for Data Query '%s' with id of '%s'"
+msgid ""
+"Error Parsing Data Query Resource XML file for Data Query '%s' with id of "
+"'%s'"
 msgstr ""
 
 #: graphs_new.php:698
 #, php-format
-msgid "Error Parsing Data Query Resource XML file for Data Query '%s' with id '%s'.  Field Name '%s' missing a 'direction' attribute"
+msgid ""
+"Error Parsing Data Query Resource XML file for Data Query '%s' with id "
+"'%s'.  Field Name '%s' missing a 'direction' attribute"
 msgstr ""
 
 #: graphs_new.php:702
 #, php-format
-msgid "Error Parsing Data Query Resource XML file for Data Query '%s' with id '%s'"
+msgid ""
+"Error Parsing Data Query Resource XML file for Data Query '%s' with id '%s'"
 msgstr ""
 
 #: graphs_new.php:743
@@ -6142,7 +6484,7 @@ msgstr ""
 msgid "Data Query [%s]"
 msgstr ""
 
-#: graphs_new.php:746 host.php:1110
+#: graphs_new.php:746 host.php:1111
 msgid "Reload Query"
 msgstr ""
 
@@ -6151,7 +6493,9 @@ msgid "From there you can get more information."
 msgstr ""
 
 #: graphs_new.php:871
-msgid "This Data Query returned 0 rows, perhaps there was a problem executing this Data Query."
+msgid ""
+"This Data Query returned 0 rows, perhaps there was a problem executing this "
+"Data Query."
 msgstr ""
 
 #: graphs_new.php:871
@@ -6159,7 +6503,9 @@ msgid "You can run this Data Query in debug mode"
 msgstr ""
 
 #: graphs_new.php:886
-msgid "The index is disabled due to the Data Query having no associated Graph Templates."
+msgid ""
+"The index is disabled due to the Data Query having no associated Graph "
+"Templates."
 msgstr ""
 
 #: graphs_new.php:939
@@ -6167,7 +6513,9 @@ msgid "Search Returned no Rows."
 msgstr ""
 
 #: graphs_new.php:944
-msgid "Error in Data Query.  This could be due to the following: File Permissions, or a missing or improperly formatted Data Query XML file."
+msgid ""
+"Error in Data Query.  This could be due to the following: File Permissions, "
+"or a missing or improperly formatted Data Query XML file."
 msgstr ""
 
 #: graphs_new.php:970
@@ -6187,25 +6535,29 @@ msgstr ""
 msgid "WARNING: Cacti Page:%s for User:%s Generated a Fatal Error %d!"
 msgstr ""
 
-#: help.php:74
+#: help.php:77
 #, php-format
-msgid "The Document page '%s' count not be reached.  The Cacti Documentation site is not reachable.  The http error was '%s'.  Consider downloading an official release to obtain the latest documentation and hosting the documentation locally."
+msgid ""
+"The Document page '%s' count not be reached.  The Cacti Documentation site "
+"is not reachable.  The http error was '%s'.  Consider downloading an "
+"official release to obtain the latest documentation and hosting the "
+"documentation locally."
 msgstr ""
 
-#: help.php:88
+#: help.php:91
 msgid "Cacti GitHub Site"
 msgstr ""
 
-#: help.php:88
+#: help.php:91
 msgid "Open a ticket at "
 msgstr ""
 
-#: help.php:88
+#: help.php:91
 #, php-format
 msgid "The Help File %s was not located on the Cacti Documentation Website."
 msgstr ""
 
-#: help.php:102
+#: help.php:105
 #, php-format
 msgid "The Document page '%s' count not be reached locally."
 msgstr ""
@@ -6222,7 +6574,7 @@ msgstr ""
 msgid "Sync to Device Template"
 msgstr ""
 
-#: host.php:59 host.php:533
+#: host.php:59 host.php:534
 msgid "Place Device on Report"
 msgstr ""
 
@@ -6250,416 +6602,439 @@ msgstr ""
 msgid "ERROR: Invalid Device ID."
 msgstr ""
 
-#: host.php:214
+#: host.php:215
 #, php-format
-msgid "Device Reindex Completed in %0.2f seconds.  There were %d items updated."
+msgid ""
+"Device Reindex Completed in %0.2f seconds.  There were %d items updated."
 msgstr ""
 
-#: host.php:358
+#: host.php:359
 #, php-format
 msgid "Unable to add some Devices to Report '%s'"
 msgstr ""
 
-#: host.php:477
+#: host.php:478
 msgid "Click 'Continue' to Delete the following Device."
 msgstr ""
 
-#: host.php:478
+#: host.php:479
 msgid "Click 'Continue' to Delete the following Devices."
 msgstr ""
 
-#: host.php:480
+#: host.php:481
 msgid "Delete Devices"
 msgstr ""
 
-#: host.php:489
-msgid "Leave all Graph(s) and Data Source(s) untouched.  Data Source(s) will be disabled."
+#: host.php:490
+msgid ""
+"Leave all Graph(s) and Data Source(s) untouched.  Data Source(s) will be "
+"disabled."
 msgstr ""
 
-#: host.php:493
+#: host.php:494
 msgid "Delete all associated Graph(s) and Data Source(s)."
 msgstr ""
 
-#: host.php:500
+#: host.php:501
 msgid "Click 'Continue' to Enable the following Device."
 msgstr ""
 
-#: host.php:501
+#: host.php:502
 msgid "Click 'Continue' to Enable the following Devices."
 msgstr ""
 
-#: host.php:502
+#: host.php:503
 msgid "Enable Device"
 msgstr ""
 
-#: host.php:503
+#: host.php:504
 msgid "Enable Devices"
 msgstr ""
 
-#: host.php:506
+#: host.php:507
 msgid "Click 'Continue' to Disable the following Device."
 msgstr ""
 
-#: host.php:507
+#: host.php:508
 msgid "Click 'Continue' to Disable the following Devices."
 msgstr ""
 
-#: host.php:508 include/global_form.php:1324
+#: host.php:509 include/global_form.php:1324
 msgid "Disable Device"
 msgstr ""
 
-#: host.php:509
+#: host.php:510
 msgid "Disable Devices"
 msgstr ""
 
-#: host.php:512
+#: host.php:513
 msgid "Click 'Continue' to Change settings for the following Device."
 msgstr ""
 
-#: host.php:513
+#: host.php:514
 msgid "Click 'Continue' to Change settings for the following Devices."
 msgstr ""
 
-#: host.php:515
+#: host.php:516
 msgid "Change Devices"
 msgstr ""
 
-#: host.php:519
+#: host.php:520
 msgid "Click 'Continue' to Clear Statistics the following Device."
 msgstr ""
 
-#: host.php:520
+#: host.php:521
 msgid "Click 'Continue' to Clear Statistics the following Devices."
 msgstr ""
 
-#: host.php:521
+#: host.php:522
 msgid "Clear Statistics for Device"
 msgstr ""
 
-#: host.php:522
+#: host.php:523
 msgid "Clear Statistics for Devices"
 msgstr ""
 
-#: host.php:525
+#: host.php:526
 msgid "Click 'Continue' to Synchronize Device to its Device Template."
 msgstr ""
 
-#: host.php:526
+#: host.php:527
 msgid "Click 'Continue' to Synchronize Devices to their Device Templates."
 msgstr ""
 
-#: host.php:527
+#: host.php:528
 msgid "Synchronize Device Template"
 msgstr ""
 
-#: host.php:528
+#: host.php:529
 msgid "Synchronize Devices Templates"
 msgstr ""
 
-#: host.php:531
+#: host.php:532
 msgid "Click 'Continue' to Place the following Device on a Report."
 msgstr ""
 
-#: host.php:532
+#: host.php:533
 msgid "Click 'Continue' to Place the following Devices on a Report."
 msgstr ""
 
-#: host.php:534
+#: host.php:535
 msgid "Place Devices on Report"
-msgstr ""
-
-#: host.php:579
-#, php-format
-msgid "Click 'Continue' to Place the following Device on Tree %s."
 msgstr ""
 
 #: host.php:580
 #, php-format
-msgid "Click 'Continue' to Place the following Devices on Tree %s."
+msgid "Click 'Continue' to Place the following Device on Tree %s."
 msgstr ""
 
 #: host.php:581
-msgid "Place Device on Tree"
+#, php-format
+msgid "Click 'Continue' to Place the following Devices on Tree %s."
 msgstr ""
 
 #: host.php:582
+msgid "Place Device on Tree"
+msgstr ""
+
+#: host.php:583
 msgid "Place Devices on Tree"
 msgstr ""
 
-#: host.php:751 include/global_arrays.php:2279
+#: host.php:752 include/global_arrays.php:2279
 msgid "Create New Graphs"
 msgstr ""
 
-#: host.php:756
+#: host.php:757
 msgid "Re-Index Device"
 msgstr ""
 
-#: host.php:761
+#: host.php:762
 msgid "Disable Device Debug"
 msgstr ""
 
-#: host.php:761
+#: host.php:762
 msgid "Enable Device Debug"
 msgstr ""
 
-#: host.php:766
+#: host.php:767
 msgid "Repopulate Poller Cache"
 msgstr ""
 
-#: host.php:771 include/global_arrays.php:2663 include/global_arrays.php:2675
+#: host.php:772 include/global_arrays.php:2663 include/global_arrays.php:2675
 #: utilities.php:896
 msgid "View Poller Cache"
 msgstr ""
 
-#: host.php:776
+#: host.php:777
 msgid "View Data Source List"
 msgstr ""
 
-#: host.php:781
+#: host.php:782
 msgid "View Graphs List"
 msgstr ""
 
-#: host.php:840
+#: host.php:841
 msgid "Device [new]"
 msgstr ""
 
-#: host.php:852
+#: host.php:853
 #, php-format
 msgid "Device [edit: %s]"
 msgstr ""
 
-#: host.php:861
+#: host.php:862
 msgid "Contacting Device"
 msgstr ""
 
-#: host.php:964 tree.php:1695 tree.php:1769 tree.php:1877
+#: host.php:965 tree.php:1695 tree.php:1769 tree.php:1877
 msgid "Edit"
 msgstr ""
 
-#: host.php:964
+#: host.php:965
 msgid "Is Being Graphed"
 msgstr ""
 
-#: host.php:964
+#: host.php:965
 msgid "Not Being Graphed"
 msgstr ""
 
-#: host.php:967
+#: host.php:968
 msgid "Delete Graph Template Association"
 msgstr ""
 
-#: host.php:974
+#: host.php:975
 msgid "No associated graph templates."
 msgstr ""
 
-#: host.php:983 host_templates.php:637
+#: host.php:984 host_templates.php:637
 msgid "Add Graph Template"
 msgstr ""
 
-#: host.php:989
+#: host.php:990
 msgid "Add Graph Template to Device"
 msgstr ""
 
-#: host.php:1005
+#: host.php:1006
 msgid "Data Query Debug Information"
 msgstr ""
 
-#: host.php:1009
+#: host.php:1010
 msgid "Copy All Data to Clipboard"
 msgstr ""
 
-#: host.php:1010
+#: host.php:1011
 msgid "Remove Debug Output"
 msgstr ""
 
-#: host.php:1025 host_templates.php:660
+#: host.php:1026 host_templates.php:660
 msgid "Associated Data Queries"
 msgstr ""
 
-#: host.php:1030 host.php:1140
+#: host.php:1031 host.php:1141
 msgid "Re-Index Method"
 msgstr ""
 
-#: host.php:1031
+#: host.php:1032
 msgid "Last Reindex"
 msgstr ""
 
-#: host.php:1032 include/global_arrays.php:612
+#: host.php:1033 include/global_arrays.php:612
 msgid "Duration"
 msgstr ""
 
-#: host.php:1104
+#: host.php:1105
 #, php-format
 msgid "%0.2f secs"
 msgstr ""
 
-#: host.php:1107
+#: host.php:1108
 #, php-format
 msgid " [%d Items, %d Rows]"
 msgstr ""
 
-#: host.php:1107
+#: host.php:1108
 msgid "Fail"
 msgstr ""
 
-#: host.php:1107 lib/functions.php:6024 lib/functions.php:6029
+#: host.php:1108 lib/functions.php:6093 lib/functions.php:6098
 msgid "Success"
 msgstr ""
 
-#: host.php:1111
+#: host.php:1112
 msgid "Verbose Query"
 msgstr ""
 
-#: host.php:1112
+#: host.php:1113
 msgid "Remove Query"
 msgstr ""
 
-#: host.php:1118 host_templates.php:686
+#: host.php:1119 host_templates.php:686
 msgid "No Associated Data Queries."
 msgstr ""
 
-#: host.php:1134 host_templates.php:695
+#: host.php:1135 host_templates.php:695
 msgid "Add Data Query"
 msgstr ""
 
-#: host.php:1146
+#: host.php:1147
 msgid "Add Data Query to Device"
 msgstr ""
 
-#: host.php:1283 host_templates.php:725
+#: host.php:1284 host_templates.php:725
 msgid "Delete Item from Device Template"
 msgstr ""
 
-#: host.php:1446
+#: host.php:1447
 msgid "Device Status will appear once created"
 msgstr ""
 
-#: host.php:1607 lib/api_automation.php:663 tree.php:912 utilities.php:603
+#: host.php:1608 lib/api_automation.php:663 tree.php:912 utilities.php:603
 msgid "Device Description"
 msgstr ""
 
-#: host.php:1610
+#: host.php:1611
 msgid "The name by which this Device will be referred to."
 msgstr ""
 
-#: host.php:1613 include/global_form.php:1272 include/global_form.php:1917
+#: host.php:1614 include/global_form.php:1272 include/global_form.php:1917
 #: lib/api_automation.php:199 lib/api_automation.php:667
-#: lib/api_automation.php:952 lib/api_automation.php:1228 managers.php:124
+#: lib/api_automation.php:952 lib/api_automation.php:1232 managers.php:124
 #: pollers.php:146 pollers.php:970 user_admin.php:1172
 #: user_group_admin.php:1042
 msgid "Hostname"
 msgstr ""
 
-#: host.php:1616
-msgid "Either an IP address, or hostname.  If a hostname, it must be resolvable by either DNS, or from your hosts file."
+#: host.php:1617
+msgid ""
+"Either an IP address, or hostname.  If a hostname, it must be resolvable by "
+"either DNS, or from your hosts file."
 msgstr ""
 
-#: host.php:1622
-msgid "The internal database ID for this Device.  Useful when performing automation or debugging."
+#: host.php:1623
+msgid ""
+"The internal database ID for this Device.  Useful when performing automation "
+"or debugging."
 msgstr ""
 
-#: host.php:1628
-msgid "The number of threads to use to collect information for this Device.  Applies to spine only."
+#: host.php:1629
+msgid ""
+"The number of threads to use to collect information for this Device.  "
+"Applies to spine only."
 msgstr ""
 
-#: host.php:1634
+#: host.php:1635
 msgid "The total number of Graphs generated from this Device."
 msgstr ""
 
-#: host.php:1640
+#: host.php:1641
 msgid "The total number of Data Sources generated from this Device."
 msgstr ""
 
-#: host.php:1643 include/global_settings.php:412 lib/clog_webapi.php:627
+#: host.php:1644 include/global_settings.php:412 lib/clog_webapi.php:627
 msgid "Errors"
 msgstr ""
 
-#: host.php:1646
-msgid "The total number current data collection errors on this Device.  Enable Device Debug to track them."
+#: host.php:1647
+msgid ""
+"The total number current data collection errors on this Device.  Enable "
+"Device Debug to track them."
 msgstr ""
 
-#: host.php:1652
-msgid "The monitoring status of the Device based upon ping results.  If this Device is a special type Device, by using the hostname \"localhost\", or due to the setting to not perform an Availability Check, it will always remain Up.  When using cmd.php data collector, a Device with no Graphs, is not pinged by the data collector and will remain in an \"Unknown\" state."
+#: host.php:1653
+msgid ""
+"The monitoring status of the Device based upon ping results.  If this Device "
+"is a special type Device, by using the hostname \"localhost\", or due to the "
+"setting to not perform an Availability Check, it will always remain Up.  "
+"When using cmd.php data collector, a Device with no Graphs, is not pinged by "
+"the data collector and will remain in an \"Unknown\" state."
 msgstr ""
 
-#: host.php:1658
+#: host.php:1659
 msgid "The site associated to this Device"
 msgstr ""
 
-#: host.php:1661 host.php:1990
+#: host.php:1662 host.php:1991
 msgid "Service Check"
 msgstr ""
 
-#: host.php:1664
-msgid "The Availability/Reachability method used to communicate with the device.  In some cases, the Availability/Reachability method will be 'none', which is not uncommon for some devices"
+#: host.php:1665
+msgid ""
+"The Availability/Reachability method used to communicate with the device.  "
+"In some cases, the Availability/Reachability method will be 'none', which is "
+"not uncommon for some devices"
 msgstr ""
 
-#: host.php:1667
+#: host.php:1668
 msgid "In State"
 msgstr ""
 
-#: host.php:1670
+#: host.php:1671
 msgid "The amount of time that this Device has been in its current state."
 msgstr ""
 
-#: host.php:1676
+#: host.php:1677
 msgid "The current amount of time that the host has been up."
 msgstr ""
 
-#: host.php:1679
+#: host.php:1680
 msgid "Poll Time"
 msgstr ""
 
-#: host.php:1682
+#: host.php:1683
 msgid "The amount of time it takes to collect data from this Device."
 msgstr ""
 
-#: host.php:1685
+#: host.php:1686
 msgid "Current (ms)"
 msgstr ""
 
-#: host.php:1688
+#: host.php:1689
 msgid "The current ping time in milliseconds to reach the Device."
 msgstr ""
 
-#: host.php:1691
+#: host.php:1692
 msgid "Average (ms)"
 msgstr ""
 
-#: host.php:1694
-msgid "The average ping time in milliseconds to reach the Device since the counters were cleared for this Device."
+#: host.php:1695
+msgid ""
+"The average ping time in milliseconds to reach the Device since the counters "
+"were cleared for this Device."
 msgstr ""
 
-#: host.php:1697
+#: host.php:1698
 msgid "Availability"
 msgstr ""
 
-#: host.php:1700
-msgid "The availability percentage based upon ping results since the counters were cleared for this Device."
+#: host.php:1701
+msgid ""
+"The availability percentage based upon ping results since the counters were "
+"cleared for this Device."
 msgstr ""
 
-#: host.php:1703
+#: host.php:1704
 msgid "Create Date"
 msgstr ""
 
-#: host.php:1706
+#: host.php:1707
 msgid "The Date that the Device was added to Cacti."
 msgstr ""
 
-#: host.php:1766 host.php:1859
+#: host.php:1767 host.php:1860
 msgid "Maintenance"
 msgstr ""
 
-#: host.php:1851 lib/api_automation.php:55 lib/api_automation.php:524
+#: host.php:1852 lib/api_automation.php:55 lib/api_automation.php:524
 msgid "Not Up"
 msgstr ""
 
-#: host.php:1854 lib/api_automation.php:58 lib/api_automation.php:527
+#: host.php:1855 lib/api_automation.php:58 lib/api_automation.php:527
 #: lib/html.php:87 lib/html_utility.php:1533 pollers.php:55
 msgid "Recovering"
 msgstr ""
 
-#: host.php:2022
+#: host.php:2023
 msgid "Export the filtered Devices"
 msgstr ""
 
@@ -6797,7 +7172,9 @@ msgid "Download Device Templates Archives"
 msgstr ""
 
 #: host_templates.php:428
-msgid "Click 'Continue' to delete the following Graph Template will be disassociated from the Device Template."
+msgid ""
+"Click 'Continue' to delete the following Graph Template will be "
+"disassociated from the Device Template."
 msgstr ""
 
 #: host_templates.php:429
@@ -6810,7 +7187,9 @@ msgid "Remove Graph Template"
 msgstr ""
 
 #: host_templates.php:494
-msgid "Click 'Continue' to delete the following Data Queries will be disassociated from the Device Template."
+msgid ""
+"Click 'Continue' to delete the following Data Queries will be disassociated "
+"from the Device Template."
 msgstr ""
 
 #: host_templates.php:495
@@ -6871,7 +7250,7 @@ msgid "Device Templates"
 msgstr ""
 
 #: host_templates.php:1038 host_templates.php:1442 lib/api_automation.php:216
-#: lib/api_automation.php:679 lib/api_automation.php:1232
+#: lib/api_automation.php:679 lib/api_automation.php:1236
 msgid "Device Template Name"
 msgstr ""
 
@@ -6884,7 +7263,9 @@ msgid "Device Class"
 msgstr ""
 
 #: host_templates.php:1047 host_templates.php:1451
-msgid "The Class of this Device Template.  The Class Name should be representative of it's function."
+msgid ""
+"The Class of this Device Template.  The Class Name should be representative "
+"of it's function."
 msgstr ""
 
 #: host_templates.php:1053 host_templates.php:1457
@@ -6915,11 +7296,15 @@ msgid "The copyright of this Device Template."
 msgstr ""
 
 #: host_templates.php:1077 host_templates.php:1481 host_templates.php:1493
-msgid "The internal database ID for this Device Template.  Useful when performing automation or debugging."
+msgid ""
+"The internal database ID for this Device Template.  Useful when performing "
+"automation or debugging."
 msgstr ""
 
 #: host_templates.php:1083
-msgid "Device Templates in use cannot be Deleted.  In use is defined as being referenced by a Device."
+msgid ""
+"Device Templates in use cannot be Deleted.  In use is defined as being "
+"referenced by a Device."
 msgstr ""
 
 #: host_templates.php:1086
@@ -6973,7 +7358,11 @@ msgid "Cacti is Locked Out for Maintenance"
 msgstr ""
 
 #: include/auth.php:146
-msgid "The primary Cacti administrator has locked out the Cacti user interface for maintenance for activities such as upgrades.  If you feel this is in error, please contact your Cacti adminnistrator.  This lockout will stay in place for approximately 30 minutes."
+msgid ""
+"The primary Cacti administrator has locked out the Cacti user interface for "
+"maintenance for activities such as upgrades.  If you feel this is in error, "
+"please contact your Cacti adminnistrator.  This lockout will stay in place "
+"for approximately 30 minutes."
 msgstr ""
 
 #: include/auth.php:199
@@ -6988,20 +7377,21 @@ msgstr ""
 msgid "FATAL: You must be logged in to access this area of Cacti."
 msgstr ""
 
-#: include/auth.php:325 include/auth.php:327 lib/auth.php:4499
+#: include/auth.php:325 include/auth.php:327 lib/auth.php:4524
 #: permission_denied.php:30 permission_denied.php:32
 msgid "Login Again"
 msgstr ""
 
-#: include/auth.php:334 lib/functions.php:8549 permission_denied.php:42
+#: include/auth.php:334 lib/functions.php:8724 permission_denied.php:42
 msgid "Permission Denied"
 msgstr ""
 
-#: include/auth.php:335 lib/functions.php:8550 permission_denied.php:45
-msgid "If you feel that this is an error. Please contact your Cacti Administrator."
+#: include/auth.php:335 lib/functions.php:8725 permission_denied.php:45
+msgid ""
+"If you feel that this is an error. Please contact your Cacti Administrator."
 msgstr ""
 
-#: include/auth.php:335 lib/functions.php:8550 permission_denied.php:43
+#: include/auth.php:335 lib/functions.php:8725 permission_denied.php:43
 msgid "You are not permitted to access this section of Cacti."
 msgstr ""
 
@@ -7010,18 +7400,20 @@ msgid "Installation In Progress"
 msgstr ""
 
 #: include/auth.php:339
-msgid "Only Cacti Administrators with Install/Upgrade privilege may login at this time"
+msgid ""
+"Only Cacti Administrators with Install/Upgrade privilege may login at this "
+"time"
 msgstr ""
 
 #: include/auth.php:339
 msgid "There is an Installation or Upgrade in progress."
 msgstr ""
 
-#: include/global.php:651
+#: include/global.php:650
 msgid "The Main Data Collector has returned to an Online Status"
 msgstr ""
 
-#: include/global.php:655
+#: include/global.php:654
 msgid "The Main Data Collector has gone to an Offline or Recovering Status"
 msgstr ""
 
@@ -7046,7 +7438,8 @@ msgid "You must select at least one field."
 msgstr ""
 
 #: include/global_arrays.php:167
-msgid "You must have built in user authentication turned on to use this feature."
+msgid ""
+"You must have built in user authentication turned on to use this feature."
 msgstr ""
 
 #: include/global_arrays.php:170
@@ -7054,7 +7447,8 @@ msgid "XML parse error."
 msgstr ""
 
 #: include/global_arrays.php:173
-msgid "The directory highlighted does not exist.  Please enter a valid directory."
+msgid ""
+"The directory highlighted does not exist.  Please enter a valid directory."
 msgstr ""
 
 #: include/global_arrays.php:176
@@ -7114,39 +7508,56 @@ msgid "User delete not permitted for designated graph export user."
 msgstr ""
 
 #: include/global_arrays.php:218
-msgid "Data Template includes deleted Data Source Profile.  Please resave the Data Template with an existing Data Source Profile."
+msgid ""
+"Data Template includes deleted Data Source Profile.  Please resave the Data "
+"Template with an existing Data Source Profile."
 msgstr ""
 
 #: include/global_arrays.php:221
-msgid "Graph Template includes deleted GPrint Prefix.  Please run database repair script to identify and/or correct."
+msgid ""
+"Graph Template includes deleted GPrint Prefix.  Please run database repair "
+"script to identify and/or correct."
 msgstr ""
 
 #: include/global_arrays.php:224
-msgid "Graph Template includes deleted CDEFs.  Please run database repair script to identify and/or correct."
+msgid ""
+"Graph Template includes deleted CDEFs.  Please run database repair script to "
+"identify and/or correct."
 msgstr ""
 
 #: include/global_arrays.php:227
-msgid "Graph Template includes deleted Data Input Method.  Please run database repair script to identify."
+msgid ""
+"Graph Template includes deleted Data Input Method.  Please run database "
+"repair script to identify."
 msgstr ""
 
 #: include/global_arrays.php:230
-msgid "Data Template not found during Export.  Please run database repair script to identify."
+msgid ""
+"Data Template not found during Export.  Please run database repair script to "
+"identify."
 msgstr ""
 
 #: include/global_arrays.php:233
-msgid "Device Template not found during Export.  Please run database repair script to identify."
+msgid ""
+"Device Template not found during Export.  Please run database repair script "
+"to identify."
 msgstr ""
 
 #: include/global_arrays.php:236
-msgid "Data Query not found during Export.  Please run database repair script to identify."
+msgid ""
+"Data Query not found during Export.  Please run database repair script to "
+"identify."
 msgstr ""
 
 #: include/global_arrays.php:239
-msgid "Graph Template not found during Export.  Please run database repair script to identify."
+msgid ""
+"Graph Template not found during Export.  Please run database repair script "
+"to identify."
 msgstr ""
 
 #: include/global_arrays.php:242
-msgid "Graph not found.  Either it has been deleted or your database needs repair."
+msgid ""
+"Graph not found.  Either it has been deleted or your database needs repair."
 msgstr ""
 
 #: include/global_arrays.php:245
@@ -7154,7 +7565,8 @@ msgid "SNMPv3 Auth Passphrases must be 8 characters or greater."
 msgstr ""
 
 #: include/global_arrays.php:248
-msgid "Some Graphs not updated. Unable to change device for Data Query based Graphs."
+msgid ""
+"Some Graphs not updated. Unable to change device for Data Query based Graphs."
 msgstr ""
 
 #: include/global_arrays.php:251
@@ -7162,7 +7574,8 @@ msgid "Unable to change device for Data Query based Graphs."
 msgstr ""
 
 #: include/global_arrays.php:254
-msgid "Some settings not saved. Check messages below.  Check red fields for errors."
+msgid ""
+"Some settings not saved. Check messages below.  Check red fields for errors."
 msgstr ""
 
 #: include/global_arrays.php:257
@@ -7174,11 +7587,15 @@ msgid "All User Settings have been returned to their default values."
 msgstr ""
 
 #: include/global_arrays.php:263
-msgid "Suggested Field Name was not entered.  Please enter a field name and try again."
+msgid ""
+"Suggested Field Name was not entered.  Please enter a field name and try "
+"again."
 msgstr ""
 
 #: include/global_arrays.php:266
-msgid "Suggested Value was not entered.  Please enter a suggested value and try again."
+msgid ""
+"Suggested Value was not entered.  Please enter a suggested value and try "
+"again."
 msgstr ""
 
 #: include/global_arrays.php:269
@@ -7186,7 +7603,9 @@ msgid "You must select at least one object from the list."
 msgstr ""
 
 #: include/global_arrays.php:272
-msgid "Device Template updated.  Remember to Sync Devices to push all changes to Devices that use this Device Template."
+msgid ""
+"Device Template updated.  Remember to Sync Devices to push all changes to "
+"Devices that use this Device Template."
 msgstr ""
 
 #: include/global_arrays.php:275
@@ -7202,19 +7621,29 @@ msgid "Unable to change password.  User account not found."
 msgstr ""
 
 #: include/global_arrays.php:284
-msgid "Data Input Saved.  You must update the Data Templates referencing this Data Input Method before creating Graphs or Data Sources."
+msgid ""
+"Data Input Saved.  You must update the Data Templates referencing this Data "
+"Input Method before creating Graphs or Data Sources."
 msgstr ""
 
 #: include/global_arrays.php:287
-msgid "Data Input Saved.  You must update the Data Templates referencing this Data Input Method before the Data Collectors will start using any new or modified Data Input - Input Fields."
+msgid ""
+"Data Input Saved.  You must update the Data Templates referencing this Data "
+"Input Method before the Data Collectors will start using any new or modified "
+"Data Input - Input Fields."
 msgstr ""
 
 #: include/global_arrays.php:290
-msgid "Data Input Field Saved.  You must update the Data Templates referencing this Data Input Method before creating Graphs or Data Sources."
+msgid ""
+"Data Input Field Saved.  You must update the Data Templates referencing this "
+"Data Input Method before creating Graphs or Data Sources."
 msgstr ""
 
 #: include/global_arrays.php:293
-msgid "Data Input Field Saved.  You must update the Data Templates referencing this Data Input Method before the Data Collectors will start using any new or modified Data Input - Input Fields."
+msgid ""
+"Data Input Field Saved.  You must update the Data Templates referencing this "
+"Data Input Method before the Data Collectors will start using any new or "
+"modified Data Input - Input Fields."
 msgstr ""
 
 #: include/global_arrays.php:296
@@ -7230,7 +7659,9 @@ msgid "Cacti log purged successfully"
 msgstr ""
 
 #: include/global_arrays.php:305
-msgid "If you force a password change, you must also allow the user to change their password."
+msgid ""
+"If you force a password change, you must also allow the user to change their "
+"password."
 msgstr ""
 
 #: include/global_arrays.php:308
@@ -7238,11 +7669,14 @@ msgid "You are not allowed to change your password."
 msgstr ""
 
 #: include/global_arrays.php:311
-msgid "Unable to determine size of password field, please check permissions of db user"
+msgid ""
+"Unable to determine size of password field, please check permissions of db "
+"user"
 msgstr ""
 
 #: include/global_arrays.php:314
-msgid "Unable to increase size of password field, pleas check permission of db user"
+msgid ""
+"Unable to increase size of password field, please check permission of db user"
 msgstr ""
 
 #: include/global_arrays.php:317
@@ -7286,7 +7720,8 @@ msgid "Unable to establish MySQL connection with Remote Data Collector."
 msgstr ""
 
 #: include/global_arrays.php:347
-msgid "Data Collector synchronization must be initiated from the main Cacti server."
+msgid ""
+"Data Collector synchronization must be initiated from the main Cacti server."
 msgstr ""
 
 #: include/global_arrays.php:350
@@ -7294,11 +7729,15 @@ msgid "Synchronization does not include the Central Cacti Database server."
 msgstr ""
 
 #: include/global_arrays.php:353
-msgid "When saving a Remote Data Collector, the Database Hostname must be unique from all others."
+msgid ""
+"When saving a Remote Data Collector, the Database Hostname must be unique "
+"from all others."
 msgstr ""
 
 #: include/global_arrays.php:356
-msgid "Your Remote Database Hostname must be something other than 'localhost' for each Remote Data Collector."
+msgid ""
+"Your Remote Database Hostname must be something other than 'localhost' for "
+"each Remote Data Collector."
 msgstr ""
 
 #: include/global_arrays.php:359
@@ -7338,11 +7777,15 @@ msgid "You must select at least one Graph to add to a Report."
 msgstr ""
 
 #: include/global_arrays.php:386
-msgid "All Graphs have been added to the Report.  Duplicate Graphs with the same Timespan were skipped."
+msgid ""
+"All Graphs have been added to the Report.  Duplicate Graphs with the same "
+"Timespan were skipped."
 msgstr ""
 
 #: include/global_arrays.php:389
-msgid "Poller Resource Cache cleared.  Main Data Collector will rebuild at the next poller start, and Remote Data Collectors will sync afterwards."
+msgid ""
+"Poller Resource Cache cleared.  Main Data Collector will rebuild at the next "
+"poller start, and Remote Data Collectors will sync afterwards."
 msgstr ""
 
 #: include/global_arrays.php:392
@@ -7399,11 +7842,14 @@ msgid "Verify All"
 msgstr ""
 
 #: include/global_arrays.php:546
-msgid "All Re-Indexing will be manual or managed through scripts or Device Automation."
+msgid ""
+"All Re-Indexing will be manual or managed through scripts or Device "
+"Automation."
 msgstr ""
 
 #: include/global_arrays.php:547
-msgid "When the Devices SNMP uptime goes backward, a Re-Index will be performed."
+msgid ""
+"When the Devices SNMP uptime goes backward, a Re-Index will be performed."
 msgstr ""
 
 #: include/global_arrays.php:548
@@ -7466,7 +7912,7 @@ msgstr ""
 msgid "Justified"
 msgstr ""
 
-#: include/global_arrays.php:601 lib/html.php:3313
+#: include/global_arrays.php:601 lib/html.php:3254
 msgid "Center"
 msgstr ""
 
@@ -7689,8 +8135,8 @@ msgstr ""
 #: include/global_arrays.php:903 include/global_arrays.php:904
 #: include/global_arrays.php:2010 include/global_arrays.php:2011
 #: include/global_arrays.php:2012 include/global_arrays.php:2013
-#: include/global_arrays.php:2014 include/global_settings.php:3041
-#: include/global_settings.php:3042
+#: include/global_arrays.php:2014 include/global_settings.php:2999
+#: include/global_settings.php:3000
 #, php-format
 msgid "Every %d Hours"
 msgstr ""
@@ -7711,7 +8157,7 @@ msgstr ""
 #: include/global_arrays.php:869 include/global_arrays.php:870
 #: include/global_arrays.php:871 include/global_arrays.php:872
 #: include/global_arrays.php:876 include/global_arrays.php:1622
-#: include/global_settings.php:2072 rrdcleaner.php:470
+#: include/global_settings.php:2076 rrdcleaner.php:470
 #, php-format
 msgid "%d Year"
 msgstr ""
@@ -7740,7 +8186,7 @@ msgstr ""
 msgid "LDAP/AD User Domains"
 msgstr ""
 
-#: include/global_arrays.php:963 lib/auth.php:577
+#: include/global_arrays.php:963 lib/auth.php:583
 msgid "LDAP"
 msgstr ""
 
@@ -7789,8 +8235,8 @@ msgid "Enabled (strict mode)"
 msgstr ""
 
 #: include/global_arrays.php:1012 include/global_form.php:2302
-#: include/global_form.php:2344 lib/api_automation.php:1355
-#: lib/api_automation.php:1469
+#: include/global_form.php:2344 lib/api_automation.php:1359
+#: lib/api_automation.php:1473
 msgid "Operator"
 msgstr ""
 
@@ -7818,13 +8264,13 @@ msgstr ""
 msgid "Numeric Ordering"
 msgstr ""
 
-#: include/global_arrays.php:1041 lib/rrd.php:3589
+#: include/global_arrays.php:1041 lib/rrd.php:3623
 msgid "Header"
 msgstr ""
 
 #: include/global_arrays.php:1042 include/global_arrays.php:1105
 #: include/global_arrays.php:1830 include/global_arrays.php:1999
-#: lib/html.php:3319
+#: lib/html.php:3260
 msgid "Graph"
 msgstr ""
 
@@ -7948,7 +8394,7 @@ msgid "Sites"
 msgstr ""
 
 #: include/global_arrays.php:1093 include/global_arrays.php:1375 tree.php:2052
-#: tree.php:2053 tree.php:2103 user_admin.php:1471 user_admin.php:2533
+#: tree.php:2053 tree.php:2103 user_admin.php:1471 user_admin.php:2535
 #: user_group_admin.php:1325 user_group_admin.php:2153
 msgid "Trees"
 msgstr ""
@@ -7968,7 +8414,7 @@ msgid "Aggregate"
 msgstr ""
 
 #: include/global_arrays.php:1110 include/global_arrays.php:1182
-#: include/global_arrays.php:1367 include/global_settings.php:749
+#: include/global_arrays.php:1367 include/global_settings.php:751
 msgid "Automation"
 msgstr ""
 
@@ -8017,12 +8463,12 @@ msgid "Configuration"
 msgstr ""
 
 #: include/global_arrays.php:1134 include/global_arrays.php:1167
-#: lib/html.php:2983 lib/html.php:3326
+#: lib/html.php:2959 lib/html.php:3267
 msgid "Settings"
 msgstr ""
 
 #: include/global_arrays.php:1135 include/global_arrays.php:2765
-#: user_admin.php:2103 user_admin.php:2139 user_admin.php:2265
+#: user_admin.php:2105 user_admin.php:2141 user_admin.php:2267
 #: user_group_admin.php:657 user_group_admin.php:2167
 msgid "Users"
 msgstr ""
@@ -8605,9 +9051,9 @@ msgstr ""
 msgid "6 Hours"
 msgstr ""
 
-#: include/global_arrays.php:1747 include/global_settings.php:1774
-#: include/global_settings.php:1775 include/global_settings.php:1845
-#: include/global_settings.php:1846 include/global_settings.php:1847
+#: include/global_arrays.php:1747 include/global_settings.php:1778
+#: include/global_settings.php:1779 include/global_settings.php:1849
+#: include/global_settings.php:1850 include/global_settings.php:1851
 #, php-format
 msgid "%s Hours"
 msgstr ""
@@ -8622,19 +9068,19 @@ msgstr ""
 msgid "Unlimited"
 msgstr ""
 
-#: include/global_arrays.php:1768 include/global_settings.php:1737
-#: include/global_settings.php:1738 include/global_settings.php:1739
-#: include/global_settings.php:1740 include/global_settings.php:1741
-#: include/global_settings.php:1757 include/global_settings.php:1758
-#: include/global_settings.php:1759 include/global_settings.php:1760
-#: include/global_settings.php:1761 include/global_settings.php:1771
-#: include/global_settings.php:1772 include/global_settings.php:1785
-#: include/global_settings.php:1786 include/global_settings.php:1787
-#: include/global_settings.php:1788 include/global_settings.php:1826
-#: include/global_settings.php:1827 include/global_settings.php:1828
-#: include/global_settings.php:1829 include/global_settings.php:1840
-#: include/global_settings.php:1841 include/global_settings.php:1842
-#: include/global_settings.php:1843
+#: include/global_arrays.php:1768 include/global_settings.php:1741
+#: include/global_settings.php:1742 include/global_settings.php:1743
+#: include/global_settings.php:1744 include/global_settings.php:1745
+#: include/global_settings.php:1761 include/global_settings.php:1762
+#: include/global_settings.php:1763 include/global_settings.php:1764
+#: include/global_settings.php:1765 include/global_settings.php:1775
+#: include/global_settings.php:1776 include/global_settings.php:1789
+#: include/global_settings.php:1790 include/global_settings.php:1791
+#: include/global_settings.php:1792 include/global_settings.php:1830
+#: include/global_settings.php:1831 include/global_settings.php:1832
+#: include/global_settings.php:1833 include/global_settings.php:1844
+#: include/global_settings.php:1845 include/global_settings.php:1846
+#: include/global_settings.php:1847
 #, php-format
 msgid "%s Minutes"
 msgstr ""
@@ -8898,7 +9344,7 @@ msgid "Every %d Weeks"
 msgstr ""
 
 #: include/global_arrays.php:2022 include/global_arrays.php:3092
-#: include/global_settings.php:1647
+#: include/global_settings.php:1651
 msgid "Daily"
 msgstr ""
 
@@ -9245,7 +9691,7 @@ msgstr ""
 msgid "List Mode"
 msgstr ""
 
-#: include/global_arrays.php:2175 include/global_settings.php:3228
+#: include/global_arrays.php:2175 include/global_settings.php:3186
 #: lib/html_graph.php:1480
 msgid "Preview Mode"
 msgstr ""
@@ -9263,7 +9709,7 @@ msgid "Graph Properties"
 msgstr ""
 
 #: include/global_arrays.php:2237 include/global_arrays.php:2243
-#: lib/functions.php:4325 lib/html.php:2156 lib/html.php:3218 links.php:262
+#: lib/functions.php:4379 lib/html.php:2156 lib/html.php:3159 links.php:262
 #: user_admin.php:1600 user_group_admin.php:1465
 msgid "Console"
 msgstr ""
@@ -9408,7 +9854,7 @@ msgstr ""
 msgid "Package Cacti Template"
 msgstr ""
 
-#: include/global_arrays.php:2855 package_repos.php:486
+#: include/global_arrays.php:2855 package_repos.php:505
 msgid "Package Repositories"
 msgstr ""
 
@@ -9482,7 +9928,7 @@ msgid "seconds"
 msgstr ""
 
 #: include/global_arrays.php:3083 lib/graphs.php:56 lib/graphs.php:65
-#: lib/html.php:3306
+#: lib/html.php:3247
 msgid "Not Templated"
 msgstr ""
 
@@ -9562,7 +10008,7 @@ msgstr ""
 msgid "Choose the SNMPv3 Privacy Passphrase."
 msgstr ""
 
-#: include/global_form.php:124 include/global_settings.php:972
+#: include/global_form.php:124 include/global_settings.php:974
 msgid "SNMP Context (v3)"
 msgstr ""
 
@@ -9570,12 +10016,14 @@ msgstr ""
 msgid "Enter the SNMP Context to use for this device."
 msgstr ""
 
-#: include/global_form.php:133 include/global_settings.php:981
+#: include/global_form.php:133 include/global_settings.php:983
 msgid "SNMP Engine ID (v3)"
 msgstr ""
 
 #: include/global_form.php:134
-msgid "Enter the SNMP v3 Engine Id to use for this device. Leave this field empty to use the SNMP Engine ID being defined per SNMPv3 Notification receiver."
+msgid ""
+"Enter the SNMP v3 Engine Id to use for this device. Leave this field empty "
+"to use the SNMP Engine ID being defined per SNMPv3 Notification receiver."
 msgstr ""
 
 #: include/global_form.php:142
@@ -9591,7 +10039,9 @@ msgid "SNMP Timeout"
 msgstr ""
 
 #: include/global_form.php:152
-msgid "The maximum number of milliseconds Cacti will wait for an SNMP response (does not work with php-snmp support)."
+msgid ""
+"The maximum number of milliseconds Cacti will wait for an SNMP response "
+"(does not work with php-snmp support)."
 msgstr ""
 
 #: include/global_form.php:160 include/global_form.php:227
@@ -9599,7 +10049,9 @@ msgid "SNMP Retries"
 msgstr ""
 
 #: include/global_form.php:161
-msgid "The maximum number of times SNMP will attempt to contact the remote device before giving up."
+msgid ""
+"The maximum number of times SNMP will attempt to contact the remote device "
+"before giving up."
 msgstr ""
 
 #: include/global_form.php:172
@@ -9607,7 +10059,8 @@ msgid "Maximum OIDs Per Get Request"
 msgstr ""
 
 #: include/global_form.php:173
-msgid "The number of SNMP OIDs that can be obtained in a single SNMP Get request."
+msgid ""
+"The number of SNMP OIDs that can be obtained in a single SNMP Get request."
 msgstr ""
 
 #: include/global_form.php:177
@@ -9632,7 +10085,17 @@ msgid "Bulk Walk Maximum Repetitions"
 msgstr ""
 
 #: include/global_form.php:198
-msgid "For SNMPv2 and SNMPv3 Devices, the SNMP Bulk Walk max-repetitions size. The default is to 'Auto Detect on Re-Index'. For very large switches, high performance servers, Jumbo Frame Networks or for high latency WAN connections, increasing this value may increase poller performance. More data is packed into a single SNMP packet which can reduce data query run time. However, some devices may completely refuse to respond to packets with a max-repetition size which is set too large. This can be especially true for lower-powered IoT type devices or smaller embedded IT appliances. Special attention to the overall network path MTU should also be considered since setting a value which is too high could lead to packet fragmentation."
+msgid ""
+"For SNMPv2 and SNMPv3 Devices, the SNMP Bulk Walk max-repetitions size. The "
+"default is to 'Auto Detect on Re-Index'. For very large switches, high "
+"performance servers, Jumbo Frame Networks or for high latency WAN "
+"connections, increasing this value may increase poller performance. More "
+"data is packed into a single SNMP packet which can reduce data query run "
+"time. However, some devices may completely refuse to respond to packets with "
+"a max-repetition size which is set too large. This can be especially true "
+"for lower-powered IoT type devices or smaller embedded IT appliances. "
+"Special attention to the overall network path MTU should also be considered "
+"since setting a value which is too high could lead to packet fragmentation."
 msgstr ""
 
 #: include/global_form.php:202
@@ -9661,7 +10124,9 @@ msgid "%d Repetitions"
 msgstr ""
 
 #: include/global_form.php:228
-msgid "The maximum number of attempts to reach a device via an SNMP readstring prior to giving up."
+msgid ""
+"The maximum number of attempts to reach a device via an SNMP readstring "
+"prior to giving up."
 msgstr ""
 
 #: include/global_form.php:241
@@ -9681,10 +10146,14 @@ msgid "The frequency that data will be collected from the Data Source?"
 msgstr ""
 
 #: include/global_form.php:258
-msgid "How long can data be missing before RRDtool records unknown data.  Increase this value if your Data Source is unstable and you wish to carry forward old data rather than show gaps in your graphs.  This value is multiplied by the X-Files Factor to determine the actual amount of time."
+msgid ""
+"How long can data be missing before RRDtool records unknown data.  Increase "
+"this value if your Data Source is unstable and you wish to carry forward old "
+"data rather than show gaps in your graphs.  This value is multiplied by the "
+"X-Files Factor to determine the actual amount of time."
 msgstr ""
 
-#: include/global_form.php:265 lib/rrd.php:3680
+#: include/global_form.php:265 lib/rrd.php:3714
 msgid "X-Files Factor"
 msgstr ""
 
@@ -9709,7 +10178,9 @@ msgid "RRDfile Size (in Bytes)"
 msgstr ""
 
 #: include/global_form.php:289
-msgid "Based upon the number of Rows in all RRAs and the number of Consolidation Functions selected, the size of this entire in the RRDfile."
+msgid ""
+"Based upon the number of Rows in all RRAs and the number of Consolidation "
+"Functions selected, the size of this entire in the RRDfile."
 msgstr ""
 
 #: include/global_form.php:311
@@ -9721,23 +10192,29 @@ msgid "Aggregation Level"
 msgstr ""
 
 #: include/global_form.php:316
-msgid "The number of samples required prior to filling a row in the RRA specification.  The first RRA should always have a value of 1."
+msgid ""
+"The number of samples required prior to filling a row in the RRA "
+"specification.  The first RRA should always have a value of 1."
 msgstr ""
 
 #: include/global_form.php:324
 msgid "How many generations data is kept in the RRA."
 msgstr ""
 
-#: include/global_form.php:332 include/global_settings.php:3178
+#: include/global_form.php:332 include/global_settings.php:3136
 msgid "Default Timespan"
 msgstr ""
 
 #: include/global_form.php:333
-msgid "When viewing a Graph based upon the RRA in question, the default Timespan to show for that Graph."
+msgid ""
+"When viewing a Graph based upon the RRA in question, the default Timespan to "
+"show for that Graph."
 msgstr ""
 
 #: include/global_form.php:340
-msgid "Based upon the Aggregation Level, the Rows, and the Polling Interval the amount of data that will be retained in the RRA"
+msgid ""
+"Based upon the Aggregation Level, the Rows, and the Polling Interval the "
+"amount of data that will be retained in the RRA"
 msgstr ""
 
 #: include/global_form.php:345
@@ -9745,7 +10222,9 @@ msgid "RRA Size (in Bytes)"
 msgstr ""
 
 #: include/global_form.php:346
-msgid "Based upon the number of Rows and the number of Consolidation Functions selected, the size of this RRA in the RRDfile."
+msgid ""
+"Based upon the number of Rows and the number of Consolidation Functions "
+"selected, the size of this RRA in the RRDfile."
 msgstr ""
 
 #: include/global_form.php:364
@@ -9777,7 +10256,8 @@ msgid "Input Type"
 msgstr ""
 
 #: include/global_form.php:433
-msgid "Choose the method you wish to use to collect data for this Data Input method."
+msgid ""
+"Choose the method you wish to use to collect data for this Data Input method."
 msgstr ""
 
 #: include/global_form.php:439
@@ -9785,7 +10265,9 @@ msgid "Input String"
 msgstr ""
 
 #: include/global_form.php:440
-msgid "The data that is sent to the script, which includes the complete path to the script and input sources in &lt;&gt; brackets."
+msgid ""
+"The data that is sent to the script, which includes the complete path to the "
+"script and input sources in &lt;&gt; brackets."
 msgstr ""
 
 #: include/global_form.php:450
@@ -9793,7 +10275,10 @@ msgid "White List Check"
 msgstr ""
 
 #: include/global_form.php:451
-msgid "The result of the Whitespace verification check for the specific Input Method.  If the Input String changes, and the Whitelist file is not update, Graphs will not be allowed to be created."
+msgid ""
+"The result of the Whitespace verification check for the specific Input "
+"Method.  If the Input String changes, and the Whitelist file is not update, "
+"Graphs will not be allowed to be created."
 msgstr ""
 
 #: include/global_form.php:467 include/global_form.php:478
@@ -9808,7 +10293,10 @@ msgstr ""
 
 #: include/global_form.php:479
 #, php-format
-msgid "Enter a name for this %s field.  Note: If using name value pairs in your script, for example: NAME:VALUE, it is important that the name match your output field name identically to the script output name or names."
+msgid ""
+"Enter a name for this %s field.  Note: If using name value pairs in your "
+"script, for example: NAME:VALUE, it is important that the name match your "
+"output field name identically to the script output name or names."
 msgstr ""
 
 #: include/global_form.php:498
@@ -9824,7 +10312,9 @@ msgid "Regular Expression Match"
 msgstr ""
 
 #: include/global_form.php:507
-msgid "If you want to require a certain regular expression to be matched against input data, enter it here (preg_match format)."
+msgid ""
+"If you want to require a certain regular expression to be matched against "
+"input data, enter it here (preg_match format)."
 msgstr ""
 
 #: include/global_form.php:514
@@ -9841,7 +10331,9 @@ msgstr ""
 
 #: include/global_form.php:523
 #, php-format
-msgid "If this field should be treated specially by host templates, indicate so here. Valid keywords for this field are %s"
+msgid ""
+"If this field should be treated specially by host templates, indicate so "
+"here. Valid keywords for this field are %s"
 msgstr ""
 
 #: include/global_form.php:555
@@ -9849,7 +10341,10 @@ msgid "The name given to this data template."
 msgstr ""
 
 #: include/global_form.php:596
-msgid "Choose a name for this data source.  It can include replacement variables such as |host_description| or |query_fieldName|.  For a complete list of supported replacement tags, please see the Cacti documentation."
+msgid ""
+"Choose a name for this data source.  It can include replacement variables "
+"such as |host_description| or |query_fieldName|.  For a complete list of "
+"supported replacement tags, please see the Cacti documentation."
 msgstr ""
 
 #: include/global_form.php:600
@@ -9866,7 +10361,10 @@ msgstr ""
 
 #: include/global_form.php:620 include/global_form.php:1851
 #: package_import.php:1378
-msgid "Select the Data Source Profile.  The Data Source Profile controls polling interval, the data aggregation, and retention policy for the resulting Data Sources."
+msgid ""
+"Select the Data Source Profile.  The Data Source Profile controls polling "
+"interval, the data aggregation, and retention policy for the resulting Data "
+"Sources."
 msgstr ""
 
 #: include/global_form.php:631
@@ -9886,7 +10384,8 @@ msgid "Internal Data Source Name"
 msgstr ""
 
 #: include/global_form.php:651
-msgid "Choose unique name to represent this piece of data inside of the RRDfile."
+msgid ""
+"Choose unique name to represent this piece of data inside of the RRDfile."
 msgstr ""
 
 #: include/global_form.php:654
@@ -9914,7 +10413,9 @@ msgid "How data is represented in the RRA."
 msgstr ""
 
 #: include/global_form.php:682
-msgid "The maximum amount of time that can pass before data is entered as 'unknown'. (Usually 2x300=600)"
+msgid ""
+"The maximum amount of time that can pass before data is entered as "
+"'unknown'. (Usually 2x300=600)"
 msgstr ""
 
 #: include/global_form.php:688 lib/html_utility.php:623
@@ -9922,11 +10423,14 @@ msgid "Not Selected"
 msgstr ""
 
 #: include/global_form.php:689
-msgid "When data is gathered, the data for this field will be put into this data source."
+msgid ""
+"When data is gathered, the data for this field will be put into this data "
+"source."
 msgstr ""
 
 #: include/global_form.php:698
-msgid "Enter a name for this GPRINT preset, make sure it is something you recognize."
+msgid ""
+"Enter a name for this GPRINT preset, make sure it is something you recognize."
 msgstr ""
 
 #: include/global_form.php:705
@@ -9946,7 +10450,10 @@ msgid "Title (--title)"
 msgstr ""
 
 #: include/global_form.php:733
-msgid "The name that is printed on the graph.  It can include replacement variables such as |host_description| or |query_fieldName|.  For a complete list of supported replacement tags, please see the Cacti documentation."
+msgid ""
+"The name that is printed on the graph.  It can include replacement variables "
+"such as |host_description| or |query_fieldName|.  For a complete list of "
+"supported replacement tags, please see the Cacti documentation."
 msgstr ""
 
 #: include/global_form.php:737
@@ -9962,7 +10469,9 @@ msgid "Image Format (--imgformat)"
 msgstr ""
 
 #: include/global_form.php:749
-msgid "The type of graph that is generated; PNG, GIF or SVG.  The selection of graph image type is very RRDtool dependent."
+msgid ""
+"The type of graph that is generated; PNG, GIF or SVG.  The selection of "
+"graph image type is very RRDtool dependent."
 msgstr ""
 
 #: include/global_form.php:752
@@ -9970,7 +10479,9 @@ msgid "Height (--height)"
 msgstr ""
 
 #: include/global_form.php:756
-msgid "The height (in pixels) of the graph area within the graph. This area does not include the legend, axis legends, or title."
+msgid ""
+"The height (in pixels) of the graph area within the graph. This area does "
+"not include the legend, axis legends, or title."
 msgstr ""
 
 #: include/global_form.php:760
@@ -9978,7 +10489,9 @@ msgid "Width (--width)"
 msgstr ""
 
 #: include/global_form.php:764
-msgid "The width (in pixels) of the graph area within the graph. This area does not include the legend, axis legends, or title."
+msgid ""
+"The width (in pixels) of the graph area within the graph. This area does not "
+"include the legend, axis legends, or title."
 msgstr ""
 
 #: include/global_form.php:768
@@ -9994,7 +10507,9 @@ msgid "Slope Mode (--slope-mode)"
 msgstr ""
 
 #: include/global_form.php:779
-msgid "Using Slope Mode evens out the shape of the graphs at the expense of some on screen resolution."
+msgid ""
+"Using Slope Mode evens out the shape of the graphs at the expense of some on "
+"screen resolution."
 msgstr ""
 
 #: include/global_form.php:782
@@ -10006,7 +10521,9 @@ msgid "Auto Scale"
 msgstr ""
 
 #: include/global_form.php:790
-msgid "Auto scale the y-axis instead of defining an upper and lower limit. Note: if this is check both the Upper and Lower limit will be ignored."
+msgid ""
+"Auto scale the y-axis instead of defining an upper and lower limit. Note: if "
+"this is check both the Upper and Lower limit will be ignored."
 msgstr ""
 
 #: include/global_form.php:794
@@ -10014,7 +10531,12 @@ msgid "Auto Scale Options"
 msgstr ""
 
 #: include/global_form.php:797
-msgid "Use <br> --alt-autoscale to scale to the absolute minimum and maximum <br> --alt-autoscale-max to scale to the maximum value, using a given lower limit <br> --alt-autoscale-min to scale to the minimum value, using a given upper limit <br> --alt-autoscale (with limits) to scale using both lower and upper limits (RRDtool default) <br>"
+msgid ""
+"Use <br> --alt-autoscale to scale to the absolute minimum and maximum <br> --"
+"alt-autoscale-max to scale to the maximum value, using a given lower limit "
+"<br> --alt-autoscale-min to scale to the minimum value, using a given upper "
+"limit <br> --alt-autoscale (with limits) to scale using both lower and upper "
+"limits (RRDtool default) <br>"
 msgstr ""
 
 #: include/global_form.php:801
@@ -10046,7 +10568,9 @@ msgid "SI Units for Logarithmic Scaling (--units=si)"
 msgstr ""
 
 #: include/global_form.php:828
-msgid "Use SI Units for Logarithmic Scaling instead of using exponential notation.<br> Note: Linear graphs use SI notation by default."
+msgid ""
+"Use SI Units for Logarithmic Scaling instead of using exponential notation."
+"<br> Note: Linear graphs use SI notation by default."
 msgstr ""
 
 #: include/global_form.php:831
@@ -10054,7 +10578,9 @@ msgid "Rigid Boundaries Mode (--rigid)"
 msgstr ""
 
 #: include/global_form.php:834
-msgid "Do not expand the lower and upper limit if the graph contains a value outside the valid range."
+msgid ""
+"Do not expand the lower and upper limit if the graph contains a value "
+"outside the valid range."
 msgstr ""
 
 #: include/global_form.php:837
@@ -10082,7 +10608,11 @@ msgid "Unit Grid Value (--unit/--y-grid)"
 msgstr ""
 
 #: include/global_form.php:862
-msgid "Sets the exponent value on the Y-axis for numbers. Note: This option is deprecated and replaced by the --y-grid option.  In this option, Y-axis grid lines appear at each grid step interval.  Labels are placed every label factor lines."
+msgid ""
+"Sets the exponent value on the Y-axis for numbers. Note: This option is "
+"deprecated and replaced by the --y-grid option.  In this option, Y-axis grid "
+"lines appear at each grid step interval.  Labels are placed every label "
+"factor lines."
 msgstr ""
 
 #: include/global_form.php:866
@@ -10090,7 +10620,9 @@ msgid "Unit Exponent Value (--units-exponent)"
 msgstr ""
 
 #: include/global_form.php:870
-msgid "What unit Cacti should use on the Y-axis. Use 3 to display everything in \"k\" or -6 to display everything in \"u\" (micro)."
+msgid ""
+"What unit Cacti should use on the Y-axis. Use 3 to display everything in "
+"\"k\" or -6 to display everything in \"u\" (micro)."
 msgstr ""
 
 #: include/global_form.php:874
@@ -10098,7 +10630,10 @@ msgid "Unit Length (--units-length &lt;length&gt;)"
 msgstr ""
 
 #: include/global_form.php:879
-msgid "How many digits should RRDtool assume the y-axis labels to be? You may have to use this option to make enough space once you start fiddling with the y-axis labeling."
+msgid ""
+"How many digits should RRDtool assume the y-axis labels to be? You may have "
+"to use this option to make enough space once you start fiddling with the y-"
+"axis labeling."
 msgstr ""
 
 #: include/global_form.php:882
@@ -10106,7 +10641,12 @@ msgid "No Gridfit (--no-gridfit)"
 msgstr ""
 
 #: include/global_form.php:885
-msgid "In order to avoid anti-aliasing blurring effects RRDtool snaps points to device resolution pixels, this results in a crisper appearance. If this is not to your liking, you can use this switch to turn this behavior off.<br><strong>Note: </strong>Gridfitting is turned off for PDF, EPS, SVG output by default."
+msgid ""
+"In order to avoid anti-aliasing blurring effects RRDtool snaps points to "
+"device resolution pixels, this results in a crisper appearance. If this is "
+"not to your liking, you can use this switch to turn this behavior off."
+"<br><strong>Note: </strong>Gridfitting is turned off for PDF, EPS, SVG "
+"output by default."
 msgstr ""
 
 #: include/global_form.php:888
@@ -10114,7 +10654,12 @@ msgid "Alternative Y Grid (--alt-y-grid)"
 msgstr ""
 
 #: include/global_form.php:891
-msgid "The algorithm ensures that you always have a grid, that there are enough but not too many grid lines, and that the grid is metric. This parameter will also ensure that you get enough decimals displayed even if your graph goes from 69.998 to 70.001.<br><strong>Note: </strong>This parameter may interfere with --alt-autoscale options."
+msgid ""
+"The algorithm ensures that you always have a grid, that there are enough but "
+"not too many grid lines, and that the grid is metric. This parameter will "
+"also ensure that you get enough decimals displayed even if your graph goes "
+"from 69.998 to 70.001.<br><strong>Note: </strong>This parameter may "
+"interfere with --alt-autoscale options."
 msgstr ""
 
 #: include/global_form.php:894
@@ -10126,7 +10671,9 @@ msgid "Right Axis (--right-axis &lt;scale:shift&gt;)"
 msgstr ""
 
 #: include/global_form.php:904
-msgid "A second axis will be drawn to the right of the graph. It is tied to the left axis via the scale and shift parameters."
+msgid ""
+"A second axis will be drawn to the right of the graph. It is tied to the "
+"left axis via the scale and shift parameters."
 msgstr ""
 
 #: include/global_form.php:907
@@ -10143,7 +10690,10 @@ msgstr ""
 
 #: include/global_form.php:920 include/global_form.php:936
 #, php-format
-msgid "By default, the format of the axis labels gets determined automatically.  If you want to do this yourself, use this option with the same %lf arguments you know from the PRINT and GPRINT commands."
+msgid ""
+"By default, the format of the axis labels gets determined automatically.  If "
+"you want to do this yourself, use this option with the same %lf arguments "
+"you know from the PRINT and GPRINT commands."
 msgstr ""
 
 #: include/global_form.php:923
@@ -10151,7 +10701,15 @@ msgid "Right Axis Formatter (--right-axis-formatter &lt;formatname&gt;)"
 msgstr ""
 
 #: include/global_form.php:928
-msgid "When you setup the right axis labeling, apply a rule to the data format.  Supported formats include \"numeric\" where data is treated as numeric, \"timestamp\" where values are interpreted as UNIX timestamps (number of seconds since January 1970) and expressed using strftime format (default is \"%Y-%m-%d %H:%M:%S\").  See also --units-length and --right-axis-format.  Finally \"duration\" where values are interpreted as duration in milliseconds.  Formatting follows the rules of valstrfduration qualified PRINT/GPRINT."
+msgid ""
+"When you setup the right axis labeling, apply a rule to the data format.  "
+"Supported formats include \"numeric\" where data is treated as numeric, "
+"\"timestamp\" where values are interpreted as UNIX timestamps (number of "
+"seconds since January 1970) and expressed using strftime format (default is "
+"\"%Y-%m-%d %H:%M:%S\").  See also --units-length and --right-axis-format.  "
+"Finally \"duration\" where values are interpreted as duration in "
+"milliseconds.  Formatting follows the rules of valstrfduration qualified "
+"PRINT/GPRINT."
 msgstr ""
 
 #: include/global_form.php:931
@@ -10163,7 +10721,14 @@ msgid "Left Axis Formatter (--left-axis-formatter &lt;formatname&gt;)"
 msgstr ""
 
 #: include/global_form.php:944
-msgid "When you setup the left axis labeling, apply a rule to the data format.  Supported formats include \"numeric\" where data is treated as numeric, \"timestamp\" where values are interpreted as UNIX timestamps (number of seconds since January 1970) and expressed using strftime format (default is \"%Y-%m-%d %H:%M:%S\").  See also --units-length.  Finally \"duration\" where values are interpreted as duration in milliseconds.  Formatting follows the rules of valstrfduration qualified PRINT/GPRINT."
+msgid ""
+"When you setup the left axis labeling, apply a rule to the data format.  "
+"Supported formats include \"numeric\" where data is treated as numeric, "
+"\"timestamp\" where values are interpreted as UNIX timestamps (number of "
+"seconds since January 1970) and expressed using strftime format (default is "
+"\"%Y-%m-%d %H:%M:%S\").  See also --units-length.  Finally \"duration\" "
+"where values are interpreted as duration in milliseconds.  Formatting "
+"follows the rules of valstrfduration qualified PRINT/GPRINT."
 msgstr ""
 
 #: include/global_form.php:947
@@ -10175,7 +10740,11 @@ msgid "Auto Padding"
 msgstr ""
 
 #: include/global_form.php:955
-msgid "Pad text so that legend and graph data always line up. Note: this could cause graphs to take longer to render because of the larger overhead. Also Auto Padding may not be accurate on all types of graphs, consistent labeling usually helps."
+msgid ""
+"Pad text so that legend and graph data always line up. Note: this could "
+"cause graphs to take longer to render because of the larger overhead. Also "
+"Auto Padding may not be accurate on all types of graphs, consistent labeling "
+"usually helps."
 msgstr ""
 
 #: include/global_form.php:958
@@ -10267,10 +10836,15 @@ msgid "Gradient Height"
 msgstr ""
 
 #: include/global_form.php:1051
-msgid "The Gradient Height parameter can create three different behaviors. If it is > 0, then the gradient is a fixed height, starting at the line going down. If it is < 0, then the gradient starts at a fixed height above the x-axis, going down to the x-axis. If it is == 0, then the gradient goes from the top of the area fill to x-axis."
+msgid ""
+"The Gradient Height parameter can create three different behaviors. If it is "
+"> 0, then the gradient is a fixed height, starting at the line going down. "
+"If it is < 0, then the gradient starts at a fixed height above the x-axis, "
+"going down to the x-axis. If it is == 0, then the gradient goes from the top "
+"of the area fill to x-axis."
 msgstr ""
 
-#: include/global_form.php:1054 lib/rrd.php:3676
+#: include/global_form.php:1054 lib/rrd.php:3710
 msgid "Consolidation Function"
 msgstr ""
 
@@ -10299,11 +10873,15 @@ msgid "Shift Data"
 msgstr ""
 
 #: include/global_form.php:1080
-msgid "Offset your data on the time axis (x-axis) by the amount specified in the 'value' field."
+msgid ""
+"Offset your data on the time axis (x-axis) by the amount specified in the "
+"'value' field."
 msgstr ""
 
 #: include/global_form.php:1088
-msgid "[HRULE|VRULE]: The value of the graph item.<br/> [TICK]: The fraction for the tick line.<br/> [SHIFT]: The time offset in seconds."
+msgid ""
+"[HRULE|VRULE]: The value of the graph item.<br/> [TICK]: The fraction for "
+"the tick line.<br/> [SHIFT]: The time offset in seconds."
 msgstr ""
 
 #: include/global_form.php:1091
@@ -10311,7 +10889,9 @@ msgid "GPRINT Type"
 msgstr ""
 
 #: include/global_form.php:1095
-msgid "If this graph item is a GPRINT, you can optionally choose another format here. You can define additional types under \"GPRINT Presets\"."
+msgid ""
+"If this graph item is a GPRINT, you can optionally choose another format "
+"here. You can define additional types under \"GPRINT Presets\"."
 msgstr ""
 
 #: include/global_form.php:1098
@@ -10319,7 +10899,12 @@ msgid "Text Alignment (TEXTALIGN)"
 msgstr ""
 
 #: include/global_form.php:1103
-msgid "All subsequent legend line(s) will be aligned as given here.  You may use this command multiple times in a single graph.  This command does not produce tabular layout.<br/><strong>Note: </strong>You may want to insert a &lt;HR&gt; on the preceding graph item.<br/> <strong>Note: </strong>A &lt;HR&gt; on this legend line will obsolete this setting!"
+msgid ""
+"All subsequent legend line(s) will be aligned as given here.  You may use "
+"this command multiple times in a single graph.  This command does not "
+"produce tabular layout.<br/><strong>Note: </strong>You may want to insert a "
+"&lt;HR&gt; on the preceding graph item.<br/> <strong>Note: </strong>A "
+"&lt;HR&gt; on this legend line will obsolete this setting!"
 msgstr ""
 
 #: include/global_form.php:1106
@@ -10335,7 +10920,10 @@ msgid "Legend for Export/Hover"
 msgstr ""
 
 #: include/global_form.php:1119
-msgid "A Legend to be displayed when Hovering over the Graph and also used for Graph Export.  Hover requires RRDtool 1.9.1 and above.  It may work for RRDtool 1.8+, but not for Thold Legends."
+msgid ""
+"A Legend to be displayed when Hovering over the Graph and also used for "
+"Graph Export.  Hover requires RRDtool 1.9.1 and above.  It may work for "
+"RRDtool 1.8+, but not for Thold Legends."
 msgstr ""
 
 #: include/global_form.php:1122
@@ -10351,7 +10939,9 @@ msgid "Line Width (decimal)"
 msgstr ""
 
 #: include/global_form.php:1133
-msgid "In case LINE was chosen, specify width of line here.  You must include a decimal precision, for example 2.00"
+msgid ""
+"In case LINE was chosen, specify width of line here.  You must include a "
+"decimal precision, for example 2.00"
 msgstr ""
 
 #: include/global_form.php:1136
@@ -10367,7 +10957,9 @@ msgid "Dash Offset (dash-offset=offset)"
 msgstr ""
 
 #: include/global_form.php:1149 include/global_form.php:1157
-msgid "The dash-offset parameter specifies an offset into the pattern at which the stroke begins."
+msgid ""
+"The dash-offset parameter specifies an offset into the pattern at which the "
+"stroke begins."
 msgstr ""
 
 #: include/global_form.php:1166
@@ -10387,7 +10979,9 @@ msgid "Multiple Instances"
 msgstr ""
 
 #: include/global_form.php:1190
-msgid "Check this checkbox if there can be more than one Graph of this type per Device."
+msgid ""
+"Check this checkbox if there can be more than one Graph of this type per "
+"Device."
 msgstr ""
 
 #: include/global_form.php:1197
@@ -10395,15 +10989,26 @@ msgid "Test Data Sources"
 msgstr ""
 
 #: include/global_form.php:1198
-msgid "Check this checkbox if you wish to test the Data Sources prior to their creation.  With Test Data Sources enabled, if the Data Source does not return valid data, the Graph will not be created.  This setting is important if you wish to have a more generic Device Template that can include more Graph Templates that can be selectively applied depending on the characteristics of the Device itself.  Note: If you have a long running script as a Data Source, the time to create Graphs will be increased."
+msgid ""
+"Check this checkbox if you wish to test the Data Sources prior to their "
+"creation.  With Test Data Sources enabled, if the Data Source does not "
+"return valid data, the Graph will not be created.  This setting is important "
+"if you wish to have a more generic Device Template that can include more "
+"Graph Templates that can be selectively applied depending on the "
+"characteristics of the Device itself.  Note: If you have a long running "
+"script as a Data Source, the time to create Graphs will be increased."
 msgstr ""
 
 #: include/global_form.php:1222
-msgid "Enter a name for this graph item input, make sure it is something you recognize."
+msgid ""
+"Enter a name for this graph item input, make sure it is something you "
+"recognize."
 msgstr ""
 
 #: include/global_form.php:1230
-msgid "Enter a description for this graph item input to describe what this input is used for."
+msgid ""
+"Enter a description for this graph item input to describe what this input is "
+"used for."
 msgstr ""
 
 #: include/global_form.php:1237
@@ -10423,11 +11028,15 @@ msgid "Give this host a meaningful description."
 msgstr ""
 
 #: include/global_form.php:1273
-msgid "Fully qualified hostname or IP address for this device. IPv6 address insert into brackets (example: [2001:abcd:1234::1])"
+msgid ""
+"Fully qualified hostname or IP address for this device. IPv6 address insert "
+"into brackets (example: [2001:abcd:1234::1])"
 msgstr ""
 
 #: include/global_form.php:1281
-msgid "The physical location of the Device.  This free form text can be a room, rack location, etc."
+msgid ""
+"The physical location of the Device.  This free form text can be a room, "
+"rack location, etc."
 msgstr ""
 
 #: include/global_form.php:1290
@@ -10443,7 +11052,9 @@ msgid "What Site is this Device associated with."
 msgstr ""
 
 #: include/global_form.php:1308
-msgid "Choose the Device Template to use to define the default Graph Templates and Data Queries associated with this Device."
+msgid ""
+"Choose the Device Template to use to define the default Graph Templates and "
+"Data Queries associated with this Device."
 msgstr ""
 
 #: include/global_form.php:1316
@@ -10451,7 +11062,9 @@ msgid "Number of Collection Threads"
 msgstr ""
 
 #: include/global_form.php:1317
-msgid "The number of concurrent threads to use for polling this device.  This applies to the Spine poller only."
+msgid ""
+"The number of concurrent threads to use for polling this device.  This "
+"applies to the Spine poller only."
 msgstr ""
 
 #: include/global_form.php:1325
@@ -10462,24 +11075,33 @@ msgstr ""
 msgid "Availability/Reachability Options"
 msgstr ""
 
-#: include/global_form.php:1336 include/global_settings.php:1046
+#: include/global_form.php:1336 include/global_settings.php:1048
 msgid "Downed Device Detection"
 msgstr ""
 
 #: include/global_form.php:1337
-msgid "The method Cacti will use to determine if a host is available for polling.  <br><i>NOTE: It is recommended that, at a minimum, SNMP always be selected.</i>"
+msgid ""
+"The method Cacti will use to determine if a host is available for polling.  "
+"<br><i>NOTE: It is recommended that, at a minimum, SNMP always be selected.</"
+"i>"
 msgstr ""
 
-#: include/global_form.php:1345 include/global_settings.php:1053
+#: include/global_form.php:1345 include/global_settings.php:1055
 msgid "Downed Device SNMP Recovery Options Set"
 msgstr ""
 
-#: include/global_form.php:1346 include/global_settings.php:1054
-msgid "If a Device goes down, use this SNMP Option Set to attempt to re-establish communication with the device and update the devices settings based upon the first matching SNMP Options Set."
+#: include/global_form.php:1346 include/global_settings.php:1056
+msgid ""
+"If a Device goes down, use this SNMP Option Set to attempt to re-establish "
+"communication with the device and update the devices settings based upon the "
+"first matching SNMP Options Set."
 msgstr ""
 
 #: include/global_form.php:1355
-msgid "The type of ping packet to sent.  <br><i>NOTE: ICMP on Linux/UNIX requires root privileges.</i>  <br><i>NOTE: TCP Ping Closed - Even if the tcp ping is not successful, the device can be considered UP.</i>"
+msgid ""
+"The type of ping packet to sent.  <br><i>NOTE: ICMP on Linux/UNIX requires "
+"root privileges.</i>  <br><i>NOTE: TCP Ping Closed - Even if the tcp ping is "
+"not successful, the device can be considered UP.</i>"
 msgstr ""
 
 #: include/global_form.php:1397 sites.php:170
@@ -10523,7 +11145,9 @@ msgid "Tags"
 msgstr ""
 
 #: include/global_form.php:1463
-msgid "A series of space delimited tags to help with searching for this Device Template."
+msgid ""
+"A series of space delimited tags to help with searching for this Device "
+"Template."
 msgstr ""
 
 #: include/global_form.php:1472
@@ -10571,15 +11195,19 @@ msgid "XML Path"
 msgstr ""
 
 #: include/global_form.php:1542
-msgid "The full path to the XML file containing definitions for this data query."
+msgid ""
+"The full path to the XML file containing definitions for this data query."
 msgstr ""
 
 #: include/global_form.php:1551
-msgid "Choose the input method for this Data Query.  This input method defines how data is collected for each Device associated with the Data Query."
+msgid ""
+"Choose the input method for this Data Query.  This input method defines how "
+"data is collected for each Device associated with the Data Query."
 msgstr ""
 
 #: include/global_form.php:1570
-msgid "Choose the Graph Template to use for this Data Query Graph Template item."
+msgid ""
+"Choose the Graph Template to use for this Data Query Graph Template item."
 msgstr ""
 
 #: include/global_form.php:1599
@@ -10591,7 +11219,7 @@ msgid "A useful name for this graph tree."
 msgstr ""
 
 #: include/global_form.php:1634 include/global_form.php:2479
-#: lib/api_automation.php:1569 tree.php:1850
+#: lib/api_automation.php:1573 tree.php:1850
 msgid "Sorting Type"
 msgstr ""
 
@@ -10612,7 +11240,9 @@ msgid "An Email Address where the User can be reached."
 msgstr ""
 
 #: include/global_form.php:1690
-msgid "Enter the password for this user twice. Remember that passwords are case sensitive!"
+msgid ""
+"Enter the password for this user twice. Remember that passwords are case "
+"sensitive!"
 msgstr ""
 
 #: include/global_form.php:1698 user_group_admin.php:88
@@ -10688,7 +11318,9 @@ msgid "Authentication Realm"
 msgstr ""
 
 #: include/global_form.php:1783
-msgid "Only used if you have LDAP or Web Basic Authentication enabled.  Changing this to a non-enabled realm will effectively disable the user."
+msgid ""
+"Only used if you have LDAP or Web Basic Authentication enabled.  Changing "
+"this to a non-enabled realm will effectively disable the user."
 msgstr ""
 
 #: include/global_form.php:1838
@@ -10696,7 +11328,9 @@ msgid "Import Template from Local File"
 msgstr ""
 
 #: include/global_form.php:1839
-msgid "If the XML file containing template data is located on your local machine, select it here."
+msgid ""
+"If the XML file containing template data is located on your local machine, "
+"select it here."
 msgstr ""
 
 #: include/global_form.php:1844 package_import.php:1372
@@ -10718,7 +11352,9 @@ msgstr ""
 
 #: include/global_form.php:1865 include/global_settings.php:683
 #: package_import.php:1392
-msgid "If checked, Cacti will delete any Graph Items from both the Graph Template and associated Graphs that are not included in the imported Graph Template."
+msgid ""
+"If checked, Cacti will delete any Graph Items from both the Graph Template "
+"and associated Graphs that are not included in the imported Graph Template."
 msgstr ""
 
 #: include/global_form.php:1870
@@ -10726,10 +11362,13 @@ msgid "Replace Data Query Suggested Value Patterns"
 msgstr ""
 
 #: include/global_form.php:1872
-msgid "Replace Data Source and Graph Template Suggested Value Records for Data Queries.  Graphs and Data Sources will take on new names after either a Data Query Reindex or by using the forced Replace Suggested Values process."
+msgid ""
+"Replace Data Source and Graph Template Suggested Value Records for Data "
+"Queries.  Graphs and Data Sources will take on new names after either a Data "
+"Query Reindex or by using the forced Replace Suggested Values process."
 msgstr ""
 
-#: include/global_form.php:1877 include/global_settings.php:812
+#: include/global_form.php:1877 include/global_settings.php:814
 #: package_import.php:1405
 msgid "Graph Template Image Format"
 msgstr ""
@@ -10738,7 +11377,7 @@ msgstr ""
 msgid "The Image Format to be used when importing or updating Graph Templates."
 msgstr ""
 
-#: include/global_form.php:1884 include/global_settings.php:819
+#: include/global_form.php:1884 include/global_settings.php:821
 #: package_import.php:1413
 msgid "Graph Template Height"
 msgstr ""
@@ -10747,7 +11386,7 @@ msgstr ""
 msgid "The Height to be used when importing or updating Graph Templates."
 msgstr ""
 
-#: include/global_form.php:1892 include/global_settings.php:827
+#: include/global_form.php:1892 include/global_settings.php:829
 #: package_import.php:1422
 msgid "Graph Template Width"
 msgstr ""
@@ -10773,7 +11412,9 @@ msgid "Disable SNMP Notification Receiver"
 msgstr ""
 
 #: include/global_form.php:1926
-msgid "Check this box if you temporary do not want to send SNMP notifications to this host."
+msgid ""
+"Check this box if you temporary do not want to send SNMP notifications to "
+"this host."
 msgstr ""
 
 #: include/global_form.php:1933
@@ -10781,7 +11422,9 @@ msgid "Maximum Log Size"
 msgstr ""
 
 #: include/global_form.php:1934
-msgid "Maximum number of day's notification log entries for this receiver need to be stored."
+msgid ""
+"Maximum number of day's notification log entries for this receiver need to "
+"be stored."
 msgstr ""
 
 #: include/global_form.php:1946
@@ -10789,7 +11432,9 @@ msgid "SNMP Message Type"
 msgstr ""
 
 #: include/global_form.php:1947
-msgid "SNMP traps are always unacknowledged. To send out acknowledged SNMP notifications, formally called \"INFORMS\", SNMPv2 or above will be required."
+msgid ""
+"SNMP traps are always unacknowledged. To send out acknowledged SNMP "
+"notifications, formally called \"INFORMS\", SNMPv2 or above will be required."
 msgstr ""
 
 #: include/global_form.php:1955
@@ -10816,12 +11461,17 @@ msgstr ""
 
 #: include/global_form.php:1996 include/global_form.php:2082
 #: include/global_form.php:2187
-msgid "Include the source Graphs GPRINT Title Text with the Aggregate Graph(s)."
+msgid ""
+"Include the source Graphs GPRINT Title Text with the Aggregate Graph(s)."
 msgstr ""
 
 #: include/global_form.php:2003 include/global_form.php:2089
 #: include/global_form.php:2194
-msgid "Use this Option to create e.g. STACKed graphs.<br>AREA/STACK: 1st graph keeps AREA/STACK items, others convert to STACK<br>LINE1: all items convert to LINE1 items<br>LINE2: all items convert to LINE2 items<br>LINE3: all items convert to LINE3 items"
+msgid ""
+"Use this Option to create e.g. STACKed graphs.<br>AREA/STACK: 1st graph "
+"keeps AREA/STACK items, others convert to STACK<br>LINE1: all items convert "
+"to LINE1 items<br>LINE2: all items convert to LINE2 items<br>LINE3: all "
+"items convert to LINE3 items"
 msgstr ""
 
 #: include/global_form.php:2010 include/global_form.php:2096
@@ -10831,7 +11481,9 @@ msgstr ""
 
 #: include/global_form.php:2011 include/global_form.php:2097
 #: include/global_form.php:2202
-msgid "Please check those Items that shall be totaled in the \"Total\" column, when selecting any totaling option here."
+msgid ""
+"Please check those Items that shall be totaled in the \"Total\" column, when "
+"selecting any totaling option here."
 msgstr ""
 
 #: include/global_form.php:2018 include/global_form.php:2105
@@ -10881,7 +11533,9 @@ msgid "Aggregate Graph Settings"
 msgstr ""
 
 #: include/global_form.php:2074 include/global_form.php:2179
-msgid "A Prefix for all GPRINT lines to distinguish e.g. different hosts.  You may use both Host as well as Data Query replacement variables in this prefix."
+msgid ""
+"A Prefix for all GPRINT lines to distinguish e.g. different hosts.  You may "
+"use both Host as well as Data Query replacement variables in this prefix."
 msgstr ""
 
 #: include/global_form.php:2157
@@ -10917,7 +11571,7 @@ msgid "A useful name for this Template."
 msgstr ""
 
 #: include/global_form.php:2286 include/global_form.php:2328
-#: lib/api_automation.php:1347 lib/api_automation.php:1467
+#: lib/api_automation.php:1351 lib/api_automation.php:1471
 msgid "Operation"
 msgstr ""
 
@@ -10934,8 +11588,8 @@ msgid "Operator."
 msgstr ""
 
 #: include/global_form.php:2310 include/global_form.php:2352
-#: include/global_form.php:2495 lib/api_automation.php:1359
-#: lib/api_automation.php:1470 lib/api_automation.php:1571
+#: include/global_form.php:2495 lib/api_automation.php:1363
+#: lib/api_automation.php:1474 lib/api_automation.php:1575
 msgid "Matching Pattern"
 msgstr ""
 
@@ -10977,7 +11631,9 @@ msgid "The Item Type that shall be dynamically added to the tree."
 msgstr ""
 
 #: include/global_form.php:2439
-msgid "Choose how graphs are grouped when drawn for this particular host on the tree."
+msgid ""
+"Choose how graphs are grouped when drawn for this particular host on the "
+"tree."
 msgstr ""
 
 #: include/global_form.php:2449
@@ -10985,7 +11641,9 @@ msgid "Optional: Sub-Tree Item"
 msgstr ""
 
 #: include/global_form.php:2450
-msgid "Choose a Sub-Tree Item to hook in.<br>Make sure, that it is still there when this rule is executed!"
+msgid ""
+"Choose a Sub-Tree Item to hook in.<br>Make sure, that it is still there when "
+"this rule is executed!"
 msgstr ""
 
 #: include/global_form.php:2471
@@ -10997,19 +11655,25 @@ msgid "Propagate Changes"
 msgstr ""
 
 #: include/global_form.php:2488
-msgid "Propagate all options on this form (except for 'Title') to all child 'Header' items."
+msgid ""
+"Propagate all options on this form (except for 'Title') to all child "
+"'Header' items."
 msgstr ""
 
 #: include/global_form.php:2496
-msgid "The String Pattern (Regular Expression) to match against.<br>Enclosing '/' must <strong>NOT</strong> be provided!"
+msgid ""
+"The String Pattern (Regular Expression) to match against.<br>Enclosing '/' "
+"must <strong>NOT</strong> be provided!"
 msgstr ""
 
-#: include/global_form.php:2503 lib/api_automation.php:1572
+#: include/global_form.php:2503 lib/api_automation.php:1576
 msgid "Replacement Pattern"
 msgstr ""
 
 #: include/global_form.php:2504
-msgid "The Replacement String Pattern for use as a Tree Header.<br>Refer to a Match by e.g. <strong>\\${1}</strong> for the first match!"
+msgid ""
+"The Replacement String Pattern for use as a Tree Header.<br>Refer to a Match "
+"by e.g. <strong>\\${1}</strong> for the first match!"
 msgstr ""
 
 #: include/global_languages.php:1105
@@ -11052,7 +11716,7 @@ msgstr ""
 msgid "Visual"
 msgstr ""
 
-#: include/global_settings.php:69 lib/functions.php:6013 lib/functions.php:6018
+#: include/global_settings.php:69 lib/functions.php:6082 lib/functions.php:6087
 msgid "Authentication"
 msgstr ""
 
@@ -11076,7 +11740,7 @@ msgstr ""
 msgid "Graph Thumbnail Settings"
 msgstr ""
 
-#: include/global_settings.php:79 include/global_settings.php:1250
+#: include/global_settings.php:79 include/global_settings.php:1252
 msgid "Tree Settings"
 msgstr ""
 
@@ -11088,11 +11752,11 @@ msgstr ""
 msgid "PHP Mail() Function"
 msgstr ""
 
-#: include/global_settings.php:149 lib/functions.php:5996
+#: include/global_settings.php:149 lib/functions.php:6065
 msgid "Sendmail"
 msgstr ""
 
-#: include/global_settings.php:150 lib/functions.php:6001
+#: include/global_settings.php:150 lib/functions.php:6070
 msgid "SMTP"
 msgstr ""
 
@@ -11157,7 +11821,9 @@ msgid "PHP Binary Path"
 msgstr ""
 
 #: include/global_settings.php:226
-msgid "The path to your PHP binary file (may require a php recompile to get this file)."
+msgid ""
+"The path to your PHP binary file (may require a php recompile to get this "
+"file)."
 msgstr ""
 
 #: include/global_settings.php:232
@@ -11165,7 +11831,9 @@ msgid "FPing Binary Path"
 msgstr ""
 
 #: include/global_settings.php:233
-msgid "The path to the FPing binary file which provides for a more precise ping command."
+msgid ""
+"The path to the FPing binary file which provides for a more precise ping "
+"command."
 msgstr ""
 
 #: include/global_settings.php:244
@@ -11173,7 +11841,9 @@ msgid "Cacti Log Path"
 msgstr ""
 
 #: include/global_settings.php:245
-msgid "The path to your Cacti log file (if blank, defaults to &lt;path_cacti&gt;/log/cacti.log)"
+msgid ""
+"The path to your Cacti log file (if blank, defaults to &lt;path_cacti&gt;/"
+"log/cacti.log)"
 msgstr ""
 
 #: include/global_settings.php:254
@@ -11181,7 +11851,9 @@ msgid "Poller Standard Error Log Path"
 msgstr ""
 
 #: include/global_settings.php:255
-msgid "If you are having issues with Cacti's Data Collectors, set this file path and the Data Collectors standard error will be redirected to this file"
+msgid ""
+"If you are having issues with Cacti's Data Collectors, set this file path "
+"and the Data Collectors standard error will be redirected to this file"
 msgstr ""
 
 #: include/global_settings.php:264
@@ -11189,7 +11861,9 @@ msgid "Boost Debug Log"
 msgstr ""
 
 #: include/global_settings.php:265
-msgid "This is the Log file where Boost will write its information to.  It much be located in the same directory as the Cacti Log file."
+msgid ""
+"This is the Log file where Boost will write its information to.  It much be "
+"located in the same directory as the Cacti Log file."
 msgstr ""
 
 #: include/global_settings.php:272
@@ -11209,7 +11883,9 @@ msgid "Spine Config File Path"
 msgstr ""
 
 #: include/global_settings.php:286
-msgid "The path to Spine configuration file.  By default, in the cwd of Spine, or /etc if not specified."
+msgid ""
+"The path to Spine configuration file.  By default, in the cwd of Spine, or /"
+"etc if not specified."
 msgstr ""
 
 #: include/global_settings.php:298
@@ -11217,7 +11893,9 @@ msgid "RRDfile Auto Clean"
 msgstr ""
 
 #: include/global_settings.php:299
-msgid "Automatically archive or delete RRDfiles when their corresponding Data Sources are removed from Cacti"
+msgid ""
+"Automatically archive or delete RRDfiles when their corresponding Data "
+"Sources are removed from Cacti"
 msgstr ""
 
 #: include/global_settings.php:304
@@ -11225,7 +11903,9 @@ msgid "RRDfile Auto Clean Method"
 msgstr ""
 
 #: include/global_settings.php:305
-msgid "The method used to Clean RRDfiles from Cacti after their Data Sources are deleted."
+msgid ""
+"The method used to Clean RRDfiles from Cacti after their Data Sources are "
+"deleted."
 msgstr ""
 
 #: include/global_settings.php:314
@@ -11233,7 +11913,8 @@ msgid "Archive directory"
 msgstr ""
 
 #: include/global_settings.php:315
-msgid "This is the directory where RRDfiles are <strong>moved</strong> for archiving"
+msgid ""
+"This is the directory where RRDfiles are <strong>moved</strong> for archiving"
 msgstr ""
 
 #: include/global_settings.php:324
@@ -11253,7 +11934,11 @@ msgid "Log Actions"
 msgstr ""
 
 #: include/global_settings.php:337
-msgid "What Log Actions do you wish to provide to the Cacti Administrator.  You can grant either purge, rotate, or both purge and rotate.  Base files can be both purged and rotated, and already rotated files can only be purged if you grant that permission."
+msgid ""
+"What Log Actions do you wish to provide to the Cacti Administrator.  You can "
+"grant either purge, rotate, or both purge and rotate.  Base files can be "
+"both purged and rotated, and already rotated files can only be purged if you "
+"grant that permission."
 msgstr ""
 
 #: include/global_settings.php:343
@@ -11261,7 +11946,9 @@ msgid "Generic Log Level"
 msgstr ""
 
 #: include/global_settings.php:344
-msgid "What level of detail do you want sent to the log file.  WARNING: Leaving in any other status than NONE or LOW can exhaust your disk space rapidly."
+msgid ""
+"What level of detail do you want sent to the log file.  WARNING: Leaving in "
+"any other status than NONE or LOW can exhaust your disk space rapidly."
 msgstr ""
 
 #: include/global_settings.php:350
@@ -11269,7 +11956,9 @@ msgid "Expand log details"
 msgstr ""
 
 #: include/global_settings.php:351
-msgid "What level of expansion do you want on the log file? Increase expansion can slow search results"
+msgid ""
+"What level of expansion do you want on the log file? Increase expansion can "
+"slow search results"
 msgstr ""
 
 #: include/global_settings.php:357
@@ -11277,7 +11966,9 @@ msgid "Log Input Validation Issues"
 msgstr ""
 
 #: include/global_settings.php:358
-msgid "Record when request fields are accessed without going through proper input validation"
+msgid ""
+"Record when request fields are accessed without going through proper input "
+"validation"
 msgstr ""
 
 #: include/global_settings.php:364
@@ -11285,7 +11976,9 @@ msgid "Data Source Tracing"
 msgstr ""
 
 #: include/global_settings.php:365
-msgid "A developer only option to trace the creation of Data Sources mainly around checks for uniqueness"
+msgid ""
+"A developer only option to trace the creation of Data Sources mainly around "
+"checks for uniqueness"
 msgstr ""
 
 #: include/global_settings.php:370
@@ -11293,7 +11986,10 @@ msgid "Log Ignored General Errors"
 msgstr ""
 
 #: include/global_settings.php:371
-msgid "Cacti will mask certain errors that are often times considered fatal and that would otherwise disable plugins and additionally confuse some users.  If you wish to see these errors instead, check the checkbox."
+msgid ""
+"Cacti will mask certain errors that are often times considered fatal and "
+"that would otherwise disable plugins and additionally confuse some users.  "
+"If you wish to see these errors instead, check the checkbox."
 msgstr ""
 
 #: include/global_settings.php:376
@@ -11301,7 +11997,10 @@ msgid "Selective File Debug"
 msgstr ""
 
 #: include/global_settings.php:377
-msgid "Select which files you wish to place in Debug mode regardless of the Generic Log Level setting.  Any files selected will be treated as they are in Debug mode."
+msgid ""
+"Select which files you wish to place in Debug mode regardless of the Generic "
+"Log Level setting.  Any files selected will be treated as they are in Debug "
+"mode."
 msgstr ""
 
 #: include/global_settings.php:383
@@ -11309,7 +12008,10 @@ msgid "Selective Plugin Debug"
 msgstr ""
 
 #: include/global_settings.php:384
-msgid "Select which Plugins you wish to place in Debug mode regardless of the Generic Log Level setting.  Any files used by this plugin will be treated as they are in Debug mode."
+msgid ""
+"Select which Plugins you wish to place in Debug mode regardless of the "
+"Generic Log Level setting.  Any files used by this plugin will be treated as "
+"they are in Debug mode."
 msgstr ""
 
 #: include/global_settings.php:390
@@ -11317,7 +12019,10 @@ msgid "Selective Device Debug"
 msgstr ""
 
 #: include/global_settings.php:391
-msgid "A comma delimited list of Device ID's that you wish to be in Debug mode during data collection.  This Debug level is only in place during the Cacti polling process."
+msgid ""
+"A comma delimited list of Device ID's that you wish to be in Debug mode "
+"during data collection.  This Debug level is only in place during the Cacti "
+"polling process."
 msgstr ""
 
 #: include/global_settings.php:398
@@ -11325,7 +12030,9 @@ msgid "Syslog/Eventlog Item Selection"
 msgstr ""
 
 #: include/global_settings.php:399
-msgid "When using Syslog/Eventlog for logging, the Cacti log messages that will be forwarded to the Syslog/Eventlog."
+msgid ""
+"When using Syslog/Eventlog for logging, the Cacti log messages that will be "
+"forwarded to the Syslog/Eventlog."
 msgstr ""
 
 #: include/global_settings.php:404
@@ -11361,7 +12068,9 @@ msgid "Log Retention"
 msgstr ""
 
 #: include/global_settings.php:437
-msgid "How many log files do you wish to retain?  Use 0 to never remove any logs. (0-365)"
+msgid ""
+"How many log files do you wish to retain?  Use 0 to never remove any logs. "
+"(0-365)"
 msgstr ""
 
 #: include/global_settings.php:447
@@ -11373,7 +12082,11 @@ msgid "Language Support"
 msgstr ""
 
 #: include/global_settings.php:453
-msgid "Choose 'enabled' to allow the localization of Cacti. The strict mode requires that the requested language will also be supported by all plugins being installed at your system. If that's not the fact everything will be displayed in English."
+msgid ""
+"Choose 'enabled' to allow the localization of Cacti. The strict mode "
+"requires that the requested language will also be supported by all plugins "
+"being installed at your system. If that's not the fact everything will be "
+"displayed in English."
 msgstr ""
 
 #: include/global_settings.php:459
@@ -11389,7 +12102,11 @@ msgid "Auto Language Detection"
 msgstr ""
 
 #: include/global_settings.php:467
-msgid "Allow to automatically determine the 'default' language of the user and provide it at login time if that language is supported by Cacti. If disabled, the default language will be in force until the user elects another language."
+msgid ""
+"Allow to automatically determine the 'default' language of the user and "
+"provide it at login time if that language is supported by Cacti. If "
+"disabled, the default language will be in force until the user elects "
+"another language."
 msgstr ""
 
 #: include/global_settings.php:476
@@ -11397,7 +12114,10 @@ msgid "Preferred Language Processor"
 msgstr ""
 
 #: include/global_settings.php:477
-msgid "Cacti includes support for multiple alternate Language Translation Processors.  If none is selected Cacti will attempt to use the first one found."
+msgid ""
+"Cacti includes support for multiple alternate Language Translation "
+"Processors.  If none is selected Cacti will attempt to use the first one "
+"found."
 msgstr ""
 
 #: include/global_settings.php:483
@@ -11405,10 +12125,12 @@ msgid "Client TimeZone Support"
 msgstr ""
 
 #: include/global_settings.php:484
-msgid "How should Cacti support Client Dates based upon the Client browsers timezone."
+msgid ""
+"How should Cacti support Client Dates based upon the Client browsers "
+"timezone."
 msgstr ""
 
-#: include/global_settings.php:493 include/global_settings.php:3135
+#: include/global_settings.php:493 include/global_settings.php:3093
 msgid "Date Display Format"
 msgstr ""
 
@@ -11416,7 +12138,7 @@ msgstr ""
 msgid "The System default date format to use in Cacti."
 msgstr ""
 
-#: include/global_settings.php:500 include/global_settings.php:3142
+#: include/global_settings.php:500 include/global_settings.php:3100
 msgid "Date Separator"
 msgstr ""
 
@@ -11466,7 +12188,17 @@ msgid "Graph Permission Method"
 msgstr ""
 
 #: include/global_settings.php:538
-msgid "There are four methods for determining a User's Graph Permissions.  The first is 'Permissive'.  Under the 'Permissive' setting, a User only needs access to either the Graph, Device or Graph Template to gain access to the Graphs that apply to them.  Under 'Restrictive', the User must have access to the Graph, the Device, and the Graph Template to gain access to the Graph.  These first two methods have scalability problems for very large installs.  So, two additional options are available.  They are 'Device Based', which means if you have access to the Device, you get access to it's Graphs.  And lastly 'Graph Template Based', which means if you have access to the 'Graph Template' you get access to all Device Graphs of that Template."
+msgid ""
+"There are four methods for determining a User's Graph Permissions.  The "
+"first is 'Permissive'.  Under the 'Permissive' setting, a User only needs "
+"access to either the Graph, Device or Graph Template to gain access to the "
+"Graphs that apply to them.  Under 'Restrictive', the User must have access "
+"to the Graph, the Device, and the Graph Template to gain access to the "
+"Graph.  These first two methods have scalability problems for very large "
+"installs.  So, two additional options are available.  They are 'Device "
+"Based', which means if you have access to the Device, you get access to it's "
+"Graphs.  And lastly 'Graph Template Based', which means if you have access "
+"to the 'Graph Template' you get access to all Device Graphs of that Template."
 msgstr ""
 
 #: include/global_settings.php:542
@@ -11486,14 +12218,16 @@ msgid "Graph/Data Source Creation Method"
 msgstr ""
 
 #: include/global_settings.php:551
-msgid "If set to Simple, Graphs and Data Sources can only be created from New Graphs.  If Advanced, legacy Graph and Data Source creation is supported."
+msgid ""
+"If set to Simple, Graphs and Data Sources can only be created from New "
+"Graphs.  If Advanced, legacy Graph and Data Source creation is supported."
 msgstr ""
 
 #: include/global_settings.php:554
 msgid "Simple"
 msgstr ""
 
-#: include/global_settings.php:555 lib/html.php:3310
+#: include/global_settings.php:555 lib/html.php:3251
 msgid "Advanced"
 msgstr ""
 
@@ -11502,7 +12236,9 @@ msgid "Show Form/Setting Help Inline"
 msgstr ""
 
 #: include/global_settings.php:560
-msgid "When checked, Form and Setting Help will be show inline.  Otherwise it will be presented when hovering over the help button."
+msgid ""
+"When checked, Form and Setting Help will be show inline.  Otherwise it will "
+"be presented when hovering over the help button."
 msgstr ""
 
 #: include/global_settings.php:565
@@ -11510,7 +12246,12 @@ msgid "Local Page Help Only"
 msgstr ""
 
 #: include/global_settings.php:566
-msgid "By default Cacti page help is located at docs.cacti.net.  However, if your system does not have access to the Internet, you may download the documentation locally in HTML format and host it in the 'docs' location of you Cacti server.  If you choose only to leverage the local location for page help documentation, check this checkbox."
+msgid ""
+"By default Cacti page help is located at docs.cacti.net.  However, if your "
+"system does not have access to the Internet, you may download the "
+"documentation locally in HTML format and host it in the 'docs' location of "
+"you Cacti server.  If you choose only to leverage the local location for "
+"page help documentation, check this checkbox."
 msgstr ""
 
 #: include/global_settings.php:571
@@ -11526,7 +12267,10 @@ msgid "Data Source Preservation Preset"
 msgstr ""
 
 #: include/global_settings.php:578
-msgid "When enabled, Cacti will set Radio Button to Delete related Data Sources of a Graph when removing Graphs.  Note: Cacti will not allow the removal of Data Sources if they are used in other Graphs."
+msgid ""
+"When enabled, Cacti will set Radio Button to Delete related Data Sources of "
+"a Graph when removing Graphs.  Note: Cacti will not allow the removal of "
+"Data Sources if they are used in other Graphs."
 msgstr ""
 
 #: include/global_settings.php:583
@@ -11534,7 +12278,9 @@ msgid "Graphs Auto Unlock"
 msgstr ""
 
 #: include/global_settings.php:584
-msgid "When enabled, Cacti will not lock Graphs.  This allow a faster manual modification of Data Sources related to a Graph."
+msgid ""
+"When enabled, Cacti will not lock Graphs.  This allow a faster manual "
+"modification of Data Sources related to a Graph."
 msgstr ""
 
 #: include/global_settings.php:589
@@ -11542,7 +12288,9 @@ msgid "Hide Cacti Dashboard"
 msgstr ""
 
 #: include/global_settings.php:590
-msgid "For use with Cacti's External Link Support.  Using this setting, you can hide the Cacti Dashboard, so you can display just your own page."
+msgid ""
+"For use with Cacti's External Link Support.  Using this setting, you can "
+"hide the Cacti Dashboard, so you can display just your own page."
 msgstr ""
 
 #: include/global_settings.php:595
@@ -11550,7 +12298,9 @@ msgid "Enable Drag-N-Drop"
 msgstr ""
 
 #: include/global_settings.php:596
-msgid "Some of Cacti's interfaces support Drag-N-Drop.  If checked this option will be enabled.  Note: For visually impaired user, this option may be disabled."
+msgid ""
+"Some of Cacti's interfaces support Drag-N-Drop.  If checked this option will "
+"be enabled.  Note: For visually impaired user, this option may be disabled."
 msgstr ""
 
 #: include/global_settings.php:601
@@ -11562,7 +12312,11 @@ msgid "Base API Repository URL"
 msgstr ""
 
 #: include/global_settings.php:607
-msgid "If you wish to get the latest plguins versions directly from GitHub or GitLab enter the GitHub or GitLab API url here.  The default is https://api.github.com/.  Change this only if you have your own repository that you maintain for Cacti Plugins."
+msgid ""
+"If you wish to get the latest plguins versions directly from GitHub or "
+"GitLab enter the GitHub or GitLab API url here.  The default is https://"
+"api.github.com/.  Change this only if you have your own repository that you "
+"maintain for Cacti Plugins."
 msgstr ""
 
 #: include/global_settings.php:614
@@ -11570,7 +12324,9 @@ msgid "GitHub User Account"
 msgstr ""
 
 #: include/global_settings.php:615
-msgid "The User account that holds your GitHub/GitLab repositories.  Change this only if you have your own repository that you maintain for Cacti Plugins."
+msgid ""
+"The User account that holds your GitHub/GitLab repositories.  Change this "
+"only if you have your own repository that you maintain for Cacti Plugins."
 msgstr ""
 
 #: include/global_settings.php:622
@@ -11578,7 +12334,9 @@ msgid "Personal Access Token"
 msgstr ""
 
 #: include/global_settings.php:623
-msgid "If you wish to get the latest plguins versions directly from GitHub without overly restricted rate limiting, enter your Personal Access Token here."
+msgid ""
+"If you wish to get the latest plguins versions directly from GitHub without "
+"overly restricted rate limiting, enter your Personal Access Token here."
 msgstr ""
 
 #: include/global_settings.php:631
@@ -11586,7 +12344,9 @@ msgid "Enable Unsafe Plugin Installs"
 msgstr ""
 
 #: include/global_settings.php:632
-msgid "If you would like to allow the installation of Cacti Plugins from their 'develop' branch, check this checkbox."
+msgid ""
+"If you would like to allow the installation of Cacti Plugins from their "
+"'develop' branch, check this checkbox."
 msgstr ""
 
 #: include/global_settings.php:637
@@ -11598,7 +12358,9 @@ msgid "Author Name"
 msgstr ""
 
 #: include/global_settings.php:643
-msgid "The name of the author that you wish published with the Device Template or Package."
+msgid ""
+"The name of the author that you wish published with the Device Template or "
+"Package."
 msgstr ""
 
 #: include/global_settings.php:650
@@ -11606,7 +12368,9 @@ msgid "Author Email Address"
 msgstr ""
 
 #: include/global_settings.php:651
-msgid "The Email address of the author that you wish published with the Device Template or Package."
+msgid ""
+"The Email address of the author that you wish published with the Device "
+"Template or Package."
 msgstr ""
 
 #: include/global_settings.php:658
@@ -11614,7 +12378,9 @@ msgid "Template/Package Copyright"
 msgstr ""
 
 #: include/global_settings.php:659
-msgid "The default copyright that you would like to use for your packaged Device Templates and Packages."
+msgid ""
+"The default copyright that you would like to use for your packaged Device "
+"Templates and Packages."
 msgstr ""
 
 #: include/global_settings.php:665
@@ -11634,7 +12400,9 @@ msgid "Automatically Trust Signer"
 msgstr ""
 
 #: include/global_settings.php:677 package_import.php:1363
-msgid "If checked, Cacti will automatically Trust the Signer for this and any future Packages by that author."
+msgid ""
+"If checked, Cacti will automatically Trust the Signer for this and any "
+"future Packages by that author."
 msgstr ""
 
 #: include/global_settings.php:688 package_import.php:1398
@@ -11642,7 +12410,10 @@ msgid "Replace Suggested Value Patterns"
 msgstr ""
 
 #: include/global_settings.php:689 package_import.php:1399
-msgid "Replace Data Source and Graph Template Suggested Value Records.  Graphs and Data Sources will take on new names after either a Data Query Reindex or by using the forced Replace Suggested Values process."
+msgid ""
+"Replace Data Source and Graph Template Suggested Value Records.  Graphs and "
+"Data Sources will take on new names after either a Data Query Reindex or by "
+"using the forced Replace Suggested Values process."
 msgstr ""
 
 #: include/global_settings.php:694
@@ -11654,7 +12425,9 @@ msgid "Force Connections over HTTPS"
 msgstr ""
 
 #: include/global_settings.php:700
-msgid "When checked, any attempts to access Cacti will be redirected to HTTPS to ensure high security."
+msgid ""
+"When checked, any attempts to access Cacti will be redirected to HTTPS to "
+"ensure high security."
 msgstr ""
 
 #: include/global_settings.php:706
@@ -11662,7 +12435,9 @@ msgid "Content-Security Allow Unsafe JavaScript eval() calls"
 msgstr ""
 
 #: include/global_settings.php:707
-msgid "Certain Cacti plugins require the use of unsafe JavaScript eval() calls.  If you select this option, they will be allowed in Cacti."
+msgid ""
+"Certain Cacti plugins require the use of unsafe JavaScript eval() calls.  If "
+"you select this option, they will be allowed in Cacti."
 msgstr ""
 
 #: include/global_settings.php:715
@@ -11670,7 +12445,12 @@ msgid "Content-Security Alternate Sources"
 msgstr ""
 
 #: include/global_settings.php:716
-msgid "Space delimited domain names that will be permitted to be accessed outside of the Web Server itself.  This is important for users choosing to use a CDN, or hosting site.  Sources can includes wildcards for example: *.mydomain.com, or a protocol, for example: https://*.example.com.  These Alternate Sources include Image, CSS and JavaScript types only."
+msgid ""
+"Space delimited domain names that will be permitted to be accessed outside "
+"of the Web Server itself.  This is important for users choosing to use a "
+"CDN, or hosting site.  Sources can includes wildcards for example: "
+"*.mydomain.com, or a protocol, for example: https://*.example.com.  These "
+"Alternate Sources include Image, CSS and JavaScript types only."
 msgstr ""
 
 #: include/global_settings.php:723
@@ -11678,7 +12458,9 @@ msgid "Remote Agent"
 msgstr ""
 
 #: include/global_settings.php:724
-msgid "When using multiple Data Collectors, there are the Settings for Communicating between Data Collectors"
+msgid ""
+"When using multiple Data Collectors, there are the Settings for "
+"Communicating between Data Collectors"
 msgstr ""
 
 #: include/global_settings.php:729
@@ -11686,1030 +12468,1219 @@ msgid "TCP Port"
 msgstr ""
 
 #: include/global_settings.php:730
-msgid "The TCP Port used for communicating with the Remote Data Collectors.  The protocol will match the Central Cacti web server (either HTTP or HTTPS).  Leave blank to use the default ports."
+msgid ""
+"The TCP Port used for communicating with the Remote Data Collectors.  The "
+"protocol will match the Central Cacti web server (either HTTP or HTTPS).  "
+"Leave blank to use the default ports."
 msgstr ""
 
-#: include/global_settings.php:738 include/global_settings.php:1556
-msgid "The amount of time, in seconds, that the Central Cacti web server will wait for a response from the Remote Data Collector to obtain various Device information before abandoning the request.  On Devices that are associated with Data Collectors other than the Central Cacti Data Collector, the Remote Agent must be used to gather Device information."
+#: include/global_settings.php:738 include/global_settings.php:1558
+msgid ""
+"The amount of time, in seconds, that the Central Cacti web server will wait "
+"for a response from the Remote Data Collector to obtain various Device "
+"information before abandoning the request.  On Devices that are associated "
+"with Data Collectors other than the Central Cacti Data Collector, the Remote "
+"Agent must be used to gather Device information."
 msgstr ""
 
-#: include/global_settings.php:754
+#: include/global_settings.php:756
 msgid "Logging Level"
 msgstr ""
 
-#: include/global_settings.php:755
-msgid "The Logging level for Automation activities.  Levels are Low, Medium and High."
+#: include/global_settings.php:757
+msgid ""
+"The Logging level for Automation activities.  Levels are Low, Medium and "
+"High."
 msgstr ""
 
-#: include/global_settings.php:762
+#: include/global_settings.php:764
 msgid "Force Serial Automation Scans"
 msgstr ""
 
-#: include/global_settings.php:763
-msgid "When enabled, Cacti Automation will scan one network at a time not in Parallel.  This setting can be useful when your Cacti Web Servers have limited cores for performing Automation checks."
+#: include/global_settings.php:765
+msgid ""
+"When enabled, Cacti Automation will scan one network at a time not in "
+"Parallel.  This setting can be useful when your Cacti Web Servers have "
+"limited cores for performing Automation checks."
 msgstr ""
 
-#: include/global_settings.php:768
+#: include/global_settings.php:770
 msgid "Enable Automatic Graph Creation"
 msgstr ""
 
-#: include/global_settings.php:769
-msgid "When disabled, Cacti Automation will not actively create any Graph.  This is useful when adjusting Device settings so as to avoid creating new Graphs each time you save an object.  Invoking Automation Rules manually will still be possible."
+#: include/global_settings.php:771
+msgid ""
+"When disabled, Cacti Automation will not actively create any Graph.  This is "
+"useful when adjusting Device settings so as to avoid creating new Graphs "
+"each time you save an object.  Invoking Automation Rules manually will still "
+"be possible."
 msgstr ""
 
-#: include/global_settings.php:774
+#: include/global_settings.php:776
 msgid "Enable Automatic Tree Item Creation"
 msgstr ""
 
-#: include/global_settings.php:775
-msgid "When disabled, Cacti Automation will not actively create any Tree Item.  This is useful when adjusting Device or Graph settings so as to avoid creating new Tree Entries each time you save an object.  Invoking Rules manually will still be possible."
+#: include/global_settings.php:777
+msgid ""
+"When disabled, Cacti Automation will not actively create any Tree Item.  "
+"This is useful when adjusting Device or Graph settings so as to avoid "
+"creating new Tree Entries each time you save an object.  Invoking Rules "
+"manually will still be possible."
 msgstr ""
 
-#: include/global_settings.php:779
+#: include/global_settings.php:781
 msgid "Automation Notification To Email"
 msgstr ""
 
-#: include/global_settings.php:780
-msgid "The Email Address to send Automation Notification Emails to if not specified at the Automation Network level.  If either this field, or the Automation Network value are left blank, Cacti will use the Primary Cacti Admins Email account."
+#: include/global_settings.php:782
+msgid ""
+"The Email Address to send Automation Notification Emails to if not specified "
+"at the Automation Network level.  If either this field, or the Automation "
+"Network value are left blank, Cacti will use the Primary Cacti Admins Email "
+"account."
 msgstr ""
 
-#: include/global_settings.php:786
+#: include/global_settings.php:788
 msgid "Automation Notification From Name"
 msgstr ""
 
-#: include/global_settings.php:787
-msgid "The Email Name to use for Automation Notification Emails to if not specified at the Automation Network level.  If either this field, or the Automation Network value are left blank, Cacti will use the system default From Name."
+#: include/global_settings.php:789
+msgid ""
+"The Email Name to use for Automation Notification Emails to if not specified "
+"at the Automation Network level.  If either this field, or the Automation "
+"Network value are left blank, Cacti will use the system default From Name."
 msgstr ""
 
-#: include/global_settings.php:794
+#: include/global_settings.php:796
 msgid "Automation Notification From Email"
 msgstr ""
 
-#: include/global_settings.php:795
-msgid "The Email Address to use for Automation Notification Emails to if not specified at the Automation Network level.  If either this field, or the Automation Network value are left blank, Cacti will use the system default From Email Address."
+#: include/global_settings.php:797
+msgid ""
+"The Email Address to use for Automation Notification Emails to if not "
+"specified at the Automation Network level.  If either this field, or the "
+"Automation Network value are left blank, Cacti will use the system default "
+"From Email Address."
 msgstr ""
 
-#: include/global_settings.php:801
+#: include/global_settings.php:803
 msgid "Graph Template Defaults"
 msgstr ""
 
-#: include/global_settings.php:807
+#: include/global_settings.php:809
 msgid "Graph Template Test Data Source"
 msgstr ""
 
-#: include/global_settings.php:808
-msgid "Check this checkbox if you wish to test the Data Sources prior to their creation for new and newly imported Graph Templates.  With Test Data Sources enabled, if the Data Source does not return valid data, the Graph will not be created.  This setting is important if you wish to have a more generic Device Template that can include more Graph Templates that can be selectively applied depending on the characteristics of the Device itself.  Note: If you have a long running script as a Data Source, the time to create Graphs will be increased."
+#: include/global_settings.php:810
+msgid ""
+"Check this checkbox if you wish to test the Data Sources prior to their "
+"creation for new and newly imported Graph Templates.  With Test Data Sources "
+"enabled, if the Data Source does not return valid data, the Graph will not "
+"be created.  This setting is important if you wish to have a more generic "
+"Device Template that can include more Graph Templates that can be "
+"selectively applied depending on the characteristics of the Device itself.  "
+"Note: If you have a long running script as a Data Source, the time to create "
+"Graphs will be increased."
 msgstr ""
 
-#: include/global_settings.php:813
+#: include/global_settings.php:815
 msgid "The default Image Format to be used for all new Graph Templates."
 msgstr ""
 
-#: include/global_settings.php:820
+#: include/global_settings.php:822
 msgid "The default Graph Height to be used for all new Graph Templates."
 msgstr ""
 
-#: include/global_settings.php:828
+#: include/global_settings.php:830
 msgid "The default Graph Width to be used for all new Graph Templates."
 msgstr ""
 
-#: include/global_settings.php:838
+#: include/global_settings.php:840
 msgid "General Defaults"
 msgstr ""
 
-#: include/global_settings.php:844
+#: include/global_settings.php:846
 msgid "The default Device Template used on all new Devices."
 msgstr ""
 
-#: include/global_settings.php:852
+#: include/global_settings.php:854
 msgid "The default Site for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:860
+#: include/global_settings.php:862
 msgid "The default Poller for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:867
+#: include/global_settings.php:869
 msgid "Device Threads"
 msgstr ""
 
-#: include/global_settings.php:868
-msgid "The default number of Device Threads.  This is only applicable when using the Spine Data Collector."
+#: include/global_settings.php:870
+msgid ""
+"The default number of Device Threads.  This is only applicable when using "
+"the Spine Data Collector."
 msgstr ""
 
-#: include/global_settings.php:872
+#: include/global_settings.php:874
 #, php-format
 msgid "%s Thread"
 msgstr ""
 
-#: include/global_settings.php:873 include/global_settings.php:874
 #: include/global_settings.php:875 include/global_settings.php:876
 #: include/global_settings.php:877 include/global_settings.php:878
 #: include/global_settings.php:879 include/global_settings.php:880
-#: include/global_settings.php:881
+#: include/global_settings.php:881 include/global_settings.php:882
+#: include/global_settings.php:883
 #, php-format
 msgid "%s Threads"
 msgstr ""
 
-#: include/global_settings.php:885
+#: include/global_settings.php:887
 msgid "Re-index Method for Data Queries"
 msgstr ""
 
-#: include/global_settings.php:886
+#: include/global_settings.php:888
 msgid "The default Re-index Method to use for all Data Queries."
 msgstr ""
 
-#: include/global_settings.php:892
+#: include/global_settings.php:894
 msgid "Default Interface Speed"
 msgstr ""
 
-#: include/global_settings.php:893
-msgid "If Cacti can not determine the interface speed due to either ifSpeed or ifHighSpeed not being set or being zero, what maximum value do you wish on the resulting RRDfiles."
-msgstr ""
-
-#: include/global_settings.php:897
-msgid "100 Mbps Ethernet"
-msgstr ""
-
-#: include/global_settings.php:898
-msgid "1 Gbps Ethernet"
+#: include/global_settings.php:895
+msgid ""
+"If Cacti can not determine the interface speed due to either ifSpeed or "
+"ifHighSpeed not being set or being zero, what maximum value do you wish on "
+"the resulting RRDfiles."
 msgstr ""
 
 #: include/global_settings.php:899
-msgid "10 Gbps Ethernet"
+msgid "100 Mbps Ethernet"
 msgstr ""
 
 #: include/global_settings.php:900
-msgid "25 Gbps Ethernet"
+msgid "1 Gbps Ethernet"
 msgstr ""
 
 #: include/global_settings.php:901
-msgid "40 Gbps Ethernet"
+msgid "10 Gbps Ethernet"
 msgstr ""
 
 #: include/global_settings.php:902
-msgid "56 Gbps Ethernet"
+msgid "25 Gbps Ethernet"
 msgstr ""
 
 #: include/global_settings.php:903
+msgid "40 Gbps Ethernet"
+msgstr ""
+
+#: include/global_settings.php:904
+msgid "56 Gbps Ethernet"
+msgstr ""
+
+#: include/global_settings.php:905
 msgid "100 Gbps Ethernet"
 msgstr ""
 
-#: include/global_settings.php:907
+#: include/global_settings.php:909
 msgid "SNMP Defaults"
 msgstr ""
 
-#: include/global_settings.php:913
+#: include/global_settings.php:915
 msgid "Default SNMP version for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:920
+#: include/global_settings.php:922
 msgid "Default SNMP read community for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:926
+#: include/global_settings.php:928
 msgid "Security Level"
 msgstr ""
 
-#: include/global_settings.php:927
+#: include/global_settings.php:929
 msgid "Default SNMP v3 Security Level for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:934
+#: include/global_settings.php:936
 msgid "Auth Protocol (v3)"
 msgstr ""
 
-#: include/global_settings.php:935
+#: include/global_settings.php:937
 msgid "Default SNMPv3 Authorization Protocol for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:940
+#: include/global_settings.php:942
 msgid "Auth User (v3)"
 msgstr ""
 
-#: include/global_settings.php:941
+#: include/global_settings.php:943
 msgid "Default SNMP v3 Authorization User for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:948
+#: include/global_settings.php:950
 msgid "Auth Passphrase (v3)"
 msgstr ""
 
-#: include/global_settings.php:949
+#: include/global_settings.php:951
 msgid "Default SNMP v3 Authorization Passphrase for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:957
+#: include/global_settings.php:959
 msgid "Privacy Protocol (v3)"
 msgstr ""
 
-#: include/global_settings.php:958
+#: include/global_settings.php:960
 msgid "Default SNMPv3 Privacy Protocol for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:964
+#: include/global_settings.php:966
 msgid "Privacy Passphrase (v3)"
 msgstr ""
 
-#: include/global_settings.php:965
+#: include/global_settings.php:967
 msgid "Default SNMPv3 Privacy Passphrase for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:973
+#: include/global_settings.php:975
 msgid "Enter the SNMP v3 Context for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:982
-msgid "Default SNMP v3 Engine Id for all new Devices. Leave this field empty to use the SNMP Engine ID being defined per SNMPv3 Notification receiver."
+#: include/global_settings.php:984
+msgid ""
+"Default SNMP v3 Engine Id for all new Devices. Leave this field empty to use "
+"the SNMP Engine ID being defined per SNMPv3 Notification receiver."
 msgstr ""
 
-#: include/global_settings.php:989
+#: include/global_settings.php:991
 msgid "Port Number"
 msgstr ""
 
-#: include/global_settings.php:990
+#: include/global_settings.php:992
 msgid "Default UDP Port for all new Devices.  Typically 161."
 msgstr ""
 
-#: include/global_settings.php:998
+#: include/global_settings.php:1000
 msgid "Default SNMP timeout in milli-seconds for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:1006
+#: include/global_settings.php:1008
 msgid "Default SNMP retries for all new Devices."
 msgstr ""
 
-#: include/global_settings.php:1013
+#: include/global_settings.php:1015
 msgid "Bulkwalk Fetch Size"
 msgstr ""
 
-#: include/global_settings.php:1014
-msgid "How many OID's should be returned per snmpbulkwalk request?  For Devices with large SNMP trees, increasing this size will increase re-index performance over a WAN."
+#: include/global_settings.php:1016
+msgid ""
+"How many OID's should be returned per snmpbulkwalk request?  For Devices "
+"with large SNMP trees, increasing this size will increase re-index "
+"performance over a WAN."
 msgstr ""
 
-#: include/global_settings.php:1033
+#: include/global_settings.php:1035
 msgid "Max OID Limit"
 msgstr ""
 
-#: include/global_settings.php:1034
-msgid "The default maximum number of SNMP Get OIDs to issue per snmpget request.  For Devices, this setting is controlled at the Device level.  You should only use this setting when using Cacti's SNMP API natively in your scripts or plugins."
+#: include/global_settings.php:1036
+msgid ""
+"The default maximum number of SNMP Get OIDs to issue per snmpget request.  "
+"For Devices, this setting is controlled at the Device level.  You should "
+"only use this setting when using Cacti's SNMP API natively in your scripts "
+"or plugins."
 msgstr ""
 
-#: include/global_settings.php:1041
+#: include/global_settings.php:1043
 msgid "Availability/Reachability"
 msgstr ""
 
-#: include/global_settings.php:1047
-msgid "Default Availability/Reachability for all new Devices.  The method Cacti will use to determine if a Device is available for polling.  <br><i>NOTE: It is recommended that, at a minimum, SNMP always be selected.</i>"
+#: include/global_settings.php:1049
+msgid ""
+"Default Availability/Reachability for all new Devices.  The method Cacti "
+"will use to determine if a Device is available for polling.  <br><i>NOTE: It "
+"is recommended that, at a minimum, SNMP always be selected.</i>"
 msgstr ""
 
-#: include/global_settings.php:1061
+#: include/global_settings.php:1063
 msgid "Downed Device SNMP Recovery Options Retry Frequency"
 msgstr ""
 
-#: include/global_settings.php:1062
-msgid "When a Device is Down, and has an SNMP Recovery Options Set established, how often do you wish to try to retry the Device using the SNMP Options Set specified?"
+#: include/global_settings.php:1064
+msgid ""
+"When a Device is Down, and has an SNMP Recovery Options Set established, how "
+"often do you wish to try to retry the Device using the SNMP Options Set "
+"specified?"
 msgstr ""
 
-#: include/global_settings.php:1068
+#: include/global_settings.php:1070
 msgid "Ping Type"
 msgstr ""
 
-#: include/global_settings.php:1069
+#: include/global_settings.php:1071
 msgid "Default Ping type for all new Devices.</i>"
 msgstr ""
 
-#: include/global_settings.php:1076
-msgid "Default Ping Port for all new Devices.  With TCP, Cacti will attempt to Syn the port.  With UDP, Cacti requires either a successful connection, or a 'port not reachable' error to determine if the Device is up or not."
+#: include/global_settings.php:1078
+msgid ""
+"Default Ping Port for all new Devices.  With TCP, Cacti will attempt to Syn "
+"the port.  With UDP, Cacti requires either a successful connection, or a "
+"'port not reachable' error to determine if the Device is up or not."
 msgstr ""
 
-#: include/global_settings.php:1084
-msgid "Default Ping Timeout value in milli-seconds for all new Devices.  The timeout values to use for Device SNMP, ICMP, UDP and TCP pinging.  ICMP Pings will be rounded up to the nearest second.  TCP and UDP connection timeouts on Windows are controlled by the operating system, and are therefore not recommended on Windows."
+#: include/global_settings.php:1086
+msgid ""
+"Default Ping Timeout value in milli-seconds for all new Devices.  The "
+"timeout values to use for Device SNMP, ICMP, UDP and TCP pinging.  ICMP "
+"Pings will be rounded up to the nearest second.  TCP and UDP connection "
+"timeouts on Windows are controlled by the operating system, and are "
+"therefore not recommended on Windows."
 msgstr ""
 
-#: include/global_settings.php:1092
-msgid "The number of times Cacti will attempt to ping a Device before marking it as down."
+#: include/global_settings.php:1094
+msgid ""
+"The number of times Cacti will attempt to ping a Device before marking it as "
+"down."
 msgstr ""
 
-#: include/global_settings.php:1099
+#: include/global_settings.php:1101
 msgid "Up/Down Settings"
 msgstr ""
 
-#: include/global_settings.php:1104
+#: include/global_settings.php:1106
 msgid "Failure Count"
 msgstr ""
 
-#: include/global_settings.php:1105
-msgid "The number of polling intervals a Device must be down before logging an error and reporting Device as down."
+#: include/global_settings.php:1107
+msgid ""
+"The number of polling intervals a Device must be down before logging an "
+"error and reporting Device as down."
 msgstr ""
 
-#: include/global_settings.php:1112
+#: include/global_settings.php:1114
 msgid "Recovery Count"
 msgstr ""
 
-#: include/global_settings.php:1113
-msgid "The number of polling intervals a Device must remain up before returning Device to an up status and issuing a notice."
+#: include/global_settings.php:1115
+msgid ""
+"The number of polling intervals a Device must remain up before returning "
+"Device to an up status and issuing a notice."
 msgstr ""
 
-#: include/global_settings.php:1123
+#: include/global_settings.php:1125
 msgid "Theme Settings"
 msgstr ""
 
-#: include/global_settings.php:1128 include/global_settings.php:1424
-#: include/global_settings.php:3074 lib/html.php:3235
+#: include/global_settings.php:1130 include/global_settings.php:1426
+#: include/global_settings.php:3032 lib/html.php:3176
 msgid "Theme"
 msgstr ""
 
-#: include/global_settings.php:1129 include/global_settings.php:3075
+#: include/global_settings.php:1131 include/global_settings.php:3033
 msgid "Please select one of the available Themes to skin your Cacti with."
 msgstr ""
 
-#: include/global_settings.php:1135
+#: include/global_settings.php:1137
 msgid "Graping of Unknown Data"
 msgstr ""
 
-#: include/global_settings.php:1140
+#: include/global_settings.php:1142
 msgid "Show Unknown Data on Graphs"
 msgstr ""
 
-#: include/global_settings.php:1141
-msgid "If you check this checkbox, Cacti will display Unknown Data with the background color selected below.."
+#: include/global_settings.php:1143
+msgid ""
+"If you check this checkbox, Cacti will display Unknown Data with the "
+"background color selected below.."
 msgstr ""
 
-#: include/global_settings.php:1146
+#: include/global_settings.php:1148
 msgid "Unknown Data Area Fill Color"
 msgstr ""
 
-#: include/global_settings.php:1147
-msgid "Select the color to use as a custom background color to highlight Unknown Data."
+#: include/global_settings.php:1149
+msgid ""
+"Select the color to use as a custom background color to highlight Unknown "
+"Data."
 msgstr ""
 
-#: include/global_settings.php:1152
+#: include/global_settings.php:1154
 msgid "Unknown Data Area Fill Opacity"
 msgstr ""
 
-#: include/global_settings.php:1156
-msgid "The Opacity of the Unknown Data Color.  The lower the value, the more transparent to area fill."
+#: include/global_settings.php:1158
+msgid ""
+"The Opacity of the Unknown Data Color.  The lower the value, the more "
+"transparent to area fill."
 msgstr ""
 
-#: include/global_settings.php:1159
+#: include/global_settings.php:1161
 msgid "Business Hour Settings"
 msgstr ""
 
-#: include/global_settings.php:1164
+#: include/global_settings.php:1166
 msgid "Show Business Hours on Graphs"
 msgstr ""
 
-#: include/global_settings.php:1165
+#: include/global_settings.php:1167
 msgid "Display business hours on rrd graphs."
 msgstr ""
 
-#: include/global_settings.php:1170
+#: include/global_settings.php:1172
 msgid "Business Hours Color"
 msgstr ""
 
-#: include/global_settings.php:1171
+#: include/global_settings.php:1173
 msgid "The color to be shown for business hours"
 msgstr ""
 
-#: include/global_settings.php:1176
+#: include/global_settings.php:1178
 msgid "Business Hours Color Opacity"
 msgstr ""
 
-#: include/global_settings.php:1177
-msgid "The Opacity of the business hours color.  The lower the value, the more transparent to area fill."
+#: include/global_settings.php:1179
+msgid ""
+"The Opacity of the business hours color.  The lower the value, the more "
+"transparent to area fill."
 msgstr ""
 
-#: include/global_settings.php:1183
+#: include/global_settings.php:1185
 msgid "Start of Business Day"
 msgstr ""
 
-#: include/global_settings.php:1184
+#: include/global_settings.php:1186
 msgid "The time your business hours start. Format: hh:mm"
 msgstr ""
 
-#: include/global_settings.php:1191
+#: include/global_settings.php:1193
 msgid "End of Business Day"
 msgstr ""
 
-#: include/global_settings.php:1192
+#: include/global_settings.php:1194
 msgid "The time your business hours end. Format: hh:mm"
 msgstr ""
 
-#: include/global_settings.php:1199
+#: include/global_settings.php:1201
 msgid "Hide Weekends"
 msgstr ""
 
-#: include/global_settings.php:1200
+#: include/global_settings.php:1202
 msgid "Only show business hours during weekdays."
 msgstr ""
 
-#: include/global_settings.php:1205
+#: include/global_settings.php:1207
 msgid "Maximum number of days to show Business Hours"
 msgstr ""
 
-#: include/global_settings.php:1206
-msgid "After this number of days, the business hours will not be added to the graph. <br/>Recommended: 62 days"
+#: include/global_settings.php:1208
+msgid ""
+"After this number of days, the business hours will not be added to the "
+"graph. <br/>Recommended: 62 days"
 msgstr ""
 
-#: include/global_settings.php:1213
+#: include/global_settings.php:1215
 msgid "Table Settings"
 msgstr ""
 
-#: include/global_settings.php:1218
+#: include/global_settings.php:1220
 msgid "Rows Per Page"
 msgstr ""
 
-#: include/global_settings.php:1219 include/global_settings.php:1236
+#: include/global_settings.php:1221 include/global_settings.php:1238
 msgid ".  This is limited by the php setting 'max_input_vars', currently:"
 msgstr ""
 
-#: include/global_settings.php:1219
+#: include/global_settings.php:1221
 msgid "The default number of rows to display on for a table."
 msgstr ""
 
-#: include/global_settings.php:1225
+#: include/global_settings.php:1227
 msgid "Autocomplete Enabled"
 msgstr ""
 
-#: include/global_settings.php:1226
-msgid "In very large systems, select lists can slow the user interface significantly.  If this option is enabled, Cacti will use autocomplete callbacks to populate the select list systematically.  Note: autocomplete is forcibly disabled on the Classic theme."
+#: include/global_settings.php:1228
+msgid ""
+"In very large systems, select lists can slow the user interface "
+"significantly.  If this option is enabled, Cacti will use autocomplete "
+"callbacks to populate the select list systematically.  Note: autocomplete is "
+"forcibly disabled on the Classic theme."
 msgstr ""
 
-#: include/global_settings.php:1235
+#: include/global_settings.php:1237
 msgid "Autocomplete Rows"
 msgstr ""
 
-#: include/global_settings.php:1236
-msgid "The default number of rows to return from an autocomplete based select pattern match."
+#: include/global_settings.php:1238
+msgid ""
+"The default number of rows to return from an autocomplete based select "
+"pattern match."
 msgstr ""
 
-#: include/global_settings.php:1242
+#: include/global_settings.php:1244
 msgid "Autocomplete Delay"
 msgstr ""
 
-#: include/global_settings.php:1243
-msgid "The number of milliseconds to wait before initiating a call to the server for autocomplete. Any value less than 500 will assume 500ms"
+#: include/global_settings.php:1245
+msgid ""
+"The number of milliseconds to wait before initiating a call to the server "
+"for autocomplete. Any value less than 500 will assume 500ms"
 msgstr ""
 
-#: include/global_settings.php:1255 include/global_settings.php:3310
+#: include/global_settings.php:1257 include/global_settings.php:3268
 msgid "Minimum Tree Width"
 msgstr ""
 
-#: include/global_settings.php:1256 include/global_settings.php:3311
+#: include/global_settings.php:1258 include/global_settings.php:3269
 msgid "The Minimum width of the Tree to contract to."
 msgstr ""
 
-#: include/global_settings.php:1263 include/global_settings.php:3318
+#: include/global_settings.php:1265 include/global_settings.php:3276
 msgid "Maximum Tree Width"
 msgstr ""
 
-#: include/global_settings.php:1264 include/global_settings.php:3319
-msgid "The Maximum width of the Tree to expand to, after which time, Tree branches will scroll on the page."
+#: include/global_settings.php:1266 include/global_settings.php:3277
+msgid ""
+"The Maximum width of the Tree to expand to, after which time, Tree branches "
+"will scroll on the page."
 msgstr ""
 
-#: include/global_settings.php:1271
+#: include/global_settings.php:1273
 msgid "Filter Settings"
 msgstr ""
 
-#: include/global_settings.php:1276
+#: include/global_settings.php:1278
 msgid "Strip Domains from Device Dropdowns"
 msgstr ""
 
-#: include/global_settings.php:1277
-msgid "When viewing Device name filter dropdowns, checking this option will strip to domain from the hostname."
+#: include/global_settings.php:1279
+msgid ""
+"When viewing Device name filter dropdowns, checking this option will strip "
+"to domain from the hostname."
 msgstr ""
 
-#: include/global_settings.php:1282
+#: include/global_settings.php:1284
 msgid "Graph/Data Source/Data Query Settings"
 msgstr ""
 
-#: include/global_settings.php:1287
+#: include/global_settings.php:1289
 msgid "Maximum Title Length"
 msgstr ""
 
-#: include/global_settings.php:1288
+#: include/global_settings.php:1290
 msgid "The maximum allowable Graph or Data Source titles."
 msgstr ""
 
-#: include/global_settings.php:1295
+#: include/global_settings.php:1297
 msgid "Data Source Field Length"
 msgstr ""
 
-#: include/global_settings.php:1296
+#: include/global_settings.php:1298
 msgid "The maximum Data Query field length."
 msgstr ""
 
-#: include/global_settings.php:1303
+#: include/global_settings.php:1305
 msgid "Graph Creation"
 msgstr ""
 
-#: include/global_settings.php:1308
+#: include/global_settings.php:1310
 msgid "Default Graph Type"
 msgstr ""
 
-#: include/global_settings.php:1309
-msgid "When creating graphs, what Graph Type would you like pre-selected?"
+#: include/global_settings.php:1311
+msgid "When creating graphs, what Graph Type would you like preselected?"
 msgstr ""
 
-#: include/global_settings.php:1313
+#: include/global_settings.php:1315
 msgid "All Types"
 msgstr ""
 
-#: include/global_settings.php:1314
+#: include/global_settings.php:1316
 msgid "By Template/Data Query"
 msgstr ""
 
-#: include/global_settings.php:1318
+#: include/global_settings.php:1320
 msgid "Log Management"
 msgstr ""
 
-#: include/global_settings.php:1323
+#: include/global_settings.php:1325
 msgid "Default Log Tail Lines"
 msgstr ""
 
-#: include/global_settings.php:1324
+#: include/global_settings.php:1326
 msgid "Default number of lines of the Cacti log file to tail."
 msgstr ""
 
-#: include/global_settings.php:1330
+#: include/global_settings.php:1332
 msgid "Maximum number of rows per page"
 msgstr ""
 
-#: include/global_settings.php:1331
-msgid "User defined number of lines for the CLOG to tail when selecting 'All lines'."
+#: include/global_settings.php:1333
+msgid ""
+"User defined number of lines for the CLOG to tail when selecting 'All lines'."
 msgstr ""
 
-#: include/global_settings.php:1338
+#: include/global_settings.php:1340
 msgid "Log Tail Refresh"
 msgstr ""
 
-#: include/global_settings.php:1339
+#: include/global_settings.php:1341
 msgid "How often do you want the Cacti log display to update."
 msgstr ""
 
-#: include/global_settings.php:1345
+#: include/global_settings.php:1347
 msgid "Log Viewer Settings"
 msgstr ""
 
-#: include/global_settings.php:1350
+#: include/global_settings.php:1352
 msgid "Exclusion Regex"
 msgstr ""
 
-#: include/global_settings.php:1351
-msgid "Any strings that match this regex will be excluded from the user display.  <strong>For example, if you want to exclude all log lines that include the words 'Admin' or 'Login' you would type '(Admin || Login)'</strong>"
+#: include/global_settings.php:1353
+msgid ""
+"Any strings that match this regex will be excluded from the user display.  "
+"<strong>For example, if you want to exclude all log lines that include the "
+"words 'Admin' or 'Login' you would type '(Admin || Login)'</strong>"
 msgstr ""
 
-#: include/global_settings.php:1358
+#: include/global_settings.php:1360
 msgid "Real-time Graphs"
 msgstr ""
 
-#: include/global_settings.php:1363
+#: include/global_settings.php:1365
 msgid "Enable Real-time Graphing"
 msgstr ""
 
-#: include/global_settings.php:1364
-msgid "When an option is checked, users will be able to put Cacti into Real-time mode."
+#: include/global_settings.php:1366
+msgid ""
+"When an option is checked, users will be able to put Cacti into Real-time "
+"mode."
 msgstr ""
 
-#: include/global_settings.php:1370
+#: include/global_settings.php:1372
 msgid "This timespan you wish to see on the default graph."
 msgstr ""
 
-#: include/global_settings.php:1376
+#: include/global_settings.php:1378
 msgid "Minimum Refresh Interval"
 msgstr ""
 
-#: include/global_settings.php:1377
-msgid "This is the minimal supported time between Graph updates.  This value is also used to set certain RRDfile attributes.  If you have a Device that caches data and does not provide realtime updates, you may have to increase the default Minimum Refresh Interval to prevent creating Graphs with gaps."
+#: include/global_settings.php:1379
+msgid ""
+"This is the minimal supported time between Graph updates.  This value is "
+"also used to set certain RRDfile attributes.  If you have a Device that "
+"caches data and does not provide realtime updates, you may have to increase "
+"the default Minimum Refresh Interval to prevent creating Graphs with gaps."
 msgstr ""
 
-#: include/global_settings.php:1383
+#: include/global_settings.php:1385
 msgid "Cache Directory"
 msgstr ""
 
-#: include/global_settings.php:1384
-msgid "This is the location, on the web server where the RRDfiles and PNG files will be cached.  This cache will be managed by the poller.  Make sure you have the correct read and write permissions on this folder"
+#: include/global_settings.php:1386
+msgid ""
+"This is the location, on the web server where the RRDfiles and PNG files "
+"will be cached.  This cache will be managed by the poller.  Make sure you "
+"have the correct read and write permissions on this folder"
 msgstr ""
 
-#: include/global_settings.php:1391
+#: include/global_settings.php:1393
 msgid "RRDtool Graph Options"
 msgstr ""
 
-#: include/global_settings.php:1396
+#: include/global_settings.php:1398
 msgid "Custom Watermark"
 msgstr ""
 
-#: include/global_settings.php:1397
+#: include/global_settings.php:1399
 msgid "Text placed at the bottom center of every Graph."
 msgstr ""
 
-#: include/global_settings.php:1404
+#: include/global_settings.php:1406
 msgid "Custom Date Format"
 msgstr ""
 
-#: include/global_settings.php:1405
+#: include/global_settings.php:1407
 msgid "To be used when formatting |date_time| on a graph"
 msgstr ""
 
-#: include/global_settings.php:1412
+#: include/global_settings.php:1414
 msgid "Disable RRDtool Watermark"
 msgstr ""
 
-#: include/global_settings.php:1413
-msgid "Provided your RRDtool version supports it, you may disable RRDtool advertisement on your Graphs by checking this option."
+#: include/global_settings.php:1415
+msgid ""
+"Provided your RRDtool version supports it, you may disable RRDtool "
+"advertisement on your Graphs by checking this option."
 msgstr ""
 
-#: include/global_settings.php:1418
+#: include/global_settings.php:1420
 msgid "Font Selection Method"
 msgstr ""
 
-#: include/global_settings.php:1419
+#: include/global_settings.php:1421
 msgid "How do you wish fonts to be handled by default?"
 msgstr ""
 
-#: include/global_settings.php:1423 lib/api_device.php:1615
+#: include/global_settings.php:1425 lib/api_device.php:1615
 msgid "System"
 msgstr ""
 
-#: include/global_settings.php:1428
+#: include/global_settings.php:1430
 msgid "Default Font"
 msgstr ""
 
-#: include/global_settings.php:1429
-msgid "When not using Theme based font control, the Pangon font-config font name to use for all Graphs. Optionally, you may leave blank and control font settings on a per object basis."
+#: include/global_settings.php:1431
+msgid ""
+"When not using Theme based font control, the Pangon font-config font name to "
+"use for all Graphs. Optionally, you may leave blank and control font "
+"settings on a per object basis."
 msgstr ""
 
-#: include/global_settings.php:1431 include/global_settings.php:1446
-#: include/global_settings.php:1461 include/global_settings.php:1476
-#: include/global_settings.php:1491
+#: include/global_settings.php:1433 include/global_settings.php:1448
+#: include/global_settings.php:1463 include/global_settings.php:1478
+#: include/global_settings.php:1493
 msgid "Enter Valid Font Config Value"
 msgstr ""
 
-#: include/global_settings.php:1435 include/global_settings.php:3335
+#: include/global_settings.php:1437 include/global_settings.php:3293
 msgid "Title Font Size"
 msgstr ""
 
-#: include/global_settings.php:1436 include/global_settings.php:3336
+#: include/global_settings.php:1438 include/global_settings.php:3294
 msgid "The size of the font used for Graph Titles"
 msgstr ""
 
-#: include/global_settings.php:1443
+#: include/global_settings.php:1445
 msgid "Title Font Setting"
 msgstr ""
 
-#: include/global_settings.php:1444
-msgid "The font to use for Graph Titles.  Enter either a valid True Type Font file or valid Pango font-config value."
+#: include/global_settings.php:1446
+msgid ""
+"The font to use for Graph Titles.  Enter either a valid True Type Font file "
+"or valid Pango font-config value."
 msgstr ""
 
-#: include/global_settings.php:1450 include/global_settings.php:3348
+#: include/global_settings.php:1452 include/global_settings.php:3306
 msgid "Legend Font Size"
 msgstr ""
 
-#: include/global_settings.php:1451 include/global_settings.php:3349
+#: include/global_settings.php:1453 include/global_settings.php:3307
 msgid "The size of the font used for Graph Legend items"
 msgstr ""
 
-#: include/global_settings.php:1458
+#: include/global_settings.php:1460
 msgid "Legend Font Setting"
 msgstr ""
 
-#: include/global_settings.php:1459
-msgid "The font to use for Graph Legends.  Enter either a valid True Type Font file or valid Pango font-config value."
+#: include/global_settings.php:1461
+msgid ""
+"The font to use for Graph Legends.  Enter either a valid True Type Font file "
+"or valid Pango font-config value."
 msgstr ""
 
-#: include/global_settings.php:1465 include/global_settings.php:3361
+#: include/global_settings.php:1467 include/global_settings.php:3319
 msgid "Axis Font Size"
 msgstr ""
 
-#: include/global_settings.php:1466 include/global_settings.php:3362
+#: include/global_settings.php:1468 include/global_settings.php:3320
 msgid "The size of the font used for Graph Axis"
 msgstr ""
 
-#: include/global_settings.php:1473
+#: include/global_settings.php:1475
 msgid "Axis Font Setting"
 msgstr ""
 
-#: include/global_settings.php:1474
-msgid "The font to use for Graph Axis items.  Enter either a valid True Type Font file or valid Pango font-config value."
+#: include/global_settings.php:1476
+msgid ""
+"The font to use for Graph Axis items.  Enter either a valid True Type Font "
+"file or valid Pango font-config value."
 msgstr ""
 
-#: include/global_settings.php:1480 include/global_settings.php:3374
+#: include/global_settings.php:1482 include/global_settings.php:3332
 msgid "Unit Font Size"
 msgstr ""
 
-#: include/global_settings.php:1481 include/global_settings.php:3375
+#: include/global_settings.php:1483 include/global_settings.php:3333
 msgid "The size of the font used for Graph Units"
 msgstr ""
 
-#: include/global_settings.php:1488
+#: include/global_settings.php:1490
 msgid "Unit Font Setting"
 msgstr ""
 
-#: include/global_settings.php:1489
-msgid "The font to use for Graph Unit items.  Enter either a valid True Type Font file or valid Pango font-config value."
+#: include/global_settings.php:1491
+msgid ""
+"The font to use for Graph Unit items.  Enter either a valid True Type Font "
+"file or valid Pango font-config value."
 msgstr ""
 
-#: include/global_settings.php:1503
+#: include/global_settings.php:1505
 msgid "Data Collection Enabled"
 msgstr ""
 
-#: include/global_settings.php:1504
+#: include/global_settings.php:1506
 msgid "If you wish to stop the polling process completely, uncheck this box."
 msgstr ""
 
-#: include/global_settings.php:1510
+#: include/global_settings.php:1512
 msgid "SNMP Agent Support Enabled"
 msgstr ""
 
-#: include/global_settings.php:1511
-msgid "If this option is checked, Cacti will populate SNMP Agent tables with Cacti device and system information.  It does not enable the SNMP Agent itself."
+#: include/global_settings.php:1513
+msgid ""
+"If this option is checked, Cacti will populate SNMP Agent tables with Cacti "
+"device and system information.  It does not enable the SNMP Agent itself."
 msgstr ""
 
-#: include/global_settings.php:1516
+#: include/global_settings.php:1518
 msgid "Poller Type"
 msgstr ""
 
-#: include/global_settings.php:1517
-msgid "The poller type to use.  This setting will take affect at next polling interval."
+#: include/global_settings.php:1519
+msgid ""
+"The poller type to use.  This setting will take affect at next polling "
+"interval."
 msgstr ""
 
-#: include/global_settings.php:1524
-msgid "The polling interval in use.  This setting will affect how often RRDfiles are checked and updated.  <strong><u>NOTE: If you change this value, you must re-populate the poller cache.  Failure to do so, may result in lost data.</u></strong>"
+#: include/global_settings.php:1526
+msgid ""
+"The polling interval in use.  This setting will affect how often RRDfiles "
+"are checked and updated.  <strong><u>NOTE: If you change this value, you "
+"must re-populate the poller cache.  Failure to do so, may result in lost "
+"data.</u></strong>"
 msgstr ""
 
-#: include/global_settings.php:1530
+#: include/global_settings.php:1532
 msgid "Cron/Daemon Interval"
 msgstr ""
 
-#: include/global_settings.php:1531
-msgid "The frequency that the Cacti data collector will be started.  You can use either crontab, a scheduled task (for windows), or the cactid systemd service to control launching the Cacti data collector.  For instructions on using the cactid daemon, review the README.md file in the service directory."
+#: include/global_settings.php:1533
+msgid ""
+"The frequency that the Cacti data collector will be started.  You can use "
+"either crontab, a scheduled task (for windows), or the cactid systemd "
+"service to control launching the Cacti data collector.  For instructions on "
+"using the cactid daemon, review the README.md file in the service directory."
 msgstr ""
 
-#: include/global_settings.php:1537
+#: include/global_settings.php:1539
 msgid "Balance Process Load"
 msgstr ""
 
-#: include/global_settings.php:1538
-msgid "If you choose this option, Cacti will attempt to balance the load of each poller process by equally distributing poller items per process."
+#: include/global_settings.php:1540
+msgid ""
+"If you choose this option, Cacti will attempt to balance the load of each "
+"poller process by equally distributing poller items per process."
 msgstr ""
 
-#: include/global_settings.php:1543
+#: include/global_settings.php:1545
 msgid "Debug Output Width"
 msgstr ""
 
-#: include/global_settings.php:1544
-msgid "If you choose this option, Cacti will check for output that exceeds Cacti's ability to store it and issue a warning when it finds it."
+#: include/global_settings.php:1546
+msgid ""
+"If you choose this option, Cacti will check for output that exceeds Cacti's "
+"ability to store it and issue a warning when it finds it."
 msgstr ""
 
-#: include/global_settings.php:1549
+#: include/global_settings.php:1551
 msgid "Disable increasing OID Check"
 msgstr ""
 
-#: include/global_settings.php:1550
+#: include/global_settings.php:1552
 msgid "Controls disabling check for increasing OID while walking OID tree."
 msgstr ""
 
-#: include/global_settings.php:1555
+#: include/global_settings.php:1557
 msgid "Remote Agent Timeout"
 msgstr ""
 
-#: include/global_settings.php:1567
+#: include/global_settings.php:1571
 msgid "Refresh Poller Table Per Cycle"
 msgstr ""
 
-#: include/global_settings.php:1568
-msgid "This setting is for a single poller systems only to rebuild the poller output table on each polling cycle to prevent the memory table from swapping on very large systems with large databases that could use swap."
+#: include/global_settings.php:1572
+msgid ""
+"This setting is for a single poller systems only to rebuild the poller "
+"output table on each polling cycle to prevent the memory table from swapping "
+"on very large systems with large databases that could use swap."
 msgstr ""
 
-#: include/global_settings.php:1573
+#: include/global_settings.php:1577
 msgid "Data Collector Replication"
 msgstr ""
 
-#: include/global_settings.php:1578
+#: include/global_settings.php:1582
 msgid "Poller Sync Interval"
 msgstr ""
 
-#: include/global_settings.php:1579
-msgid "The default polling sync interval to use when creating a poller.  This setting will affect how often remote pollers are checked and updated."
+#: include/global_settings.php:1583
+msgid ""
+"The default polling sync interval to use when creating a poller.  This "
+"setting will affect how often remote pollers are checked and updated."
 msgstr ""
 
-#: include/global_settings.php:1585
+#: include/global_settings.php:1589
 msgid "Disable Resource Cache Replication"
 msgstr ""
 
-#: include/global_settings.php:1586
-msgid "By default, the main Cacti Data Collector will cache the entire web site and plugins into a Resource Cache.  Then, periodically the Remote Data Collectors will update themselves with any updates from the main Cacti Data Collector.  This Resource Cache essentially allows Remote Data Collectors to self upgrade.  If you do not wish to use this option, you can disable it using this setting."
+#: include/global_settings.php:1590
+msgid ""
+"By default, the main Cacti Data Collector will cache the entire web site and "
+"plugins into a Resource Cache.  Then, periodically the Remote Data "
+"Collectors will update themselves with any updates from the main Cacti Data "
+"Collector.  This Resource Cache essentially allows Remote Data Collectors to "
+"self upgrade.  If you do not wish to use this option, you can disable it "
+"using this setting."
 msgstr ""
 
-#: include/global_settings.php:1591
+#: include/global_settings.php:1595
 msgid "Disable Automatic Full Sync on Upgrade"
 msgstr ""
 
-#: include/global_settings.php:1592
-msgid "By default, upon upgrading the Main Cacti system, it will perform a Full Sync to all Data Collectors.  This process may be time consuming.  Therefore, to allow upgrades to be completed quicker, we provide this option.  Note that if this is disabled, the Cacti administrator must force this process from the Data Collectors interface after upgrade."
+#: include/global_settings.php:1596
+msgid ""
+"By default, upon upgrading the Main Cacti system, it will perform a Full "
+"Sync to all Data Collectors.  This process may be time consuming.  "
+"Therefore, to allow upgrades to be completed quicker, we provide this "
+"option.  Note that if this is disabled, the Cacti administrator must force "
+"this process from the Data Collectors interface after upgrade."
 msgstr ""
 
-#: include/global_settings.php:1597
+#: include/global_settings.php:1601
 msgid "Additional Data Collector Settings"
 msgstr ""
 
-#: include/global_settings.php:1602
+#: include/global_settings.php:1606
 msgid "Invalid Data Logging"
 msgstr ""
 
-#: include/global_settings.php:1603
-msgid "How would you like the Data Collector output errors logged?  Options include: 'Detailed' which details every error, 'Summary' which provides the number of output errors per Device, and 'None', which does not provide error counts."
+#: include/global_settings.php:1607
+msgid ""
+"How would you like the Data Collector output errors logged?  Options "
+"include: 'Detailed' which details every error, 'Summary' which provides the "
+"number of output errors per Device, and 'None', which does not provide error "
+"counts."
 msgstr ""
 
-#: include/global_settings.php:1608 support.php:79
+#: include/global_settings.php:1612 support.php:79
 msgid "Summary"
 msgstr ""
 
-#: include/global_settings.php:1609
+#: include/global_settings.php:1613
 msgid "Detailed"
 msgstr ""
 
-#: include/global_settings.php:1613
+#: include/global_settings.php:1617
 msgid "Number of PHP Script Servers"
 msgstr ""
 
-#: include/global_settings.php:1614
-msgid "The number of concurrent script server processes to run per spine process.  Settings between 1 and 15 are accepted.  This parameter will help if you are running several threads and script server scripts and is only valid for the spine Data Collector."
+#: include/global_settings.php:1618
+msgid ""
+"The number of concurrent script server processes to run per spine process.  "
+"Settings between 1 and 15 are accepted.  This parameter will help if you are "
+"running several threads and script server scripts and is only valid for the "
+"spine Data Collector."
 msgstr ""
 
-#: include/global_settings.php:1621
+#: include/global_settings.php:1625
 msgid "Script and Script Server Timeout Value"
 msgstr ""
 
-#: include/global_settings.php:1622
-msgid "The maximum time that spine will wait on a script to complete.  This timeout value is in seconds and valid for both cmd.php and spine Data Collectors."
+#: include/global_settings.php:1626
+msgid ""
+"The maximum time that spine will wait on a script to complete.  This timeout "
+"value is in seconds and valid for both cmd.php and spine Data Collectors."
 msgstr ""
 
-#: include/global_settings.php:1629
+#: include/global_settings.php:1633
 msgid "Poller Output Not Empty Debouncing"
 msgstr ""
 
-#: include/global_settings.php:1630
-msgid "If you are having issues with some data sources, your Email could be flooded with 'Poller Output Not Empty' warnings.  If this is happening, you can debounce the setting based upon this interval."
+#: include/global_settings.php:1634
+msgid ""
+"If you are having issues with some data sources, your Email could be flooded "
+"with 'Poller Output Not Empty' warnings.  If this is happening, you can "
+"debounce the setting based upon this interval."
 msgstr ""
 
-#: include/global_settings.php:1636
+#: include/global_settings.php:1640
 msgid "Periodic All Device Re-Index"
 msgstr ""
 
-#: include/global_settings.php:1641
+#: include/global_settings.php:1645
 msgid "Re-Index All Device Schedule"
 msgstr ""
 
-#: include/global_settings.php:1642
-msgid "At what frequency do you wish to Re-Index all Devices.  This Re-Index will occur at midnight at the frequency that you select."
+#: include/global_settings.php:1646
+msgid ""
+"At what frequency do you wish to Re-Index all Devices.  This Re-Index will "
+"occur at midnight at the frequency that you select."
 msgstr ""
 
-#: include/global_settings.php:1648
+#: include/global_settings.php:1652
 msgid "Weekly on Sunday"
 msgstr ""
 
-#: include/global_settings.php:1649
+#: include/global_settings.php:1653
 msgid "Monthly on Sunday"
 msgstr ""
 
-#: include/global_settings.php:1653
+#: include/global_settings.php:1657
 msgid "Runtime Variation/Deviance Settings"
 msgstr ""
 
-#: include/global_settings.php:1658
+#: include/global_settings.php:1662
 msgid "One Hour Count Warning Threshold"
 msgstr ""
 
-#: include/global_settings.php:1659
-msgid "When the Poller Guarded Ratio (below) is reached breached more than this many times in an hour, a warning will be written to the Cacti log and an Email will be sent to the Primary Cact Administraror notifying them of the Poller runtime deviation."
+#: include/global_settings.php:1663
+msgid ""
+"When the Poller Guarded Ratio (below) is reached breached more than this "
+"many times in an hour, a warning will be written to the Cacti log and an "
+"Email will be sent to the Primary Cact Administraror notifying them of the "
+"Poller runtime deviation."
 msgstr ""
 
-#: include/global_settings.php:1664
+#: include/global_settings.php:1668
 #, php-format
 msgid "%d Poller Cycle"
 msgstr ""
 
-#: include/global_settings.php:1665 include/global_settings.php:1666
-#: include/global_settings.php:1667 include/global_settings.php:1668
 #: include/global_settings.php:1669 include/global_settings.php:1670
 #: include/global_settings.php:1671 include/global_settings.php:1672
-#: include/global_settings.php:1673
+#: include/global_settings.php:1673 include/global_settings.php:1674
+#: include/global_settings.php:1675 include/global_settings.php:1676
+#: include/global_settings.php:1677
 #, php-format
 msgid "%d Poller Cycles"
 msgstr ""
 
-#: include/global_settings.php:1677
+#: include/global_settings.php:1681
 msgid "One Hour Guarded Poller Ratio average/max Runtime"
 msgstr ""
 
-#: include/global_settings.php:1678 include/global_settings.php:1692
-msgid "Define a Guarded Poller Ratio average/max runtime (in percent).  Cacti will track breaches in these statistics and issue warnings to the Primary Cacti Administrator via Email when they happen."
+#: include/global_settings.php:1682 include/global_settings.php:1696
+msgid ""
+"Define a Guarded Poller Ratio average/max runtime (in percent).  Cacti will "
+"track breaches in these statistics and issue warnings to the Primary Cacti "
+"Administrator via Email when they happen."
 msgstr ""
 
-#: include/global_settings.php:1683 include/global_settings.php:1684
-#: include/global_settings.php:1685 include/global_settings.php:1686
-#: include/global_settings.php:1687 include/global_settings.php:1697
-#: include/global_settings.php:1698 include/global_settings.php:1699
-#: include/global_settings.php:1700 include/global_settings.php:1701
+#: include/global_settings.php:1687 include/global_settings.php:1688
+#: include/global_settings.php:1689 include/global_settings.php:1690
+#: include/global_settings.php:1691 include/global_settings.php:1701
+#: include/global_settings.php:1702 include/global_settings.php:1703
+#: include/global_settings.php:1704 include/global_settings.php:1705
 #, php-format
 msgid "%d Percent"
 msgstr ""
 
-#: include/global_settings.php:1691
+#: include/global_settings.php:1695
 msgid "24 Hour Guarded Poller Ratio average/max Runtime"
 msgstr ""
 
-#: include/global_settings.php:1713
+#: include/global_settings.php:1717
 msgid "Max Running Tasks"
 msgstr ""
 
-#: include/global_settings.php:1714
-msgid "The maximum number of concurrent scheduled tasks allowed to run concurrently."
+#: include/global_settings.php:1718
+msgid ""
+"The maximum number of concurrent scheduled tasks allowed to run concurrently."
 msgstr ""
 
-#: include/global_settings.php:1718
+#: include/global_settings.php:1722
 msgid "1 Scheduled Task"
 msgstr ""
 
-#: include/global_settings.php:1719 include/global_settings.php:1720
-#: include/global_settings.php:1721 include/global_settings.php:1722
 #: include/global_settings.php:1723 include/global_settings.php:1724
 #: include/global_settings.php:1725 include/global_settings.php:1726
-#: include/global_settings.php:1727
+#: include/global_settings.php:1727 include/global_settings.php:1728
+#: include/global_settings.php:1729 include/global_settings.php:1730
+#: include/global_settings.php:1731
 #, php-format
 msgid "%d Scheduled Tasks"
 msgstr ""
 
-#: include/global_settings.php:1731
+#: include/global_settings.php:1735
 msgid "Default Maximum Task Runtime"
 msgstr ""
 
-#: include/global_settings.php:1732
-msgid "The maximum amount of time a Scheduled Task can run without generating a timeout error and being killed."
+#: include/global_settings.php:1736
+msgid ""
+"The maximum amount of time a Scheduled Task can run without generating a "
+"timeout error and being killed."
 msgstr ""
 
-#: include/global_settings.php:1736 include/global_settings.php:1756
-#: include/global_settings.php:1784 include/global_settings.php:1825
-#: include/global_settings.php:1839
+#: include/global_settings.php:1740 include/global_settings.php:1760
+#: include/global_settings.php:1788 include/global_settings.php:1829
+#: include/global_settings.php:1843
 #, php-format
 msgid "%s Minute"
 msgstr ""
 
-#: include/global_settings.php:1745
+#: include/global_settings.php:1749
 msgid "Miscelanious Task Parallelism and Timeouts"
 msgstr ""
 
-#: include/global_settings.php:1748
-msgid "For Tasks not managed by the Cacti Scheduler, there are their parallelism and timeout settings"
+#: include/global_settings.php:1752
+msgid ""
+"For Tasks not managed by the Cacti Scheduler, there are their parallelism "
+"and timeout settings"
 msgstr ""
 
-#: include/global_settings.php:1751
+#: include/global_settings.php:1755
 msgid "Data Source Statistics Timeout"
 msgstr ""
 
-#: include/global_settings.php:1752
-msgid "The maximum amount of time Cacti's Data Source Statistics script can run without generating a timeout error and being killed."
+#: include/global_settings.php:1756
+msgid ""
+"The maximum amount of time Cacti's Data Source Statistics script can run "
+"without generating a timeout error and being killed."
 msgstr ""
 
-#: include/global_settings.php:1766
+#: include/global_settings.php:1770
 msgid "RRDChecker Timeout"
 msgstr ""
 
-#: include/global_settings.php:1767
-msgid "The maximum amount of time Cacti's RRDfile Check script can run without generating a timeout error and being killed."
+#: include/global_settings.php:1771
+msgid ""
+"The maximum amount of time Cacti's RRDfile Check script can run without "
+"generating a timeout error and being killed."
 msgstr ""
 
-#: include/global_settings.php:1773 include/global_settings.php:1830
-#: include/global_settings.php:1844
+#: include/global_settings.php:1777 include/global_settings.php:1834
+#: include/global_settings.php:1848
 #, php-format
 msgid "%s Hour"
 msgstr ""
 
-#: include/global_settings.php:1779
+#: include/global_settings.php:1783
 msgid "Poller Commands Timeout"
 msgstr ""
 
-#: include/global_settings.php:1780
-msgid "The maximum amount of time Cacti's Background Commands script can run without generating a timeout error and being killed.  This script will perform tasks such as re-indexing Devices and pruning devices from Remote Data Collectors."
+#: include/global_settings.php:1784
+msgid ""
+"The maximum amount of time Cacti's Background Commands script can run "
+"without generating a timeout error and being killed.  This script will "
+"perform tasks such as re-indexing Devices and pruning devices from Remote "
+"Data Collectors."
 msgstr ""
 
-#: include/global_settings.php:1792
+#: include/global_settings.php:1796
 msgid "Poller Command Concurrent Processes"
 msgstr ""
 
-#: include/global_settings.php:1793
-msgid "The number of concurrent Poller Command processes.  The will be at most one concurrent command per host within the Poller Command pool."
+#: include/global_settings.php:1797
+msgid ""
+"The number of concurrent Poller Command processes.  The will be at most one "
+"concurrent command per host within the Poller Command pool."
 msgstr ""
 
-#: include/global_settings.php:1797 include/global_settings.php:2510
-#: include/global_settings.php:2635 include/global_settings.php:2742
+#: include/global_settings.php:1801 include/global_settings.php:2514
+#: include/global_settings.php:2639 include/global_settings.php:2746
 msgid "1 Process"
 msgstr ""
 
-#: include/global_settings.php:1798 include/global_settings.php:1799
-#: include/global_settings.php:1800 include/global_settings.php:1801
 #: include/global_settings.php:1802 include/global_settings.php:1803
 #: include/global_settings.php:1804 include/global_settings.php:1805
 #: include/global_settings.php:1806 include/global_settings.php:1807
@@ -12717,9 +13688,9 @@ msgstr ""
 #: include/global_settings.php:1810 include/global_settings.php:1811
 #: include/global_settings.php:1812 include/global_settings.php:1813
 #: include/global_settings.php:1814 include/global_settings.php:1815
-#: include/global_settings.php:1816 include/global_settings.php:2511
-#: include/global_settings.php:2512 include/global_settings.php:2513
-#: include/global_settings.php:2514 include/global_settings.php:2515
+#: include/global_settings.php:1816 include/global_settings.php:1817
+#: include/global_settings.php:1818 include/global_settings.php:1819
+#: include/global_settings.php:1820 include/global_settings.php:2515
 #: include/global_settings.php:2516 include/global_settings.php:2517
 #: include/global_settings.php:2518 include/global_settings.php:2519
 #: include/global_settings.php:2520 include/global_settings.php:2521
@@ -12727,8 +13698,8 @@ msgstr ""
 #: include/global_settings.php:2524 include/global_settings.php:2525
 #: include/global_settings.php:2526 include/global_settings.php:2527
 #: include/global_settings.php:2528 include/global_settings.php:2529
-#: include/global_settings.php:2636 include/global_settings.php:2637
-#: include/global_settings.php:2638 include/global_settings.php:2639
+#: include/global_settings.php:2530 include/global_settings.php:2531
+#: include/global_settings.php:2532 include/global_settings.php:2533
 #: include/global_settings.php:2640 include/global_settings.php:2641
 #: include/global_settings.php:2642 include/global_settings.php:2643
 #: include/global_settings.php:2644 include/global_settings.php:2645
@@ -12736,9 +13707,9 @@ msgstr ""
 #: include/global_settings.php:2648 include/global_settings.php:2649
 #: include/global_settings.php:2650 include/global_settings.php:2651
 #: include/global_settings.php:2652 include/global_settings.php:2653
-#: include/global_settings.php:2654 include/global_settings.php:2743
-#: include/global_settings.php:2744 include/global_settings.php:2745
-#: include/global_settings.php:2746 include/global_settings.php:2747
+#: include/global_settings.php:2654 include/global_settings.php:2655
+#: include/global_settings.php:2656 include/global_settings.php:2657
+#: include/global_settings.php:2658 include/global_settings.php:2747
 #: include/global_settings.php:2748 include/global_settings.php:2749
 #: include/global_settings.php:2750 include/global_settings.php:2751
 #: include/global_settings.php:2752 include/global_settings.php:2753
@@ -12746,1409 +13717,1610 @@ msgstr ""
 #: include/global_settings.php:2756 include/global_settings.php:2757
 #: include/global_settings.php:2758 include/global_settings.php:2759
 #: include/global_settings.php:2760 include/global_settings.php:2761
+#: include/global_settings.php:2762 include/global_settings.php:2763
+#: include/global_settings.php:2764 include/global_settings.php:2765
 #, php-format
 msgid "%d Processes"
 msgstr ""
 
-#: include/global_settings.php:1820
+#: include/global_settings.php:1824
 msgid "Maintenance Background Generation Timeout"
 msgstr ""
 
-#: include/global_settings.php:1821
-msgid "The maximum amount of time a Cacti's Maintenance script can run without generating a timeout error and being killed."
+#: include/global_settings.php:1825
+msgid ""
+"The maximum amount of time a Cacti's Maintenance script can run without "
+"generating a timeout error and being killed."
 msgstr ""
 
-#: include/global_settings.php:1834
+#: include/global_settings.php:1838
 msgid "Spikekill Background Generation Timeout"
 msgstr ""
 
-#: include/global_settings.php:1835
-msgid "The maximum amount of time a Cacti's Spikekill script can run without generating a timeout error and being killed."
+#: include/global_settings.php:1839
+msgid ""
+"The maximum amount of time a Cacti's Spikekill script can run without "
+"generating a timeout error and being killed."
 msgstr ""
 
-#: include/global_settings.php:1859
+#: include/global_settings.php:1863
 msgid "Authentication Method"
 msgstr ""
 
-#: include/global_settings.php:1860
-msgid "<blockquote><i>Built-in Authentication</i> - Cacti handles user authentication, which allows you to create users and give them rights to different areas within Cacti.<br><br><i>Web Basic Authentication</i> - Authentication is handled by the web server. Users can be added or created automatically on first login if the Template User is defined, otherwise the defined guest permissions will be used.<br><br><i>LDAP Authentication</i> - Allows for authentication against a LDAP server. Users will be created automatically on first login if the Template User is defined, otherwise the defined guest permissions will be used.  If PHPs LDAP module is not enabled, LDAP Authentication will not appear as a selectable option.<br><br><i>Multiple LDAP/AD Domain Authentication</i> - Allows administrators to support multiple disparate groups from different LDAP/AD directories to access Cacti resources.  Just as LDAP Authentication, the PHP LDAP module is required to utilize this method.</blockquote>"
+#: include/global_settings.php:1864
+msgid ""
+"<blockquote><i>Built-in Authentication</i> - Cacti handles user "
+"authentication, which allows you to create users and give them rights to "
+"different areas within Cacti.<br><br><i>Web Basic Authentication</i> - "
+"Authentication is handled by the web server. Users can be added or created "
+"automatically on first login if the Template User is defined, otherwise the "
+"defined guest permissions will be used.<br><br><i>LDAP Authentication</i> - "
+"Allows for authentication against a LDAP server. Users will be created "
+"automatically on first login if the Template User is defined, otherwise the "
+"defined guest permissions will be used.  If PHPs LDAP module is not enabled, "
+"LDAP Authentication will not appear as a selectable option."
+"<br><br><i>Multiple LDAP/AD Domain Authentication</i> - Allows "
+"administrators to support multiple disparate groups from different LDAP/AD "
+"directories to access Cacti resources.  Just as LDAP Authentication, the PHP "
+"LDAP module is required to utilize this method.</blockquote>"
 msgstr ""
 
-#: include/global_settings.php:1866
+#: include/global_settings.php:1870
 msgid "Support Authentication Cookies"
 msgstr ""
 
-#: include/global_settings.php:1867
-msgid "If a user authenticates and selects 'Keep me signed in', an authentication cookie will be created on the user's computer allowing that user to stay logged in.  The authentication cookie expires after 90 days of non-use.  Note, the client must use HTTPS to leverage this feature."
+#: include/global_settings.php:1871
+msgid ""
+"If a user authenticates and selects 'Keep me signed in', an authentication "
+"cookie will be created on the user's computer allowing that user to stay "
+"logged in.  The authentication cookie expires after 90 days of non-use.  "
+"Note, the client must use HTTPS to leverage this feature."
 msgstr ""
 
-#: include/global_settings.php:1872
+#: include/global_settings.php:1876
 msgid "Maintenance Settings"
 msgstr ""
 
-#: include/global_settings.php:1877
+#: include/global_settings.php:1881
 msgid "Maintenance Lockout Type"
 msgstr ""
 
-#: include/global_settings.php:1878
-msgid "When the Cacti system is locked out for maintenance, how do you want the maintenance enforced?"
+#: include/global_settings.php:1882
+msgid ""
+"When the Cacti system is locked out for maintenance, how do you want the "
+"maintenance enforced?"
 msgstr ""
 
-#: include/global_settings.php:1882
+#: include/global_settings.php:1886
 msgid "Disable Cacti Lockout Feature"
 msgstr ""
 
-#: include/global_settings.php:1883
+#: include/global_settings.php:1887
 msgid "Primary Admin (all logins)"
 msgstr ""
 
-#: include/global_settings.php:1884
+#: include/global_settings.php:1888
 msgid "Primary Admin (lockout session only)"
 msgstr ""
 
-#: include/global_settings.php:1888
+#: include/global_settings.php:1892
 msgid "Special Users"
 msgstr ""
 
-#: include/global_settings.php:1893
+#: include/global_settings.php:1897
 msgid "Primary Admin"
 msgstr ""
 
-#: include/global_settings.php:1894
-msgid "The name of the primary administrative account that will automatically receive Emails when the Cacti system experiences issues.  To receive these Emails, ensure that your mail settings are correct, and the administrative account has an Email address that is set."
+#: include/global_settings.php:1898
+msgid ""
+"The name of the primary administrative account that will automatically "
+"receive Emails when the Cacti system experiences issues.  To receive these "
+"Emails, ensure that your mail settings are correct, and the administrative "
+"account has an Email address that is set."
 msgstr ""
 
-#: include/global_settings.php:1896 include/global_settings.php:1904
-#: include/global_settings.php:1912 user_domains.php:313
+#: include/global_settings.php:1900 include/global_settings.php:1908
+#: include/global_settings.php:1916 user_domains.php:313
 msgid "No User"
 msgstr ""
 
-#: include/global_settings.php:1901
+#: include/global_settings.php:1905
 msgid "Guest User"
 msgstr ""
 
-#: include/global_settings.php:1902
+#: include/global_settings.php:1906
 msgid "The name of the guest user for viewing graphs; is 'No User' by default."
 msgstr ""
 
-#: include/global_settings.php:1909 user_domains.php:309
+#: include/global_settings.php:1913 user_domains.php:309
 msgid "User Template"
 msgstr ""
 
-#: include/global_settings.php:1910
-msgid "The name of the user that Cacti will use as a template for new Web Basic and LDAP users; is 'guest' by default.  This user account will be disabled from logging in upon being selected."
+#: include/global_settings.php:1914
+msgid ""
+"The name of the user that Cacti will use as a template for new Web Basic and "
+"LDAP users; is 'guest' by default.  This user account will be disabled from "
+"logging in upon being selected."
 msgstr ""
 
-#: include/global_settings.php:1917
+#: include/global_settings.php:1921
 msgid "Account Locking"
 msgstr ""
 
-#: include/global_settings.php:1922
+#: include/global_settings.php:1926
 msgid "Lock Accounts"
 msgstr ""
 
-#: include/global_settings.php:1923
+#: include/global_settings.php:1927
 msgid "Lock an account after this many failed attempts in 1 hour."
 msgstr ""
 
-#: include/global_settings.php:1928
+#: include/global_settings.php:1932
 msgid "1 Attempt"
 msgstr ""
 
-#: include/global_settings.php:1929 include/global_settings.php:1930
-#: include/global_settings.php:1931 include/global_settings.php:1932
-#: include/global_settings.php:1933
+#: include/global_settings.php:1933 include/global_settings.php:1934
+#: include/global_settings.php:1935 include/global_settings.php:1936
+#: include/global_settings.php:1937
 #, php-format
 msgid "%d Attempts"
 msgstr ""
 
-#: include/global_settings.php:1937
+#: include/global_settings.php:1941
 msgid "Auto Unlock"
 msgstr ""
 
-#: include/global_settings.php:1938
-msgid "An account will automatically be unlocked after this many minutes.  Even if the correct password is entered, the account will not unlock until this time limit has been met.  Max of 1440 minutes (1 Day)"
+#: include/global_settings.php:1942
+msgid ""
+"An account will automatically be unlocked after this many minutes.  Even if "
+"the correct password is entered, the account will not unlock until this time "
+"limit has been met.  Max of 1440 minutes (1 Day)"
 msgstr ""
 
-#: include/global_settings.php:1954 include/global_settings.php:3423
+#: include/global_settings.php:1958 include/global_settings.php:3381
 msgid "1 Day"
 msgstr ""
 
-#: include/global_settings.php:1958
+#: include/global_settings.php:1962
 msgid "Pwned Checks (Online)"
 msgstr ""
 
-#: include/global_settings.php:1963
+#: include/global_settings.php:1967
 msgid "Pwned Check"
 msgstr ""
 
-#: include/global_settings.php:1964
+#: include/global_settings.php:1968
 msgid "Check password against haveibeenpwned.com"
 msgstr ""
 
-#: include/global_settings.php:1969
+#: include/global_settings.php:1973
 msgid "Pwned Threshold"
 msgstr ""
 
-#: include/global_settings.php:1970
+#: include/global_settings.php:1974
 msgid "Block use of a password once it reaches this reported usage level"
 msgstr ""
 
-#: include/global_settings.php:1977
+#: include/global_settings.php:1981
 msgid "Localized 2FA"
 msgstr ""
 
-#: include/global_settings.php:1982
+#: include/global_settings.php:1986
 msgid "Enable Localized 2FA"
 msgstr ""
 
-#: include/global_settings.php:1983
-msgid "Check this option if you wish users to locally enable Two Factor Authentication for their accounts.  Note that most Enterprise level MFA does not require intervention by the Cacti Administrator."
+#: include/global_settings.php:1987
+msgid ""
+"Check this option if you wish users to locally enable Two Factor "
+"Authentication for their accounts.  Note that most Enterprise level MFA does "
+"not require intervention by the Cacti Administrator."
 msgstr ""
 
-#: include/global_settings.php:1988
+#: include/global_settings.php:1992
 msgid "Token Lifetime"
 msgstr ""
 
-#: include/global_settings.php:1989
-msgid "How long the Two Factor Auth Token lasts before being rechecked up to a max of 1 week."
+#: include/global_settings.php:1993
+msgid ""
+"How long the Two Factor Auth Token lasts before being rechecked up to a max "
+"of 1 week."
 msgstr ""
 
-#: include/global_settings.php:2003
+#: include/global_settings.php:2007
 msgid "Basic Authentication Settings"
 msgstr ""
 
-#: include/global_settings.php:2008
+#: include/global_settings.php:2012
 msgid "Basic Auth Login Failure Message"
 msgstr ""
 
-#: include/global_settings.php:2009
-msgid "When using basic authentication, if there are issues mapping the username to a valid Cacti account, the message included here will be displayed to users.  It can include both text and HTML."
+#: include/global_settings.php:2013
+msgid ""
+"When using basic authentication, if there are issues mapping the username to "
+"a valid Cacti account, the message included here will be displayed to "
+"users.  It can include both text and HTML."
 msgstr ""
 
-#: include/global_settings.php:2016
+#: include/global_settings.php:2020
 msgid "Basic Auth Mapfile"
 msgstr ""
 
-#: include/global_settings.php:2017
-msgid "When using basic authentication, if the basic account needs to be translated to a different login account, you can specify a CSV file here to map the basic account to the desired login account."
+#: include/global_settings.php:2021
+msgid ""
+"When using basic authentication, if the basic account needs to be translated "
+"to a different login account, you can specify a CSV file here to map the "
+"basic account to the desired login account."
 msgstr ""
 
-#: include/global_settings.php:2025
+#: include/global_settings.php:2029
 msgid "Local Account Complexity Requirements"
 msgstr ""
 
-#: include/global_settings.php:2030
+#: include/global_settings.php:2034
 msgid "Minimum Length"
 msgstr ""
 
-#: include/global_settings.php:2031
+#: include/global_settings.php:2035
 msgid "This is minimal length of allowed passwords."
 msgstr ""
 
-#: include/global_settings.php:2038
+#: include/global_settings.php:2042
 msgid "Require Mix Case"
 msgstr ""
 
-#: include/global_settings.php:2039
-msgid "This will require new passwords to contains both lower and upper-case characters."
+#: include/global_settings.php:2043
+msgid ""
+"This will require new passwords to contains both lower and upper-case "
+"characters."
 msgstr ""
 
-#: include/global_settings.php:2044
+#: include/global_settings.php:2048
 msgid "Require Number"
 msgstr ""
 
-#: include/global_settings.php:2045
-msgid "This will require new passwords to contain at least 1 numerical character."
+#: include/global_settings.php:2049
+msgid ""
+"This will require new passwords to contain at least 1 numerical character."
 msgstr ""
 
-#: include/global_settings.php:2050
+#: include/global_settings.php:2054
 msgid "Require Special Character"
 msgstr ""
 
-#: include/global_settings.php:2051
-msgid "This will require new passwords to contain at least 1 special character."
+#: include/global_settings.php:2055
+msgid ""
+"This will require new passwords to contain at least 1 special character."
 msgstr ""
 
-#: include/global_settings.php:2056
+#: include/global_settings.php:2060
 msgid "Force Complexity Upon Old Passwords"
 msgstr ""
 
-#: include/global_settings.php:2057
-msgid "This will require all old passwords to also meet the new complexity requirements upon login.  If not met, it will force a password change."
+#: include/global_settings.php:2061
+msgid ""
+"This will require all old passwords to also meet the new complexity "
+"requirements upon login.  If not met, it will force a password change."
 msgstr ""
 
-#: include/global_settings.php:2062
+#: include/global_settings.php:2066
 msgid "Expire Inactive Accounts"
 msgstr ""
 
-#: include/global_settings.php:2063
-msgid "This is maximum number of days before inactive accounts are disabled.  The Admin account is excluded from this policy."
+#: include/global_settings.php:2067
+msgid ""
+"This is maximum number of days before inactive accounts are disabled.  The "
+"Admin account is excluded from this policy."
 msgstr ""
 
-#: include/global_settings.php:2077
+#: include/global_settings.php:2081
 msgid "Expire Password"
 msgstr ""
 
-#: include/global_settings.php:2078
+#: include/global_settings.php:2082
 msgid "This is maximum number of days before a password is set to expire."
 msgstr ""
 
-#: include/global_settings.php:2090
+#: include/global_settings.php:2094
 msgid "Password History"
 msgstr ""
 
-#: include/global_settings.php:2091
-msgid "Remember this number of old passwords and disallow re-using them."
+#: include/global_settings.php:2095
+msgid "Remember this number of old passwords and disallow reusing them."
 msgstr ""
 
-#: include/global_settings.php:2096
+#: include/global_settings.php:2100
 msgid "1 Change"
 msgstr ""
 
-#: include/global_settings.php:2097 include/global_settings.php:2098
-#: include/global_settings.php:2099 include/global_settings.php:2100
 #: include/global_settings.php:2101 include/global_settings.php:2102
 #: include/global_settings.php:2103 include/global_settings.php:2104
 #: include/global_settings.php:2105 include/global_settings.php:2106
-#: include/global_settings.php:2107
+#: include/global_settings.php:2107 include/global_settings.php:2108
+#: include/global_settings.php:2109 include/global_settings.php:2110
+#: include/global_settings.php:2111
 #, php-format
 msgid "%d Changes"
 msgstr ""
 
-#: include/global_settings.php:2111
+#: include/global_settings.php:2115
 msgid "Account Email Notification"
 msgstr ""
 
-#: include/global_settings.php:2116
+#: include/global_settings.php:2120
 msgid "Send email to new user"
 msgstr ""
 
-#: include/global_settings.php:2117
-msgid "When an admin creates a new account and an email address is entered, send an informational email to it."
+#: include/global_settings.php:2121
+msgid ""
+"When an admin creates a new account and an email address is entered, send an "
+"informational email to it."
 msgstr ""
 
-#: include/global_settings.php:2122
+#: include/global_settings.php:2126
 msgid "Subject of new account message"
 msgstr ""
 
-#: include/global_settings.php:2123
+#: include/global_settings.php:2127
 msgid "This is the Email subject that will be used for a new account message."
 msgstr ""
 
-#: include/global_settings.php:2130
+#: include/global_settings.php:2134
 msgid "Email body for new account message"
 msgstr ""
 
-#: include/global_settings.php:2131
-msgid "This is the message that will be send to new user account. Max 1024 characters. HTML is allowed. There are several common replacement tags that may be used in include &#060CACTIURL&#062 &#060USERNAME&#062 &#060PASSWORD&#062"
-msgstr ""
-
-#: include/global_settings.php:2136
-msgid "New Cacti account created. <br>Server: <a href=\"<CACTIURL>\"><CACTIURL></a><br>Username: <USERNAME><br>To login and set a new password, click the <a href=\"<PWDRESETLINK>\">password reset link</a><br><br>"
-msgstr ""
-
-#: include/global_settings.php:2139
-msgid "Send email when an admin changes an account password"
+#: include/global_settings.php:2135
+msgid ""
+"This is the message that will be send to new user account. Max 1024 "
+"characters. HTML is allowed. There are several common replacement tags that "
+"may be used in include &#060CACTIURL&#062 &#060USERNAME&#062 "
+"&#060PASSWORD&#062"
 msgstr ""
 
 #: include/global_settings.php:2140
-msgid "When an admin changes the password of an account and the email address for that account is entered, an informational email will be sent to that address."
+msgid ""
+"New Cacti account created. <br>Server: <a href=\"<CACTIURL>\"><CACTIURL></"
+"a><br>Username: <USERNAME><br>To login and set a new password, click the <a "
+"href=\"<PWDRESETLINK>\">password reset link</a><br><br>"
 msgstr ""
 
-#: include/global_settings.php:2145
+#: include/global_settings.php:2143
+msgid "Send email when an admin changes an account password"
+msgstr ""
+
+#: include/global_settings.php:2144
+msgid ""
+"When an admin changes the password of an account and the email address for "
+"that account is entered, an informational email will be sent to that address."
+msgstr ""
+
+#: include/global_settings.php:2149
 msgid "Subject of password reset message"
 msgstr ""
 
-#: include/global_settings.php:2146
-msgid "This is the Email subject that will be used when an admin changes an account password or a user uses 'Forgot password'."
+#: include/global_settings.php:2150
+msgid ""
+"This is the Email subject that will be used when an admin changes an account "
+"password or a user uses 'Forgot password'."
 msgstr ""
 
-#: include/global_settings.php:2148
+#: include/global_settings.php:2152
 msgid "Cacti password reset"
 msgstr ""
 
-#: include/global_settings.php:2153
+#: include/global_settings.php:2157
 msgid "Email body for password reset message"
 msgstr ""
 
-#: include/global_settings.php:2154
-msgid "This is the message that will be sent when a user requests a password reset. Max 1024 characters. HTML is allowed. There are several common replacement tags that may be used in include &#060CACTIURL&#062 &#060USERNAME&#062 &#060PASSWORD&#062"
-msgstr ""
-
-#: include/global_settings.php:2159
-msgid "Your account password has been reset. <br>Server: <a href=\"<CACTIURL>\"><CACTIURL></a><br>Username: <USERNAME><br>To set a new password, click the <a href=\"<PWDRESETLINK>\">password reset link</a><br><br>"
-msgstr ""
-
-#: include/global_settings.php:2162
-msgid "Reset link validity"
+#: include/global_settings.php:2158
+msgid ""
+"This is the message that will be sent when a user requests a password reset. "
+"Max 1024 characters. HTML is allowed. There are several common replacement "
+"tags that may be used in include &#060CACTIURL&#062 &#060USERNAME&#062 "
+"&#060PASSWORD&#062"
 msgstr ""
 
 #: include/global_settings.php:2163
+msgid ""
+"Your account password has been reset. <br>Server: <a "
+"href=\"<CACTIURL>\"><CACTIURL></a><br>Username: <USERNAME><br>To set a new "
+"password, click the <a href=\"<PWDRESETLINK>\">password reset link</"
+"a><br><br>"
+msgstr ""
+
+#: include/global_settings.php:2166
+msgid "Reset link validity"
+msgstr ""
+
+#: include/global_settings.php:2167
 msgid "How long the password reset link is valid in minutes"
 msgstr ""
 
-#: include/global_settings.php:2177
+#: include/global_settings.php:2181
 msgid "URL Linking"
 msgstr ""
 
-#: include/global_settings.php:2182
+#: include/global_settings.php:2186
 msgid "Server Base URL"
 msgstr ""
 
-#: include/global_settings.php:2183
-msgid "This is a the server location that will be used for links to the Cacti site. This should include the subdirectory if Cacti does not run from root folder."
-msgstr ""
-
-#: include/global_settings.php:2190
-msgid "Emailing Options"
+#: include/global_settings.php:2187
+msgid ""
+"This is a the server location that will be used for links to the Cacti site. "
+"This should include the subdirectory if Cacti does not run from root folder."
 msgstr ""
 
 #: include/global_settings.php:2194
+msgid "Emailing Options"
+msgstr ""
+
+#: include/global_settings.php:2198
 msgid "Notify Primary Admin of Issues"
 msgstr ""
 
-#: include/global_settings.php:2195
-msgid "In cases where the Cacti server is experiencing problems, should the Primary Administrator be notified by Email?  The Primary Administrator's Cacti user account is specified under the Authentication tab on Cacti's settings page. It defaults to the 'admin' account."
+#: include/global_settings.php:2199
+msgid ""
+"In cases where the Cacti server is experiencing problems, should the Primary "
+"Administrator be notified by Email?  The Primary Administrator's Cacti user "
+"account is specified under the Authentication tab on Cacti's settings page. "
+"It defaults to the 'admin' account."
 msgstr ""
 
-#: include/global_settings.php:2200
+#: include/global_settings.php:2204
 msgid "Test Email"
 msgstr ""
 
-#: include/global_settings.php:2201
-msgid "This is a Email account used for sending a test message to ensure everything is working properly."
+#: include/global_settings.php:2205
+msgid ""
+"This is a Email account used for sending a test message to ensure everything "
+"is working properly."
 msgstr ""
 
-#: include/global_settings.php:2206
+#: include/global_settings.php:2210
 msgid "Mail Services"
 msgstr ""
 
-#: include/global_settings.php:2207
+#: include/global_settings.php:2211
 msgid "Which mail service to use in order to send mail"
 msgstr ""
 
-#: include/global_settings.php:2213
+#: include/global_settings.php:2217
 msgid "Ping Mail Server"
 msgstr ""
 
-#: include/global_settings.php:2214
+#: include/global_settings.php:2218
 msgid "Ping the Mail Server before sending test Email?"
 msgstr ""
 
-#: include/global_settings.php:2223 lib/html_reports.php:160
+#: include/global_settings.php:2227 lib/html_reports.php:160
 msgid "From Email Address"
 msgstr ""
 
-#: include/global_settings.php:2224
+#: include/global_settings.php:2228
 msgid "This is the Email address that the Email will appear from."
 msgstr ""
 
-#: include/global_settings.php:2229 lib/html_reports.php:152
+#: include/global_settings.php:2233 lib/html_reports.php:152
 msgid "From Name"
 msgstr ""
 
-#: include/global_settings.php:2230
-msgid "This is the actual name that the Email will appear from. Not used for OAuth2 method."
+#: include/global_settings.php:2234
+msgid ""
+"This is the actual name that the Email will appear from. Not used for OAuth2 "
+"method."
 msgstr ""
 
-#: include/global_settings.php:2235
+#: include/global_settings.php:2239
 msgid "Word Wrap"
 msgstr ""
 
-#: include/global_settings.php:2236
-msgid "This is how many characters will be allowed before a line in the Email is automatically word wrapped. (0 = Disabled)"
+#: include/global_settings.php:2240
+msgid ""
+"This is how many characters will be allowed before a line in the Email is "
+"automatically word wrapped. (0 = Disabled)"
 msgstr ""
 
-#: include/global_settings.php:2243
+#: include/global_settings.php:2247
 msgid "Sendmail Options"
 msgstr ""
 
-#: include/global_settings.php:2248 lib/functions.php:5996
+#: include/global_settings.php:2252 lib/functions.php:6065
 msgid "Sendmail Path"
 msgstr ""
 
-#: include/global_settings.php:2249
-msgid "This is the path to sendmail on your server. (Only used if Sendmail is selected as the Mail Service)"
+#: include/global_settings.php:2253
+msgid ""
+"This is the path to sendmail on your server. (Only used if Sendmail is "
+"selected as the Mail Service)"
 msgstr ""
 
-#: include/global_settings.php:2257
+#: include/global_settings.php:2261
 msgid "SMTP Options"
 msgstr ""
 
-#: include/global_settings.php:2262 include/global_settings.php:2362
+#: include/global_settings.php:2266 include/global_settings.php:2366
 msgid "SMTP Hostname"
 msgstr ""
 
-#: include/global_settings.php:2263 include/global_settings.php:2363
-msgid "This is the hostname/IP of the SMTP Server you will send the Email to. For failover, separate your hosts using a semi-colon."
+#: include/global_settings.php:2267 include/global_settings.php:2367
+msgid ""
+"This is the hostname/IP of the SMTP Server you will send the Email to. For "
+"failover, separate your hosts using a semi-colon."
 msgstr ""
 
-#: include/global_settings.php:2269 include/global_settings.php:2369
+#: include/global_settings.php:2273 include/global_settings.php:2373
 msgid "SMTP Port"
 msgstr ""
 
-#: include/global_settings.php:2270 include/global_settings.php:2370
+#: include/global_settings.php:2274 include/global_settings.php:2374
 msgid "The port on the SMTP Server to use."
 msgstr ""
 
-#: include/global_settings.php:2277
+#: include/global_settings.php:2281
 msgid "SMTP Username"
 msgstr ""
 
-#: include/global_settings.php:2278
-msgid "The username to authenticate with when sending via SMTP. (Leave blank if you do not require authentication.)"
+#: include/global_settings.php:2282
+msgid ""
+"The username to authenticate with when sending via SMTP. (Leave blank if you "
+"do not require authentication.)"
 msgstr ""
 
-#: include/global_settings.php:2283
+#: include/global_settings.php:2287
 msgid "SMTP Password"
 msgstr ""
 
-#: include/global_settings.php:2284
-msgid "The password to authenticate with when sending via SMTP. (Leave blank if you do not require authentication.)"
+#: include/global_settings.php:2288
+msgid ""
+"The password to authenticate with when sending via SMTP. (Leave blank if you "
+"do not require authentication.)"
 msgstr ""
 
-#: include/global_settings.php:2289 include/global_settings.php:2377
+#: include/global_settings.php:2293 include/global_settings.php:2381
 msgid "SMTP Security"
 msgstr ""
 
-#: include/global_settings.php:2290 include/global_settings.php:2378
+#: include/global_settings.php:2294 include/global_settings.php:2382
 msgid "The encryption method to use for the Email."
 msgstr ""
 
-#: include/global_settings.php:2294 include/global_settings.php:2382
+#: include/global_settings.php:2298 include/global_settings.php:2386
 msgid "SSL"
 msgstr ""
 
-#: include/global_settings.php:2295 include/global_settings.php:2383
+#: include/global_settings.php:2299 include/global_settings.php:2387
 msgid "TLS"
 msgstr ""
 
-#: include/global_settings.php:2300 include/global_settings.php:2388
+#: include/global_settings.php:2304 include/global_settings.php:2392
 msgid "SMTP Timeout"
 msgstr ""
 
-#: include/global_settings.php:2301 include/global_settings.php:2389
+#: include/global_settings.php:2305 include/global_settings.php:2393
 msgid "Please enter the SMTP timeout in seconds."
 msgstr ""
 
-#: include/global_settings.php:2308
+#: include/global_settings.php:2312
 msgid "OAuth 2 Options"
 msgstr ""
 
-#: include/global_settings.php:2313
+#: include/global_settings.php:2317
 msgid "OAuth2 Provider"
 msgstr ""
 
-#: include/global_settings.php:2314
+#: include/global_settings.php:2318
 msgid "Choose your OAuth2 provider."
 msgstr ""
 
-#: include/global_settings.php:2326
+#: include/global_settings.php:2330
 msgid "Email address connected with your oauth."
 msgstr ""
 
-#: include/global_settings.php:2331
+#: include/global_settings.php:2335
 msgid "OAuth2 Client ID"
 msgstr ""
 
-#: include/global_settings.php:2332
+#: include/global_settings.php:2336
 msgid "Please enter OAuth Client"
 msgstr ""
 
-#: include/global_settings.php:2337
+#: include/global_settings.php:2341
 msgid "OAuth2 Client Secret"
 msgstr ""
 
-#: include/global_settings.php:2338
+#: include/global_settings.php:2342
 msgid "Please enter OAuth secret"
 msgstr ""
 
-#: include/global_settings.php:2343
+#: include/global_settings.php:2347
 msgid "Azure Tenant ID"
 msgstr ""
 
-#: include/global_settings.php:2344
+#: include/global_settings.php:2348
 msgid "Only relevant for Azure"
 msgstr ""
 
-#: include/global_settings.php:2349
+#: include/global_settings.php:2353
 msgid "OAuth2 Redirect URI"
 msgstr ""
 
-#: include/global_settings.php:2350
+#: include/global_settings.php:2354
 msgid "Please check this URI. It could be accessible from internet."
 msgstr ""
 
-#: include/global_settings.php:2356
+#: include/global_settings.php:2360
 msgid "OAuth2 refresh token"
 msgstr ""
 
-#: include/global_settings.php:2357
-msgid "You can insert here OAuth2 refresh token directly, if you know it. Second option is retrieved from oauth2 provider. In this case set correct OAuth2 setting, save setting and open new browser tab or window and go to OAuth2 Redirect URI"
+#: include/global_settings.php:2361
+msgid ""
+"You can insert here OAuth2 refresh token directly, if you know it. Second "
+"option is retrieved from oauth2 provider. In this case set correct OAuth2 "
+"setting, save setting and open new browser tab or window and go to OAuth2 "
+"Redirect URI"
 msgstr ""
 
-#: include/global_settings.php:2396
+#: include/global_settings.php:2400
 msgid "Reporting Presets"
 msgstr ""
 
-#: include/global_settings.php:2401
+#: include/global_settings.php:2405
 msgid "Default Graph Image Format"
 msgstr ""
 
-#: include/global_settings.php:2402
-msgid "When creating a new report, what image type should be used for the inline graphs."
+#: include/global_settings.php:2406
+msgid ""
+"When creating a new report, what image type should be used for the inline "
+"graphs."
 msgstr ""
 
-#: include/global_settings.php:2408
+#: include/global_settings.php:2412
 msgid "Maximum E-Mail Size"
 msgstr ""
 
-#: include/global_settings.php:2409
+#: include/global_settings.php:2413
 msgid "The maximum size of the E-Mail message including all attachments."
 msgstr ""
 
-#: include/global_settings.php:2415
+#: include/global_settings.php:2419
 msgid "Poller Logging Level for Cacti Reporting"
 msgstr ""
 
-#: include/global_settings.php:2416
-msgid "What level of detail do you want sent to the log file. WARNING: Leaving in any other status than NONE or LOW can exhaust your disk space rapidly."
+#: include/global_settings.php:2420
+msgid ""
+"What level of detail do you want sent to the log file. WARNING: Leaving in "
+"any other status than NONE or LOW can exhaust your disk space rapidly."
 msgstr ""
 
-#: include/global_settings.php:2422
+#: include/global_settings.php:2426
 msgid "DNS Options"
 msgstr ""
 
-#: include/global_settings.php:2427
+#: include/global_settings.php:2431
 msgid "Primary DNS IP Address"
 msgstr ""
 
-#: include/global_settings.php:2428
+#: include/global_settings.php:2432
 msgid "Enter the primary DNS IP Address to utilize for reverse lookups."
 msgstr ""
 
-#: include/global_settings.php:2434
+#: include/global_settings.php:2438
 msgid "Secondary DNS IP Address"
 msgstr ""
 
-#: include/global_settings.php:2435
+#: include/global_settings.php:2439
 msgid "Enter the secondary DNS IP Address to utilize for reverse lookups."
 msgstr ""
 
-#: include/global_settings.php:2441
+#: include/global_settings.php:2445
 msgid "DNS Timeout"
 msgstr ""
 
-#: include/global_settings.php:2442
-msgid "Please enter the DNS timeout in milliseconds.  Cacti uses a PHP based DNS resolver."
+#: include/global_settings.php:2446
+msgid ""
+"Please enter the DNS timeout in milliseconds.  Cacti uses a PHP based DNS "
+"resolver."
 msgstr ""
 
-#: include/global_settings.php:2449
+#: include/global_settings.php:2453
 msgid "Internet Proxy Settings"
 msgstr ""
 
-#: include/global_settings.php:2454
+#: include/global_settings.php:2458
 msgid "Internet Proxy Address"
 msgstr ""
 
-#: include/global_settings.php:2455
-msgid "For either core Cacti Services or Plugins that require internet access, enter the proxy server and port here in the following format IP:PORT.  For example 192.168.1.1:8080."
+#: include/global_settings.php:2459
+msgid ""
+"For either core Cacti Services or Plugins that require internet access, "
+"enter the proxy server and port here in the following format IP:PORT.  For "
+"example 192.168.1.1:8080."
 msgstr ""
 
-#: include/global_settings.php:2462
+#: include/global_settings.php:2466
 msgid "Internet Proxy User"
 msgstr ""
 
-#: include/global_settings.php:2463
+#: include/global_settings.php:2467
 msgid "If your Internet Proxy requires a username, enter it here."
 msgstr ""
 
-#: include/global_settings.php:2470
+#: include/global_settings.php:2474
 msgid "Internet Proxy Password"
 msgstr ""
 
-#: include/global_settings.php:2471
+#: include/global_settings.php:2475
 msgid "If your Internet Proxy requires a password, enter it here."
 msgstr ""
 
-#: include/global_settings.php:2481
+#: include/global_settings.php:2485
 msgid "On-demand RRD Update Settings"
 msgstr ""
 
-#: include/global_settings.php:2486
+#: include/global_settings.php:2490
 msgid "Enable On-demand RRD Updating"
 msgstr ""
 
-#: include/global_settings.php:2487
-msgid "Should Boost enable on demand RRD updating in Cacti?  If you disable, this change will not take affect until after the next polling cycle.  When you have Remote Data Collectors, this settings is required to be on."
+#: include/global_settings.php:2491
+msgid ""
+"Should Boost enable on demand RRD updating in Cacti?  If you disable, this "
+"change will not take affect until after the next polling cycle.  When you "
+"have Remote Data Collectors, this settings is required to be on."
 msgstr ""
 
-#: include/global_settings.php:2492
+#: include/global_settings.php:2496
 msgid "System Level RRD Updater"
 msgstr ""
 
-#: include/global_settings.php:2493
-msgid "Before RRD On-demand Update Can be Cleared, a poller run must always pass"
+#: include/global_settings.php:2497
+msgid ""
+"Before RRD On-demand Update Can be Cleared, a poller run must always pass"
 msgstr ""
 
-#: include/global_settings.php:2498
+#: include/global_settings.php:2502
 msgid "How Often Should Boost Update All RRDs"
 msgstr ""
 
-#: include/global_settings.php:2499
-msgid "When you enable boost, your RRD files are only updated when they are requested by a user, or when this time period elapses."
+#: include/global_settings.php:2503
+msgid ""
+"When you enable boost, your RRD files are only updated when they are "
+"requested by a user, or when this time period elapses."
 msgstr ""
 
-#: include/global_settings.php:2505
+#: include/global_settings.php:2509
 msgid "Number of Boost Processes"
 msgstr ""
 
-#: include/global_settings.php:2506
-msgid "The number of concurrent boost processes to use to use to process all of the RRDs in the boost table."
+#: include/global_settings.php:2510
+msgid ""
+"The number of concurrent boost processes to use to use to process all of the "
+"RRDs in the boost table."
 msgstr ""
 
-#: include/global_settings.php:2533
+#: include/global_settings.php:2537
 msgid "Maximum Records"
 msgstr ""
 
-#: include/global_settings.php:2534
-msgid "If the boost output table exceeds this size, in records, an update will take place."
+#: include/global_settings.php:2538
+msgid ""
+"If the boost output table exceeds this size, in records, an update will take "
+"place."
 msgstr ""
 
-#: include/global_settings.php:2541
+#: include/global_settings.php:2545
 msgid "Maximum Data Source Items Per Pass"
 msgstr ""
 
-#: include/global_settings.php:2542
-msgid "To optimize performance, the boost RRD updater needs to know how many Data Source Items should be retrieved in one pass.  Please be careful not to set too high as graphing performance during major updates can be compromised.  If you encounter graphing or polling slowness during updates, lower this number.  The default value is 50000."
+#: include/global_settings.php:2546
+msgid ""
+"To optimize performance, the boost RRD updater needs to know how many Data "
+"Source Items should be retrieved in one pass.  Please be careful not to set "
+"too high as graphing performance during major updates can be compromised.  "
+"If you encounter graphing or polling slowness during updates, lower this "
+"number.  The default value is 50000."
 msgstr ""
 
-#: include/global_settings.php:2548
+#: include/global_settings.php:2552
 msgid "Maximum Argument Length"
 msgstr ""
 
-#: include/global_settings.php:2549
-msgid "When boost sends update commands to RRDtool, it must not exceed the operating systems Maximum Argument Length.  This varies by operating system and kernel level.  For example: Windows 2000 <= 2048, FreeBSD <= 65535, Linux 2.6.22-- <= 131072, Linux 2.6.23++ unlimited"
+#: include/global_settings.php:2553
+msgid ""
+"When boost sends update commands to RRDtool, it must not exceed the "
+"operating systems Maximum Argument Length.  This varies by operating system "
+"and kernel level.  For example: Windows 2000 <= 2048, FreeBSD <= 65535, "
+"Linux 2.6.22-- <= 131072, Linux 2.6.23++ unlimited"
 msgstr ""
 
-#: include/global_settings.php:2556
+#: include/global_settings.php:2560
 msgid "Memory Limit for Boost and Poller"
 msgstr ""
 
-#: include/global_settings.php:2557
+#: include/global_settings.php:2561
 msgid "The maximum amount of memory for the Cacti Poller and Boosts Poller"
 msgstr ""
 
-#: include/global_settings.php:2563
+#: include/global_settings.php:2567
 msgid "Maximum RRD Update Script Run Time"
 msgstr ""
 
-#: include/global_settings.php:2564
-msgid "If the boost poller exceeds this runtime, a warning will be placed in the cacti log,"
+#: include/global_settings.php:2568
+msgid ""
+"If the boost poller exceeds this runtime, a warning will be placed in the "
+"cacti log,"
 msgstr ""
 
-#: include/global_settings.php:2570
+#: include/global_settings.php:2574
 msgid "Enable Direct Population of Boost Table"
 msgstr ""
 
-#: include/global_settings.php:2571
-msgid "Enables direct insert of records into poller output boost table with results in a 25% time reduction in each poll cycle."
+#: include/global_settings.php:2575
+msgid ""
+"Enables direct insert of records into poller output boost table with results "
+"in a 25% time reduction in each poll cycle."
 msgstr ""
 
-#: include/global_settings.php:2576
+#: include/global_settings.php:2580
 msgid "Enable Boost Debugging"
 msgstr ""
 
-#: include/global_settings.php:2577
-msgid "If set, Boost will log debug information directly to the Boost log file.  Please note, enabling can cause a high I/O rate on the local file system."
+#: include/global_settings.php:2581
+msgid ""
+"If set, Boost will log debug information directly to the Boost log file.  "
+"Please note, enabling can cause a high I/O rate on the local file system."
 msgstr ""
 
-#: include/global_settings.php:2582 utilities.php:1475
+#: include/global_settings.php:2586 utilities.php:1475
 msgid "Image Caching"
 msgstr ""
 
-#: include/global_settings.php:2587
+#: include/global_settings.php:2591
 msgid "Enable Image Caching"
 msgstr ""
 
-#: include/global_settings.php:2588
+#: include/global_settings.php:2592
 msgid "Should image caching be enabled?"
 msgstr ""
 
-#: include/global_settings.php:2593
+#: include/global_settings.php:2597
 msgid "Location for Image Files"
 msgstr ""
 
-#: include/global_settings.php:2594
-msgid "Specify the location where Boost should place your image files.  These files will be automatically purged by the poller when they expire."
+#: include/global_settings.php:2598
+msgid ""
+"Specify the location where Boost should place your image files.  These files "
+"will be automatically purged by the poller when they expire."
 msgstr ""
 
-#: include/global_settings.php:2603
+#: include/global_settings.php:2607
 msgid "Data Sources Statistics"
 msgstr ""
 
-#: include/global_settings.php:2608
+#: include/global_settings.php:2612
 msgid "Enable Data Source Statistics Collection"
 msgstr ""
 
-#: include/global_settings.php:2609
+#: include/global_settings.php:2613
 msgid "Should Data Source Statistics be collected for this Cacti system?"
 msgstr ""
 
-#: include/global_settings.php:2614
+#: include/global_settings.php:2618
 msgid "Data Collection Method"
 msgstr ""
 
-#: include/global_settings.php:2615
-msgid "Data Source Statistics can use a legacy method where it will determine peak and average values, or an advanced mode which will calculated several additional statistical values in addition to peak and average.  Using All Statistical Metrics can place additional CPU and IO load on the system."
+#: include/global_settings.php:2619
+msgid ""
+"Data Source Statistics can use a legacy method where it will determine peak "
+"and average values, or an advanced mode which will calculated several "
+"additional statistical values in addition to peak and average.  Using All "
+"Statistical Metrics can place additional CPU and IO load on the system."
 msgstr ""
 
-#: include/global_settings.php:2619
+#: include/global_settings.php:2623
 msgid "Peak/Average Only"
 msgstr ""
 
-#: include/global_settings.php:2620
+#: include/global_settings.php:2624
 msgid "All Statistical Metrics"
 msgstr ""
 
-#: include/global_settings.php:2624
+#: include/global_settings.php:2628
 msgid "Calculate Peaks Stats in Addition to Average Stats"
 msgstr ""
 
-#: include/global_settings.php:2625
-msgid "This option will double the data collection time.  If will use the MAX consolidation function and calculate statistics from the max values in each of the respective time ranges."
+#: include/global_settings.php:2629
+msgid ""
+"This option will double the data collection time.  If will use the MAX "
+"consolidation function and calculate statistics from the max values in each "
+"of the respective time ranges."
 msgstr ""
 
-#: include/global_settings.php:2630
+#: include/global_settings.php:2634
 msgid "Number of DSStats Processes"
 msgstr ""
 
-#: include/global_settings.php:2631
-msgid "The number of concurrent DSStats processes to use to use to process all of the Data Sources."
+#: include/global_settings.php:2635
+msgid ""
+"The number of concurrent DSStats processes to use to use to process all of "
+"the Data Sources."
 msgstr ""
 
-#: include/global_settings.php:2658
+#: include/global_settings.php:2662
 msgid "Daily Update Frequency"
 msgstr ""
 
-#: include/global_settings.php:2659
+#: include/global_settings.php:2663
 msgid "How frequent should Daily Stats be updated?"
 msgstr ""
 
-#: include/global_settings.php:2665
+#: include/global_settings.php:2669
 msgid "Hourly Average Window"
 msgstr ""
 
-#: include/global_settings.php:2666
-msgid "The number of consecutive hours that represent the hourly average.  Keep in mind that a setting too high can result in very large memory tables"
+#: include/global_settings.php:2670
+msgid ""
+"The number of consecutive hours that represent the hourly average.  Keep in "
+"mind that a setting too high can result in very large memory tables"
 msgstr ""
 
-#: include/global_settings.php:2672
+#: include/global_settings.php:2676
 msgid "Maintenance Time"
 msgstr ""
 
-#: include/global_settings.php:2673
-msgid "What time of day should Weekly, Monthly, and Yearly Data be updated?  Format is HH:MM [am/pm]"
+#: include/global_settings.php:2677
+msgid ""
+"What time of day should Weekly, Monthly, and Yearly Data be updated?  Format "
+"is HH:MM [am/pm]"
 msgstr ""
 
-#: include/global_settings.php:2680
+#: include/global_settings.php:2684
 msgid "Memory Limit for Data Source Statistics Data Collector"
 msgstr ""
 
-#: include/global_settings.php:2681
-msgid "The maximum amount of memory for the Cacti Poller and Data Source Statistics Poller"
+#: include/global_settings.php:2685
+msgid ""
+"The maximum amount of memory for the Cacti Poller and Data Source Statistics "
+"Poller"
 msgstr ""
 
-#: include/global_settings.php:2687
+#: include/global_settings.php:2691
 msgid "Data Source Retention Settings"
 msgstr ""
 
-#: include/global_settings.php:2692
+#: include/global_settings.php:2696
 msgid "Save Historical Data in Database Tables"
 msgstr ""
 
-#: include/global_settings.php:2693
-msgid "Check this setting in order to keep a table for each day, week, month, and year data.  The times that these tables will be created will be based upon the following formula: Daily - One partition per day, Weekly - One Partition per Week, Monthly - One partition per Month, Yearly - One Partition per Year.  All tables will have the following suffixes by type Daily: YYYYDDD, Weekly: YYYYWW, Monthly: YYYYMM, and Yearly: YYYY suffixes."
+#: include/global_settings.php:2697
+msgid ""
+"Check this setting in order to keep a table for each day, week, month, and "
+"year data.  The times that these tables will be created will be based upon "
+"the following formula: Daily - One partition per day, Weekly - One Partition "
+"per Week, Monthly - One partition per Month, Yearly - One Partition per "
+"Year.  All tables will have the following suffixes by type Daily: YYYYDDD, "
+"Weekly: YYYYWW, Monthly: YYYYMM, and Yearly: YYYY suffixes."
 msgstr ""
 
-#: include/global_settings.php:2698
+#: include/global_settings.php:2702
 msgid "Daily Partition Retention"
 msgstr ""
 
-#: include/global_settings.php:2699
+#: include/global_settings.php:2703
 msgid "The number of Days, Weeks, Months, or Years to keep daily statistics."
 msgstr ""
 
-#: include/global_settings.php:2705
+#: include/global_settings.php:2709
 msgid "Weekly Partition Retention"
 msgstr ""
 
-#: include/global_settings.php:2706
+#: include/global_settings.php:2710
 msgid "The number of Days, Weeks, Months, or Years to keep weekly statistics."
 msgstr ""
 
-#: include/global_settings.php:2712
+#: include/global_settings.php:2716
 msgid "Monthly Partition Retention"
 msgstr ""
 
-#: include/global_settings.php:2713
+#: include/global_settings.php:2717
 msgid "The number of Days, Weeks, Months, or Years to keep monthly statistics."
 msgstr ""
 
-#: include/global_settings.php:2719
+#: include/global_settings.php:2723
 msgid "Yearly Partition Retention"
 msgstr ""
 
-#: include/global_settings.php:2720
+#: include/global_settings.php:2724
 msgid "The number of Days, Weeks, Months, or Years to keep yearly statistics."
 msgstr ""
 
-#: include/global_settings.php:2726
+#: include/global_settings.php:2730
 msgid "RRDfile Check"
 msgstr ""
 
-#: include/global_settings.php:2731
+#: include/global_settings.php:2735
 msgid "Enable RRDfile Check"
 msgstr ""
 
-#: include/global_settings.php:2732
+#: include/global_settings.php:2736
 msgid "Should RRDfile Check be enabled for this Cacti system?"
 msgstr ""
 
-#: include/global_settings.php:2737
+#: include/global_settings.php:2741
 msgid "Number of RRDfile Check Processes"
 msgstr ""
 
-#: include/global_settings.php:2738
-msgid "The number of concurrent RRDfile Check processes to use to use to process all of rrd files."
+#: include/global_settings.php:2742
+msgid ""
+"The number of concurrent RRDfile Check processes to use to use to process "
+"all of rrd files."
 msgstr ""
 
-#: include/global_settings.php:2765
+#: include/global_settings.php:2769
 msgid "Check Frequency"
 msgstr ""
 
-#: include/global_settings.php:2766
+#: include/global_settings.php:2770
 msgid "How frequent should RRD be checked ?"
 msgstr ""
 
-#: include/global_settings.php:2772
+#: include/global_settings.php:2776
 msgid "Data Storage Settings"
 msgstr ""
 
-#: include/global_settings.php:2778
-msgid "Choose if RRDs will be stored locally or being handled by an external RRDtool proxy server."
+#: include/global_settings.php:2782
+msgid ""
+"Choose if RRDs will be stored locally or being handled by an external "
+"RRDtool proxy server."
 msgstr ""
 
-#: include/global_settings.php:2782 lib/auth.php:534 lib/auth.php:556
-#: lib/auth.php:566 lib/auth.php:576 user_admin.php:2054
+#: include/global_settings.php:2786 lib/auth.php:540 lib/auth.php:562
+#: lib/auth.php:572 lib/auth.php:582 user_admin.php:2056
 msgid "Local"
 msgstr ""
 
-#: include/global_settings.php:2783 include/global_settings.php:2817
+#: include/global_settings.php:2787 include/global_settings.php:2821
 msgid "RRDtool Proxy Server"
 msgstr ""
 
-#: include/global_settings.php:2787
+#: include/global_settings.php:2791
 msgid "Structure RRDfile Paths"
 msgstr ""
 
-#: include/global_settings.php:2792
+#: include/global_settings.php:2796
 msgid "Enable Structured Paths"
 msgstr ""
 
-#: include/global_settings.php:2793
-msgid "Use a separate subfolder for each hosts RRD files.  The naming of the RRDfiles will be one of the following:<br><ul><li>&lt;path_cacti&gt;/rra/host_id/local_data_id.rrd,</li><li>&lt;path_cacti&gt;/rra/device_id/data_query_id/local_data_id.rrd,</li><li>&lt;path_cacti&gt;/rra/device_hash/device_id/local_data_id.rrd,</li><li>&lt;path_cacti&gt;/rra/device_hash/device_id/data_query_id/local_data_id.rrd.</li></ul><br>You can make this change after install by running the CLI script <b>structure_rra_paths.php</b> after you make the change.  NOTE: If you change Max Directories value to decrease the number of directories, or if you change the Directory Pattern, empty directories will not be pruned after you rerun the <b>structure_rra_paths.php</b> script."
+#: include/global_settings.php:2797
+msgid ""
+"Use a separate subfolder for each hosts RRD files.  The naming of the "
+"RRDfiles will be one of the following:<br><ul><li>&lt;path_cacti&gt;/rra/"
+"host_id/local_data_id.rrd,</li><li>&lt;path_cacti&gt;/rra/device_id/"
+"data_query_id/local_data_id.rrd,</li><li>&lt;path_cacti&gt;/rra/device_hash/"
+"device_id/local_data_id.rrd,</li><li>&lt;path_cacti&gt;/rra/device_hash/"
+"device_id/data_query_id/local_data_id.rrd.</li></ul><br>You can make this "
+"change after install by running the CLI script <b>structure_rra_paths.php</"
+"b> after you make the change.  NOTE: If you change Max Directories value to "
+"decrease the number of directories, or if you change the Directory Pattern, "
+"empty directories will not be pruned after you rerun the "
+"<b>structure_rra_paths.php</b> script."
 msgstr ""
 
-#: include/global_settings.php:2797
+#: include/global_settings.php:2801
 msgid "Directory Pattern"
 msgstr ""
 
-#: include/global_settings.php:2798
-msgid "Which Directory Pattern do you wish to use for Structured RRD Paths.  'Device ID' is the default.  The setting 'Device ID/Data Query ID' should be used when you have Devices with thousands of Graphs.  After Changing the Directory Pattern, you must run the Structured Path CLI script again to modify the RRDfile paths to the new Pattern."
+#: include/global_settings.php:2802
+msgid ""
+"Which Directory Pattern do you wish to use for Structured RRD Paths.  "
+"'Device ID' is the default.  The setting 'Device ID/Data Query ID' should be "
+"used when you have Devices with thousands of Graphs.  After Changing the "
+"Directory Pattern, you must run the Structured Path CLI script again to "
+"modify the RRDfile paths to the new Pattern."
 msgstr ""
 
-#: include/global_settings.php:2802
+#: include/global_settings.php:2806
 msgid "Device ID"
 msgstr ""
 
-#: include/global_settings.php:2803
+#: include/global_settings.php:2807
 msgid "Device ID/Data Query ID"
 msgstr ""
 
-#: include/global_settings.php:2804
+#: include/global_settings.php:2808
 msgid "Device Hash/Device ID"
 msgstr ""
 
-#: include/global_settings.php:2805
+#: include/global_settings.php:2809
 msgid "Device Hash/Device ID/Data Query ID"
 msgstr ""
 
-#: include/global_settings.php:2809
+#: include/global_settings.php:2813
 msgid "Max Device Hash Directories"
 msgstr ""
 
-#: include/global_settings.php:2810
-msgid "The maximum number of Device Directories to be created based upon hashed Device ID's."
+#: include/global_settings.php:2814
+msgid ""
+"The maximum number of Device Directories to be created based upon hashed "
+"Device ID's."
 msgstr ""
 
-#: include/global_settings.php:2822 include/global_settings.php:2854
+#: include/global_settings.php:2826 include/global_settings.php:2858
 msgid "Proxy Server"
 msgstr ""
 
-#: include/global_settings.php:2823
+#: include/global_settings.php:2827
 msgid "The DNS hostname or IP address of the RRDtool proxy server."
 msgstr ""
 
-#: include/global_settings.php:2828 include/global_settings.php:2860
+#: include/global_settings.php:2832 include/global_settings.php:2864
 msgid "Proxy Port Number"
 msgstr ""
 
-#: include/global_settings.php:2829
+#: include/global_settings.php:2833
 msgid "TCP port for encrypted communication."
 msgstr ""
 
-#: include/global_settings.php:2836 include/global_settings.php:2868
+#: include/global_settings.php:2840 include/global_settings.php:2872
 #: support.php:1224
 msgid "RSA Fingerprint"
 msgstr ""
 
-#: include/global_settings.php:2837
-msgid "The fingerprint of the current public RSA key the proxy is using. This is required to establish a trusted connection."
+#: include/global_settings.php:2841
+msgid ""
+"The fingerprint of the current public RSA key the proxy is using. This is "
+"required to establish a trusted connection."
 msgstr ""
 
-#: include/global_settings.php:2844
+#: include/global_settings.php:2848
 msgid "RRDtool Proxy Server - Backup"
 msgstr ""
 
-#: include/global_settings.php:2849
+#: include/global_settings.php:2853
 msgid "Load Balancing"
 msgstr ""
 
-#: include/global_settings.php:2850
-msgid "If both main and backup proxy are receivable this option allows to spread all requests against RRDtool."
+#: include/global_settings.php:2854
+msgid ""
+"If both main and backup proxy are receivable this option allows to spread "
+"all requests against RRDtool."
 msgstr ""
 
-#: include/global_settings.php:2855
-msgid "The DNS hostname or IP address of the RRDtool backup proxy server if proxy is running in MSR mode."
+#: include/global_settings.php:2859
+msgid ""
+"The DNS hostname or IP address of the RRDtool backup proxy server if proxy "
+"is running in MSR mode."
 msgstr ""
 
-#: include/global_settings.php:2861
+#: include/global_settings.php:2865
 msgid "TCP port for encrypted communication with the backup proxy."
 msgstr ""
 
-#: include/global_settings.php:2869
-msgid "The fingerprint of the current public RSA key the backup proxy is using. This required to establish a trusted connection."
+#: include/global_settings.php:2873
+msgid ""
+"The fingerprint of the current public RSA key the backup proxy is using. "
+"This required to establish a trusted connection."
 msgstr ""
 
-#: include/global_settings.php:2879
+#: include/global_settings.php:2883
 msgid "Spike Kill Settings"
 msgstr ""
 
-#: include/global_settings.php:2884
+#: include/global_settings.php:2888
 msgid "Removal Method"
 msgstr ""
 
-#: include/global_settings.php:2885
-msgid "There are two removal methods.  The first, Standard Deviation, will remove any sample that is X number of standard deviations away from the average of samples.  The second method, Variance, will remove any sample that is X% more than the Variance average.  The Variance method takes into account a certain number of 'outliers'.  Those are exceptional samples, like the spike, that need to be excluded from the Variance Average calculation."
+#: include/global_settings.php:2889
+msgid ""
+"There are two removal methods.  The first, Standard Deviation, will remove "
+"any sample that is X number of standard deviations away from the average of "
+"samples."
 msgstr ""
 
-#: include/global_settings.php:2889
+#: include/global_settings.php:2893
 msgid "Standard Deviation"
 msgstr ""
 
-#: include/global_settings.php:2890
-msgid "Variance Based w/Outliers Removed"
-msgstr ""
-
-#: include/global_settings.php:2894 lib/html.php:2930
+#: include/global_settings.php:2897 lib/html.php:2922
 msgid "Replacement Method"
 msgstr ""
 
-#: include/global_settings.php:2895
-msgid "There are three replacement methods.  The first method replaces the spike with the average of the data source in question.  The second method replaces the spike with a 'NaN'.  The last replaces the spike with the last known good value found."
+#: include/global_settings.php:2898
+msgid ""
+"There are three replacement methods.  The first method replaces the spike "
+"with the average of the data source in question.  The second method replaces "
+"the spike with a 'NaN'.  The last replaces the spike with the last known "
+"good value found."
 msgstr ""
 
-#: include/global_settings.php:2899 lib/html.php:2549 lib/html.php:2565
-#: lib/html.php:2580 lib/html.php:2926
+#: include/global_settings.php:2902 lib/html.php:2549 lib/html.php:2565
+#: lib/html.php:2580 lib/html.php:2918
 msgid "Average"
 msgstr ""
 
-#: include/global_settings.php:2900 lib/html.php:2927
+#: include/global_settings.php:2903 lib/html.php:2919
 msgid "NaN's"
 msgstr ""
 
-#: include/global_settings.php:2901 lib/html.php:2928
+#: include/global_settings.php:2904 lib/html.php:2920
 msgid "Last Known Good"
 msgstr ""
 
-#: include/global_settings.php:2905
+#: include/global_settings.php:2908
 msgid "Number of Standard Deviations"
 msgstr ""
 
-#: include/global_settings.php:2906
-msgid "Any value that is this many standard deviations above the average will be excluded.  A good number will be dependent on the type of data to be operated on.  We recommend a number no lower than 5 Standard Deviations."
+#: include/global_settings.php:2909
+msgid ""
+"Any value that is this many standard deviations above the average will be "
+"excluded.  A good number will be dependent on the type of data to be "
+"operated on.  We recommend a number no lower than 5 Standard Deviations."
 msgstr ""
 
-#: include/global_settings.php:2910 include/global_settings.php:2911
-#: include/global_settings.php:2912 include/global_settings.php:2913
-#: include/global_settings.php:2914 include/global_settings.php:2915
-#: include/global_settings.php:2916 include/global_settings.php:2917
-#: include/global_settings.php:2918 include/global_settings.php:2919
-#: include/global_settings.php:2920 include/global_settings.php:2921
-#: include/global_settings.php:2922
+#: include/global_settings.php:2913 include/global_settings.php:2914
+#: include/global_settings.php:2915 include/global_settings.php:2916
+#: include/global_settings.php:2917 include/global_settings.php:2918
+#: include/global_settings.php:2919 include/global_settings.php:2920
+#: include/global_settings.php:2921 include/global_settings.php:2922
+#: include/global_settings.php:2923 include/global_settings.php:2924
+#: include/global_settings.php:2925
 #, php-format
 msgid "%d Standard Deviations"
 msgstr ""
 
-#: include/global_settings.php:2926 lib/html.php:2944
-msgid "Variance Percentage"
-msgstr ""
-
-#: include/global_settings.php:2927
-#, php-format
-msgid "This value represents the percentage above the adjusted sample average once outliers have been removed from the sample.  For example, a Variance Percentage of 100%% on an adjusted average of 50 would remove any sample above the quantity of 100 from the graph."
-msgstr ""
-
-#: include/global_settings.php:2950
-msgid "Variance Number of Outliers"
-msgstr ""
-
-#: include/global_settings.php:2951
-msgid "This value represents the number of high and low average samples will be removed from the sample set prior to calculating the Variance Average.  If you choose an outlier value of 5, then both the top and bottom 5 averages are removed."
-msgstr ""
-
-#: include/global_settings.php:2955 include/global_settings.php:2956
-#: include/global_settings.php:2957 include/global_settings.php:2958
-#: include/global_settings.php:2959 include/global_settings.php:2960
-#: include/global_settings.php:2961 include/global_settings.php:2962
-#: include/global_settings.php:2963 include/global_settings.php:2964
-#: include/global_settings.php:2965 include/global_settings.php:2966
-#: include/global_settings.php:2967
-#, php-format
-msgid "%d High/Low Samples"
-msgstr ""
-
-#: include/global_settings.php:2971
+#: include/global_settings.php:2929
 msgid "Max Kills Per RRA"
 msgstr ""
 
-#: include/global_settings.php:2972
-msgid "This value represents the maximum number of spikes to remove from a Graph RRA."
+#: include/global_settings.php:2930
+msgid ""
+"This value represents the maximum number of spikes to remove from a Graph "
+"RRA."
 msgstr ""
 
-#: include/global_settings.php:2976 include/global_settings.php:2977
-#: include/global_settings.php:2978 include/global_settings.php:2979
-#: include/global_settings.php:2980 include/global_settings.php:2981
-#: include/global_settings.php:2982 include/global_settings.php:2983
-#: include/global_settings.php:2984 include/global_settings.php:2985
-#: include/global_settings.php:2986 include/global_settings.php:2987
+#: include/global_settings.php:2934 include/global_settings.php:2935
+#: include/global_settings.php:2936 include/global_settings.php:2937
+#: include/global_settings.php:2938 include/global_settings.php:2939
+#: include/global_settings.php:2940 include/global_settings.php:2941
+#: include/global_settings.php:2942 include/global_settings.php:2943
+#: include/global_settings.php:2944 include/global_settings.php:2945
 #, php-format
 msgid "%d Spikes"
 msgstr ""
 
-#: include/global_settings.php:2991
+#: include/global_settings.php:2949
 msgid "Absolute Maximum Value"
 msgstr ""
 
-#: include/global_settings.php:2992
-msgid "This value represents the maximum raw value of any data point to remove from a Graph RRA."
+#: include/global_settings.php:2950
+msgid ""
+"This value represents the maximum raw value of any data point to remove from "
+"a Graph RRA."
 msgstr ""
 
-#: include/global_settings.php:2996
+#: include/global_settings.php:2954
 msgid "1 Thousand"
 msgstr ""
 
-#: include/global_settings.php:2997
+#: include/global_settings.php:2955
 msgid "10 Thousand"
 msgstr ""
 
-#: include/global_settings.php:2998
+#: include/global_settings.php:2956
 msgid "100 Thousand"
 msgstr ""
 
-#: include/global_settings.php:2999
+#: include/global_settings.php:2957
 msgid "1 Million"
 msgstr ""
 
-#: include/global_settings.php:3000
+#: include/global_settings.php:2958
 msgid "2.5 Million (20 Megabits)"
 msgstr ""
 
-#: include/global_settings.php:3001
+#: include/global_settings.php:2959
 msgid "7.5 Million (60 Megabits)"
 msgstr ""
 
-#: include/global_settings.php:3002
+#: include/global_settings.php:2960
 msgid "10 Million"
 msgstr ""
 
-#: include/global_settings.php:3003
+#: include/global_settings.php:2961
 msgid "12.5 Million (100 Megabits)"
 msgstr ""
 
-#: include/global_settings.php:3004
+#: include/global_settings.php:2962
 msgid "31.3 Million (250 Megabits)"
 msgstr ""
 
-#: include/global_settings.php:3005
+#: include/global_settings.php:2963
 msgid "75 Million (600 Megabits)"
 msgstr ""
 
-#: include/global_settings.php:3006
+#: include/global_settings.php:2964
 msgid "100 Million"
 msgstr ""
 
-#: include/global_settings.php:3007
+#: include/global_settings.php:2965
 msgid "125 Million (1 Gigabit)"
 msgstr ""
 
-#: include/global_settings.php:3008
+#: include/global_settings.php:2966
 msgid "1 Billion"
 msgstr ""
 
-#: include/global_settings.php:3009
+#: include/global_settings.php:2967
 msgid "1.25 Billion (10 Gigabits)"
 msgstr ""
 
-#: include/global_settings.php:3010
+#: include/global_settings.php:2968
 msgid "12.5 Billion (100 Gigabits)"
 msgstr ""
 
-#: include/global_settings.php:3014
+#: include/global_settings.php:2972
 msgid "DS Filter"
 msgstr ""
 
-#: include/global_settings.php:3015
-msgid "Specifies the DSes inside an RRD upon which Spikekill will operate. A string of comma-separated values that contains index numbers or names of desired DSes. If left blank, all DSes will match. An example is <i>\"5,traffic_*\"</i>, which would match DS index 5 as well as any DS whose name begins with <i>\"traffic_\"</i>. "
+#: include/global_settings.php:2973
+msgid ""
+"Specifies the DSes inside an RRD upon which Spikekill will operate. A string "
+"of comma-separated values that contains index numbers or names of desired "
+"DSes. If left blank, all DSes will match. An example is <i>\"5,traffic_*\"</"
+"i>, which would match DS index 5 as well as any DS whose name begins with "
+"<i>\"traffic_\"</i>. "
 msgstr ""
 
-#: include/global_settings.php:3022
+#: include/global_settings.php:2980
 msgid "RRDfile Backup Directory"
 msgstr ""
 
-#: include/global_settings.php:3023
-msgid "If this directory is not empty, then your original RRDfiles will be backed up to this location."
+#: include/global_settings.php:2981
+msgid ""
+"If this directory is not empty, then your original RRDfiles will be backed "
+"up to this location."
 msgstr ""
 
-#: include/global_settings.php:3030
+#: include/global_settings.php:2988
 msgid "Batch Spike Kill Settings"
 msgstr ""
 
-#: include/global_settings.php:3035
+#: include/global_settings.php:2993
 msgid "Removal Schedule"
 msgstr ""
 
-#: include/global_settings.php:3036
-msgid "Do you wish to periodically remove spikes from your graphs?  If so, select the frequency below."
+#: include/global_settings.php:2994
+msgid ""
+"Do you wish to periodically remove spikes from your graphs?  If so, select "
+"the frequency below."
 msgstr ""
 
-#: include/global_settings.php:3043
+#: include/global_settings.php:3001
 msgid "Once a Day"
 msgstr ""
 
-#: include/global_settings.php:3044
+#: include/global_settings.php:3002
 msgid "Every Other Day"
 msgstr ""
 
-#: include/global_settings.php:3048
+#: include/global_settings.php:3006
 msgid "Base Time"
 msgstr ""
 
-#: include/global_settings.php:3049
-msgid "The Base Time for Spike removal to occur.  For example, if you use '12:00am' and you choose once per day, the batch removal would begin at approximately midnight every day."
+#: include/global_settings.php:3007
+msgid ""
+"The Base Time for Spike removal to occur.  For example, if you use '12:00am' "
+"and you choose once per day, the batch removal would begin at approximately "
+"midnight every day."
 msgstr ""
 
-#: include/global_settings.php:3056
+#: include/global_settings.php:3014
 msgid "Graph Templates to Spike Kill"
 msgstr ""
 
-#: include/global_settings.php:3058
-msgid "When performing batch spike removal, only the templates selected below will be acted on."
+#: include/global_settings.php:3016
+msgid ""
+"When performing batch spike removal, only the templates selected below will "
+"be acted on."
 msgstr ""
 
-#: include/global_settings.php:3062
+#: include/global_settings.php:3020
 msgid "Backup Retention"
 msgstr ""
 
-#: include/global_settings.php:3063
-msgid "When SpikeKill kills spikes in graphs, it makes a backup of the RRDfile.  How long should these backup files be retained?"
+#: include/global_settings.php:3021
+msgid ""
+"When SpikeKill kills spikes in graphs, it makes a backup of the RRDfile.  "
+"How long should these backup files be retained?"
 msgstr ""
 
-#: include/global_settings.php:3081
+#: include/global_settings.php:3039
 msgid "Default View Mode"
 msgstr ""
 
-#: include/global_settings.php:3082
-msgid "Which Graph mode you want displayed by default when you first visit the Graphs page?"
+#: include/global_settings.php:3040
+msgid ""
+"Which Graph mode you want displayed by default when you first visit the "
+"Graphs page?"
 msgstr ""
 
-#: include/global_settings.php:3088
+#: include/global_settings.php:3046
 msgid "TimeZone Support"
 msgstr ""
 
-#: include/global_settings.php:3089
-msgid "How would you like Cacti to present dates?  This setting will also change the way that Cacti Graphs dates are represented."
+#: include/global_settings.php:3047
+msgid ""
+"How would you like Cacti to present dates?  This setting will also change "
+"the way that Cacti Graphs dates are represented."
 msgstr ""
 
-#: include/global_settings.php:3092
+#: include/global_settings.php:3050
 msgid "Cacti Server Timezone"
 msgstr ""
 
-#: include/global_settings.php:3093
+#: include/global_settings.php:3051
 msgid "My Browsers Timezone"
 msgstr ""
 
-#: include/global_settings.php:3098
+#: include/global_settings.php:3056
 msgid "User Language"
 msgstr ""
 
-#: include/global_settings.php:3099
+#: include/global_settings.php:3057
 msgid "Defines the preferred GUI language."
 msgstr ""
 
-#: include/global_settings.php:3105
+#: include/global_settings.php:3063
 msgid "Show Graph Title"
 msgstr ""
 
-#: include/global_settings.php:3106
-msgid "Display the graph title on the page so that it may be searched using the browser."
+#: include/global_settings.php:3064
+msgid ""
+"Display the graph title on the page so that it may be searched using the "
+"browser."
 msgstr ""
 
-#: include/global_settings.php:3111
+#: include/global_settings.php:3069
 msgid "Show Business Hours"
 msgstr ""
 
-#: include/global_settings.php:3112
+#: include/global_settings.php:3070
 msgid "Show business hours on the Graphs by default."
 msgstr ""
 
-#: include/global_settings.php:3117
+#: include/global_settings.php:3075
 msgid "Hide Disabled"
 msgstr ""
 
-#: include/global_settings.php:3118
+#: include/global_settings.php:3076
 msgid "Hides Disabled Devices and Graphs when viewing outside of Console tab."
 msgstr ""
 
-#: include/global_settings.php:3123
+#: include/global_settings.php:3081
 msgid "Show Device Aggregates"
 msgstr ""
 
-#: include/global_settings.php:3124
-msgid "If a Device Data Source is included in an Aggregate Graph, show that Graph along with other Device Graphs"
+#: include/global_settings.php:3082
+msgid ""
+"If a Device Data Source is included in an Aggregate Graph, show that Graph "
+"along with other Device Graphs"
 msgstr ""
 
-#: include/global_settings.php:3129
+#: include/global_settings.php:3087
 msgid "Enable Horizontal Scrolling"
 msgstr ""
 
-#: include/global_settings.php:3130
-msgid "Enable Horizontal Scrolling of Tables, Disabling Responsive Column Visibility."
+#: include/global_settings.php:3088
+msgid ""
+"Enable Horizontal Scrolling of Tables, Disabling Responsive Column "
+"Visibility."
 msgstr ""
 
-#: include/global_settings.php:3136
+#: include/global_settings.php:3094
 msgid "The date format to use in Cacti."
 msgstr ""
 
-#: include/global_settings.php:3143
+#: include/global_settings.php:3101
 msgid "The date separator to be used in Cacti."
 msgstr ""
 
-#: include/global_settings.php:3149
+#: include/global_settings.php:3107
 msgid "Page Refresh"
 msgstr ""
 
-#: include/global_settings.php:3150
+#: include/global_settings.php:3108
 msgid "The number of seconds between automatic page refreshes."
 msgstr ""
 
-#: include/global_settings.php:3162
+#: include/global_settings.php:3120
 msgid "Preview Graphs Per Page"
 msgstr ""
 
-#: include/global_settings.php:3163 include/global_settings.php:3292
+#: include/global_settings.php:3121 include/global_settings.php:3250
 msgid "The number of graphs to display on one page in preview mode."
 msgstr ""
 
-#: include/global_settings.php:3171
+#: include/global_settings.php:3129
 msgid "Default Time Range"
 msgstr ""
 
-#: include/global_settings.php:3172
+#: include/global_settings.php:3130
 msgid "The default RRA to use in rare occasions."
 msgstr ""
 
-#: include/global_settings.php:3179
-msgid "The default Timespan displayed when viewing Graphs and other time specific data."
+#: include/global_settings.php:3137
+msgid ""
+"The default Timespan displayed when viewing Graphs and other time specific "
+"data."
 msgstr ""
 
-#: include/global_settings.php:3185
+#: include/global_settings.php:3143
 msgid "Default Timeshift"
 msgstr ""
 
-#: include/global_settings.php:3186
-msgid "The default Timeshift displayed when viewing Graphs and other time specific data."
+#: include/global_settings.php:3144
+msgid ""
+"The default Timeshift displayed when viewing Graphs and other time specific "
+"data."
 msgstr ""
 
-#: include/global_settings.php:3192
+#: include/global_settings.php:3150
 msgid "Allow Graph to extend to Future"
 msgstr ""
 
-#: include/global_settings.php:3193
+#: include/global_settings.php:3151
 msgid "When displaying Graphs, allow Graph Dates to extend 'to future'"
 msgstr ""
 
-#: include/global_settings.php:3198
+#: include/global_settings.php:3156
 msgid "First Day of the Week"
 msgstr ""
 
-#: include/global_settings.php:3199
+#: include/global_settings.php:3157
 msgid "The first Day of the Week for weekly Graph Displays"
 msgstr ""
 
-#: include/global_settings.php:3205
+#: include/global_settings.php:3163
 msgid "Start of Daily Shift"
 msgstr ""
 
-#: include/global_settings.php:3206
+#: include/global_settings.php:3164
 msgid "Start Time of the Daily Shift."
 msgstr ""
 
-#: include/global_settings.php:3213
+#: include/global_settings.php:3171
 msgid "End of Daily Shift"
 msgstr ""
 
-#: include/global_settings.php:3214
+#: include/global_settings.php:3172
 msgid "End Time of the Daily Shift."
 msgstr ""
 
-#: include/global_settings.php:3223
+#: include/global_settings.php:3181
 msgid "Thumbnail Sections"
 msgstr ""
 
-#: include/global_settings.php:3224
+#: include/global_settings.php:3182
 msgid "Which portions of Cacti display Thumbnails by default."
 msgstr ""
 
-#: include/global_settings.php:3238
+#: include/global_settings.php:3196
 msgid "Preview Thumbnail Columns"
 msgstr ""
 
-#: include/global_settings.php:3239
-msgid "The number of columns to use when displaying Thumbnail graphs in Preview mode."
+#: include/global_settings.php:3197
+msgid ""
+"The number of columns to use when displaying Thumbnail graphs in Preview "
+"mode."
 msgstr ""
 
-#: include/global_settings.php:3243 include/global_settings.php:3257
+#: include/global_settings.php:3201 include/global_settings.php:3215
 msgid "1 Column"
 msgstr ""
 
-#: include/global_settings.php:3244 include/global_settings.php:3245
-#: include/global_settings.php:3246 include/global_settings.php:3247
-#: include/global_settings.php:3248 include/global_settings.php:3258
-#: include/global_settings.php:3259 include/global_settings.php:3260
-#: include/global_settings.php:3261 include/global_settings.php:3262
+#: include/global_settings.php:3202 include/global_settings.php:3203
+#: include/global_settings.php:3204 include/global_settings.php:3205
+#: include/global_settings.php:3206 include/global_settings.php:3216
+#: include/global_settings.php:3217 include/global_settings.php:3218
+#: include/global_settings.php:3219 include/global_settings.php:3220
 #: lib/html_graph.php:193 lib/html_graph.php:194 lib/html_graph.php:195
 #: lib/html_graph.php:196 lib/html_graph.php:197 lib/html_tree.php:977
 #: lib/html_tree.php:978 lib/html_tree.php:979 lib/html_tree.php:980
@@ -14157,133 +15329,146 @@ msgstr ""
 msgid "%d Columns"
 msgstr ""
 
-#: include/global_settings.php:3252
+#: include/global_settings.php:3210
 msgid "Tree View Thumbnail Columns"
 msgstr ""
 
-#: include/global_settings.php:3253
-msgid "The number of columns to use when displaying Thumbnail graphs in Tree mode."
+#: include/global_settings.php:3211
+msgid ""
+"The number of columns to use when displaying Thumbnail graphs in Tree mode."
 msgstr ""
 
-#: include/global_settings.php:3266
+#: include/global_settings.php:3224
 msgid "Thumbnail Height"
 msgstr ""
 
-#: include/global_settings.php:3267
+#: include/global_settings.php:3225
 msgid "The height of Thumbnail graphs in pixels."
 msgstr ""
 
-#: include/global_settings.php:3274
+#: include/global_settings.php:3232
 msgid "Thumbnail Width"
 msgstr ""
 
-#: include/global_settings.php:3275
+#: include/global_settings.php:3233
 msgid "The width of Thumbnail graphs in pixels."
 msgstr ""
 
-#: include/global_settings.php:3284
+#: include/global_settings.php:3242
 msgid "Default Tree"
 msgstr ""
 
-#: include/global_settings.php:3285
+#: include/global_settings.php:3243
 msgid "The default graph tree to use when displaying graphs in tree mode."
 msgstr ""
 
-#: include/global_settings.php:3291
+#: include/global_settings.php:3249
 msgid "Graphs Per Page"
 msgstr ""
 
-#: include/global_settings.php:3298
+#: include/global_settings.php:3256
 msgid "Expand Devices"
 msgstr ""
 
-#: include/global_settings.php:3299
-msgid "Choose whether to expand the Graph Templates and Data Queries used by a Device on Tree."
+#: include/global_settings.php:3257
+msgid ""
+"Choose whether to expand the Graph Templates and Data Queries used by a "
+"Device on Tree."
 msgstr ""
 
-#: include/global_settings.php:3304
+#: include/global_settings.php:3262
 msgid "Tree History"
 msgstr ""
 
-#: include/global_settings.php:3305
-msgid "If enabled, Cacti will remember your Tree History between logins and when you return to the Graphs page."
+#: include/global_settings.php:3263
+msgid ""
+"If enabled, Cacti will remember your Tree History between logins and when "
+"you return to the Graphs page."
 msgstr ""
 
-#: include/global_settings.php:3328
+#: include/global_settings.php:3286
 msgid "Use Custom Fonts"
 msgstr ""
 
-#: include/global_settings.php:3329
-msgid "Choose whether to use your own custom fonts and font sizes or utilize the system defaults."
+#: include/global_settings.php:3287
+msgid ""
+"Choose whether to use your own custom fonts and font sizes or utilize the "
+"system defaults."
 msgstr ""
 
-#: include/global_settings.php:3342
+#: include/global_settings.php:3300
 msgid "Title Font File"
 msgstr ""
 
-#: include/global_settings.php:3343
+#: include/global_settings.php:3301
 msgid "The font file to use for Graph Titles"
 msgstr ""
 
-#: include/global_settings.php:3355
+#: include/global_settings.php:3313
 msgid "Legend Font File"
 msgstr ""
 
-#: include/global_settings.php:3356
+#: include/global_settings.php:3314
 msgid "The font file to be used for Graph Legend items"
 msgstr ""
 
-#: include/global_settings.php:3368
+#: include/global_settings.php:3326
 msgid "Axis Font File"
 msgstr ""
 
-#: include/global_settings.php:3369
+#: include/global_settings.php:3327
 msgid "The font file to be used for Graph Axis items"
 msgstr ""
 
-#: include/global_settings.php:3381
+#: include/global_settings.php:3339
 msgid "Unit Font File"
 msgstr ""
 
-#: include/global_settings.php:3382
+#: include/global_settings.php:3340
 msgid "The font file to be used for Graph Unit items"
 msgstr ""
 
-#: include/global_settings.php:3396
+#: include/global_settings.php:3354
 msgid "Realtime View Mode"
 msgstr ""
 
-#: include/global_settings.php:3397
+#: include/global_settings.php:3355
 msgid "How do you wish to view Realtime Graphs?"
 msgstr ""
 
-#: include/global_settings.php:3400
+#: include/global_settings.php:3358
 msgid "Inline"
 msgstr ""
 
-#: include/global_settings.php:3401
+#: include/global_settings.php:3359
 msgid "New Window"
 msgstr ""
 
-#: include/global_settings.php:3416
+#: include/global_settings.php:3374
 msgid "System Setting"
 msgstr ""
 
-#: include/global_settings.php:3424
+#: include/global_settings.php:3382
 msgid "1 Week"
 msgstr ""
 
-#: include/global_settings.php:3437
+#: include/global_settings.php:3395
 msgid "Auto Log Out Time"
 msgstr ""
 
-#: include/global_settings.php:3438
-msgid "For users with Console access only, how long this user can stay logged in before being automatically logged out.  Note that if you have not been active in more than an hour, you may have to refresh your browser.  Also note that this setting has no affect when Authentication Cookies are enabled."
+#: include/global_settings.php:3396
+msgid ""
+"For users with Console access only, how long this user can stay logged in "
+"before being automatically logged out.  Note that if you have not been "
+"active in more than an hour, you may have to refresh your browser.  Also "
+"note that this setting has no affect when Authentication Cookies are enabled."
 msgstr ""
 
 #: index.php:68
 #, php-format
-msgid "You are now logged into <a href=\"%s\"><b>Cacti</b></a>. You can follow these basic steps to get started."
+msgid ""
+"You are now logged into <a href=\"%s\"><b>Cacti</b></a>. You can follow "
+"these basic steps to get started."
 msgstr ""
 
 #: index.php:71
@@ -14322,32 +15507,49 @@ msgid "Number of Offline Records:"
 msgstr ""
 
 #: index.php:89
-msgid "<strong>NOTE:</strong> You are logged into a Remote Data Collector.  When <b>'online'</b>, you will be able to view and control much of the Main Cacti Web Site just as if you were logged into it.  Also, it's important to note that Remote Data Collectors are required to use the Cacti's Performance Boosting Services <b>'On Demand Updating'</b> feature, and we always recommend using Spine.  When the Remote Data Collector is <b>'offline'</b>, the Remote Data Collectors Web Site will contain much less information.  However, it will cache all updates until the Main Cacti Database and Web Server are reachable.  Then it will dump it's Boost table output back to the Main Cacti Database for updating."
+msgid ""
+"<strong>NOTE:</strong> You are logged into a Remote Data Collector.  When "
+"<b>'online'</b>, you will be able to view and control much of the Main Cacti "
+"Web Site just as if you were logged into it.  Also, it's important to note "
+"that Remote Data Collectors are required to use the Cacti's Performance "
+"Boosting Services <b>'On Demand Updating'</b> feature, and we always "
+"recommend using Spine.  When the Remote Data Collector is <b>'offline'</b>, "
+"the Remote Data Collectors Web Site will contain much less information.  "
+"However, it will cache all updates until the Main Cacti Database and Web "
+"Server are reachable.  Then it will dump it's Boost table output back to the "
+"Main Cacti Database for updating."
 msgstr ""
 
 #: index.php:94
-msgid "<strong>NOTE:</strong> None of the Core Cacti Plugins, to date, have been re-designed to work with Remote Data Collectors.  Therefore, Plugins such as MacTrack, and HMIB, which require direct access to devices will not work with Remote Data Collectors at this time.  However, plugins such as Thold will work so long as the Remote Data Collector is in <b>'online'</b> mode."
+msgid ""
+"<strong>NOTE:</strong> None of the Core Cacti Plugins, to date, have been re-"
+"designed to work with Remote Data Collectors.  Therefore, Plugins such as "
+"MacTrack, and HMIB, which require direct access to devices will not work "
+"with Remote Data Collectors at this time.  However, plugins such as Thold "
+"will work so long as the Remote Data Collector is in <b>'online'</b> mode."
 msgstr ""
 
-#: install/functions.php:469
+#: install/functions.php:478
 #, php-format
-msgid "Test Failed! Remote version newer than Primary.  Main Primary at %s and Remote at %s."
+msgid ""
+"Test Failed! Remote version newer than Primary.  Main Primary at %s and "
+"Remote at %s."
 msgstr ""
 
-#: install/functions.php:472
+#: install/functions.php:481
 msgid "Check ran successfully."
 msgstr ""
 
-#: install/functions.php:479
+#: install/functions.php:488
 msgid "Unable to connect to the main Cacti server."
 msgstr ""
 
-#: install/functions.php:1021
+#: install/functions.php:1034
 #, php-format
 msgid "Path for %s"
 msgstr ""
 
-#: install/functions.php:1262
+#: install/functions.php:1275
 msgid "New Poller"
 msgstr ""
 
@@ -14375,15 +15577,21 @@ msgstr ""
 
 #: install/install.php:122
 #, php-format
-msgid "Please wait while the installation system for Cacti Version %s initializes. You must have JavaScript enabled for this to work."
+msgid ""
+"Please wait while the installation system for Cacti Version %s initializes. "
+"You must have JavaScript enabled for this to work."
 msgstr ""
 
 #: install/install.php:126
-msgid "FATAL: We are unable to continue with this installation. In order to install Cacti, PHP must be at version 7.4 or later."
+msgid ""
+"FATAL: We are unable to continue with this installation. In order to install "
+"Cacti, PHP must be at version 7.4 or later."
 msgstr ""
 
 #: install/install.php:130
-msgid "See the PHP Manual: <a href=\"http://php.net/manual/en/book.json.php\">JavaScript Object Notation</a>."
+msgid ""
+"See the PHP Manual: <a href=\"http://php.net/manual/en/"
+"book.json.php\">JavaScript Object Notation</a>."
 msgstr ""
 
 #: install/install.php:130
@@ -14391,7 +15599,9 @@ msgid "The php-json module must also be installed."
 msgstr ""
 
 #: install/install.php:135
-msgid "See the PHP Manual: <a href=\"http://php.net/manual/en/ini.core.php#ini.disable-functions\">Disable Functions</a>."
+msgid ""
+"See the PHP Manual: <a href=\"http://php.net/manual/en/"
+"ini.core.php#ini.disable-functions\">Disable Functions</a>."
 msgstr ""
 
 #: install/install.php:135
@@ -14417,11 +15627,17 @@ msgid "Display Graphs from this Aggregate"
 msgstr ""
 
 #: lib/api_aggregate.php:1707
-msgid "The Graphs chosen for the Aggregate Graph below represent Graphs from multiple Graph Templates.  Aggregate does not support creating Aggregate Graphs from multiple Graph Templates."
+msgid ""
+"The Graphs chosen for the Aggregate Graph below represent Graphs from "
+"multiple Graph Templates.  Aggregate does not support creating Aggregate "
+"Graphs from multiple Graph Templates."
 msgstr ""
 
 #: lib/api_aggregate.php:1715
-msgid "The Graphs chosen for the Aggregate Graph do not use Graph Templates.  Aggregate does not support creating Aggregate Graphs from non-templated graphs."
+msgid ""
+"The Graphs chosen for the Aggregate Graph do not use Graph Templates.  "
+"Aggregate does not support creating Aggregate Graphs from non-templated "
+"graphs."
 msgstr ""
 
 #: lib/api_aggregate.php:1724
@@ -14473,7 +15689,9 @@ msgid "Objects"
 msgstr ""
 
 #: lib/api_automation.php:944
-msgid "A blue font color indicates that the rule will be applied to the objects in question.  Other objects will not be subject to the rule."
+msgid ""
+"A blue font color indicates that the rule will be applied to the objects in "
+"question.  Other objects will not be subject to the rule."
 msgstr ""
 
 #: lib/api_automation.php:944
@@ -14485,283 +15703,300 @@ msgstr ""
 msgid "Device Status"
 msgstr ""
 
-#: lib/api_automation.php:978
+#: lib/api_automation.php:982
 msgid "There are no Objects that match this rule."
 msgstr ""
 
-#: lib/api_automation.php:1029
+#: lib/api_automation.php:1033
 msgid "Error Message"
 msgstr ""
 
-#: lib/api_automation.php:1031
+#: lib/api_automation.php:1035
 #, php-format
 msgid "Index Errors [ %s ]"
 msgstr ""
 
-#: lib/api_automation.php:1033
+#: lib/api_automation.php:1037
 msgid "Error in data query"
 msgstr ""
 
-#: lib/api_automation.php:1244
+#: lib/api_automation.php:1248
 msgid "Resulting Branch"
 msgstr ""
 
-#: lib/api_automation.php:1282
+#: lib/api_automation.php:1286
 msgid "No Items Found"
 msgstr ""
 
-#: lib/api_automation.php:1335
+#: lib/api_automation.php:1339
 msgid "Show Matching Device SQL Query"
 msgstr ""
 
-#: lib/api_automation.php:1427
+#: lib/api_automation.php:1431
 msgid "No Device Selection Criteria"
 msgstr ""
 
-#: lib/api_automation.php:1462
+#: lib/api_automation.php:1466
 msgid "Show Matching Indexes SQL Query"
 msgstr ""
 
-#: lib/api_automation.php:1525
+#: lib/api_automation.php:1529
 msgid "No Graph Creation Criteria"
 msgstr ""
 
-#: lib/api_automation.php:1537
+#: lib/api_automation.php:1541
 msgid "Warning matching Graph Rule returned no matches"
 msgstr ""
 
-#: lib/api_automation.php:1570
+#: lib/api_automation.php:1574
 msgid "Propagate Change"
 msgstr ""
 
-#: lib/api_automation.php:1634
+#: lib/api_automation.php:1638
 msgid "No Tree Creation Criteria"
 msgstr ""
 
-#: lib/api_automation.php:2383 lib/api_automation.php:2452
+#: lib/api_automation.php:2392 lib/api_automation.php:2461
 msgid "Device Match Rule"
 msgstr ""
 
-#: lib/api_automation.php:2406
+#: lib/api_automation.php:2415
 msgid "Create Graph Rule"
 msgstr ""
 
-#: lib/api_automation.php:2455
+#: lib/api_automation.php:2464
 msgid "Graph Match Rule"
 msgstr ""
 
-#: lib/api_automation.php:2489
+#: lib/api_automation.php:2498
 msgid "Create Tree Rule (Device)"
 msgstr ""
 
-#: lib/api_automation.php:2492
+#: lib/api_automation.php:2501
 msgid "Create Tree Rule (Graph)"
 msgstr ""
 
-#: lib/api_automation.php:2538
+#: lib/api_automation.php:2547
 #, php-format
 msgid "Rule Item [edit rule item for %s: %s]"
 msgstr ""
 
-#: lib/api_automation.php:2540
+#: lib/api_automation.php:2549
 #, php-format
 msgid "Rule Item [new rule item for %s: %s]"
 msgstr ""
 
-#: lib/api_automation.php:3565
+#: lib/api_automation.php:3574
 msgid "Added by Cacti Automation"
 msgstr ""
 
-#: lib/api_automation.php:3895
+#: lib/api_automation.php:3904
 msgid "ERROR: IP ranges in the form of range1-range2 are no longer supported."
 msgstr ""
 
-#: lib/api_automation.php:5236
+#: lib/api_automation.php:5273
 #, php-format
 msgid "Can not find the Tree Rule with the ID %s"
 msgstr ""
 
-#: lib/api_automation.php:5445 lib/api_automation.php:5447
+#: lib/api_automation.php:5488 lib/api_automation.php:5490
 #, php-format
 msgid "Automation Network SNMP Rule '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:5451 lib/api_automation.php:5453
+#: lib/api_automation.php:5494 lib/api_automation.php:5496
 #, php-format
 msgid "Automation Network SNMP Rule '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:5482 lib/api_automation.php:5484
+#: lib/api_automation.php:5525 lib/api_automation.php:5527
 #, php-format
 msgid "Automation Network SNMP Option %s!"
 msgstr ""
 
-#: lib/api_automation.php:5488 lib/api_automation.php:5490
+#: lib/api_automation.php:5531 lib/api_automation.php:5533
 #, php-format
 msgid "Automation Network SNMP Option %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:5530
+#: lib/api_automation.php:5573
 msgid "The Automation Network Rule does not include any SNMP Options!"
 msgstr ""
 
-#: lib/api_automation.php:5534
-msgid "The Automation Network Rule import columns do not match the database schema"
+#: lib/api_automation.php:5577
+msgid ""
+"The Automation Network Rule import columns do not match the database schema"
 msgstr ""
 
-#: lib/api_automation.php:5560
-msgid "The Device Template related to the Network Rule is not loaded in this Cacti System.  Please edit this Network and set the Device Template, or Import the Device Template and then re-import this Automation Rule."
+#: lib/api_automation.php:5603
+msgid ""
+"The Device Template related to the Network Rule is not loaded in this Cacti "
+"System.  Please edit this Network and set the Device Template, or Import the "
+"Device Template and then re-import this Automation Rule."
 msgstr ""
 
-#: lib/api_automation.php:5566
+#: lib/api_automation.php:5609
 msgid "Unknown Device Template"
 msgstr ""
 
-#: lib/api_automation.php:5586 lib/api_automation.php:5588
+#: lib/api_automation.php:5629 lib/api_automation.php:5631
 #, php-format
 msgid "Automation Network Rule '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:5592 lib/api_automation.php:5594
+#: lib/api_automation.php:5635 lib/api_automation.php:5637
 #, php-format
 msgid "Automation Network Rule '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:5600
-msgid "Automation Network Rule Import data is either for another object type or not JSON formatted."
+#: lib/api_automation.php:5643
+msgid ""
+"Automation Network Rule Import data is either for another object type or not "
+"JSON formatted."
 msgstr ""
 
-#: lib/api_automation.php:5639 lib/api_automation.php:5940
+#: lib/api_automation.php:5682 lib/api_automation.php:5983
 #, php-format
 msgid "The Cacti install does not include the Data Query with the hash '%s'!"
 msgstr ""
 
-#: lib/api_automation.php:5651 lib/api_automation.php:5952
+#: lib/api_automation.php:5694 lib/api_automation.php:5995
 #, php-format
-msgid "The Cacti install does not include the Data Query Graph mapping with the hash '%s'!"
+msgid ""
+"The Cacti install does not include the Data Query Graph mapping with the "
+"hash '%s'!"
 msgstr ""
 
-#: lib/api_automation.php:5682 lib/api_automation.php:5684
-#: lib/api_automation.php:6043 lib/api_automation.php:6045
+#: lib/api_automation.php:5725 lib/api_automation.php:5727
+#: lib/api_automation.php:6086 lib/api_automation.php:6088
 #, php-format
 msgid "Automation Graph Rule '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:5688 lib/api_automation.php:5690
-#: lib/api_automation.php:6049 lib/api_automation.php:6051
+#: lib/api_automation.php:5731 lib/api_automation.php:5733
+#: lib/api_automation.php:6092 lib/api_automation.php:6094
 #, php-format
 msgid "Automation Graph Rule '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:5709 lib/api_automation.php:5711
-#: lib/api_automation.php:6070 lib/api_automation.php:6072
+#: lib/api_automation.php:5752 lib/api_automation.php:5754
+#: lib/api_automation.php:6113 lib/api_automation.php:6115
 #, php-format
 msgid "Automation Graph Rule Item '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:5715 lib/api_automation.php:5717
-#: lib/api_automation.php:6076 lib/api_automation.php:6078
+#: lib/api_automation.php:5758 lib/api_automation.php:5760
+#: lib/api_automation.php:6119 lib/api_automation.php:6121
 #, php-format
 msgid "Automation Graph Rule Item '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:5738 lib/api_automation.php:5740
-#: lib/api_automation.php:6099 lib/api_automation.php:6101
+#: lib/api_automation.php:5781 lib/api_automation.php:5783
+#: lib/api_automation.php:6142 lib/api_automation.php:6144
 #, php-format
 msgid "Automation Graph Rule Match Item '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:5744 lib/api_automation.php:5746
-#: lib/api_automation.php:6105 lib/api_automation.php:6107
+#: lib/api_automation.php:5787 lib/api_automation.php:5789
+#: lib/api_automation.php:6148 lib/api_automation.php:6150
 #, php-format
 msgid "Automation Graph Rule Match Item '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:5754
-msgid "Automation Graph Rule Import data is either for another object type or not JSON formatted."
+#: lib/api_automation.php:5797
+msgid ""
+"Automation Graph Rule Import data is either for another object type or not "
+"JSON formatted."
 msgstr ""
 
-#: lib/api_automation.php:5816 lib/api_automation.php:5818
-#: lib/api_automation.php:6152 lib/api_automation.php:6154
+#: lib/api_automation.php:5859 lib/api_automation.php:5861
+#: lib/api_automation.php:6195 lib/api_automation.php:6197
 #, php-format
 msgid "Automation Tree Rule '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:5822 lib/api_automation.php:5824
-#: lib/api_automation.php:6158 lib/api_automation.php:6160
+#: lib/api_automation.php:5865 lib/api_automation.php:5867
+#: lib/api_automation.php:6201 lib/api_automation.php:6203
 #, php-format
 msgid "Automation Tree Device Rule '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:5841 lib/api_automation.php:5843
-#: lib/api_automation.php:6177 lib/api_automation.php:6179
+#: lib/api_automation.php:5884 lib/api_automation.php:5886
+#: lib/api_automation.php:6220 lib/api_automation.php:6222
 #, php-format
 msgid "Automation Tree Rule Item '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:5847 lib/api_automation.php:5849
-#: lib/api_automation.php:6183 lib/api_automation.php:6185
+#: lib/api_automation.php:5890 lib/api_automation.php:5892
+#: lib/api_automation.php:6226 lib/api_automation.php:6228
 #, php-format
 msgid "Automation Tree Device Rule Item '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:5872 lib/api_automation.php:5874
-#: lib/api_automation.php:6208 lib/api_automation.php:6210
+#: lib/api_automation.php:5915 lib/api_automation.php:5917
+#: lib/api_automation.php:6251 lib/api_automation.php:6253
 #, php-format
 msgid "Automation Tree Rule Match Item '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:5878 lib/api_automation.php:5880
-#: lib/api_automation.php:6214 lib/api_automation.php:6216
+#: lib/api_automation.php:5921 lib/api_automation.php:5923
+#: lib/api_automation.php:6257 lib/api_automation.php:6259
 #, php-format
 msgid "Automation Tree Device Rule Match Item '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:5887
-msgid "Automation Tree Rule Import data is either for another object type or not JSON formatted."
+#: lib/api_automation.php:5930
+msgid ""
+"Automation Tree Rule Import data is either for another object type or not "
+"JSON formatted."
 msgstr ""
 
-#: lib/api_automation.php:5925
+#: lib/api_automation.php:5968
 #, php-format
-msgid "The Cacti install does not include the Device Template with the hash '%s'!"
+msgid ""
+"The Cacti install does not include the Device Template with the hash '%s'!"
 msgstr ""
 
-#: lib/api_automation.php:5985 lib/api_automation.php:5987
+#: lib/api_automation.php:6028 lib/api_automation.php:6030
 #, php-format
 msgid "Automation Device Rule '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:5991 lib/api_automation.php:5993
+#: lib/api_automation.php:6034 lib/api_automation.php:6036
 #, php-format
 msgid "Automation Device Rule '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:6264 lib/api_automation.php:6266
+#: lib/api_automation.php:6307 lib/api_automation.php:6309
 #, php-format
 msgid "Automation Device Rule Item '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:6270 lib/api_automation.php:6272
+#: lib/api_automation.php:6313 lib/api_automation.php:6315
 #, php-format
 msgid "Automation Device Rule Item '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:6281
-msgid "The Thold Plugin is not Installed on this system.  So, Thresholds will not be imported."
+#: lib/api_automation.php:6324
+msgid ""
+"The Thold Plugin is not Installed on this system.  So, Thresholds will not "
+"be imported."
 msgstr ""
 
-#: lib/api_automation.php:6316 lib/api_automation.php:6318
+#: lib/api_automation.php:6359 lib/api_automation.php:6361
 #, php-format
 msgid "Automation Threshold Template '%s' %s!"
 msgstr ""
 
-#: lib/api_automation.php:6322 lib/api_automation.php:6324
+#: lib/api_automation.php:6365 lib/api_automation.php:6367
 #, php-format
 msgid "Automation Threshold Template Device '%s' %s Failed!"
 msgstr ""
 
-#: lib/api_automation.php:6340
-msgid "Automation Device Rule Import data is either for another object type or not JSON formatted."
+#: lib/api_automation.php:6383
+msgid ""
+"Automation Device Rule Import data is either for another object type or not "
+"JSON formatted."
 msgstr ""
 
 #: lib/api_device.php:136 lib/api_device.php:139 lib/api_device.php:316
@@ -14779,7 +16014,9 @@ msgstr ""
 #: lib/utility.php:729 lib/utility.php:751 lib/utility.php:755
 #: lib/utility.php:778 lib/utility.php:781
 #, php-format
-msgid "Remote Poller %s is Down, you will need to perform a FullSync once it is up again"
+msgid ""
+"Remote Poller %s is Down, you will need to perform a FullSync once it is up "
+"again"
 msgstr ""
 
 #: lib/api_device.php:1545
@@ -14846,8 +16083,8 @@ msgstr ""
 msgid "Contact:"
 msgstr ""
 
-#: lib/api_device.php:1696 lib/functions.php:6027 lib/functions.php:6029
-#: lib/functions.php:6033
+#: lib/api_device.php:1696 lib/functions.php:6096 lib/functions.php:6098
+#: lib/functions.php:6102
 msgid "Ping Results"
 msgstr ""
 
@@ -14872,7 +16109,9 @@ msgstr ""
 
 #: lib/api_device.php:3090 lib/api_device.php:3197
 #, php-format
-msgid "Export Could not find the Device Template with the ID %s!.  Check the Cacti Log for details"
+msgid ""
+"Export Could not find the Device Template with the ID %s!.  Check the Cacti "
+"Log for details"
 msgstr ""
 
 #: lib/api_device.php:3182
@@ -15029,193 +16268,210 @@ msgstr ""
 
 #: lib/api_scheduler.php:361
 #, php-format
-msgid "ERROR: You must specify both the Months and Days of Month.  Disabling Network %s!"
+msgid ""
+"ERROR: You must specify both the Months and Days of Month.  Disabling "
+"Network %s!"
 msgstr ""
 
 #: lib/api_scheduler.php:367
 #, php-format
-msgid "ERROR: You must specify the Months, Weeks of Months, and Days of Week.  Disabling Network %s!"
+msgid ""
+"ERROR: You must specify the Months, Weeks of Months, and Days of Week.  "
+"Disabling Network %s!"
 msgstr ""
 
 #: lib/api_tree.php:242
 msgid "New Branch"
 msgstr ""
 
-#: lib/auth.php:578
+#: lib/auth.php:584
 msgid "Web Basic"
 msgstr ""
 
-#: lib/auth.php:2267
+#: lib/auth.php:2283
 msgid "Device:(Hide Disabled)"
 msgstr ""
 
-#: lib/auth.php:2286 lib/auth.php:2288 lib/auth.php:2294 lib/auth.php:2296
+#: lib/auth.php:2302 lib/auth.php:2304 lib/auth.php:2310 lib/auth.php:2312
 #, php-format
 msgid "Graph:(%s%s)"
 msgstr ""
 
-#: lib/auth.php:2309 lib/auth.php:2315 lib/auth.php:2382 lib/auth.php:2384
-#: lib/auth.php:2388 lib/auth.php:2390
+#: lib/auth.php:2325 lib/auth.php:2331 lib/auth.php:2398 lib/auth.php:2400
+#: lib/auth.php:2404 lib/auth.php:2406
 #, php-format
 msgid "Device:(%s%s)"
 msgstr ""
 
-#: lib/auth.php:2323 lib/auth.php:2329 lib/auth.php:2398 lib/auth.php:2400
-#: lib/auth.php:2404 lib/auth.php:2406
+#: lib/auth.php:2339 lib/auth.php:2345 lib/auth.php:2414 lib/auth.php:2416
+#: lib/auth.php:2420 lib/auth.php:2422
 #, php-format
 msgid "Template:(%s%s)"
 msgstr ""
 
-#: lib/auth.php:2336
+#: lib/auth.php:2352
 #, php-format
 msgid "Graph+Device+Template:(%s%s)"
 msgstr ""
 
-#: lib/auth.php:2373 lib/auth.php:2375
+#: lib/auth.php:2389 lib/auth.php:2391
 #, php-format
 msgid "Device+Template:(%s%s)"
 msgstr ""
 
-#: lib/auth.php:2419 lib/auth.php:2426 lib/auth.php:2435
+#: lib/auth.php:2435 lib/auth.php:2442 lib/auth.php:2451
 msgid "Restricted By: "
 msgstr ""
 
-#: lib/auth.php:2423
+#: lib/auth.php:2439
 msgid "Granted By: "
 msgstr ""
 
-#: lib/auth.php:2430
+#: lib/auth.php:2446
 msgid "Granted"
 msgstr ""
 
-#: lib/auth.php:2432 lib/auth.php:2437
+#: lib/auth.php:2448 lib/auth.php:2453
 msgid "Restricted"
 msgstr ""
 
-#: lib/auth.php:2639
+#: lib/auth.php:2659
 msgid "Branch:"
 msgstr ""
 
-#: lib/auth.php:2648 lib/html_tree.php:1316 lib/reports.php:1185
+#: lib/auth.php:2668 lib/html_tree.php:1316 lib/reports.php:1185
 #: support.php:678
 msgid "Device:"
 msgstr ""
 
-#: lib/auth.php:3515 lib/auth.php:3594
+#: lib/auth.php:3535 lib/auth.php:3614
 msgid "Your account has been locked.  Please contact your Administrator."
 msgstr ""
 
-#: lib/auth.php:3557
+#: lib/auth.php:3577
 msgid "Access Denied!  Login Disabled."
 msgstr ""
 
-#: lib/auth.php:3600 lib/auth.php:3606 lib/auth.php:3724 lib/auth.php:4023
-#: lib/auth.php:4089
+#: lib/auth.php:3620 lib/auth.php:3626 lib/auth.php:3744 lib/auth.php:4055
+#: lib/auth.php:4121
 msgid "Access Denied!  Login Failed."
 msgstr ""
 
-#: lib/auth.php:3627
-msgid "Web Basic Authentication configured, but no username was passed from the web server. Please make sure you have authentication enabled on the web server."
+#: lib/auth.php:3647
+msgid ""
+"Web Basic Authentication configured, but no username was passed from the web "
+"server. Please make sure you have authentication enabled on the web server."
 msgstr ""
 
-#: lib/auth.php:3641
+#: lib/auth.php:3661
 #, php-format
-msgid "%s authenticated by Web Server, but both Template and Guest Users are not defined in Cacti."
+msgid ""
+"%s authenticated by Web Server, but both Template and Guest Users are not "
+"defined in Cacti."
 msgstr ""
 
-#: lib/auth.php:3749
+#: lib/auth.php:3769
 #, php-format
 msgid "LDAP Search Error: %s"
 msgstr ""
 
-#: lib/auth.php:3842 lib/auth.php:4692
+#: lib/auth.php:3862 lib/auth.php:4717
 #, php-format
-msgid "Access Denied!  Template user id %s does not exist.  Please contact your Administrator."
+msgid ""
+"Access Denied!  Template user id %s does not exist.  Please contact your "
+"Administrator."
 msgstr ""
 
-#: lib/auth.php:3850
+#: lib/auth.php:3870
 #, php-format
 msgid "Access Denied!  LDAP Error: %s"
 msgstr ""
 
-#: lib/auth.php:3862 lib/auth.php:4063
+#: lib/auth.php:3882 lib/auth.php:4095
 msgid "Access Denied!  No password provided by user."
 msgstr ""
 
-#: lib/auth.php:4053
+#: lib/auth.php:4085
 msgid "Access Denied!  Login failed, account disabled."
 msgstr ""
 
-#: lib/auth.php:4079
+#: lib/auth.php:4111
 msgid "Access Denied! Login Failed."
 msgstr ""
 
-#: lib/auth.php:4079
+#: lib/auth.php:4111
 msgid "Reset password"
 msgstr ""
 
-#: lib/auth.php:4110
-msgid "Your Cacti administrator has forced complex passwords for logins and your current Cacti password does not match the new requirements.  Therefore, you must change your password now."
+#: lib/auth.php:4142
+msgid ""
+"Your Cacti administrator has forced complex passwords for logins and your "
+"current Cacti password does not match the new requirements.  Therefore, you "
+"must change your password now."
 msgstr ""
 
-#: lib/auth.php:4143
+#: lib/auth.php:4175
 #, php-format
 msgid "Password must be at least %d characters!"
 msgstr ""
 
-#: lib/auth.php:4149
+#: lib/auth.php:4181
 msgid "Your password must contain at least 1 numerical character!"
 msgstr ""
 
-#: lib/auth.php:4153
-msgid "Your password must contain a mix of lower case and upper case characters!"
+#: lib/auth.php:4185
+msgid ""
+"Your password must contain a mix of lower case and upper case characters!"
 msgstr ""
 
-#: lib/auth.php:4159
+#: lib/auth.php:4191
 msgid "Your password must contain at least 1 special character!"
 msgstr ""
 
-#: lib/auth.php:4195
-msgid "This password appears to be a well known password, please use a different one"
+#: lib/auth.php:4226
+msgid ""
+"This password appears to be a well known password, please use a different one"
 msgstr ""
 
-#: lib/auth.php:4492
+#: lib/auth.php:4517
 msgid "Cacti Login Failure"
 msgstr ""
 
-#: lib/auth.php:4768
-msgid "Authentication was previously not set.  Attempted to set to Local Authentication, but no Administrative account was found."
+#: lib/auth.php:4793
+msgid ""
+"Authentication was previously not set.  Attempted to set to Local "
+"Authentication, but no Administrative account was found."
 msgstr ""
 
-#: lib/auth.php:4810 lib/auth.php:4851 lib/auth.php:4896
+#: lib/auth.php:4835 lib/auth.php:4876 lib/auth.php:4924
 msgid "Unknown error"
 msgstr ""
 
-#: lib/auth.php:4814 lib/auth.php:4855 lib/auth.php:4900
+#: lib/auth.php:4839 lib/auth.php:4880 lib/auth.php:4928
 msgid "ERROR: Unable to find user"
 msgstr ""
 
-#: lib/auth.php:4826
+#: lib/auth.php:4851
 msgid "2FA failed to be disabled"
 msgstr ""
 
-#: lib/auth.php:4829
+#: lib/auth.php:4854
 msgid "2FA is now disabled"
 msgstr ""
 
-#: lib/auth.php:4870
+#: lib/auth.php:4898
 msgid "2FA secret failed to be generated/updated"
 msgstr ""
 
-#: lib/auth.php:4873
+#: lib/auth.php:4901
 msgid "2FA secret has needs verification"
 msgstr ""
 
-#: lib/auth.php:4908
+#: lib/auth.php:4936
 msgid "ERROR: Code was not verified, please try again"
 msgstr ""
 
-#: lib/auth.php:4913
+#: lib/auth.php:4941
 msgid "2FA has been enabled and verified"
 msgstr ""
 
@@ -15236,17 +16492,23 @@ msgstr ""
 
 #: lib/clog_webapi.php:139
 #, php-format
-msgid "Cacti Log file rotation failed for Log File '%s'.  User '%s' wished to rotate, but rotating is disabled"
+msgid ""
+"Cacti Log file rotation failed for Log File '%s'.  User '%s' wished to "
+"rotate, but rotating is disabled"
 msgstr ""
 
 #: lib/clog_webapi.php:145
 #, php-format
-msgid "Cacti Log file purging failed for Log File '%s'.  User '%s' wished to purge, but purging is disabled"
+msgid ""
+"Cacti Log file purging failed for Log File '%s'.  User '%s' wished to purge, "
+"but purging is disabled"
 msgstr ""
 
 #: lib/clog_webapi.php:151
 #, php-format
-msgid "Cacti Log file rotation failed for Log File '%s'.  User '%s' wished to rotate, but rotating is not allowed on already rotated files"
+msgid ""
+"Cacti Log file rotation failed for Log File '%s'.  User '%s' wished to "
+"rotate, but rotating is not allowed on already rotated files"
 msgstr ""
 
 #: lib/clog_webapi.php:157
@@ -15261,7 +16523,9 @@ msgstr ""
 
 #: lib/clog_webapi.php:174
 #, php-format
-msgid "Removal Failed due to the Administrator blocking removal of archived files.  The file '%s' can not be removed."
+msgid ""
+"Removal Failed due to the Administrator blocking removal of archived files.  "
+"The file '%s' can not be removed."
 msgstr ""
 
 #: lib/clog_webapi.php:272
@@ -15385,8 +16649,8 @@ msgid "Tail Lines"
 msgstr ""
 
 #: lib/clog_webapi.php:686 lib/html.php:1445 lib/html_reports.php:1037
-#: lib/html_reports.php:1665 lib/rrd.php:3618 package_import.php:357
-#: package_repos.php:462 support.php:1302 utilities.php:1629
+#: lib/html_reports.php:1665 lib/rrd.php:3652 package_import.php:357
+#: package_repos.php:481 support.php:1302 utilities.php:1629
 msgid "Type"
 msgstr ""
 
@@ -15426,7 +16690,8 @@ msgid "Unknown Type = '%s'."
 msgstr ""
 
 #: lib/data_query.php:211
-msgid "WARNING: Sort Field Association has Changed.  Re-mapping issues may occur!"
+msgid ""
+"WARNING: Sort Field Association has Changed.  Re-mapping issues may occur!"
 msgstr ""
 
 #: lib/data_query.php:223
@@ -15481,7 +16746,9 @@ msgstr ""
 
 #: lib/data_query.php:435
 #, php-format
-msgid "Update Re-Index Cache complete. There were %s index changes, and %s orphaned indexes."
+msgid ""
+"Update Re-Index Cache complete. There were %s index changes, and %s orphaned "
+"indexes."
 msgstr ""
 
 #: lib/data_query.php:439
@@ -15489,7 +16756,8 @@ msgid "Update Poller Cache for Query complete"
 msgstr ""
 
 #: lib/data_query.php:441
-msgid "No Index Changes Detected, Skipping Re-Index and Poller Cache Re-population"
+msgid ""
+"No Index Changes Detected, Skipping Re-Index and Poller Cache Re-population"
 msgstr ""
 
 #: lib/data_query.php:488
@@ -15541,7 +16809,9 @@ msgid "Invalid field &lt;index_order&gt;%s&lt;/index_order&gt;"
 msgstr ""
 
 #: lib/data_query.php:775 lib/data_query.php:993
-msgid "Must contain &lt;direction&gt;input&lt;/direction&gt; or &lt;direction&gt;input-output&lt;/direction&gt; fields only"
+msgid ""
+"Must contain &lt;direction&gt;input&lt;/direction&gt; or "
+"&lt;direction&gt;input-output&lt;/direction&gt; fields only"
 msgstr ""
 
 #: lib/data_query.php:793
@@ -15549,7 +16819,9 @@ msgid "Data Query returned no indexes."
 msgstr ""
 
 #: lib/data_query.php:794
-msgid "&lt;arg_num_indexes&gt; exists in XML file but no data returned., 'Index Count Changed' not supported"
+msgid ""
+"&lt;arg_num_indexes&gt; exists in XML file but no data returned., 'Index "
+"Count Changed' not supported"
 msgstr ""
 
 #: lib/data_query.php:797
@@ -15563,11 +16835,15 @@ msgid "Found number of indexes: %s"
 msgstr ""
 
 #: lib/data_query.php:804
-msgid "&lt;arg_num_indexes&gt; missing in XML file, 'Index Count Changed' not supported"
+msgid ""
+"&lt;arg_num_indexes&gt; missing in XML file, 'Index Count Changed' not "
+"supported"
 msgstr ""
 
 #: lib/data_query.php:806
-msgid "&lt;arg_num_indexes&gt; missing in XML file, 'Index Count Changed' emulated by counting arg_index entries"
+msgid ""
+"&lt;arg_num_indexes&gt; missing in XML file, 'Index Count Changed' emulated "
+"by counting arg_index entries"
 msgstr ""
 
 #: lib/data_query.php:817
@@ -15651,7 +16927,9 @@ msgid "Executing SNMP get for num of indexes @ '%s' Index Count: %s"
 msgstr ""
 
 #: lib/data_query.php:1078
-msgid "&lt;oid_num_indexes&gt; missing in XML file, 'Index Count Changed' emulated by counting oid_index entries"
+msgid ""
+"&lt;oid_num_indexes&gt; missing in XML file, 'Index Count Changed' emulated "
+"by counting oid_index entries"
 msgstr ""
 
 #: lib/data_query.php:1081
@@ -15690,7 +16968,9 @@ msgstr ""
 
 #: lib/data_query.php:1153
 #, php-format
-msgid "Fixing wrong 'method' field for '%s' since 'rewrite_index' or 'oid_suffix' is defined"
+msgid ""
+"Fixing wrong 'method' field for '%s' since 'rewrite_index' or 'oid_suffix' "
+"is defined"
 msgstr ""
 
 #: lib/data_query.php:1160
@@ -15827,19 +17107,27 @@ msgstr ""
 
 #: lib/data_query.php:2844
 #, php-format
-msgid "You must select an XML output column for Data Source '%s' and toggle the checkbox to its right"
+msgid ""
+"You must select an XML output column for Data Source '%s' and toggle the "
+"checkbox to its right"
 msgstr ""
 
 #: lib/data_query.php:2850
-msgid "Your Graph Template has not Data Templates in use.  Please correct your Graph Template"
+msgid ""
+"Your Graph Template has not Data Templates in use.  Please correct your "
+"Graph Template"
 msgstr ""
 
 #: lib/database.php:2320
-msgid "Failed to determine password field length, can not continue as may corrupt password"
+msgid ""
+"Failed to determine password field length, can not continue as may corrupt "
+"password"
 msgstr ""
 
 #: lib/database.php:2330
-msgid "Failed to alter password field length, can not continue as may corrupt password"
+msgid ""
+"Failed to alter password field length, can not continue as may corrupt "
+"password"
 msgstr ""
 
 #: lib/dsdebug.php:190
@@ -15861,12 +17149,15 @@ msgstr ""
 
 #: lib/dsdebug.php:293
 #, php-format
-msgid "RRDfile Folder (rra) is not writable by Poller.  Folder owner: %s.  Poller runs as: %s"
+msgid ""
+"RRDfile Folder (rra) is not writable by Poller.  Folder owner: %s.  Poller "
+"runs as: %s"
 msgstr ""
 
 #: lib/dsdebug.php:298
 #, php-format
-msgid "RRDfile is not writable by Poller.  RRDfile owner: %s.  Poller runs as %s"
+msgid ""
+"RRDfile is not writable by Poller.  RRDfile owner: %s.  Poller runs as %s"
 msgstr ""
 
 #: lib/dsdebug.php:307
@@ -15905,7 +17196,9 @@ msgstr ""
 
 #: lib/functions.php:884
 #, php-format
-msgid "Form Validation Failed: Variable '%s' does not allow nulls and variable is null"
+msgid ""
+"Form Validation Failed: Variable '%s' does not allow nulls and variable is "
+"null"
 msgstr ""
 
 #: lib/functions.php:886
@@ -15935,160 +17228,168 @@ msgstr ""
 msgid "Error %s is not readable"
 msgstr ""
 
-#: lib/functions.php:4091
+#: lib/functions.php:4141
 msgid "Logged in a Guest"
 msgstr ""
 
-#: lib/functions.php:4091 lib/functions.php:4107
+#: lib/functions.php:4141 lib/functions.php:4161
 msgid "Logged in as"
 msgstr ""
 
-#: lib/functions.php:4091
+#: lib/functions.php:4141
 msgid "Login as Regular User"
 msgstr ""
 
-#: lib/functions.php:4091
+#: lib/functions.php:4141
 msgid "guest"
 msgstr ""
 
-#: lib/functions.php:4094 lib/functions.php:4117 lib/html.php:3217
+#: lib/functions.php:4144 lib/functions.php:4171 lib/html.php:3158
 msgid "User Community"
 msgstr ""
 
-#: lib/functions.php:4095 lib/functions.php:4118 lib/html.php:3223
+#: lib/functions.php:4145 lib/functions.php:4172 lib/html.php:3164
 #: lib/utility.php:1378
 msgid "Documentation"
 msgstr ""
 
-#: lib/functions.php:4110
+#: lib/functions.php:4164
 #, php-format
 msgid "Logged in as %s"
 msgstr ""
 
-#: lib/functions.php:4112 lib/html.php:3252
+#: lib/functions.php:4166 lib/html.php:3193
 msgid "Edit Profile"
 msgstr ""
 
-#: lib/functions.php:4122 lib/html.php:3265
+#: lib/functions.php:4176 lib/html.php:3206
 msgid "Logout"
 msgstr ""
 
-#: lib/functions.php:4272
+#: lib/functions.php:4326
 msgid "Leaf"
 msgstr ""
 
-#: lib/functions.php:4292 lib/html_tree.php:830 lib/html_tree.php:894
+#: lib/functions.php:4346 lib/html_tree.php:830 lib/html_tree.php:894
 #: lib/html_tree.php:1280 lib/html_tree.php:1288 lib/html_tree.php:1711
 msgid "Non Query Based"
 msgstr ""
 
-#: lib/functions.php:4328
+#: lib/functions.php:4382
 #, php-format
 msgid "Link %s"
 msgstr ""
 
-#: lib/functions.php:4799
+#: lib/functions.php:4868
 msgid "Copy Section Output to Clipboard"
 msgstr ""
 
-#: lib/functions.php:5460
+#: lib/functions.php:5529
 msgid "No OAuth2 refresh token is specified. Configure OAuth2 correctly."
 msgstr ""
 
-#: lib/functions.php:5585
-msgid "Mailer Error: No recipient address set!!<br>If using the <i>Test Mail</i> link, please set the <b>Alert e-mail</b> setting."
+#: lib/functions.php:5654
+msgid ""
+"Mailer Error: No recipient address set!!<br>If using the <i>Test Mail</i> "
+"link, please set the <b>Alert e-mail</b> setting."
 msgstr ""
 
-#: lib/functions.php:5958
+#: lib/functions.php:6027
 #, php-format
 msgid "Authentication failed: %s"
 msgstr ""
 
-#: lib/functions.php:5962
+#: lib/functions.php:6031
 #, php-format
 msgid "HELO failed: %s"
 msgstr ""
 
-#: lib/functions.php:5965
+#: lib/functions.php:6034
 #, php-format
 msgid "Connect failed: %s"
 msgstr ""
 
-#: lib/functions.php:5968
+#: lib/functions.php:6037
 msgid "SMTP error: "
 msgstr ""
 
-#: lib/functions.php:5979
-msgid "This is a test message generated from Cacti.  This message was sent to test the configuration of your Mail Settings."
+#: lib/functions.php:6048
+msgid ""
+"This is a test message generated from Cacti.  This message was sent to test "
+"the configuration of your Mail Settings."
 msgstr ""
 
-#: lib/functions.php:5980
+#: lib/functions.php:6049
 msgid "Your email settings are currently set as follows"
 msgstr ""
 
-#: lib/functions.php:5983
+#: lib/functions.php:6052
 msgid "Checking Configuration...<br>"
 msgstr ""
 
-#: lib/functions.php:5994
+#: lib/functions.php:6063
 msgid "PHP's Mailer Class"
 msgstr ""
 
-#: lib/functions.php:6000
+#: lib/functions.php:6069
 msgid "Method: SMTP"
 msgstr ""
 
-#: lib/functions.php:6015
+#: lib/functions.php:6084
 msgid "Not Shown for Security Reasons"
 msgstr ""
 
-#: lib/functions.php:6016
+#: lib/functions.php:6085
 msgid "Security"
 msgstr ""
 
-#: lib/functions.php:6024
+#: lib/functions.php:6093
 msgid "Ping Results:"
 msgstr ""
 
-#: lib/functions.php:6033
+#: lib/functions.php:6102
 msgid "Bypassed"
 msgstr ""
 
-#: lib/functions.php:6043
+#: lib/functions.php:6112
 msgid "Creating Message Text..."
 msgstr ""
 
-#: lib/functions.php:6046
+#: lib/functions.php:6115
 msgid "Sending Message..."
 msgstr ""
 
-#: lib/functions.php:6050
+#: lib/functions.php:6119
 msgid "Cacti Test Message"
 msgstr ""
 
-#: lib/functions.php:6053
+#: lib/functions.php:6122
 msgid "Success!"
 msgstr ""
 
-#: lib/functions.php:6056
+#: lib/functions.php:6125
 msgid "Message Not Sent due to ping failure."
 msgstr ""
 
-#: lib/functions.php:6378
+#: lib/functions.php:6455
 msgid "Since Install"
 msgstr ""
 
-#: lib/functions.php:6710 lib/functions.php:6803
+#: lib/functions.php:6813 lib/functions.php:6906
 #, php-format
-msgid "Cacti disabled plugin %s due to the following error: %s!  See the Cacti logfile for more details."
+msgid ""
+"Cacti disabled plugin %s due to the following error: %s!  See the Cacti "
+"logfile for more details."
 msgstr ""
 
-#: lib/functions.php:6913
+#: lib/functions.php:7016
 #, php-format
-msgid "WARNING: PollerID:%s has an invalid hostname:%s.  Is it not reachable via DNS!"
+msgid ""
+"WARNING: PollerID:%s has an invalid hostname:%s.  Is it not reachable via "
+"DNS!"
 msgstr ""
 
-#: lib/functions.php:6941
+#: lib/functions.php:7044
 #, php-format
 msgid ""
 "Failed to Contact Remote Agent %s\n"
@@ -16096,27 +17397,29 @@ msgid ""
 "See Cacti Log for details."
 msgstr ""
 
-#: lib/functions.php:7416
+#: lib/functions.php:7524
 #, php-format
 msgid "- Dev %s"
 msgstr ""
 
-#: lib/functions.php:7418
+#: lib/functions.php:7526
 #, php-format
 msgid "- Beta %s"
 msgstr ""
 
-#: lib/functions.php:7486
+#: lib/functions.php:7594
 #, php-format
 msgid "Version %s %s"
 msgstr ""
 
-#: lib/functions.php:8033
+#: lib/functions.php:8151
 #, php-format
-msgid "WARNING: Key Cacti Include File \"%s\" missing.  Please locate and replace this file as we checked in \"%s\""
+msgid ""
+"WARNING: Key Cacti Include File \"%s\" missing.  Please locate and replace "
+"this file as we checked in \"%s\""
 msgstr ""
 
-#: lib/functions.php:9190
+#: lib/functions.php:9354
 msgid "System Device"
 msgstr ""
 
@@ -16156,7 +17459,7 @@ msgstr ""
 msgid "CSV Export of Graph Data"
 msgstr ""
 
-#: lib/html.php:540 lib/html.php:3299
+#: lib/html.php:540 lib/html.php:3240
 msgid "Time Graph View"
 msgstr ""
 
@@ -16201,7 +17504,11 @@ msgid "Legend"
 msgstr ""
 
 #: lib/html.php:1454
-msgid "When exporting or showing the values while hovering over the Graph, what legend to you want displayed?  If empty, it will default to data_source_name (consolidation function).  This does not work for some Cacti items such as TOTAL_ALL_DATA_SOURCES for example."
+msgid ""
+"When exporting or showing the values while hovering over the Graph, what "
+"legend to you want displayed?  If empty, it will default to data_source_name "
+"(consolidation function).  This does not work for some Cacti items such as "
+"TOTAL_ALL_DATA_SOURCES for example."
 msgstr ""
 
 #: lib/html.php:1522
@@ -16240,7 +17547,7 @@ msgstr ""
 msgid "Maximum"
 msgstr ""
 
-#: lib/html.php:2555 lib/spikekill.php:1153
+#: lib/html.php:2555 lib/spikekill.php:1016
 msgid "CF"
 msgstr ""
 
@@ -16276,411 +17583,402 @@ msgstr ""
 msgid "Business Hours"
 msgstr ""
 
-#: lib/html.php:2937
+#: lib/html.php:2929
 msgid "Standard Deviations"
 msgstr ""
 
-#: lib/html.php:2951
-msgid "Variance Outliers"
-msgstr ""
-
-#: lib/html.php:2958
+#: lib/html.php:2936
 msgid "Kills Per RRA"
 msgstr ""
 
-#: lib/html.php:2965
+#: lib/html.php:2943
 msgid "Absolute Max Value"
 msgstr ""
 
-#: lib/html.php:2971
+#: lib/html.php:2949
 msgid "Remove StdDev"
 msgstr ""
 
-#: lib/html.php:2972
-msgid "Remove Variance"
-msgstr ""
-
-#: lib/html.php:2973
+#: lib/html.php:2950
 msgid "Gap Fill Range"
 msgstr ""
 
-#: lib/html.php:2974 lib/spikekill.php:300
+#: lib/html.php:2951 lib/spikekill.php:261
 msgid "Float Range"
 msgstr ""
 
-#: lib/html.php:2975
+#: lib/html.php:2952
 msgid "Absolute Maximum"
 msgstr ""
 
-#: lib/html.php:2977
+#: lib/html.php:2954
 msgid "Dry Run StdDev"
 msgstr ""
 
-#: lib/html.php:2978
-msgid "Dry Run Variance"
-msgstr ""
-
-#: lib/html.php:2979
+#: lib/html.php:2955
 msgid "Dry Run Gap Fill Range"
 msgstr ""
 
-#: lib/html.php:2980
+#: lib/html.php:2956
 msgid "Dry Run Float Range"
 msgstr ""
 
-#: lib/html.php:2981
+#: lib/html.php:2957
 msgid "Dry Run Absolute Maximum"
 msgstr ""
 
-#: lib/html.php:3215
+#: lib/html.php:3156
 msgid "Charts"
 msgstr ""
 
-#: lib/html.php:3216
+#: lib/html.php:3157
 msgid "Client"
 msgstr ""
 
-#: lib/html.php:3220
+#: lib/html.php:3161
 msgid "Contribute to the Cacti Project"
 msgstr ""
 
-#: lib/html.php:3221
+#: lib/html.php:3162
 msgid "Panels"
 msgstr ""
 
-#: lib/html.php:3222
+#: lib/html.php:3163
 msgid "Help in Developing"
 msgstr ""
 
-#: lib/html.php:3224
+#: lib/html.php:3165
 msgid "Donation & Sponsoring"
 msgstr ""
 
-#: lib/html.php:3227
+#: lib/html.php:3168
 msgid "Cacti Home"
 msgstr ""
 
-#: lib/html.php:3228
+#: lib/html.php:3169
 msgid "Keyboard"
 msgstr ""
 
-#: lib/html.php:3229
+#: lib/html.php:3170
 msgid "Miscellaneous"
 msgstr ""
 
-#: lib/html.php:3231
+#: lib/html.php:3172
 msgid "Cacti Project Page"
 msgstr ""
 
-#: lib/html.php:3232
+#: lib/html.php:3173
 msgid "RRDProxy"
 msgstr ""
 
-#: lib/html.php:3233
+#: lib/html.php:3174
 msgid "Shortcuts"
 msgstr ""
 
-#: lib/html.php:3234
+#: lib/html.php:3175
 msgid "Spine"
 msgstr ""
 
-#: lib/html.php:3236
+#: lib/html.php:3177
 msgid "Help in Translating"
 msgstr ""
 
-#: lib/html.php:3239
+#: lib/html.php:3180
 msgid "Clear Current Filter"
 msgstr ""
 
-#: lib/html.php:3240
+#: lib/html.php:3181
 msgid "Clipboard"
 msgstr ""
 
-#: lib/html.php:3241
+#: lib/html.php:3182
 msgid "Failed to find data to copy!"
 msgstr ""
 
-#: lib/html.php:3242
+#: lib/html.php:3183
 msgid "Clipboard ID"
 msgstr ""
 
-#: lib/html.php:3243
+#: lib/html.php:3184
 msgid "Copy operation is unavailable at this time"
 msgstr ""
 
-#: lib/html.php:3244
+#: lib/html.php:3185
 msgid "Sorry, your clipboard could not be updated at this time"
 msgstr ""
 
-#: lib/html.php:3245
+#: lib/html.php:3186
 msgid "Clipboard has been updated"
 msgstr ""
 
-#: lib/html.php:3246
+#: lib/html.php:3187
 msgid "Compact Mode"
 msgstr ""
 
-#: lib/html.php:3248
+#: lib/html.php:3189
 msgid "Dark Color Mode"
 msgstr ""
 
-#: lib/html.php:3253
+#: lib/html.php:3194
 msgid "Error:"
 msgstr ""
 
-#: lib/html.php:3254
+#: lib/html.php:3195
 msgid "Sorry, we could not process your last action."
 msgstr ""
 
-#: lib/html.php:3255
+#: lib/html.php:3196
 msgid "Reason:"
 msgstr ""
 
-#: lib/html.php:3256
+#: lib/html.php:3197
 msgid "Action failed"
 msgstr ""
 
-#: lib/html.php:3257
+#: lib/html.php:3198
 msgid "The response to the last action was unexpected."
 msgstr ""
 
-#: lib/html.php:3260
+#: lib/html.php:3201
 msgid "Help"
 msgstr ""
 
-#: lib/html.php:3261
+#: lib/html.php:3202
 msgid "Ignore System Color"
 msgstr ""
 
-#: lib/html.php:3262 plugins.php:1136 plugins.php:1284
+#: lib/html.php:3203 plugins.php:1136 plugins.php:1284
 msgid "Cacti"
 msgstr ""
 
-#: lib/html.php:3263
+#: lib/html.php:3204
 msgid "Light Color Mode"
 msgstr ""
 
-#: lib/html.php:3266
+#: lib/html.php:3207
 msgid "Note, we could not process all your actions.  Details are below."
 msgstr ""
 
-#: lib/html.php:3267
+#: lib/html.php:3208
 msgid "Some Actions failed"
 msgstr ""
 
-#: lib/html.php:3268
+#: lib/html.php:3209
 msgid "No file selected"
 msgstr ""
 
-#: lib/html.php:3270
+#: lib/html.php:3211
 msgid "Passphrases match"
 msgstr ""
 
-#: lib/html.php:3271
+#: lib/html.php:3212
 msgid "Passphrase matches but too short"
 msgstr ""
 
-#: lib/html.php:3272
+#: lib/html.php:3213
 msgid "Passphrases do not match"
 msgstr ""
 
-#: lib/html.php:3273
+#: lib/html.php:3214
 msgid "Passphrase too short and not matching"
 msgstr ""
 
-#: lib/html.php:3274
+#: lib/html.php:3215
 msgid "Passphrase length meets 8 character minimum"
 msgstr ""
 
-#: lib/html.php:3275
+#: lib/html.php:3216
 msgid "Passphrase too short"
 msgstr ""
 
-#: lib/html.php:3276
+#: lib/html.php:3217
 msgid "Password Validation Passes"
 msgstr ""
 
-#: lib/html.php:3278
+#: lib/html.php:3219
 msgid "Click again to take this Graph out of Realtime"
 msgstr ""
 
-#: lib/html.php:3279
+#: lib/html.php:3220
 msgid "Click to view just this Graph in Realtime"
 msgstr ""
 
-#: lib/html.php:3280
+#: lib/html.php:3221
 msgid "Report a bug"
 msgstr ""
 
-#: lib/html.php:3282
+#: lib/html.php:3223
 msgid "Enter a regular expression"
 msgstr ""
 
-#: lib/html.php:3283
+#: lib/html.php:3224
 msgid "Select to Search"
 msgstr ""
 
-#: lib/html.php:3285 settings.php:344 settings.php:361 settings.php:412
+#: lib/html.php:3226 settings.php:344 settings.php:361 settings.php:412
 msgid "Enter keyword"
 msgstr ""
 
-#: lib/html.php:3288 lib/html_graph.php:1533
+#: lib/html.php:3229 lib/html_graph.php:1533
 msgid "Ok"
 msgstr ""
 
-#: lib/html.php:3289
+#: lib/html.php:3230
 msgid "Pause"
 msgstr ""
 
-#: lib/html.php:3290
+#: lib/html.php:3231
 msgid "The Operation was successful.  Details are below."
 msgstr ""
 
-#: lib/html.php:3291
+#: lib/html.php:3232
 msgid "Operation successful"
 msgstr ""
 
-#: lib/html.php:3292
+#: lib/html.php:3233
 msgid "Click to Show/Hide Filter"
 msgstr ""
 
-#: lib/html.php:3293
+#: lib/html.php:3234
 msgid "SpikeKill Results"
 msgstr ""
 
-#: lib/html.php:3294
+#: lib/html.php:3235
 msgid "Standard Mode"
 msgstr ""
 
-#: lib/html.php:3295
-msgid "Allow or limit the table columns to extend beyond the current windows limits."
+#: lib/html.php:3236
+msgid ""
+"Allow or limit the table columns to extend beyond the current windows limits."
 msgstr ""
 
-#: lib/html.php:3296 pollers.php:907
+#: lib/html.php:3237 pollers.php:907
 msgid "Connection Failed"
 msgstr ""
 
-#: lib/html.php:3297 pollers.php:905
+#: lib/html.php:3238 pollers.php:905
 msgid "Connection Successful"
 msgstr ""
 
-#: lib/html.php:3301
+#: lib/html.php:3242
 msgid "Use System Color"
 msgstr ""
 
-#: lib/html.php:3303
+#: lib/html.php:3244
 msgid "Utility View"
 msgstr ""
 
-#: lib/html.php:3304
+#: lib/html.php:3245
 msgid "All Graph Templates"
 msgstr ""
 
-#: lib/html.php:3305 settings.php:371
+#: lib/html.php:3246 settings.php:371
 msgid "Templates Selected"
 msgstr ""
 
-#: lib/html.php:3309
+#: lib/html.php:3250
 msgid "3rd Mouse Button"
 msgstr ""
 
-#: lib/html.php:3311
+#: lib/html.php:3252
 msgid "Auto"
 msgstr ""
 
-#: lib/html.php:3312
+#: lib/html.php:3253
 msgid "Begin with"
 msgstr ""
 
-#: lib/html.php:3314 lib/html_form.php:1830 lib/html_form.php:1920
+#: lib/html.php:3255 lib/html_form.php:1830 lib/html_form.php:1920
 msgid "Close"
 msgstr ""
 
-#: lib/html.php:3315
+#: lib/html.php:3256
 msgid "Copy graph"
 msgstr ""
 
-#: lib/html.php:3316
+#: lib/html.php:3257
 msgid "Copy graph link"
 msgstr ""
 
-#: lib/html.php:3318
+#: lib/html.php:3259
 msgid "End with"
 msgstr ""
 
-#: lib/html.php:3320
+#: lib/html.php:3261
 msgid "Zoom Mode"
 msgstr ""
 
-#: lib/html.php:3321
+#: lib/html.php:3262
 msgid "Open in new tab"
 msgstr ""
 
-#: lib/html.php:3322
+#: lib/html.php:3263
 msgid "Always Off"
 msgstr ""
 
-#: lib/html.php:3323
+#: lib/html.php:3264
 msgid "Always On"
 msgstr ""
 
-#: lib/html.php:3324
+#: lib/html.php:3265
 msgid "Quick"
 msgstr ""
 
-#: lib/html.php:3325
+#: lib/html.php:3266
 msgid "Save graph"
 msgstr ""
 
-#: lib/html.php:3327
+#: lib/html.php:3268
 msgid "Timestamps"
 msgstr ""
 
-#: lib/html.php:3328
+#: lib/html.php:3269
 msgid "2x"
 msgstr ""
 
-#: lib/html.php:3329
+#: lib/html.php:3270
 msgid "4x"
 msgstr ""
 
-#: lib/html.php:3330
+#: lib/html.php:3271
 msgid "8x"
 msgstr ""
 
-#: lib/html.php:3331
+#: lib/html.php:3272
 msgid "16x"
 msgstr ""
 
-#: lib/html.php:3332
+#: lib/html.php:3273
 msgid "32x"
 msgstr ""
 
-#: lib/html.php:3333
+#: lib/html.php:3274
 msgid "Zoom In"
 msgstr ""
 
-#: lib/html.php:3334
+#: lib/html.php:3275
 msgid "Zoom Out"
 msgstr ""
 
-#: lib/html.php:3335
+#: lib/html.php:3276
 msgid "Zoom Out Factor"
 msgstr ""
 
-#: lib/html.php:3336
+#: lib/html.php:3277
 msgid "Zoom Out Positioning"
 msgstr ""
 
-#: lib/html.php:3337
+#: lib/html.php:3278
 msgid "Zoom Window Out of Range"
 msgstr ""
 
-#: lib/html.php:3338
-msgid "Zoom Dates before January 1, 1993 are not supported in Cacti!  Pick a more recent date."
+#: lib/html.php:3279
+msgid ""
+"Zoom Dates before January 1, 1993 are not supported in Cacti!  Pick a more "
+"recent date."
 msgstr ""
 
-#: lib/html.php:3576
+#: lib/html.php:3517
 #, php-format
 msgid "Version %s | %s"
 msgstr ""
@@ -16811,7 +18109,9 @@ msgid "Unsaved Changes Detected"
 msgstr ""
 
 #: lib/html_form.php:2050
-msgid "You have unsaved changes on this form.  If you press 'Continue' these changes will be discarded.  Press 'Cancel' to continue editing the form."
+msgid ""
+"You have unsaved changes on this form.  If you press 'Continue' these "
+"changes will be discarded.  Press 'Cancel' to continue editing the form."
 msgstr ""
 
 #: lib/html_form_template.php:169
@@ -16824,7 +18124,9 @@ msgstr ""
 
 #: lib/html_form_template.php:171
 #, php-format
-msgid "A client attempted to create a SQL Injection into Cacti likely from an external host with the address %s"
+msgid ""
+"A client attempted to create a SQL Injection into Cacti likely from an "
+"external host with the address %s"
 msgstr ""
 
 #: lib/html_form_template.php:657 lib/html_form_template.php:669
@@ -16997,7 +18299,12 @@ msgid "Format File to Use"
 msgstr ""
 
 #: lib/html_reports.php:70
-msgid "Choose the custom html wrapper and CSS file to use.  This file contains both html and CSS to wrap around your report.  If it contains more than simply CSS, you need to place a special <REPORT> tag inside of the file.  This format tag will be replaced by the report content.  These files are located in the 'formats' directory."
+msgid ""
+"Choose the custom html wrapper and CSS file to use.  This file contains both "
+"html and CSS to wrap around your report.  If it contains more than simply "
+"CSS, you need to place a special <REPORT> tag inside of the file.  This "
+"format tag will be replaced by the report content.  These files are located "
+"in the 'formats' directory."
 msgstr ""
 
 #: lib/html_reports.php:75
@@ -17005,7 +18312,9 @@ msgid "Default Text Font Size"
 msgstr ""
 
 #: lib/html_reports.php:76
-msgid "Defines the default font size for all text in the report including the Report Title."
+msgid ""
+"Defines the default font size for all text in the report including the "
+"Report Title."
 msgstr ""
 
 #: lib/html_reports.php:83
@@ -17061,7 +18370,9 @@ msgid "Cacti Report"
 msgstr ""
 
 #: lib/html_reports.php:147
-msgid "This value will be used as the default Email subject.  The report name will be used if left blank."
+msgid ""
+"This value will be used as the default Email subject.  The report name will "
+"be used if left blank."
 msgstr ""
 
 #: lib/html_reports.php:155
@@ -17237,7 +18548,9 @@ msgid "Graph Tree Branch"
 msgstr ""
 
 #: lib/html_reports.php:1059
-msgid "Select a Tree Branch to use for Graphs and Devices.  Devices will be considered as Branches."
+msgid ""
+"Select a Tree Branch to use for Graphs and Devices.  Devices will be "
+"considered as Branches."
 msgstr ""
 
 #: lib/html_reports.php:1064
@@ -17257,11 +18570,15 @@ msgid "Select a Device Template to use to filter for Devices or Graphs."
 msgstr ""
 
 #: lib/html_reports.php:1102
-msgid "Select a Device to be used to filter for of select for Graphs in the case of a Device Type."
+msgid ""
+"Select a Device to be used to filter for of select for Graphs in the case of "
+"a Device Type."
 msgstr ""
 
 #: lib/html_reports.php:1113
-msgid "Select a Graph Template for the Device to be used to filter for or select Graphs in the case of a Device Type."
+msgid ""
+"Select a Graph Template for the Device to be used to filter for or select "
+"Graphs in the case of a Device Type."
 msgstr ""
 
 #: lib/html_reports.php:1122
@@ -17269,7 +18586,9 @@ msgid "Graph Name Regular Expression"
 msgstr ""
 
 #: lib/html_reports.php:1125
-msgid "A Perl compatible regular expression (REGEXP) used to select Graphs to include from the Tree or Device."
+msgid ""
+"A Perl compatible regular expression (REGEXP) used to select Graphs to "
+"include from the Tree or Device."
 msgstr ""
 
 #: lib/html_reports.php:1133
@@ -17277,7 +18596,11 @@ msgid "The Graph to use for this report item."
 msgstr ""
 
 #: lib/html_reports.php:1145
-msgid "The Graph End time will be set to the scheduled report send time.  So, if you wish the end time on the various Graphs to be midnight, ensure you send the report at midnight.  The Graph Start time will be the End Time minus the Graph Timespan."
+msgid ""
+"The Graph End time will be set to the scheduled report send time.  So, if "
+"you wish the end time on the various Graphs to be midnight, ensure you send "
+"the report at midnight.  The Graph Start time will be the End Time minus the "
+"Graph Timespan."
 msgstr ""
 
 #: lib/html_reports.php:1150 lib/html_reports.php:1668
@@ -17322,7 +18645,7 @@ msgstr ""
 msgid "Send Report"
 msgstr ""
 
-#: lib/html_reports.php:1523 lib/import.php:2919 user_admin.php:1876
+#: lib/html_reports.php:1523 lib/import.php:2919 user_admin.php:1878
 msgid "[new]"
 msgstr ""
 
@@ -17535,7 +18858,9 @@ msgid "The regular expression \"%s\" is not valid. Error is %s"
 msgstr ""
 
 #: lib/html_utility.php:1439
-msgid "Cacti regular expressions are limited to 50 characters only for security reasons."
+msgid ""
+"Cacti regular expressions are limited to 50 characters only for security "
+"reasons."
 msgstr ""
 
 #: lib/html_utility.php:1443
@@ -17568,7 +18893,9 @@ msgstr ""
 
 #: lib/html_validate.php:99
 #, php-format
-msgid "Validation error for variable %s with a value of %s.  See backtrace below for more details."
+msgid ""
+"Validation error for variable %s with a value of %s.  See backtrace below "
+"for more details."
 msgstr ""
 
 #: lib/html_validate.php:119
@@ -17741,31 +19068,47 @@ msgstr ""
 
 #: lib/installer.php:1893
 #, php-format
-msgid "You are attempting to install Cacti %s onto a 0.6.x database. Unfortunately, this can not be performed."
+msgid ""
+"You are attempting to install Cacti %s onto a 0.6.x database. Unfortunately, "
+"this can not be performed."
 msgstr ""
 
 #: lib/installer.php:1894
-msgid "To be able continue, you <b>MUST</b> create a new database, import \"cacti.sql\" into it:"
+msgid ""
+"To be able continue, you <b>MUST</b> create a new database, import "
+"\"cacti.sql\" into it:"
 msgstr ""
 
 #: lib/installer.php:1896
-msgid "You <b>MUST</b> then update \"include/config.php\" to point to the new database."
+msgid ""
+"You <b>MUST</b> then update \"include/config.php\" to point to the new "
+"database."
 msgstr ""
 
 #: lib/installer.php:1897
-msgid "NOTE: Your existing data will not be modified, nor will it or any history be available to the new install"
+msgid ""
+"NOTE: Your existing data will not be modified, nor will it or any history be "
+"available to the new install"
 msgstr ""
 
 #: lib/installer.php:1905
-msgid "You have created a new database, but have not yet imported the 'cacti.sql' file. At the command line, execute the following to continue:"
+msgid ""
+"You have created a new database, but have not yet imported the 'cacti.sql' "
+"file. At the command line, execute the following to continue:"
 msgstr ""
 
 #: lib/installer.php:1907
-msgid "This error may also be generated if the cacti database user does not have correct permissions on the Cacti database. Please ensure that the Cacti database user has the ability to SELECT, INSERT, DELETE, UPDATE, CREATE, ALTER, DROP, INDEX on the Cacti database."
+msgid ""
+"This error may also be generated if the cacti database user does not have "
+"correct permissions on the Cacti database. Please ensure that the Cacti "
+"database user has the ability to SELECT, INSERT, DELETE, UPDATE, CREATE, "
+"ALTER, DROP, INDEX on the Cacti database."
 msgstr ""
 
 #: lib/installer.php:1908
-msgid "You <b>MUST</b> also import MySQL TimeZone information into MySQL and grant the Cacti user SELECT access to the mysql.time_zone_name table"
+msgid ""
+"You <b>MUST</b> also import MySQL TimeZone information into MySQL and grant "
+"the Cacti user SELECT access to the mysql.time_zone_name table"
 msgstr ""
 
 #: lib/installer.php:1911
@@ -17773,7 +19116,11 @@ msgid "On Linux/UNIX, run the following as 'root' in a shell:"
 msgstr ""
 
 #: lib/installer.php:1914
-msgid "On Windows, you must follow the instructions here <a target='_blank' href='https://dev.mysql.com/downloads/timezones.html'>Time zone description table</a>.  Once that is complete, you can issue the following command to grant the Cacti user access to the tables:"
+msgid ""
+"On Windows, you must follow the instructions here <a target='_blank' "
+"href='https://dev.mysql.com/downloads/timezones.html'>Time zone description "
+"table</a>.  Once that is complete, you can issue the following command to "
+"grant the Cacti user access to the tables:"
 msgstr ""
 
 #: lib/installer.php:1917
@@ -17807,38 +19154,61 @@ msgstr ""
 
 #: lib/installer.php:2065
 #, php-format
-msgid "This version of Cacti (%s) does not appear to have a valid version code, please contact the Cacti Development Team to ensure this is corrected.  If you are seeing this error in a release, please raise a report immediately on GitHub"
+msgid ""
+"This version of Cacti (%s) does not appear to have a valid version code, "
+"please contact the Cacti Development Team to ensure this is corrected.  If "
+"you are seeing this error in a release, please raise a report immediately on "
+"GitHub"
 msgstr ""
 
 #: lib/installer.php:2068
-msgid "Thanks for taking the time to download and install Cacti, the complete graphing solution for your network. Before you can start making cool graphs, there are a few pieces of data that Cacti needs to know."
+msgid ""
+"Thanks for taking the time to download and install Cacti, the complete "
+"graphing solution for your network. Before you can start making cool graphs, "
+"there are a few pieces of data that Cacti needs to know."
 msgstr ""
 
 #: lib/installer.php:2069
 #, php-format
-msgid "Make sure you have read and followed the required steps needed to install Cacti before continuing. Install information can be found for <a href=\"%1$s\">Unix</a> and <a href=\"%2$s\">Win32</a>-based operating systems."
+msgid ""
+"Make sure you have read and followed the required steps needed to install "
+"Cacti before continuing. Install information can be found for <a "
+"href=\"%1$s\">Unix</a> and <a href=\"%2$s\">Win32</a>-based operating "
+"systems."
 msgstr ""
 
 #: lib/installer.php:2072
 #, php-format
-msgid "This process will guide you through the steps for upgrading from version '%s'. "
+msgid ""
+"This process will guide you through the steps for upgrading from version "
+"'%s'. "
 msgstr ""
 
 #: lib/installer.php:2073
 #, php-format
-msgid "Also, if this is an upgrade, be sure to read the <a href=\"%s\">Upgrade</a> information file."
+msgid ""
+"Also, if this is an upgrade, be sure to read the <a href=\"%s\">Upgrade</a> "
+"information file."
 msgstr ""
 
 #: lib/installer.php:2077
-msgid "It is NOT recommended to downgrade as the database structure may be inconsistent"
+msgid ""
+"It is NOT recommended to downgrade as the database structure may be "
+"inconsistent"
 msgstr ""
 
 #: lib/installer.php:2080
-msgid "Cacti is licensed under the GNU General Public License, you must agree to its provisions before continuing:"
+msgid ""
+"Cacti is licensed under the GNU General Public License, you must agree to "
+"its provisions before continuing:"
 msgstr ""
 
 #: lib/installer.php:2084
-msgid "This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details."
+msgid ""
+"This program is distributed in the hope that it will be useful, but WITHOUT "
+"ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
+"FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for "
+"more details."
 msgstr ""
 
 #: lib/installer.php:2127
@@ -17858,11 +19228,15 @@ msgid "Location checks"
 msgstr ""
 
 #: lib/installer.php:2187
-msgid "Please update config.php with the correct relative URI location of Cacti (url_path)."
+msgid ""
+"Please update config.php with the correct relative URI location of Cacti "
+"(url_path)."
 msgstr ""
 
 #: lib/installer.php:2190
-msgid "Your Cacti configuration has the relative correct path (url_path) in config.php."
+msgid ""
+"Your Cacti configuration has the relative correct path (url_path) in "
+"config.php."
 msgstr ""
 
 #: lib/installer.php:2199
@@ -17907,7 +19281,9 @@ msgid "Restart Required"
 msgstr ""
 
 #: lib/installer.php:2244
-msgid "The specified value appears to be different in the running config versus the INI file."
+msgid ""
+"The specified value appears to be different in the running config versus the "
+"INI file."
 msgstr ""
 
 #: lib/installer.php:2277
@@ -17915,11 +19291,19 @@ msgid "PHP - Module Support (Required)"
 msgstr ""
 
 #: lib/installer.php:2278
-msgid "Cacti requires several PHP Modules to be installed to work properly. If any of these are not installed, you will be unable to continue the installation until corrected. In addition, for optimal system performance Cacti should be run with certain MySQL system variables set.  Please follow the MySQL recommendations at your discretion.  Always seek the MySQL documentation if you have any questions."
+msgid ""
+"Cacti requires several PHP Modules to be installed to work properly. If any "
+"of these are not installed, you will be unable to continue the installation "
+"until corrected. In addition, for optimal system performance Cacti should be "
+"run with certain MySQL system variables set.  Please follow the MySQL "
+"recommendations at your discretion.  Always seek the MySQL documentation if "
+"you have any questions."
 msgstr ""
 
 #: lib/installer.php:2280
-msgid "The following PHP extensions are mandatory, and MUST be installed before continuing your Cacti install."
+msgid ""
+"The following PHP extensions are mandatory, and MUST be installed before "
+"continuing your Cacti install."
 msgstr ""
 
 #: lib/installer.php:2284
@@ -17939,7 +19323,11 @@ msgid "PHP - Module Support (Optional)"
 msgstr ""
 
 #: lib/installer.php:2310
-msgid "The following PHP extensions are recommended, and should be installed before continuing your Cacti install.  NOTE: If you are planning on supporting SNMPv3 with IPv6 or SNMPv3 with stronger ciphers, you should not install the php-snmp module at this time."
+msgid ""
+"The following PHP extensions are recommended, and should be installed before "
+"continuing your Cacti install.  NOTE: If you are planning on supporting "
+"SNMPv3 with IPv6 or SNMPv3 with stronger ciphers, you should not install the "
+"php-snmp module at this time."
 msgstr ""
 
 #: lib/installer.php:2314
@@ -17955,15 +19343,23 @@ msgid "MySQL - TimeZone Support"
 msgstr ""
 
 #: lib/installer.php:2348
-msgid "Your MySQL TimeZone database is not populated.  Please populate this database before proceeding."
+msgid ""
+"Your MySQL TimeZone database is not populated.  Please populate this "
+"database before proceeding."
 msgstr ""
 
 #: lib/installer.php:2352
-msgid "Your Cacti database login account does not have access to the MySQL TimeZone database.  Please provide the Cacti database account \"select\" access to the \"time_zone_name\" table in the \"mysql\" database, and populate MySQL's TimeZone information before proceeding."
+msgid ""
+"Your Cacti database login account does not have access to the MySQL TimeZone "
+"database.  Please provide the Cacti database account \"select\" access to "
+"the \"time_zone_name\" table in the \"mysql\" database, and populate MySQL's "
+"TimeZone information before proceeding."
 msgstr ""
 
 #: lib/installer.php:2357
-msgid "Your Cacti database account has access to the MySQL TimeZone database and that database is populated with global TimeZone information."
+msgid ""
+"Your Cacti database account has access to the MySQL TimeZone database and "
+"that database is populated with global TimeZone information."
 msgstr ""
 
 #: lib/installer.php:2362
@@ -17971,7 +19367,9 @@ msgid "MySQL - Settings"
 msgstr ""
 
 #: lib/installer.php:2363
-msgid "These MySQL performance tuning settings will help your Cacti system perform better without issues for a longer time."
+msgid ""
+"These MySQL performance tuning settings will help your Cacti system perform "
+"better without issues for a longer time."
 msgstr ""
 
 #: lib/installer.php:2365
@@ -17988,15 +19386,28 @@ msgid "Upgrade from <strong>%s</strong> to <strong>%s</strong>"
 msgstr ""
 
 #: lib/installer.php:2402
-msgid "In the event of issues, It is highly recommended that you clear your browser cache, closing then reopening your browser (not just the tab Cacti is on) and retrying, before raising an issue with The Cacti Group"
+msgid ""
+"In the event of issues, It is highly recommended that you clear your browser "
+"cache, closing then reopening your browser (not just the tab Cacti is on) "
+"and retrying, before raising an issue with The Cacti Group"
 msgstr ""
 
 #: lib/installer.php:2403
-msgid "On rare occasions, we have had reports from users who experience some minor issues due to changes in the code.  These issues are caused by the browser retaining pre-upgrade code and whilst we have taken steps to minimise the chances of this, it may still occur.  If you need instructions on how to clear your browser cache, <a href='https://www.refreshyourcache.com' target='_blank'>https://www.refreshyourcache.com/</a> is a good starting point."
+msgid ""
+"On rare occasions, we have had reports from users who experience some minor "
+"issues due to changes in the code.  These issues are caused by the browser "
+"retaining pre-upgrade code and whilst we have taken steps to minimise the "
+"chances of this, it may still occur.  If you need instructions on how to "
+"clear your browser cache, <a href='https://www.refreshyourcache.com' "
+"target='_blank'>https://www.refreshyourcache.com/</a> is a good starting "
+"point."
 msgstr ""
 
 #: lib/installer.php:2404
-msgid "If after clearing your cache and restarting your browser, you still experience issues, please raise the issue with us and we will try to identify the cause of it."
+msgid ""
+"If after clearing your cache and restarting your browser, you still "
+"experience issues, please raise the issue with us and we will try to "
+"identify the cause of it."
 msgstr ""
 
 #: lib/installer.php:2411
@@ -18005,7 +19416,9 @@ msgid "Downgrade from <strong>%s</strong> to <strong>%s</strong>"
 msgstr ""
 
 #: lib/installer.php:2412
-msgid "You appear to be downgrading to a previous version.  Database changes made for the newer version will not be reversed and <i>could</i> cause issues."
+msgid ""
+"You appear to be downgrading to a previous version.  Database changes made "
+"for the newer version will not be reversed and <i>could</i> cause issues."
 msgstr ""
 
 #: lib/installer.php:2418
@@ -18029,11 +19442,16 @@ msgid "New Remote Poller"
 msgstr ""
 
 #: lib/installer.php:2424
-msgid "Remote Pollers are used to access networks that are not readily accessible to the Primary site."
+msgid ""
+"Remote Pollers are used to access networks that are not readily accessible "
+"to the Primary site."
 msgstr ""
 
 #: lib/installer.php:2480
-msgid "The following information has been determined from Cacti's configuration file. If it is not correct, please edit \"include/config.php\" before continuing."
+msgid ""
+"The following information has been determined from Cacti's configuration "
+"file. If it is not correct, please edit \"include/config.php\" before "
+"continuing."
 msgstr ""
 
 #: lib/installer.php:2484
@@ -18074,7 +19492,10 @@ msgid "Configuration Readonly!"
 msgstr ""
 
 #: lib/installer.php:2510
-msgid "Your config.php file must be writable by the web server during install in order to configure the Remote poller.  Once installation is complete, you must set this file to Read Only to prevent possible security issues."
+msgid ""
+"Your config.php file must be writable by the web server during install in "
+"order to configure the Remote poller.  Once installation is complete, you "
+"must set this file to Read Only to prevent possible security issues."
 msgstr ""
 
 #: lib/installer.php:2514
@@ -18082,7 +19503,12 @@ msgid "Configuration of Poller"
 msgstr ""
 
 #: lib/installer.php:2515
-msgid "Your Remote Cacti Poller information has not been included in your config.php file.  Please review the config.php.dist, and set the variables: <i>$rdatabase_default, $rdatabase_username</i>, etc.  These variables must be set and point back to your Primary Cacti database server.  Correct this and try again."
+msgid ""
+"Your Remote Cacti Poller information has not been included in your "
+"config.php file.  Please review the config.php.dist, and set the variables: "
+"<i>$rdatabase_default, $rdatabase_username</i>, etc.  These variables must "
+"be set and point back to your Primary Cacti database server.  Correct this "
+"and try again."
 msgstr ""
 
 #: lib/installer.php:2519
@@ -18090,15 +19516,23 @@ msgid "Remote Poller Variables"
 msgstr ""
 
 #: lib/installer.php:2521
-msgid "The variables that must be set in the config.php file include the following:"
+msgid ""
+"The variables that must be set in the config.php file include the following:"
 msgstr ""
 
 #: lib/installer.php:2532
-msgid "The Installer automatically assigns a $poller_id and adds it to the config.php file."
+msgid ""
+"The Installer automatically assigns a $poller_id and adds it to the "
+"config.php file."
 msgstr ""
 
 #: lib/installer.php:2534
-msgid "Once the variables are all set in the config.php file, you must also grant the $rdatabase_username access to the main Cacti database server.  Follow the same procedure you would with any other Cacti install.  You may then press the 'Test Connection' button.  If the test is successful you will be able to proceed and complete the install."
+msgid ""
+"Once the variables are all set in the config.php file, you must also grant "
+"the $rdatabase_username access to the main Cacti database server.  Follow "
+"the same procedure you would with any other Cacti install.  You may then "
+"press the 'Test Connection' button.  If the test is successful you will be "
+"able to proceed and complete the install."
 msgstr ""
 
 #: lib/installer.php:2538
@@ -18106,7 +19540,11 @@ msgid "Additional Steps After Installation"
 msgstr ""
 
 #: lib/installer.php:2540
-msgid "It is essential that the Central Cacti server can communicate via MySQL to each remote Cacti database server.  Once the install is complete, you must edit the Remote Data Collector and ensure the settings are correct.  You can verify using the 'Test Connection' when editing the Remote Data Collector."
+msgid ""
+"It is essential that the Central Cacti server can communicate via MySQL to "
+"each remote Cacti database server.  Once the install is complete, you must "
+"edit the Remote Data Collector and ensure the settings are correct.  You can "
+"verify using the 'Test Connection' when editing the Remote Data Collector."
 msgstr ""
 
 #: lib/installer.php:2554
@@ -18126,23 +19564,42 @@ msgid "Directory Permission Checks"
 msgstr ""
 
 #: lib/installer.php:2644
-msgid "Please ensure the directory permissions below are correct before proceeding.  During the install, these directories need to be owned by the Web Server user.  These permission changes are required to allow the Installer to install Device Template packages which include XML and script files that will be placed in these directories.  If you choose not to install the packages, there is an 'install_package.php' cli script that can be used from the command line after the install is complete."
+msgid ""
+"Please ensure the directory permissions below are correct before "
+"proceeding.  During the install, these directories need to be owned by the "
+"Web Server user.  These permission changes are required to allow the "
+"Installer to install Device Template packages which include XML and script "
+"files that will be placed in these directories.  If you choose not to "
+"install the packages, there is an 'install_package.php' cli script that can "
+"be used from the command line after the install is complete."
 msgstr ""
 
 #: lib/installer.php:2647
-msgid "After the install is complete, you can make some of these directories read only to increase security."
+msgid ""
+"After the install is complete, you can make some of these directories read "
+"only to increase security."
 msgstr ""
 
 #: lib/installer.php:2649
-msgid "These directories will be required to stay read writable after the install so that the Cacti remote synchronization process can update them as the Main Cacti Web Site changes"
+msgid ""
+"These directories will be required to stay read writable after the install "
+"so that the Cacti remote synchronization process can update them as the Main "
+"Cacti Web Site changes"
 msgstr ""
 
 #: lib/installer.php:2653
-msgid "If you are installing packages, once the packages are installed, you should change the scripts directory back to read only as this presents some exposure to the web site."
+msgid ""
+"If you are installing packages, once the packages are installed, you should "
+"change the scripts directory back to read only as this presents some "
+"exposure to the web site."
 msgstr ""
 
 #: lib/installer.php:2655
-msgid "For remote pollers, it is critical that the paths that you will be updating frequently, including the plugins, scripts, and resources paths have read/write access as the data collector will have to update these paths from the main web server content."
+msgid ""
+"For remote pollers, it is critical that the paths that you will be updating "
+"frequently, including the plugins, scripts, and resources paths have read/"
+"write access as the data collector will have to update these paths from the "
+"main web server content."
 msgstr ""
 
 #: lib/installer.php:2662
@@ -18162,11 +19619,16 @@ msgid "Potential permission issues"
 msgstr ""
 
 #: lib/installer.php:2735
-msgid "Please make sure that your webserver has read/write access to the cacti folders that show errors below."
+msgid ""
+"Please make sure that your webserver has read/write access to the cacti "
+"folders that show errors below."
 msgstr ""
 
 #: lib/installer.php:2739
-msgid "If SELinux is enabled on your server, you can either permanently disable this, or temporarily disable it and then add the appropriate permissions using the SELinux command-line tools."
+msgid ""
+"If SELinux is enabled on your server, you can either permanently disable "
+"this, or temporarily disable it and then add the appropriate permissions "
+"using the SELinux command-line tools."
 msgstr ""
 
 #: lib/installer.php:2749
@@ -18175,7 +19637,10 @@ msgid "The user '%s' should have MODIFY permission to enable read/write."
 msgstr ""
 
 #: lib/installer.php:2759
-msgid "An example of how to set folder permissions is shown here, though you may need to adjust this depending on your operating system, user accounts and desired permissions."
+msgid ""
+"An example of how to set folder permissions is shown here, though you may "
+"need to adjust this depending on your operating system, user accounts and "
+"desired permissions."
 msgstr ""
 
 #: lib/installer.php:2760
@@ -18183,7 +19648,8 @@ msgid "EXAMPLE:"
 msgstr ""
 
 #: lib/installer.php:2761
-msgid "Once installation has completed the CSRF path, should be set to read-only."
+msgid ""
+"Once installation has completed the CSRF path, should be set to read-only."
 msgstr ""
 
 #: lib/installer.php:2763
@@ -18195,7 +19661,12 @@ msgid "Linux kernel security modules"
 msgstr ""
 
 #: lib/installer.php:2777
-msgid "Cacti needs to establish network connections, execute binaries and write files to work. Linux security features such as <b>SELinux</b>, <b>AppArmor</b> or <b>ModSecurity</b> may cause Cacti to become inoperable in some configurations. If problems occur, check the settings of these security tools.<br/><br/>"
+msgid ""
+"Cacti needs to establish network connections, execute binaries and write "
+"files to work. Linux security features such as <b>SELinux</b>, <b>AppArmor</"
+"b> or <b>ModSecurity</b> may cause Cacti to become inoperable in some "
+"configurations. If problems occur, check the settings of these security "
+"tools.<br/><br/>"
 msgstr ""
 
 #: lib/installer.php:2779
@@ -18203,27 +19674,47 @@ msgid "Input Validation Whitelist Protection"
 msgstr ""
 
 #: lib/installer.php:2780
-msgid "Cacti Data Input methods that call a script can be exploited in ways that a non-administrator can perform damage to either files owned by the poller account, and in cases where someone runs the Cacti poller as root, can compromise the operating system allowing attackers to exploit your infrastructure."
+msgid ""
+"Cacti Data Input methods that call a script can be exploited in ways that a "
+"non-administrator can perform damage to either files owned by the poller "
+"account, and in cases where someone runs the Cacti poller as root, can "
+"compromise the operating system allowing attackers to exploit your "
+"infrastructure."
 msgstr ""
 
 #: lib/installer.php:2781
-msgid "Therefore, several versions ago, Cacti was enhanced to provide Whitelist capabilities on the these types of Data Input Methods.  Though this does secure Cacti more thoroughly, it does increase the amount of work required by the Cacti administrator to import and manage Templates and Packages."
+msgid ""
+"Therefore, several versions ago, Cacti was enhanced to provide Whitelist "
+"capabilities on the these types of Data Input Methods.  Though this does "
+"secure Cacti more thoroughly, it does increase the amount of work required "
+"by the Cacti administrator to import and manage Templates and Packages."
 msgstr ""
 
 #: lib/installer.php:2782
-msgid "The way that the Whitelisting works is that when you first import a Data Input Method, or you re-import a Data Input Method, and the script and or arguments change in any way, the Data Input Method, and all the corresponding Data Sources will be immediately disabled until the administrator validates that the Data Input Method is valid."
+msgid ""
+"The way that the Whitelisting works is that when you first import a Data "
+"Input Method, or you re-import a Data Input Method, and the script and or "
+"arguments change in any way, the Data Input Method, and all the "
+"corresponding Data Sources will be immediately disabled until the "
+"administrator validates that the Data Input Method is valid."
 msgstr ""
 
 #: lib/installer.php:2783
-msgid "To make identifying Data Input Methods in this state, we have provided a validation script in Cacti's CLI directory that can be run with the following options:"
+msgid ""
+"To make identifying Data Input Methods in this state, we have provided a "
+"validation script in Cacti's CLI directory that can be run with the "
+"following options:"
 msgstr ""
 
 #: lib/installer.php:2787
-msgid "This script option will search for any Data Input Methods that are currently banned and provide details as to why."
+msgid ""
+"This script option will search for any Data Input Methods that are currently "
+"banned and provide details as to why."
 msgstr ""
 
 #: lib/installer.php:2788
-msgid "This script option un-ban the Data Input Methods that are currently banned."
+msgid ""
+"This script option un-ban the Data Input Methods that are currently banned."
 msgstr ""
 
 #: lib/installer.php:2789
@@ -18231,11 +19722,17 @@ msgid "This script option will re-enable any disabled Data Sources."
 msgstr ""
 
 #: lib/installer.php:2793
-msgid "It is strongly suggested that you update your config.php to enable this feature by uncommenting the <b>$input_whitelist</b> variable and then running the three CLI script options above after the web based install has completed.<br/><br/>"
+msgid ""
+"It is strongly suggested that you update your config.php to enable this "
+"feature by uncommenting the <b>$input_whitelist</b> variable and then "
+"running the three CLI script options above after the web based install has "
+"completed.<br/><br/>"
 msgstr ""
 
 #: lib/installer.php:2795
-msgid "Check the Checkbox below to acknowledge that you have read and understand this security concern"
+msgid ""
+"Check the Checkbox below to acknowledge that you have read and understand "
+"this security concern"
 msgstr ""
 
 #: lib/installer.php:2797
@@ -18247,7 +19744,11 @@ msgid "Admin email address"
 msgstr ""
 
 #: lib/installer.php:2814
-msgid "In case of problems cacti can send emails to the administrator. The address filled in here will be assigned to the admin account and \"Notify Primary Admin of Issue\" will be enabled. You can change this setting and the email address later. Do not forget to set up the email settings after installation."
+msgid ""
+"In case of problems cacti can send emails to the administrator. The address "
+"filled in here will be assigned to the admin account and \"Notify Primary "
+"Admin of Issue\" will be enabled. You can change this setting and the email "
+"address later. Do not forget to set up the email settings after installation."
 msgstr ""
 
 #: lib/installer.php:2841 lib/installer.php:2848
@@ -18255,11 +19756,19 @@ msgid "Default Profile"
 msgstr ""
 
 #: lib/installer.php:2842
-msgid "Please select the default Data Source Profile to be used for polling sources. This is the maximum amount of time between scanning devices for information so the lower the polling interval, the more work is placed on the Cacti Server host. Long retention profiles store more data, so they take up more disk capacity. Their advantage is that older data is not as consolidated and is therefore more accurate than using shorter retention."
+msgid ""
+"Please select the default Data Source Profile to be used for polling "
+"sources. This is the maximum amount of time between scanning devices for "
+"information so the lower the polling interval, the more work is placed on "
+"the Cacti Server host. Long retention profiles store more data, so they take "
+"up more disk capacity. Their advantage is that older data is not as "
+"consolidated and is therefore more accurate than using shorter retention."
 msgstr ""
 
 #: lib/installer.php:2843
-msgid "Also, select the intended, or configured Cron interval that you wish to use for Data Collection."
+msgid ""
+"Also, select the intended, or configured Cron interval that you wish to use "
+"for Data Collection."
 msgstr ""
 
 #: lib/installer.php:2854
@@ -18271,11 +19780,17 @@ msgid "Default Automation Network"
 msgstr ""
 
 #: lib/installer.php:2876
-msgid "Cacti can automatically scan the network once installation has completed. This will utilise the network range below to work out the range of IPs that can be scanned.  A predefined set of options are defined for scanning which include using both 'public' and 'private' communities."
+msgid ""
+"Cacti can automatically scan the network once installation has completed. "
+"This will utilise the network range below to work out the range of IPs that "
+"can be scanned.  A predefined set of options are defined for scanning which "
+"include using both 'public' and 'private' communities."
 msgstr ""
 
 #: lib/installer.php:2877
-msgid "If your devices require a different set of options to be used first, you may define them below and they will be utilized before the defaults"
+msgid ""
+"If your devices require a different set of options to be used first, you may "
+"define them below and they will be utilized before the defaults"
 msgstr ""
 
 #: lib/installer.php:2878
@@ -18311,7 +19826,9 @@ msgid "The installation cannot continue because no profiles could be found."
 msgstr ""
 
 #: lib/installer.php:2933
-msgid "This may occur if you have a blank database and have not yet imported the cacti.sql file"
+msgid ""
+"This may occur if you have a blank database and have not yet imported the "
+"cacti.sql file"
 msgstr ""
 
 #: lib/installer.php:2941
@@ -18319,15 +19836,27 @@ msgid "Template Setup"
 msgstr ""
 
 #: lib/installer.php:2944
-msgid "Please select the Device Templates that you wish to update during the Upgrade."
+msgid ""
+"Please select the Device Templates that you wish to update during the "
+"Upgrade."
 msgstr ""
 
 #: lib/installer.php:2945
-msgid "Updating Templates that you have already made modifications to is not advisable.  The Upgrade of the Templates will NOT remove modifications to Graph and Data Templates, and can lead to unexpected behavior.  However, if you have not made changes to any Graph, Data Query, or Data Template, reimporting the Package should not have any affect.  In that case, you would have to 'Sync Graphs' to from the Templates after update."
+msgid ""
+"Updating Templates that you have already made modifications to is not "
+"advisable.  The Upgrade of the Templates will NOT remove modifications to "
+"Graph and Data Templates, and can lead to unexpected behavior.  However, if "
+"you have not made changes to any Graph, Data Query, or Data Template, "
+"reimporting the Package should not have any affect.  In that case, you would "
+"have to 'Sync Graphs' to from the Templates after update."
 msgstr ""
 
 #: lib/installer.php:2947
-msgid "Please select the Device Templates that you wish to use after the Install.  If you Operating System is Windows, you need to ensure that you select the 'Windows Device' Template.  If your Operating System is Linux/UNIX, make sure you select the 'Local Linux Machine' Device Template."
+msgid ""
+"Please select the Device Templates that you wish to use after the Install.  "
+"If you Operating System is Windows, you need to ensure that you select the "
+"'Windows Device' Template.  If your Operating System is Linux/UNIX, make "
+"sure you select the 'Local Linux Machine' Device Template."
 msgstr ""
 
 #: lib/installer.php:2953 package.php:407 package_import.php:984
@@ -18335,7 +19864,11 @@ msgid "Homepage"
 msgstr ""
 
 #: lib/installer.php:2980
-msgid "Device Templates allow you to monitor and graph a vast assortment of data within Cacti.  After you select the desired Device Templates, press 'Next' and the installation will complete.  Please be patient on this step, as the importation of the Device Templates can take a few minutes."
+msgid ""
+"Device Templates allow you to monitor and graph a vast assortment of data "
+"within Cacti.  After you select the desired Device Templates, press 'Next' "
+"and the installation will complete.  Please be patient on this step, as the "
+"importation of the Device Templates can take a few minutes."
 msgstr ""
 
 #: lib/installer.php:2988
@@ -18351,7 +19884,9 @@ msgid "Your server collation does NOT appear to be fully UTF8 compliant. "
 msgstr ""
 
 #: lib/installer.php:3000
-msgid "Under the [mysqld] section, locate the entries named 'character-set-server' and 'collation-server' and set them as follows:"
+msgid ""
+"Under the [mysqld] section, locate the entries named 'character-set-server' "
+"and 'collation-server' and set them as follows:"
 msgstr ""
 
 #: lib/installer.php:3007
@@ -18363,11 +19898,15 @@ msgid "Your database default collation appears to be UTF8 compliant"
 msgstr ""
 
 #: lib/installer.php:3016
-msgid "Your database default collation does NOT appear to be full UTF8 compliant. "
+msgid ""
+"Your database default collation does NOT appear to be full UTF8 compliant. "
 msgstr ""
 
 #: lib/installer.php:3017
-msgid "Any tables created by plugins may have issues linked against Cacti Core tables if the collation is not matched.   Please ensure your database is changed to 'utf8mb4_unicode_ci' by running the following: "
+msgid ""
+"Any tables created by plugins may have issues linked against Cacti Core "
+"tables if the collation is not matched.   Please ensure your database is "
+"changed to 'utf8mb4_unicode_ci' by running the following: "
 msgstr ""
 
 #: lib/installer.php:3024
@@ -18376,11 +19915,18 @@ msgstr ""
 
 #: lib/installer.php:3036
 #, php-format
-msgid "You have more tables than your PHP configuration will allow us to display/convert.  Please modify the max_input_vars setting in php.ini to a value above %s"
+msgid ""
+"You have more tables than your PHP configuration will allow us to display/"
+"convert.  Please modify the max_input_vars setting in php.ini to a value "
+"above %s"
 msgstr ""
 
 #: lib/installer.php:3039
-msgid "Conversion of tables may take some time especially on larger tables.  The conversion of these tables will occur in the background but will not prevent the installer from completing.  This may slow down some servers if there are not enough resources for MySQL to handle the conversion."
+msgid ""
+"Conversion of tables may take some time especially on larger tables.  The "
+"conversion of these tables will occur in the background but will not prevent "
+"the installer from completing.  This may slow down some servers if there are "
+"not enough resources for MySQL to handle the conversion."
 msgstr ""
 
 #: lib/installer.php:3043
@@ -18400,11 +19946,17 @@ msgid "Row Format"
 msgstr ""
 
 #: lib/installer.php:3077
-msgid "One or more tables are too large to convert during the installation.  You should use the cli/convert_tables.php script to perform the conversion, then refresh this page. For example: "
+msgid ""
+"One or more tables are too large to convert during the installation.  You "
+"should use the cli/convert_tables.php script to perform the conversion, then "
+"refresh this page. For example: "
 msgstr ""
 
 #: lib/installer.php:3081
-msgid "The following tables should be converted to UTF8 and InnoDB with a Dynamic row format.  Please select the tables that you wish to convert during the installation process."
+msgid ""
+"The following tables should be converted to UTF8 and InnoDB with a Dynamic "
+"row format.  Please select the tables that you wish to convert during the "
+"installation process."
 msgstr ""
 
 #: lib/installer.php:3087
@@ -18432,20 +19984,29 @@ msgid "DOWNGRADE DETECTED"
 msgstr ""
 
 #: lib/installer.php:3116
-msgid "YOU MUST MANUALLY CHANGE THE CACTI DATABASE TO REVERT ANY UPGRADE CHANGES THAT HAVE BEEN MADE.<br/>THE INSTALLER HAS NO METHOD TO DO THIS AUTOMATICALLY FOR YOU"
+msgid ""
+"YOU MUST MANUALLY CHANGE THE CACTI DATABASE TO REVERT ANY UPGRADE CHANGES "
+"THAT HAVE BEEN MADE.<br/>THE INSTALLER HAS NO METHOD TO DO THIS "
+"AUTOMATICALLY FOR YOU"
 msgstr ""
 
 #: lib/installer.php:3117
-msgid "Downgrading should only be performed when absolutely necessary and doing so may break your installation"
+msgid ""
+"Downgrading should only be performed when absolutely necessary and doing so "
+"may break your installation"
 msgstr ""
 
 #: lib/installer.php:3123
-msgid "Your Cacti Server is almost ready.  Please check that you are happy to proceed."
+msgid ""
+"Your Cacti Server is almost ready.  Please check that you are happy to "
+"proceed."
 msgstr ""
 
 #: lib/installer.php:3128
 #, php-format
-msgid "Press '%s' then click '%s' to complete the installation process after selecting your Device Templates."
+msgid ""
+"Press '%s' then click '%s' to complete the installation process after "
+"selecting your Device Templates."
 msgstr ""
 
 #: lib/installer.php:3156
@@ -18486,7 +20047,9 @@ msgid "Device/Graph Automation"
 msgstr ""
 
 #: lib/installer.php:3210
-msgid "The following Device and Graph Automation rules will be applied.  These rules allow you to quickly setup monitoring of your network or networks."
+msgid ""
+"The following Device and Graph Automation rules will be applied.  These "
+"rules allow you to quickly setup monitoring of your network or networks."
 msgstr ""
 
 #: lib/installer.php:3213
@@ -18544,7 +20107,9 @@ msgid "%d Tables to be Upgraded"
 msgstr ""
 
 #: lib/installer.php:3249
-msgid "The following Tables will be Upgraded to InnoDB and Converted to utf8mb4 for performance and internationalization."
+msgid ""
+"The following Tables will be Upgraded to InnoDB and Converted to utf8mb4 for "
+"performance and internationalization."
 msgstr ""
 
 #: lib/installer.php:3252
@@ -18575,7 +20140,9 @@ msgstr ""
 
 #: lib/installer.php:3385
 #, php-format
-msgid "Your Cacti Server v%s has been installed/updated.  You may now start using the software."
+msgid ""
+"Your Cacti Server v%s has been installed/updated.  You may now start using "
+"the software."
 msgstr ""
 
 #: lib/installer.php:3390
@@ -18650,7 +20217,9 @@ msgstr ""
 
 #: lib/installer.php:3750
 #, php-format
-msgid "Updating automation network (%s), mode \"%s\" => \"%s\", subnet \"%s\" => %s\""
+msgid ""
+"Updating automation network (%s), mode \"%s\" => \"%s\", subnet \"%s\" => "
+"%s\""
 msgstr ""
 
 #: lib/installer.php:3765
@@ -18726,7 +20295,9 @@ msgid "No templated graphs for Default Device were found"
 msgstr ""
 
 #: lib/installer.php:3902
-msgid "WARNING: Device Template for your Operating System Not Found.  You will need to import Device Templates or Cacti Packages to monitor your Cacti server."
+msgid ""
+"WARNING: Device Template for your Operating System Not Found.  You will need "
+"to import Device Templates or Cacti Packages to monitor your Cacti server."
 msgstr ""
 
 #: lib/installer.php:3909
@@ -18939,7 +20510,11 @@ msgid "Packaging Key Information Not Found"
 msgstr ""
 
 #: lib/package.php:119 package_import.php:86
-msgid "In order to use this Packaging Tool, you must first run the <b><i class=\"deviceUp\">genkey.php</i></b> script in the cli directory.  Once that is complete, you will have a public and private key used to sign your packages."
+msgid ""
+"In order to use this Packaging Tool, you must first run the <b><i "
+"class=\"deviceUp\">genkey.php</i></b> script in the cli directory.  Once "
+"that is complete, you will have a public and private key used to sign your "
+"packages."
 msgstr ""
 
 #: lib/package.php:164
@@ -18969,7 +20544,9 @@ msgstr ""
 
 #: lib/package.php:447
 #, php-format
-msgid "A Critical Template file '%s' is missing.  Please locate this file before packaging"
+msgid ""
+"A Critical Template file '%s' is missing.  Please locate this file before "
+"packaging"
 msgstr ""
 
 #: lib/ping.php:130
@@ -19007,7 +20584,7 @@ msgstr ""
 msgid "Destination address not specified"
 msgstr ""
 
-#: lib/ping.php:401 lib/ping.php:531 package_repos.php:503
+#: lib/ping.php:401 lib/ping.php:531 package_repos.php:522
 msgid "default"
 msgstr ""
 
@@ -19073,17 +20650,23 @@ msgstr ""
 
 #: lib/plugins.php:739
 #, php-format
-msgid "The Plugin directory '%s' needs to be renamed to remove 'plugin_' from the name before it can be installed."
+msgid ""
+"The Plugin directory '%s' needs to be renamed to remove 'plugin_' from the "
+"name before it can be installed."
 msgstr ""
 
 #: lib/plugins.php:743
 #, php-format
-msgid "The Plugin in the directory '%s' does not include an version function '%s()'.  This function must exist for the plugin to be installed."
+msgid ""
+"The Plugin in the directory '%s' does not include an version function "
+"'%s()'.  This function must exist for the plugin to be installed."
 msgstr ""
 
 #: lib/plugins.php:777
 #, php-format
-msgid "The Plugin in the directory '%s' does not include an install function '%s()'.  This function must exist for the plugin to be installed."
+msgid ""
+"The Plugin in the directory '%s' does not include an install function "
+"'%s()'.  This function must exist for the plugin to be installed."
 msgstr ""
 
 #: lib/plugins.php:973
@@ -19093,7 +20676,9 @@ msgstr ""
 
 #: lib/plugins.php:975
 #, php-format
-msgid "Data for Plugin %s including Tables and Settings has not been removed due to missing removal function."
+msgid ""
+"Data for Plugin %s including Tables and Settings has not been removed due to "
+"missing removal function."
 msgstr ""
 
 #: lib/plugins.php:1439
@@ -19103,22 +20688,30 @@ msgstr ""
 
 #: lib/plugins.php:1489
 #, php-format
-msgid "Restore failed!  The Plugin '%s' archive Restore failed.  Unable to create directory '%s'."
+msgid ""
+"Restore failed!  The Plugin '%s' archive Restore failed.  Unable to create "
+"directory '%s'."
 msgstr ""
 
 #: lib/plugins.php:1491
 #, php-format
-msgid "Restore failed!  The available Plugin '%s' Load failed.  Unable to create directory '%s'."
+msgid ""
+"Restore failed!  The available Plugin '%s' Load failed.  Unable to create "
+"directory '%s'."
 msgstr ""
 
 #: lib/plugins.php:1592
 #, php-format
-msgid "Restore failed!  The archived Plugin '%s' Restore failed. Unable to create directory %s"
+msgid ""
+"Restore failed!  The archived Plugin '%s' Restore failed. Unable to create "
+"directory %s"
 msgstr ""
 
 #: lib/plugins.php:1594
 #, php-format
-msgid "Load failed!  The available Plugin '%s' Load failed. Unable to create directory %s"
+msgid ""
+"Load failed!  The available Plugin '%s' Load failed. Unable to create "
+"directory %s"
 msgstr ""
 
 #: lib/plugins.php:1614
@@ -19133,22 +20726,30 @@ msgstr ""
 
 #: lib/plugins.php:1639
 #, php-format
-msgid "Restore failed!  The archived Plugin '%s' Restore failed.  Check the cacti.log for warnings."
+msgid ""
+"Restore failed!  The archived Plugin '%s' Restore failed.  Check the "
+"cacti.log for warnings."
 msgstr ""
 
 #: lib/plugins.php:1641
 #, php-format
-msgid "Load failed!  The available Plugin '%s' Load failed.  Check the cacti.log for warnings."
+msgid ""
+"Load failed!  The available Plugin '%s' Load failed.  Check the cacti.log "
+"for warnings."
 msgstr ""
 
 #: lib/plugins.php:1648
 #, php-format
-msgid "Restore failed!  Unable to locate the archive record for Plugin '%s' in the database."
+msgid ""
+"Restore failed!  Unable to locate the archive record for Plugin '%s' in the "
+"database."
 msgstr ""
 
 #: lib/plugins.php:1650
 #, php-format
-msgid "Load failed!  Unable to locate the available record for Plugin '%s' in the database."
+msgid ""
+"Load failed!  Unable to locate the available record for Plugin '%s' in the "
+"database."
 msgstr ""
 
 #: lib/plugins.php:1719
@@ -19158,12 +20759,16 @@ msgstr ""
 
 #: lib/plugins.php:1721
 #, php-format
-msgid "The Plugin '%s' archiving process has failed.  Check the Cacti log for errors."
+msgid ""
+"The Plugin '%s' archiving process has failed.  Check the Cacti log for "
+"errors."
 msgstr ""
 
 #: lib/plugins.php:1724
 #, php-format
-msgid "The Plugin '%s' archiving process has failed due to the plugin directory being missing."
+msgid ""
+"The Plugin '%s' archiving process has failed due to the plugin directory "
+"being missing."
 msgstr ""
 
 #: lib/plugins.php:1732 lib/plugins.php:1734 lib/plugins.php:1741
@@ -19185,7 +20790,10 @@ msgid "Not Stated"
 msgstr ""
 
 #: lib/plugins.php:1917
-msgid "Unable to retrieve Cacti Plugins due to the Base API Repository URL or User not being set in Configuration > Settings > General > GitHub/GitLab API Settings."
+msgid ""
+"Unable to retrieve Cacti Plugins due to the Base API Repository URL or User "
+"not being set in Configuration > Settings > General > GitHub/GitLab API "
+"Settings."
 msgstr ""
 
 #: lib/plugins.php:1933
@@ -19208,21 +20816,28 @@ msgstr ""
 
 #: lib/plugins.php:2116
 #, php-format
-msgid "Unable to get develop repo data for plugin %s from GitHub/GitLab location."
+msgid ""
+"Unable to get develop repo data for plugin %s from GitHub/GitLab location."
 msgstr ""
 
 #: lib/plugins.php:2264
 #, php-format
-msgid "There were '%s' Plugins found at The Cacti Groups GitHub site and '%s' Plugins Tags/Releases were retrieved and updated in %0.2f seconds."
+msgid ""
+"There were '%s' Plugins found at The Cacti Groups GitHub site and '%s' "
+"Plugins Tags/Releases were retrieved and updated in %0.2f seconds."
 msgstr ""
 
 #: lib/plugins.php:2266
 #, php-format
-msgid "Unable to reach The Cacti Groups GitHub site.  No plugin data retrieved in %0.2f seconds."
+msgid ""
+"Unable to reach The Cacti Groups GitHub site.  No plugin data retrieved in "
+"%0.2f seconds."
 msgstr ""
 
-#: lib/plugins.php:2328
-msgid "You have been rate limited by Google.  Please create yourself a personal access token before trying this again"
+#: lib/plugins.php:2326
+msgid ""
+"You have been rate limited by Google.  Please create yourself a personal "
+"access token before trying this again"
 msgstr ""
 
 #: lib/reports.php:146
@@ -19241,7 +20856,8 @@ msgstr ""
 
 #: lib/reports.php:635
 #, php-format
-msgid "Problems sending Report '%s' Problem with e-mail Subsystem Error is '%s'"
+msgid ""
+"Problems sending Report '%s' Problem with e-mail Subsystem Error is '%s'"
 msgstr ""
 
 #: lib/reports.php:644
@@ -19251,12 +20867,15 @@ msgstr ""
 
 #: lib/reports.php:851
 #, php-format
-msgid "Report '%s' History Removed by user '%s' or a Report Administrator can remove the report."
+msgid ""
+"Report '%s' History Removed by user '%s' or a Report Administrator can "
+"remove the report."
 msgstr ""
 
 #: lib/reports.php:853
 #, php-format
-msgid "Only the owning user '%s' or a Report Administrator can remove the report."
+msgid ""
+"Only the owning user '%s' or a Report Administrator can remove the report."
 msgstr ""
 
 #: lib/reports.php:1208 lib/reports.php:1545
@@ -19267,236 +20886,245 @@ msgstr ""
 msgid "(Non Query Based)"
 msgstr ""
 
-#: lib/reports.php:1994
+#: lib/reports.php:1992
 msgid "Add to Report"
 msgstr ""
 
-#: lib/reports.php:2015
-msgid "Choose the Report to associate these graphs with.  The defaults for alignment will be used for each graph in the list below."
+#: lib/reports.php:2013
+msgid ""
+"Choose the Report to associate these graphs with.  The defaults for "
+"alignment will be used for each graph in the list below."
 msgstr ""
 
-#: lib/reports.php:2017
+#: lib/reports.php:2015
 msgid "Report:"
 msgstr ""
 
-#: lib/reports.php:2025
+#: lib/reports.php:2023
 msgid "Graph Timespan:"
 msgstr ""
 
-#: lib/reports.php:2028
+#: lib/reports.php:2026
 msgid "Graph Alignment:"
 msgstr ""
 
-#: lib/reports.php:2119
+#: lib/reports.php:2117
 #, php-format
 msgid "Created Report Graph Item '<i>%s</i>'"
 msgstr ""
 
-#: lib/reports.php:2121
+#: lib/reports.php:2119
 #, php-format
 msgid "Failed Adding Report Graph Item '<i>%s</i>' Already Exists"
 msgstr ""
 
-#: lib/reports.php:2124
+#: lib/reports.php:2122
 #, php-format
 msgid "Skipped Report Graph Item '<i>%s</i>' Already Exists"
 msgstr ""
 
-#: lib/reports.php:2181
+#: lib/reports.php:2179
 #, php-format
 msgid "Cacti %s"
 msgstr ""
 
-#: lib/reports.php:2356
+#: lib/reports.php:2354
 #, php-format
 msgid "The Report '%s' from source %s with id %s is scheduled to run!"
 msgstr ""
 
-#: lib/reports.php:2362
+#: lib/reports.php:2360
 #, php-format
-msgid "The Report '%s' from source %s with id %s was not scheduled to run due to an error!"
+msgid ""
+"The Report '%s' from source %s with id %s was not scheduled to run due to an "
+"error!"
 msgstr ""
 
-#: lib/rrd.php:404
+#: lib/rrd.php:414
 #, php-format
 msgid "WARNING: RRDtool Crashed executing the following command line %s.  %s"
 msgstr ""
 
-#: lib/rrd.php:407
+#: lib/rrd.php:417
 msgid "RRDtool Command Crashed"
 msgstr ""
 
-#: lib/rrd.php:3381
+#: lib/rrd.php:3415
 #, php-format
 msgid "The required RRDfile step size is '%s' but observed step is '%s'"
 msgstr ""
 
-#: lib/rrd.php:3441
+#: lib/rrd.php:3475
 #, php-format
 msgid "Type for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: lib/rrd.php:3447
+#: lib/rrd.php:3481
 #, php-format
 msgid "Heartbeat for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: lib/rrd.php:3459
+#: lib/rrd.php:3493
 #, php-format
 msgid "RRD minimum for Data Source '%s' should be '%s'"
 msgstr ""
 
-#: lib/rrd.php:3468
+#: lib/rrd.php:3502
 #, php-format
 msgid "DS '%s' missing in Cacti definition"
 msgstr ""
 
-#: lib/rrd.php:3482 lib/rrd.php:3483
+#: lib/rrd.php:3516 lib/rrd.php:3517
 #, php-format
 msgid "Cacti RRA '%s' has same CF/steps (%s, %s) as '%s'"
 msgstr ""
 
-#: lib/rrd.php:3497 lib/rrd.php:3498
+#: lib/rrd.php:3531 lib/rrd.php:3532
 #, php-format
 msgid "File RRA '%s' has same CF/steps (%s, %s) as '%s'"
 msgstr ""
 
-#: lib/rrd.php:3532
+#: lib/rrd.php:3566
 #, php-format
-msgid "The pdp_per_row of '%s' is invalid for RRA '%s' should be '%s'.  Consider deleting and allowing Cacti to re-create RRDfile."
+msgid ""
+"The pdp_per_row of '%s' is invalid for RRA '%s' should be '%s'.  Consider "
+"deleting and allowing Cacti to re-create RRDfile."
 msgstr ""
 
-#: lib/rrd.php:3536
+#: lib/rrd.php:3570
 #, php-format
 msgid "The XFF for Cacti RRA id is '%s' but should be '%s'"
 msgstr ""
 
-#: lib/rrd.php:3540
+#: lib/rrd.php:3574
 #, php-format
-msgid "The number of rows for Cacti RRA id '%s' is incorrect.  The number of rows are '%s' but should be '%s'"
+msgid ""
+"The number of rows for Cacti RRA id '%s' is incorrect.  The number of rows "
+"are '%s' but should be '%s'"
 msgstr ""
 
-#: lib/rrd.php:3559
+#: lib/rrd.php:3593
 #, php-format
 msgid "The RRA '%s' missing in the existing Cacti RRDfile"
 msgstr ""
 
-#: lib/rrd.php:3566
+#: lib/rrd.php:3600
 #, php-format
 msgid "RRA '%s' missing in Cacti definition"
 msgstr ""
 
-#: lib/rrd.php:3585
+#: lib/rrd.php:3619
 msgid "RRD File Information"
 msgstr ""
 
-#: lib/rrd.php:3617
+#: lib/rrd.php:3651
 msgid "Data Source Items"
 msgstr ""
 
-#: lib/rrd.php:3619
+#: lib/rrd.php:3653
 msgid "Minimal Heartbeat"
 msgstr ""
 
-#: lib/rrd.php:3620
+#: lib/rrd.php:3654
 msgid "Min"
 msgstr ""
 
-#: lib/rrd.php:3621
+#: lib/rrd.php:3655
 msgid "Max"
 msgstr ""
 
-#: lib/rrd.php:3622
+#: lib/rrd.php:3656
 msgid "Last DS"
 msgstr ""
 
-#: lib/rrd.php:3624
+#: lib/rrd.php:3658
 msgid "Unknown Sec"
 msgstr ""
 
-#: lib/rrd.php:3675
+#: lib/rrd.php:3709
 msgid "Round Robin Archive"
 msgstr ""
 
-#: lib/rrd.php:3678
+#: lib/rrd.php:3712
 msgid "Cur Row"
 msgstr ""
 
-#: lib/rrd.php:3679
+#: lib/rrd.php:3713
 msgid "PDP per Row"
 msgstr ""
 
-#: lib/rrd.php:3681
+#: lib/rrd.php:3715
 msgid "CDP Prep Value (0)"
 msgstr ""
 
-#: lib/rrd.php:3682
+#: lib/rrd.php:3716
 msgid "CDP Unknown Data points (0)"
 msgstr ""
 
-#: lib/rrd.php:3753
+#: lib/rrd.php:3787
 msgid "Errors Found"
 msgstr ""
 
-#: lib/rrd.php:3765
+#: lib/rrd.php:3799
 msgid "Optional Tuning Recommendations"
 msgstr ""
 
-#: lib/rrd.php:3790 lib/rrd.php:3793
+#: lib/rrd.php:3824 lib/rrd.php:3827
 #, php-format
 msgid "rename %s to %s"
 msgstr ""
 
-#: lib/rrd.php:3861
+#: lib/rrd.php:3895
 msgid "Error while parsing the XML of rrdtool dump"
 msgstr ""
 
-#: lib/rrd.php:3895 lib/rrd.php:3959 lib/rrd.php:4024
+#: lib/rrd.php:3930 lib/rrd.php:3994 lib/rrd.php:4059
 #, php-format
 msgid "ERROR while writing XML file: %s"
 msgstr ""
 
-#: lib/rrd.php:3907 lib/rrd.php:3971 lib/rrd.php:4036
+#: lib/rrd.php:3942 lib/rrd.php:4006 lib/rrd.php:4071
 #, php-format
 msgid "ERROR: RRDfile %s not writeable"
 msgstr ""
 
-#: lib/rrd.php:3940 lib/rrd.php:4005
+#: lib/rrd.php:3975 lib/rrd.php:4040
 msgid "Error while parsing the XML of RRDtool dump"
 msgstr ""
 
-#: lib/rrd.php:4267
+#: lib/rrd.php:4331
 #, php-format
 msgid "RRA (CF=%s, ROWS=%d, PDP_PER_ROW=%d, XFF=%1.2f) removed from RRD file"
 msgstr ""
 
-#: lib/rrd.php:4307
+#: lib/rrd.php:4375
 #, php-format
 msgid "RRA (CF=%s, ROWS=%d, PDP_PER_ROW=%d, XFF=%1.2f) adding to RRD file"
 msgstr ""
 
-#: lib/rrd.php:4401 lib/rrd.php:4417
+#: lib/rrd.php:4472 lib/rrd.php:4488
 #, php-format
-msgid "Website does not have write access to %s, may be unable to create/update RRDs"
+msgid ""
+"Website does not have write access to %s, may be unable to create/update RRDs"
 msgstr ""
 
-#: lib/rrd.php:4413
+#: lib/rrd.php:4484
 msgid "(Custom)"
 msgstr ""
 
-#: lib/rrd.php:4419
+#: lib/rrd.php:4490
 msgid "Failed to open data file, poller may not have run yet"
 msgstr ""
 
-#: lib/rrd.php:4422
+#: lib/rrd.php:4493
 msgid "RRA Folder"
 msgstr ""
 
-#: lib/rrd.php:4422
+#: lib/rrd.php:4493
 msgid "Root"
 msgstr ""
 
-#: lib/rrd.php:4535
+#: lib/rrd.php:4634
 msgid "Unknown RRDtool Error"
 msgstr ""
 
@@ -19506,271 +21134,256 @@ msgstr ""
 msgid "SNMP Command is: %s"
 msgstr ""
 
-#: lib/spikekill.php:200
+#: lib/spikekill.php:184
 #, php-format
 msgid "FATAL: File '%s' does not exist."
 msgstr ""
 
-#: lib/spikekill.php:202
+#: lib/spikekill.php:186
 #, php-format
 msgid "FATAL: File '%s' is not writable by '%s'."
 msgstr ""
 
-#: lib/spikekill.php:285 lib/spikekill.php:1153
+#: lib/spikekill.php:251 lib/spikekill.php:1016
 msgid "StdDev"
 msgstr ""
 
-#: lib/spikekill.php:290
-msgid "Variance"
-msgstr ""
-
-#: lib/spikekill.php:295
+#: lib/spikekill.php:256
 msgid "Gap Fill"
 msgstr ""
 
-#: lib/spikekill.php:305
+#: lib/spikekill.php:266
 msgid "Absolute Max"
 msgstr ""
 
-#: lib/spikekill.php:309
-msgid "FATAL: You must specify either 'stddev', 'variance', 'float', or 'fill' as methods."
+#: lib/spikekill.php:270
+msgid "FATAL: You must specify either 'stddev', 'float', or 'fill' as methods."
 msgstr ""
 
-#: lib/spikekill.php:313
+#: lib/spikekill.php:274
 msgid "FATAL: Standard Deviation must be a positive integer."
 msgstr ""
 
-#: lib/spikekill.php:317
+#: lib/spikekill.php:278
 msgid "FATAL: The Spike Kill Window Start must be a date or timestamp."
 msgstr ""
 
-#: lib/spikekill.php:321
+#: lib/spikekill.php:282
 msgid "FATAL: The Spike Kill Window End must be a date or timestamp."
 msgstr ""
 
-#: lib/spikekill.php:338
-msgid "FATAL: The outlier-start and outlier-end arguments must be in the format of YYYY-MM-DD HH:MM or a UNIX timestamp."
+#: lib/spikekill.php:299
+msgid ""
+"FATAL: The outlier-start and outlier-end arguments must be in the format of "
+"YYYY-MM-DD HH:MM or a UNIX timestamp."
 msgstr ""
 
-#: lib/spikekill.php:343
-msgid "FATAL: The number of outliers to exclude must be a positive integer."
-msgstr ""
-
-#: lib/spikekill.php:351
-msgid "FATAL: Percent deviation must be a positive floating point number."
-msgstr ""
-
-#: lib/spikekill.php:357
+#: lib/spikekill.php:305
 msgid "FATAL: Number of spikes to remove must be a positive integer"
 msgstr ""
 
-#: lib/spikekill.php:363
+#: lib/spikekill.php:311
 msgid "FATAL: Number value for absolute maximum value positive integer"
 msgstr ""
 
-#: lib/spikekill.php:369
-msgid "FATAL: Outlier time range requires outlier-start and outlier-end to be specified."
+#: lib/spikekill.php:317
+msgid ""
+"FATAL: Outlier time range requires outlier-start and outlier-end to be "
+"specified."
 msgstr ""
 
-#: lib/spikekill.php:375
-msgid "FATAL: Outlier time range requires outlier-start to be less than outlier-end."
+#: lib/spikekill.php:323
+msgid ""
+"FATAL: Outlier time range requires outlier-start to be less than outlier-end."
 msgstr ""
 
-#: lib/spikekill.php:380
-msgid "FATAL: The 'float' removal method requires the specification of a start and end date or timestamp."
+#: lib/spikekill.php:328
+msgid ""
+"FATAL: The 'float' removal method requires the specification of a start and "
+"end date or timestamp."
 msgstr ""
 
-#: lib/spikekill.php:384
-msgid "FATAL: The 'fill' removal method requires the specification of a start and end date or timestamp."
+#: lib/spikekill.php:332
+msgid ""
+"FATAL: The 'fill' removal method requires the specification of a start and "
+"end date or timestamp."
 msgstr ""
 
-#: lib/spikekill.php:388
-msgid "FATAL: The 'absolute' removal method requires the specification of a start and end date or timestamp."
+#: lib/spikekill.php:336
+msgid ""
+"FATAL: The 'absolute' removal method requires the specification of a start "
+"and end date or timestamp."
 msgstr ""
 
-#: lib/spikekill.php:398
-msgid "FATAL: You must specify either 'last', 'avg' or 'nan' as a replacement method."
+#: lib/spikekill.php:346
+msgid ""
+"FATAL: You must specify either 'last', 'avg' or 'nan' as a replacement "
+"method."
 msgstr ""
 
-#: lib/spikekill.php:401
+#: lib/spikekill.php:349
 msgid "Spike Kill Settings Used for Analysis/Correction"
 msgstr ""
 
-#: lib/spikekill.php:407
+#: lib/spikekill.php:355
 #, php-format
 msgid "Method:        %s"
 msgstr ""
 
-#: lib/spikekill.php:408
+#: lib/spikekill.php:356
 #, php-format
 msgid "RRDfile:       %s"
 msgstr ""
 
-#: lib/spikekill.php:409
+#: lib/spikekill.php:357
 #, php-format
 msgid "Repair Type:   %s"
 msgstr ""
 
-#: lib/spikekill.php:412
-#, php-format
-msgid "Num Outliers:  %s"
-msgstr ""
-
-#: lib/spikekill.php:413
+#: lib/spikekill.php:360
 #, php-format
 msgid "Max Kills:     %s"
 msgstr ""
 
-#: lib/spikekill.php:415
-msgid "Max Kills:     Unlimited"
-msgstr ""
-
-#: lib/spikekill.php:419
+#: lib/spikekill.php:361
 #, php-format
 msgid "Standard Devs: %s"
 msgstr ""
 
-#: lib/spikekill.php:421
-msgid "Variance %%%:    %s %%%"
+#: lib/spikekill.php:363
+msgid "Max Kills:     Unlimited"
 msgstr ""
 
-#: lib/spikekill.php:425
+#: lib/spikekill.php:367
 #, php-format
 msgid "Window Start:  %s (%s)"
 msgstr ""
 
-#: lib/spikekill.php:426
+#: lib/spikekill.php:368
 #, php-format
 msgid "Window End:    %s (%s)"
 msgstr ""
 
-#: lib/spikekill.php:428
+#: lib/spikekill.php:370
 msgid "Window Range:  All"
 msgstr ""
 
-#: lib/spikekill.php:461
+#: lib/spikekill.php:403
 msgid "NOTE: Removing Outliers in Range and Replacing with Last"
 msgstr ""
 
-#: lib/spikekill.php:465
-#, php-format
-msgid "NOTE: Variance Calculation removes top and bottom %s samples due to Outliers setting"
-msgstr ""
-
-#: lib/spikekill.php:469
+#: lib/spikekill.php:407
 #, php-format
 msgid "NOTE: Creating XML file '%s' from '%s'"
 msgstr ""
 
-#: lib/spikekill.php:515
-msgid "FATAL: RRDtool Command Failed.  Please verify that the RRDtool path is valid in Settings->Paths!"
+#: lib/spikekill.php:448
+msgid ""
+"FATAL: RRDtool Command Failed.  Please verify that the RRDtool path is valid "
+"in Settings->Paths!"
 msgstr ""
 
-#: lib/spikekill.php:523
+#: lib/spikekill.php:456
 #, php-format
 msgid "NOTE: RRDfile '%s' backed up to '%s'"
 msgstr ""
 
-#: lib/spikekill.php:525
+#: lib/spikekill.php:458
 #, php-format
 msgid "FATAL: RRDfile Backup of '%s' to '%s' FAILED!"
 msgstr ""
 
-#: lib/spikekill.php:745
+#: lib/spikekill.php:672
 #, php-format
 msgid "NOTE: Searching for Spikes in XML file '%s'"
 msgstr ""
 
-#: lib/spikekill.php:748
+#: lib/spikekill.php:675
 #, php-format
 msgid "NOTE: Limited to Time Window: %s through %s"
 msgstr ""
 
-#: lib/spikekill.php:789
+#: lib/spikekill.php:716
 #, php-format
 msgid "NOTE: No Window Spikes found in '%s'"
 msgstr ""
 
-#: lib/spikekill.php:792
+#: lib/spikekill.php:719
 #, php-format
 msgid "NOTE: No Spikes found in '%s'"
 msgstr ""
 
-#: lib/spikekill.php:804
+#: lib/spikekill.php:731
 #, php-format
-msgid "NOTE: Parse:%.2f, Variance:%.2f, Stats:%.2f, Update:%.2f, Kills:%d"
+msgid "NOTE: Parse:%.2f, Stats:%.2f, Update:%.2f, Kills:%d"
 msgstr ""
 
-#: lib/spikekill.php:815
+#: lib/spikekill.php:742
 #, php-format
 msgid "NOTE: Time:%s, Spikes Found and Remediated.  Total Spikes %s"
 msgstr ""
 
-#: lib/spikekill.php:818
+#: lib/spikekill.php:745
 #, php-format
 msgid "FATAL: Time:%s, Unable to backup '%s'"
 msgstr ""
 
-#: lib/spikekill.php:822
+#: lib/spikekill.php:749
 #, php-format
 msgid "FATAL: Time:%s, Unable to write XML file '%s'"
 msgstr ""
 
-#: lib/spikekill.php:826
+#: lib/spikekill.php:753
 #, php-format
 msgid "NOTE: Time:%s, No Spikes Found."
 msgstr ""
 
-#: lib/spikekill.php:831
+#: lib/spikekill.php:758
 #, php-format
 msgid "NOTE: Time:%s, Dryrun requested.  No updates performed"
 msgstr ""
 
-#: lib/spikekill.php:1153
+#: lib/spikekill.php:1016
 msgid "Avg"
 msgstr ""
 
-#: lib/spikekill.php:1153
+#: lib/spikekill.php:1016
 msgid "DataSource"
 msgstr ""
 
-#: lib/spikekill.php:1153
+#: lib/spikekill.php:1016
 msgid "NonNan"
 msgstr ""
 
-#: lib/spikekill.php:1153
+#: lib/spikekill.php:1016
 msgid "Samples"
 msgstr ""
 
-#: lib/spikekill.php:1154
+#: lib/spikekill.php:1017
 msgid "MaxStdDev"
 msgstr ""
 
-#: lib/spikekill.php:1154
+#: lib/spikekill.php:1017
 msgid "MaxValue"
 msgstr ""
 
-#: lib/spikekill.php:1154
+#: lib/spikekill.php:1017
 msgid "MinStdDev"
 msgstr ""
 
-#: lib/spikekill.php:1154
+#: lib/spikekill.php:1017
 msgid "MinValue"
 msgstr ""
 
-#: lib/spikekill.php:1154
+#: lib/spikekill.php:1017
 msgid "StdKilled"
 msgstr ""
 
-#: lib/spikekill.php:1154
-msgid "VarKilled"
-msgstr ""
-
-#: lib/spikekill.php:1154
+#: lib/spikekill.php:1017
 msgid "WindKilled"
 msgstr ""
 
-#: lib/spikekill.php:1154
+#: lib/spikekill.php:1017
 msgid "WindSamples"
 msgstr ""
 
@@ -19798,164 +21411,305 @@ msgstr ""
 
 #: lib/template.php:2361
 #, php-format
-msgid "NOTE: Graph not added for Data Query %s and index %s due to Data Source verification failure"
+msgid ""
+"NOTE: Graph not added for Data Query %s and index %s due to Data Source "
+"verification failure"
 msgstr ""
 
-#: lib/timespan_settings.php:152
+#: lib/timespan_settings.php:153
 #, php-format
-msgid "Your Start Date '%s' is before January 1993.  Please pick a more recent Start Date."
+msgid ""
+"Your Start Date '%s' is before January 1993.  Please pick a more recent "
+"Start Date."
 msgstr ""
 
-#: lib/timespan_settings.php:157
+#: lib/timespan_settings.php:158
 #, php-format
-msgid "Your End Date '%s' is before January 1993.  Please pick a more recent End Date."
+msgid ""
+"Your End Date '%s' is before January 1993.  Please pick a more recent End "
+"Date."
 msgstr ""
 
 #: lib/utility.php:1087
-msgid "MySQL 5.6+ and MariaDB 10.0+ are great releases, and are very good versions to choose. Make sure you run the very latest release though which fixes a long standing low level networking issue that was causing spine many issues with reliability."
+msgid ""
+"MySQL 5.6+ and MariaDB 10.0+ are great releases, and are very good versions "
+"to choose. Make sure you run the very latest release though which fixes a "
+"long standing low level networking issue that was causing spine many issues "
+"with reliability."
 msgstr ""
 
 #: lib/utility.php:1099
 #, php-format
-msgid "It is STRONGLY recommended that you enable InnoDB in any %s version greater than 5.5.3."
+msgid ""
+"It is STRONGLY recommended that you enable InnoDB in any %s version greater "
+"than 5.5.3."
 msgstr ""
 
 #: lib/utility.php:1112 lib/utility.php:1148
-msgid "When using Cacti with languages other than English, it is important to use the utf8mb4_unicode_ci collation type as some characters take more than a single byte."
+msgid ""
+"When using Cacti with languages other than English, it is important to use "
+"the utf8mb4_unicode_ci collation type as some characters take more than a "
+"single byte."
 msgstr ""
 
 #: lib/utility.php:1118 lib/utility.php:1124 lib/utility.php:1154
 #: lib/utility.php:1160
-msgid "When using Cacti with languages other than English, it is important to use the utf8mb4 character set as some characters take more than a single byte."
+msgid ""
+"When using Cacti with languages other than English, it is important to use "
+"the utf8mb4 character set as some characters take more than a single byte."
 msgstr ""
 
 #: lib/utility.php:1136
 #, php-format
-msgid "It is recommended that you enable InnoDB in any %s version greater than 5.1."
+msgid ""
+"It is recommended that you enable InnoDB in any %s version greater than 5.1."
 msgstr ""
 
 #: lib/utility.php:1169
 #, php-format
-msgid "Depending on the number of logins and use of spine data collector, %s will need many connections.  The calculation for spine is: total_connections = total_processes * (total_threads + script_servers + 1), then you must leave headroom for user connections, which will change depending on the number of concurrent login accounts."
+msgid ""
+"Depending on the number of logins and use of spine data collector, %s will "
+"need many connections.  The calculation for spine is: total_connections = "
+"total_processes * (total_threads + script_servers + 1), then you must leave "
+"headroom for user connections, which will change depending on the number of "
+"concurrent login accounts."
 msgstr ""
 
 #: lib/utility.php:1174
-msgid "Keeping the table cache larger means less file open/close operations when using innodb_file_per_table."
+msgid ""
+"Keeping the table cache larger means less file open/close operations when "
+"using innodb_file_per_table."
 msgstr ""
 
 #: lib/utility.php:1179
-msgid "With Remote polling capabilities, large amounts of data will be synced from the main server to the remote pollers.  Therefore, keep this value at or above 16M."
+msgid ""
+"With Remote polling capabilities, large amounts of data will be synced from "
+"the main server to the remote pollers.  Therefore, keep this value at or "
+"above 16M."
 msgstr ""
 
 #: lib/utility.php:1185
 #, php-format
-msgid "If using the Cacti Performance Booster and choosing a memory storage engine, you have to be careful to flush your Performance Booster buffer before the system runs out of memory table space.  This is done two ways, first reducing the size of your output column to just the right size.  This column is in the tables poller_output, and poller_output_boost.  The second thing you can do is allocate more memory to memory tables.  We have arbitrarily chosen a recommended value of 10%% of system memory, but if you are using SSD disk drives, or have a smaller system, you may ignore this recommendation or choose a different storage engine.  You may see the expected consumption of the Performance Booster tables under Console -> System Utilities -> View Boost Status."
+msgid ""
+"If using the Cacti Performance Booster and choosing a memory storage engine, "
+"you have to be careful to flush your Performance Booster buffer before the "
+"system runs out of memory table space.  This is done two ways, first "
+"reducing the size of your output column to just the right size.  This column "
+"is in the tables poller_output, and poller_output_boost.  The second thing "
+"you can do is allocate more memory to memory tables.  We have arbitrarily "
+"chosen a recommended value of 10%% of system memory, but if you are using "
+"SSD disk drives, or have a smaller system, you may ignore this "
+"recommendation or choose a different storage engine.  You may see the "
+"expected consumption of the Performance Booster tables under Console -> "
+"System Utilities -> View Boost Status."
 msgstr ""
 
 #: lib/utility.php:1191
-msgid "When executing subqueries, having a larger temporary table size, keep those temporary tables in memory."
+msgid ""
+"When executing subqueries, having a larger temporary table size, keep those "
+"temporary tables in memory."
 msgstr ""
 
 #: lib/utility.php:1197
-msgid "If this number is negative, reduce the innodb_buffer_pool_size until the join_buffer_size turns positive, but allocate approximately from between 25%-50% of memory to the innodb_buffer_pool_size if the database is hosted on the Cacti server, or upto 80% of the systems memory if the database is separate from the Cacti web server.  However, try to not go below the default of 262,144.  When performing joins, if they are below this size, they will be kept in memory and never written to a temporary file.  As this is a per connection memory allocation, care must be taken not to increase it too high.  The sum of the join_buffer_size + sort_buffer_size + read_buffer_size + read_rnd_buffer_size + thread_stack + binlog_cache_size + Core MySQL/MariaDB memory should be below 80% if the database is hosted on the Cacti web server and less if you intend to have very large RRDfiles or hundreds of thousands to millions long term."
+msgid ""
+"If this number is negative, reduce the innodb_buffer_pool_size until the "
+"join_buffer_size turns positive, but allocate approximately from between "
+"25%-50% of memory to the innodb_buffer_pool_size if the database is hosted "
+"on the Cacti server, or upto 80% of the systems memory if the database is "
+"separate from the Cacti web server.  However, try to not go below the "
+"default of 262,144.  When performing joins, if they are below this size, "
+"they will be kept in memory and never written to a temporary file.  As this "
+"is a per connection memory allocation, care must be taken not to increase it "
+"too high.  The sum of the join_buffer_size + sort_buffer_size + "
+"read_buffer_size + read_rnd_buffer_size + thread_stack + binlog_cache_size + "
+"Core MySQL/MariaDB memory should be below 80% if the database is hosted on "
+"the Cacti web server and less if you intend to have very large RRDfiles or "
+"hundreds of thousands to millions long term."
 msgstr ""
 
 #: lib/utility.php:1203
-msgid "If this number is negative, reduce the innodb_buffer_pool_size until the sort_buffer_size turns positive, but allocate approximately from between 25%-50% of memory to the innodb_buffer_pool_size if the database is hosted on the Cacti server, or upto 80% of the system memory if the database is separate from the Cacti web server.  However, try to not go below the default setting of 2,097,152.  A sort buffer performs sorts for some queries using ORDER BY or GROUP BY. Configuring sort_buffer_size decides how much memory will be allocated for sort queries.  The sort_buffer_size may need to be adjusted from the default if the workload requires a significant number of sort queries. The sort_buffer_size is defined on a per-session variable.  Use the same equation as that of the join_buffer_size to determine the per connection possible memory."
+msgid ""
+"If this number is negative, reduce the innodb_buffer_pool_size until the "
+"sort_buffer_size turns positive, but allocate approximately from between "
+"25%-50% of memory to the innodb_buffer_pool_size if the database is hosted "
+"on the Cacti server, or upto 80% of the system memory if the database is "
+"separate from the Cacti web server.  However, try to not go below the "
+"default setting of 2,097,152.  A sort buffer performs sorts for some queries "
+"using ORDER BY or GROUP BY. Configuring sort_buffer_size decides how much "
+"memory will be allocated for sort queries.  The sort_buffer_size may need to "
+"be adjusted from the default if the workload requires a significant number "
+"of sort queries. The sort_buffer_size is defined on a per-session variable.  "
+"Use the same equation as that of the join_buffer_size to determine the per "
+"connection possible memory."
 msgstr ""
 
 #: lib/utility.php:1209
 #, php-format
-msgid "When using InnoDB storage it is important to keep your table spaces separate.  This makes managing the tables simpler for long time users of %s.  If you are running with this currently off, you can migrate to the per file storage by enabling the feature, and then running an alter statement on all InnoDB tables."
+msgid ""
+"When using InnoDB storage it is important to keep your table spaces "
+"separate.  This makes managing the tables simpler for long time users of "
+"%s.  If you are running with this currently off, you can migrate to the per "
+"file storage by enabling the feature, and then running an alter statement on "
+"all InnoDB tables."
 msgstr ""
 
 #: lib/utility.php:1215
-msgid "When using innodb_file_per_table, it is important to set the innodb_file_format to Barracuda.  This setting will allow longer indexes important for certain Cacti tables."
+msgid ""
+"When using innodb_file_per_table, it is important to set the "
+"innodb_file_format to Barracuda.  This setting will allow longer indexes "
+"important for certain Cacti tables."
 msgstr ""
 
 #: lib/utility.php:1221
-msgid "If your tables have very large indexes, you must operate with the Barracuda innodb_file_format and the innodb_large_prefix equal to 1.  Failure to do this may result in plugins that can not properly create tables."
+msgid ""
+"If your tables have very large indexes, you must operate with the Barracuda "
+"innodb_file_format and the innodb_large_prefix equal to 1.  Failure to do "
+"this may result in plugins that can not properly create tables."
 msgstr ""
 
 #: lib/utility.php:1227
 #, php-format
-msgid "InnoDB will hold as much tables and indexes in system memory as is possible.  Therefore, you should make the innodb_buffer_pool large enough to hold as much of the tables and index in memory.  Checking the size of the /var/lib/mysql/cacti directory will help in determining this value.  We are recommending 25%% of your systems total memory, but your requirements will vary depending on your systems size.  If you database is very large or remote, you can consider increasing this size.  If remote, it can by as high as 80% of the systems memory.  However, cautions must be taken to reduce the swappiness of the system, or to remove swap to keep the system from swapping."
+msgid ""
+"InnoDB will hold as much tables and indexes in system memory as is "
+"possible.  Therefore, you should make the innodb_buffer_pool large enough to "
+"hold as much of the tables and index in memory.  Checking the size of the /"
+"var/lib/mysql/cacti directory will help in determining this value.  We are "
+"recommending 25%% of your systems total memory, but your requirements will "
+"vary depending on your systems size.  If you database is very large or "
+"remote, you can consider increasing this size.  If remote, it can by as high "
+"as 80% of the systems memory.  However, cautions must be taken to reduce the "
+"swappiness of the system, or to remove swap to keep the system from swapping."
 msgstr ""
 
 #: lib/utility.php:1233
-msgid "This settings should remain ON unless your Cacti instances is running on either ZFS or FusionI/O which both have internal journaling to accommodate abrupt system crashes.  However, if you have very good power, and your systems rarely go down and you have backups, turning this setting to OFF can net you almost a 50% increase in database performance."
+msgid ""
+"This settings should remain ON unless your Cacti instances is running on "
+"either ZFS or FusionI/O which both have internal journaling to accommodate "
+"abrupt system crashes.  However, if you have very good power, and your "
+"systems rarely go down and you have backups, turning this setting to OFF can "
+"net you almost a 50% increase in database performance."
 msgstr ""
 
 #: lib/utility.php:1238
-msgid "This is where metadata is stored. If you had a lot of tables, it would be useful to increase this."
+msgid ""
+"This is where metadata is stored. If you had a lot of tables, it would be "
+"useful to increase this."
 msgstr ""
 
 #: lib/utility.php:1243
-msgid "Rogue queries should not for the database to go offline to others.  Kill these queries before they kill your system."
+msgid ""
+"Rogue queries should not for the database to go offline to others.  Kill "
+"these queries before they kill your system."
 msgstr ""
 
 #: lib/utility.php:1248
-msgid "Maximum I/O performance happens when you use the O_DIRECT method to flush pages."
+msgid ""
+"Maximum I/O performance happens when you use the O_DIRECT method to flush "
+"pages."
 msgstr ""
 
 #: lib/utility.php:1258
 #, php-format
-msgid "Setting this value to 2 means that you will flush all transactions every second rather than at commit.  This allows %s to perform writing less often."
+msgid ""
+"Setting this value to 2 means that you will flush all transactions every "
+"second rather than at commit.  This allows %s to perform writing less often."
 msgstr ""
 
 #: lib/utility.php:1263
-msgid "With modern SSD type storage, having multiple io threads is advantageous for applications with high io characteristics."
+msgid ""
+"With modern SSD type storage, having multiple io threads is advantageous for "
+"applications with high io characteristics."
 msgstr ""
 
 #: lib/utility.php:1271 lib/utility.php:1313
 #, php-format
-msgid "As of %s %s, the you can control how often %s flushes transactions to disk.  The default is 1 second, but in high I/O systems setting to a value greater than 1 can allow disk I/O to be more sequential"
+msgid ""
+"As of %s %s, the you can control how often %s flushes transactions to disk.  "
+"The default is 1 second, but in high I/O systems setting to a value greater "
+"than 1 can allow disk I/O to be more sequential"
 msgstr ""
 
 #: lib/utility.php:1276
-msgid "With modern SSD type storage, having multiple read io threads is advantageous for applications with high io characteristics.  Depending on your MariaDB/MySQL versions, this value can go as high as 64.  But try to keep the number less than your total SMT threads on the database server."
+msgid ""
+"With modern SSD type storage, having multiple read io threads is "
+"advantageous for applications with high io characteristics.  Depending on "
+"your MariaDB/MySQL versions, this value can go as high as 64.  But try to "
+"keep the number less than your total SMT threads on the database server."
 msgstr ""
 
 #: lib/utility.php:1281
-msgid "With modern SSD type storage, having multiple write io threads is advantageous for applications with high io characteristics.  Depending on your MariaDB/MySQL versions, this value can go as high as 64.  But try to keep the number less than your total SMT threads on the database server."
+msgid ""
+"With modern SSD type storage, having multiple write io threads is "
+"advantageous for applications with high io characteristics.  Depending on "
+"your MariaDB/MySQL versions, this value can go as high as 64.  But try to "
+"keep the number less than your total SMT threads on the database server."
 msgstr ""
 
 #: lib/utility.php:1287
 #, php-format
-msgid "%s will divide the innodb_buffer_pool into memory regions to improve performance for versions of MariaDB less than 10.5.  The max value is 64, but should not exceed more than the number of CPU cores/threads.  When your innodb_buffer_pool is less than 1GB, you should use the pool size divided by 128MB.  Continue to use this equation up to the max the number of CPU cores or 64."
+msgid ""
+"%s will divide the innodb_buffer_pool into memory regions to improve "
+"performance for versions of MariaDB less than 10.5.  The max value is 64, "
+"but should not exceed more than the number of CPU cores/threads.  When your "
+"innodb_buffer_pool is less than 1GB, you should use the pool size divided by "
+"128MB.  Continue to use this equation up to the max the number of CPU cores "
+"or 64."
 msgstr ""
 
 #: lib/utility.php:1287
 #, php-format
-msgid "%s will divide the innodb_buffer_pool into memory regions to improve performance for versions of MySQL upto and including MySQL 8.0.  The max value is 64, but should not exceed more than the number of CPU cores/threads.  When your innodb_buffer_pool is less than 1GB, you should use the pool size divided by 128MB.  Continue to use this equation up to the max of the number of CPU cores or 64."
+msgid ""
+"%s will divide the innodb_buffer_pool into memory regions to improve "
+"performance for versions of MySQL upto and including MySQL 8.0.  The max "
+"value is 64, but should not exceed more than the number of CPU cores/"
+"threads.  When your innodb_buffer_pool is less than 1GB, you should use the "
+"pool size divided by 128MB.  Continue to use this equation up to the max of "
+"the number of CPU cores or 64."
 msgstr ""
 
 #: lib/utility.php:1293 lib/utility.php:1329
-msgid "If you have SSD disks, use this suggestion.  If you have physical hard drives, use 200 * the number of active drives in the array.  If using NVMe or PCIe Flash, much larger numbers as high as 100000 can be used."
+msgid ""
+"If you have SSD disks, use this suggestion.  If you have physical hard "
+"drives, use 200 * the number of active drives in the array.  If using NVMe "
+"or PCIe Flash, much larger numbers as high as 100000 can be used."
 msgstr ""
 
 #: lib/utility.php:1299 lib/utility.php:1335
-msgid "If you have SSD disks, use this suggestion.  If you have physical hard drives, use 2000 * the number of active drives in the array.  If using NVMe or PCIe Flash, much larger numbers as high as 200000 can be used."
+msgid ""
+"If you have SSD disks, use this suggestion.  If you have physical hard "
+"drives, use 2000 * the number of active drives in the array.  If using NVMe "
+"or PCIe Flash, much larger numbers as high as 200000 can be used."
 msgstr ""
 
 #: lib/utility.php:1305 lib/utility.php:1341
-msgid "If you have SSD disks, use this suggestion. Otherwise, do not set this setting."
+msgid ""
+"If you have SSD disks, use this suggestion. Otherwise, do not set this "
+"setting."
 msgstr ""
 
 #: lib/utility.php:1318
-msgid "With modern SSD type storage, having multiple read io threads is advantageous for applications with high io characteristics."
+msgid ""
+"With modern SSD type storage, having multiple read io threads is "
+"advantageous for applications with high io characteristics."
 msgstr ""
 
 #: lib/utility.php:1323
-msgid "With modern SSD type storage, having multiple write io threads is advantageous for applications with high io characteristics."
+msgid ""
+"With modern SSD type storage, having multiple write io threads is "
+"advantageous for applications with high io characteristics."
 msgstr ""
 
 #: lib/utility.php:1354
-msgid "When using MariaDB 10.2.4 and above, this setting should be off if atomic writes are enabled.  Therefore, please enable atomic writes instead of the double write buffer as it will increase performance."
+msgid ""
+"When using MariaDB 10.2.4 and above, this setting should be off if atomic "
+"writes are enabled.  Therefore, please enable atomic writes instead of the "
+"double write buffer as it will increase performance."
 msgstr ""
 
 #: lib/utility.php:1361
-msgid "When using MariaDB 10.2.4 and above, you can use atomic writes over the doublewrite buffer to increase performance."
+msgid ""
+"When using MariaDB 10.2.4 and above, you can use atomic writes over the "
+"doublewrite buffer to increase performance."
 msgstr ""
 
 #: lib/utility.php:1378
@@ -20008,7 +21762,9 @@ msgstr ""
 
 #: link.php:79
 #, php-format
-msgid "External Link ID '%s' with Title '%s' attempted to inject an invalid URL and was blocked!"
+msgid ""
+"External Link ID '%s' with Title '%s' attempted to inject an invalid URL and "
+"was blocked!"
 msgstr ""
 
 #: links.php:84
@@ -20124,7 +21880,9 @@ msgid "Console Menu Section"
 msgstr ""
 
 #: links.php:487
-msgid "Under which Console heading should this item appear? (All External Link menus will appear between Configuration and Utilities)"
+msgid ""
+"Under which Console heading should this item appear? (All External Link "
+"menus will appear between Configuration and Utilities)"
 msgstr ""
 
 #: links.php:491
@@ -20152,7 +21910,9 @@ msgid "Web URL Below"
 msgstr ""
 
 #: links.php:510
-msgid "The file that contains the content for this page. This file needs to be in the Cacti 'include/content/' directory."
+msgid ""
+"The file that contains the content for this page. This file needs to be in "
+"the Cacti 'include/content/' directory."
 msgstr ""
 
 #: links.php:514
@@ -20160,7 +21920,11 @@ msgid "Web URL Location"
 msgstr ""
 
 #: links.php:516
-msgid "The valid URL to use for this external link.  Must include the type, for example http://www.cacti.net.  Note that many websites do not allow them to be embedded in an iframe from a foreign site, and therefore External Linking may not work."
+msgid ""
+"The valid URL to use for this external link.  Must include the type, for "
+"example http://www.cacti.net.  Note that many websites do not allow them to "
+"be embedded in an iframe from a foreign site, and therefore External Linking "
+"may not work."
 msgstr ""
 
 #: links.php:525
@@ -20352,11 +22116,15 @@ msgid "Enable Notification Receivers"
 msgstr ""
 
 #: managers.php:890
-msgid "Click 'Continue' to Disable Forwarding the following Notification Object the following Notification Receiver."
+msgid ""
+"Click 'Continue' to Disable Forwarding the following Notification Object the "
+"following Notification Receiver."
 msgstr ""
 
 #: managers.php:891
-msgid "Click 'Continue' to Disable Forwarding the following Notification Objects to the following Notification Receiver."
+msgid ""
+"Click 'Continue' to Disable Forwarding the following Notification Objects to "
+"the following Notification Receiver."
 msgstr ""
 
 #: managers.php:892
@@ -20368,11 +22136,15 @@ msgid "Disable Forwarding Objects"
 msgstr ""
 
 #: managers.php:896
-msgid "Click 'Continue' to Enable Forwarding the following Notification Object to this Notification Receiver."
+msgid ""
+"Click 'Continue' to Enable Forwarding the following Notification Object to "
+"this Notification Receiver."
 msgstr ""
 
 #: managers.php:897
-msgid "Click 'Continue' to Enable Forwarding the following Notification Objects Notification Receivers."
+msgid ""
+"Click 'Continue' to Enable Forwarding the following Notification Objects "
+"Notification Receivers."
 msgstr ""
 
 #: managers.php:898
@@ -20388,11 +22160,14 @@ msgid "Refresh Token: "
 msgstr ""
 
 #: oauth2.php:117
-msgid "Store this token in Settings -> Mail/Reporting/DNS -> Oauth2 refresh token. "
+msgid ""
+"Store this token in Settings -> Mail/Reporting/DNS -> Oauth2 refresh token. "
 msgstr ""
 
 #: oauth2.php:118
-msgid "If the token is empty, it means it stays the same. The Oatuh2 provider will not resend it in that case. "
+msgid ""
+"If the token is empty, it means it stays the same. The Oatuh2 provider will "
+"not resend it in that case. "
 msgstr ""
 
 #: package.php:113 templates_export.php:67
@@ -20449,7 +22224,9 @@ msgid "Include Dependencies"
 msgstr ""
 
 #: package.php:331 templates_export.php:127
-msgid "Some templates rely on other items in Cacti to function properly. It is highly recommended that you select this box or the resulting import may fail."
+msgid ""
+"Some templates rely on other items in Cacti to function properly. It is "
+"highly recommended that you select this box or the resulting import may fail."
 msgstr ""
 
 #: package.php:337
@@ -20477,7 +22254,10 @@ msgid "Assign various searchable attributes to the Package."
 msgstr ""
 
 #: package.php:388
-msgid "Some Packages require additional changes outside of Cacti's scope such as setting up an SNMP Agent Extension on the Devices to be monitored.  You should add those instructions here.."
+msgid ""
+"Some Packages require additional changes outside of Cacti's scope such as "
+"setting up an SNMP Agent Extension on the Devices to be monitored.  You "
+"should add those instructions here.."
 msgstr ""
 
 #: package.php:395
@@ -20501,7 +22281,7 @@ msgstr ""
 msgid "Package"
 msgstr ""
 
-#: package.php:499
+#: package.php:497
 msgid "Package Contents Include"
 msgstr ""
 
@@ -20532,8 +22312,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: package_import.php:324
-msgid "The following Selected Package will be skipped as no Files or Template Items were selected."
-msgid_plural "The following selected Packages will be skipped as no Files or Template Items were selected."
+msgid ""
+"The following Selected Package will be skipped as no Files or Template Items "
+"were selected."
+msgid_plural ""
+"The following selected Packages will be skipped as no Files or Template "
+"Items were selected."
 msgstr[0] ""
 msgstr[1] ""
 
@@ -20560,7 +22344,8 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: package_import.php:369
-msgid "You must select either a File or a Template Item to import before proceeding"
+msgid ""
+"You must select either a File or a Template Item to import before proceeding"
 msgstr ""
 
 #: package_import.php:738
@@ -20569,7 +22354,8 @@ msgstr ""
 
 #: package_import.php:739
 #, php-format
-msgid "The Repo '%s' is NOT Reachable at the URL Location in the package.manifest."
+msgid ""
+"The Repo '%s' is NOT Reachable at the URL Location in the package.manifest."
 msgstr ""
 
 #: package_import.php:740
@@ -20591,7 +22377,9 @@ msgid "<b>Package:</b> %s"
 msgstr ""
 
 #: package_import.php:781
-msgid "Press 'Ok' to start Trusting the Signer.  Press 'Cancel' or hit escape to Cancel."
+msgid ""
+"Press 'Ok' to start Trusting the Signer.  Press 'Cancel' or hit escape to "
+"Cancel."
 msgstr ""
 
 #: package_import.php:785
@@ -20606,9 +22394,11 @@ msgstr ""
 msgid "All Package Signatures Validated"
 msgstr ""
 
-#: package_import.php:837 package_import.php:1922 package_repos.php:121
+#: package_import.php:837 package_import.php:1941 package_repos.php:140
 #, php-format
-msgid "The Repo '%s' is NOT Reachable at the URL Location or the package.manifest file is missing."
+msgid ""
+"The Repo '%s' is NOT Reachable at the URL Location or the package.manifest "
+"file is missing."
 msgstr ""
 
 #: package_import.php:904 package_import.php:910 package_import.php:950
@@ -20617,7 +22407,10 @@ msgid "Error in Package"
 msgstr ""
 
 #: package_import.php:904
-msgid "See the cacti.log for more information.  It could be that you had either an API Key error or the package was tamered with, or the location is not available."
+msgid ""
+"See the cacti.log for more information.  It could be that you had either an "
+"API Key error or the package was tamered with, or the location is not "
+"available."
 msgstr ""
 
 #: package_import.php:904
@@ -20626,7 +22419,10 @@ msgid "The package \"%s\" download or validation failed"
 msgstr ""
 
 #: package_import.php:910
-msgid "See the cacti.log for more information.  It could be that you had either an API Key error or the package was tamered with, or the location is not available"
+msgid ""
+"See the cacti.log for more information.  It could be that you had either an "
+"API Key error or the package was tamered with, or the location is not "
+"available"
 msgstr ""
 
 #: package_import.php:910
@@ -20638,11 +22434,15 @@ msgid "Package XML File Damaged."
 msgstr ""
 
 #: package_import.php:950
-msgid "The XML files appears to be invalid and does not contain a public key.  Please contact the package author to obtain a revised package."
+msgid ""
+"The XML files appears to be invalid and does not contain a public key.  "
+"Please contact the package author to obtain a revised package."
 msgstr ""
 
 #: package_import.php:953
-msgid "Check the package repository file for files that should exist and find the one that is missing"
+msgid ""
+"Check the package repository file for files that should exist and find the "
+"one that is missing"
 msgstr ""
 
 #: package_import.php:953
@@ -20658,7 +22458,9 @@ msgid "Email"
 msgstr ""
 
 #: package_import.php:1014
-msgid "Import Package Filenames [ None selected imports all, Check to import selectively ]"
+msgid ""
+"Import Package Filenames [ None selected imports all, Check to import "
+"selectively ]"
 msgstr ""
 
 #: package_import.php:1021
@@ -20674,7 +22476,9 @@ msgid "Unchanged"
 msgstr ""
 
 #: package_import.php:1089
-msgid "Import Package Templates [ None selected imports all, Check to import selectively ]"
+msgid ""
+"Import Package Templates [ None selected imports all, Check to import "
+"selectively ]"
 msgstr ""
 
 #: package_import.php:1094
@@ -20737,22 +22541,29 @@ msgstr ""
 msgid "No Packages Found"
 msgstr ""
 
-#: package_import.php:1903
+#: package_import.php:1922
 #, php-format
-msgid "The Repo '%s' is NOT Reachable on GitHub or the '%s' file is missing or it could be an invalid branch.  Valid Package Locations are normally: https://github.com/Author/RepoName/."
+msgid ""
+"The Repo '%s' is NOT Reachable on GitHub or the '%s' file is missing or it "
+"could be an invalid branch.  Valid Package Locations are normally: https://"
+"github.com/Author/RepoName/."
 msgstr ""
 
-#: package_import.php:1935
+#: package_import.php:1954
 #, php-format
-msgid "The Repo '%s' is Reachable on the Local Cacti Server.  But not data returned from the manifest file."
+msgid ""
+"The Repo '%s' is Reachable on the Local Cacti Server.  But not data returned "
+"from the manifest file."
 msgstr ""
 
-#: package_import.php:1938 package_repos.php:129
+#: package_import.php:1957 package_repos.php:148
 #, php-format
-msgid "The Repo '%s' is NOT Reachable on the Local Cacti Server or the package.manifest file is missing."
+msgid ""
+"The Repo '%s' is NOT Reachable on the Local Cacti Server or the "
+"package.manifest file is missing."
 msgstr ""
 
-#: package_keys.php:99 package_repos.php:207
+#: package_keys.php:99 package_repos.php:226
 msgid "Click 'Continue' to delete the following ."
 msgid_plural "Click 'Continue' to delete following Package Repositories."
 msgstr[0] ""
@@ -20796,120 +22607,135 @@ msgstr ""
 msgid "Direct URL"
 msgstr ""
 
-#: package_repos.php:102
+#: package_repos.php:121
 #, php-format
 msgid "The Repo '%s' is Reachable on GitHub."
 msgstr ""
 
-#: package_repos.php:104
+#: package_repos.php:123
 #, php-format
-msgid "The Repo '%s' is NOT Reachable on GitHub or the package.manifest file is missing or it could be an invalid branch.  Valid Package Locations are normally: https://github.com/Author/RepoName/."
+msgid ""
+"The Repo '%s' is NOT Reachable on GitHub or the package.manifest file is "
+"missing or it could be an invalid branch.  Valid Package Locations are "
+"normally: https://github.com/Author/RepoName/."
 msgstr ""
 
-#: package_repos.php:119
+#: package_repos.php:138
 #, php-format
 msgid "The Repo '%s' is Reachable at the URL Location."
 msgstr ""
 
-#: package_repos.php:127
+#: package_repos.php:146
 #, php-format
 msgid "The Repo '%s' is Reachable on the Local Cacti Server."
 msgstr ""
 
-#: package_repos.php:213
+#: package_repos.php:232
 msgid "Delete Package Repository"
 msgid_plural "Delete Package Repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: package_repos.php:217
+#: package_repos.php:236
 msgid "Click 'Continue' to disable the following Package Repository."
 msgid_plural "Click 'Continue' to disable following Package Repositories."
 msgstr[0] ""
 msgstr[1] ""
 
-#: package_repos.php:223
+#: package_repos.php:242
 msgid "Disable Package Repository"
 msgid_plural "Disable Package Repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: package_repos.php:227
+#: package_repos.php:246
 msgid "Click 'Continue' to enable the following Package Repository."
 msgstr ""
 
-#: package_repos.php:233
+#: package_repos.php:252
 msgid "Enabled Package Repository"
 msgid_plural "Enable Package Repositories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: package_repos.php:237
-msgid "Click 'Continue' to make the following the following Package Repository the default one."
+#: package_repos.php:256
+msgid ""
+"Click 'Continue' to make the following the following Package Repository the "
+"default one."
 msgstr ""
 
-#: package_repos.php:243
+#: package_repos.php:262
 msgid "Make Selected Repository Default"
 msgstr ""
 
-#: package_repos.php:295
+#: package_repos.php:314
 #, php-format
 msgid "Package Repository [edit: %s]"
 msgstr ""
 
-#: package_repos.php:297
+#: package_repos.php:316
 msgid "Package Repository [new]"
 msgstr ""
 
-#: package_repos.php:315
+#: package_repos.php:334
 msgid "Enter a meaningful name for this Package Repository."
 msgstr ""
 
-#: package_repos.php:321
+#: package_repos.php:340
 msgid "Repository Type"
 msgstr ""
 
-#: package_repos.php:322
+#: package_repos.php:341
 msgid "Choose what Package Repository type this is."
 msgstr ""
 
-#: package_repos.php:330
-msgid "Either the full path on the Cacti Web Server to the Repository or a URL to the Repository.  For example: https://github.com/Cacti/packages/"
+#: package_repos.php:349
+msgid ""
+"Either the full path on the Cacti Web Server to the Repository or a URL to "
+"the Repository.  For example: https://github.com/Cacti/packages/"
 msgstr ""
 
-#: package_repos.php:337 package_repos.php:470
+#: package_repos.php:356 package_repos.php:489
 msgid "Branch"
 msgstr ""
 
-#: package_repos.php:338
-msgid "For GitHub based repositories, the branch to include such as 'develop', 'master', etc."
+#: package_repos.php:357
+msgid ""
+"For GitHub based repositories, the branch to include such as 'develop', "
+"'master', etc."
 msgstr ""
 
-#: package_repos.php:345
+#: package_repos.php:364
 msgid "API Key (optional)"
 msgstr ""
 
-#: package_repos.php:346
-msgid "For GitHub based repositories, the optional API key required to access the repository."
+#: package_repos.php:365
+msgid ""
+"For GitHub based repositories, the optional API key required to access the "
+"repository."
 msgstr ""
 
-#: package_repos.php:354
-msgid "If this checkbox is checked, you will be able to import packages from this Repository."
+#: package_repos.php:373
+msgid ""
+"If this checkbox is checked, you will be able to import packages from this "
+"Repository."
 msgstr ""
 
-#: package_repos.php:361
-msgid "If this checkbox is checked, this will be the first Repository shown to the user."
+#: package_repos.php:380
+msgid ""
+"If this checkbox is checked, this will be the first Repository shown to the "
+"user."
 msgstr ""
 
-#: package_repos.php:417
+#: package_repos.php:436
 msgid "Package Repositorites"
 msgstr ""
 
-#: package_repos.php:419
+#: package_repos.php:438
 msgid "Repos"
 msgstr ""
 
-#: package_repos.php:512
+#: package_repos.php:531
 msgid "No Package Repositories Found"
 msgstr ""
 
@@ -21031,12 +22857,16 @@ msgstr ""
 
 #: plugins.php:167
 #, php-format
-msgid "The action '%s' on Plugin '%s' can not be performed due to the Plugin in it's current state."
+msgid ""
+"The action '%s' on Plugin '%s' can not be performed due to the Plugin in "
+"it's current state."
 msgstr ""
 
 #: plugins.php:174
 #, php-format
-msgid "The action '%s' '%s' on Plugin '%s' can not be taken as the Plugin is integrated."
+msgid ""
+"The action '%s' '%s' on Plugin '%s' can not be taken as the Plugin is "
+"integrated."
 msgstr ""
 
 #: plugins.php:224
@@ -21048,21 +22878,30 @@ msgid "The fetch latest plugins process has already been started."
 msgstr ""
 
 #: plugins.php:231
-msgid "You must enter your GitHub user, repo and personal access token before you can refresh the plugins.  You can set the GitHub defaults under Console > Configuration > Settings > General."
+msgid ""
+"You must enter your GitHub user, repo and personal access token before you "
+"can refresh the plugins.  You can set the GitHub defaults under Console > "
+"Configuration > Settings > General."
 msgstr ""
 
 #: plugins.php:285
 #, php-format
-msgid "Plugin '%s' has passed it's Configuration Check test and can not be Installed"
+msgid ""
+"Plugin '%s' has passed it's Configuration Check test and can not be Installed"
 msgstr ""
 
 #: plugins.php:287
 #, php-format
-msgid "Plugin '%s' Check Configuration function returned a null response which is invalid.  Please check with Plugin Developer for an update."
+msgid ""
+"Plugin '%s' Check Configuration function returned a null response which is "
+"invalid.  Please check with Plugin Developer for an update."
 msgstr ""
 
 #: plugins.php:591
-msgid "Uninstalling this Plugin and may remove all Plugin Data and Settings.  If you really want to Uninstall the Plugin, click 'Uninstall' below.  Otherwise click 'Cancel'."
+msgid ""
+"Uninstalling this Plugin and may remove all Plugin Data and Settings.  If "
+"you really want to Uninstall the Plugin, click 'Uninstall' below.  Otherwise "
+"click 'Cancel'."
 msgstr ""
 
 #: plugins.php:592
@@ -21070,7 +22909,10 @@ msgid "Are you sure you want to Uninstall?"
 msgstr ""
 
 #: plugins.php:594
-msgid "Removing Plugin Data and Settings for will remove all Plugin Data and Settings.  If you really want to Remove Data and Settings for this Plugin, click 'Remove Data' below.  Otherwise click 'Cancel'."
+msgid ""
+"Removing Plugin Data and Settings for will remove all Plugin Data and "
+"Settings.  If you really want to Remove Data and Settings for this Plugin, "
+"click 'Remove Data' below.  Otherwise click 'Cancel'."
 msgstr ""
 
 #: plugins.php:595
@@ -21078,7 +22920,10 @@ msgid "Are you sure you want to Remove all Plugin Data and Settings?"
 msgstr ""
 
 #: plugins.php:597
-msgid "Restoring this Plugin Archive will overwrite the current Plugin directory.  If you really want to Restore this Plugin Archive, click 'Restore' below.  Otherwise click 'Cancel'."
+msgid ""
+"Restoring this Plugin Archive will overwrite the current Plugin directory.  "
+"If you really want to Restore this Plugin Archive, click 'Restore' below.  "
+"Otherwise click 'Cancel'."
 msgstr ""
 
 #: plugins.php:598
@@ -21086,7 +22931,10 @@ msgid "Are you sure you want to Restore this Archive?"
 msgstr ""
 
 #: plugins.php:600
-msgid "Deleting this Plugin Archive is not reversible without a table restore.  If you really want to Delete the Plugin Archive, click 'Delete' below.  Otherwise click 'Cancel'."
+msgid ""
+"Deleting this Plugin Archive is not reversible without a table restore.  If "
+"you really want to Delete the Plugin Archive, click 'Delete' below.  "
+"Otherwise click 'Cancel'."
 msgstr ""
 
 #: plugins.php:601
@@ -21094,7 +22942,11 @@ msgid "Are you sure you want to Delete this Archive?"
 msgstr ""
 
 #: plugins.php:603
-msgid "Archiving makes a backup of the plugin that you may restore at a later date.  Before archiving, you may enter an archive note that will be stored with the Archive for later reference.  If you really want to Archive the Plugin, click 'Delete' below.  Otherwise click 'Cancel'."
+msgid ""
+"Archiving makes a backup of the plugin that you may restore at a later "
+"date.  Before archiving, you may enter an archive note that will be stored "
+"with the Archive for later reference.  If you really want to Archive the "
+"Plugin, click 'Delete' below.  Otherwise click 'Cancel'."
 msgstr ""
 
 #: plugins.php:607
@@ -21154,7 +23006,9 @@ msgid "Fetch the list of the latest Cacti Plugins"
 msgstr ""
 
 #: plugins.php:673
-msgid "To enable fetching of plugins, set your credentials under Console > Configuration > Settings > General"
+msgid ""
+"To enable fetching of plugins, set your credentials under Console > "
+"Configuration > Settings > General"
 msgstr ""
 
 #: plugins.php:822
@@ -21190,7 +23044,9 @@ msgid "Plugin Name"
 msgstr ""
 
 #: plugins.php:1110 plugins.php:1186 plugins.php:1263
-msgid "The name for this Plugin.  The name is controlled by the directory it resides in."
+msgid ""
+"The name for this Plugin.  The name is controlled by the directory it "
+"resides in."
 msgstr ""
 
 #: plugins.php:1113 plugins.php:1189 plugins.php:1266
@@ -21210,7 +23066,9 @@ msgid "Main / Remote Status"
 msgstr ""
 
 #: plugins.php:1127 plugins.php:1275
-msgid "The Status of this available Plugin.  Loadable means it is currently not installed and can be loaded."
+msgid ""
+"The Status of this available Plugin.  Loadable means it is currently not "
+"installed and can be loaded."
 msgstr ""
 
 #: plugins.php:1133 plugins.php:1204 plugins.php:1281
@@ -21254,7 +23112,9 @@ msgid "The date that this Plugin was last Installed or Upgraded."
 msgstr ""
 
 #: plugins.php:1180 plugins.php:1257
-msgid "Actions available include 'Install', 'Activate', 'Disable', 'Enable', 'Uninstall'."
+msgid ""
+"Actions available include 'Install', 'Activate', 'Disable', 'Enable', "
+"'Uninstall'."
 msgstr ""
 
 #: plugins.php:1198
@@ -21266,7 +23126,9 @@ msgid "Cacti Releases"
 msgstr ""
 
 #: plugins.php:1210
-msgid "The Cacti Releases that are eligible to use this Plugin.  The format of the allowed versions follows common naming."
+msgid ""
+"The Cacti Releases that are eligible to use this Plugin.  The format of the "
+"allowed versions follows common naming."
 msgstr ""
 
 #: plugins.php:1213
@@ -21306,7 +23168,9 @@ msgid "Load Order"
 msgstr ""
 
 #: plugins.php:1311
-msgid "The load order of the Plugin.  You can change the load order by first sorting by it, then moving a Plugin either up or down."
+msgid ""
+"The load order of the Plugin.  You can change the load order by first "
+"sorting by it, then moving a Plugin either up or down."
 msgstr ""
 
 #: plugins.php:1362
@@ -21512,7 +23376,9 @@ msgid "Plugin already Archived and Unchanged in the Archive"
 msgstr ""
 
 #: plugins.php:1904
-msgid "Plugin was Disabled due to a Plugin Error.  Click to Re-enable the Plugin.  Search for 'DISABLING' in the Cacti log to find the reason."
+msgid ""
+"Plugin was Disabled due to a Plugin Error.  Click to Re-enable the Plugin.  "
+"Search for 'DISABLING' in the Cacti log to find the reason."
 msgstr ""
 
 #: plugins.php:1914
@@ -21546,12 +23412,17 @@ msgstr ""
 
 #: poller.php:405
 #, php-format
-msgid "WARNING: %s is out of sync with the Poller Interval for Poller[%d]!  The Poller Interval is %d seconds, with a maximum of a %d seconds, but %d seconds have passed since the last poll!"
+msgid ""
+"WARNING: %s is out of sync with the Poller Interval for Poller[%d]!  The "
+"Poller Interval is %d seconds, with a maximum of a %d seconds, but %d "
+"seconds have passed since the last poll!"
 msgstr ""
 
 #: poller.php:594
 #, php-format
-msgid "WARNING: There are %d processes detected as overrunning a polling cycle for Poller[%d], please investigate."
+msgid ""
+"WARNING: There are %d processes detected as overrunning a polling cycle for "
+"Poller[%d], please investigate."
 msgstr ""
 
 #: poller.php:652
@@ -21561,7 +23432,9 @@ msgstr ""
 
 #: poller.php:693
 #, php-format
-msgid "ERROR: The spine path: %s is invalid for Poller[%d].  Poller can not continue!"
+msgid ""
+"ERROR: The spine path: %s is invalid for Poller[%d].  Poller can not "
+"continue!"
 msgstr ""
 
 #: poller.php:842
@@ -21580,12 +23453,16 @@ msgstr ""
 
 #: poller.php:1383
 #, php-format
-msgid "WARNING: 24 Hour Poller[%d] Average run time threshold breached.  It is %f seconds (more than %d &#37; of threshold.)"
+msgid ""
+"WARNING: 24 Hour Poller[%d] Average run time threshold breached.  It is %f "
+"seconds (more than %d &#37; of threshold.)"
 msgstr ""
 
 #: poller.php:1399
 #, php-format
-msgid "WARNING: In last hour Poller[%d] run time exceeded the threshold %d times (limit %d) by %d percent of the time limit."
+msgid ""
+"WARNING: In last hour Poller[%d] run time exceeded the threshold %d times "
+"(limit %d) by %d percent of the time limit."
 msgstr ""
 
 #: poller.php:1423
@@ -21593,7 +23470,9 @@ msgid "Cacti System Notification"
 msgstr ""
 
 #: poller.php:1423
-msgid "NOTE: A second Cacti data collector has been added.  Therefore, enabling boost automatically!"
+msgid ""
+"NOTE: A second Cacti data collector has been added.  Therefore, enabling "
+"boost automatically!"
 msgstr ""
 
 #: poller_automation.php:57
@@ -21609,28 +23488,38 @@ msgstr ""
 msgid "Cacti Automation Report requires an html based Email client"
 msgstr ""
 
-#: poller_boost.php:396
+#: poller_boost.php:395
 msgid "WARNING: Detected Poller Boost Overrun, Possible Boost Poller Crash"
 msgstr ""
 
 #: poller_maintenance.php:1069
 #, php-format
-msgid "WARNING: CPU cores changed for poller %d with name %s. Maybe you should adjust the Poller settings (Processes and threads)"
+msgid ""
+"WARNING: CPU cores changed for poller %d with name %s. Maybe you should "
+"adjust the Poller settings (Processes and threads)"
 msgstr ""
 
 #: poller_maintenance.php:1076
 #, php-format
-msgid "WARNING: Default number of processes on poller %d with name %s. It looks like this cmd poller uses default settings. To achieve optimal performance, change poller settings (Processes)"
+msgid ""
+"WARNING: Default number of processes on poller %d with name %s. It looks "
+"like this cmd poller uses default settings. To achieve optimal performance, "
+"change poller settings (Processes)"
 msgstr ""
 
 #: poller_maintenance.php:1080
 #, php-format
-msgid "WARNING: Default number of processes/threads on poller %d with name %s. It looks like this spine poller uses default settings. To achieve optimal performance, change poller settings (Processes and threads)"
+msgid ""
+"WARNING: Default number of processes/threads on poller %d with name %s. It "
+"looks like this spine poller uses default settings. To achieve optimal "
+"performance, change poller settings (Processes and threads)"
 msgstr ""
 
 #: poller_maintenance.php:1086
 #, php-format
-msgid "WARNING: Number of CMD poller processes on poller %d with name %s is too high. To achieve optimal performance, change poller settings (Processes)"
+msgid ""
+"WARNING: Number of CMD poller processes on poller %d with name %s is too "
+"high. To achieve optimal performance, change poller settings (Processes)"
 msgstr ""
 
 #: pollers.php:45
@@ -21666,7 +23555,10 @@ msgid "Data Collector Hostname"
 msgstr ""
 
 #: pollers.php:79
-msgid "The hostname for Data Collector.  It may have to be a Fully Qualified Domain name for the remote Pollers to contact it for activities such as re-indexing, Real-time graphing, etc."
+msgid ""
+"The hostname for Data Collector.  It may have to be a Fully Qualified Domain "
+"name for the remote Pollers to contact it for activities such as re-"
+"indexing, Real-time graphing, etc."
 msgstr ""
 
 #: pollers.php:87
@@ -21674,7 +23566,9 @@ msgid "Custom Log Level"
 msgstr ""
 
 #: pollers.php:88
-msgid "In Cases where you need to perform debugging for a single Data Collector Only, you can change it's log level here."
+msgid ""
+"In Cases where you need to perform debugging for a single Data Collector "
+"Only, you can change it's log level here."
 msgstr ""
 
 #: pollers.php:95 sites.php:128
@@ -21710,7 +23604,9 @@ msgid "Sync Interval"
 msgstr ""
 
 #: pollers.php:135
-msgid "The polling sync interval in use.  This setting will affect how often this poller is checked and updated."
+msgid ""
+"The polling sync interval in use.  This setting will affect how often this "
+"poller is checked and updated."
 msgstr ""
 
 #: pollers.php:142
@@ -21758,7 +23654,8 @@ msgid "Remote Database Retries"
 msgstr ""
 
 #: pollers.php:192
-msgid "The number of times to attempt to retry to connect to the remote database."
+msgid ""
+"The number of times to attempt to retry to connect to the remote database."
 msgstr ""
 
 #: pollers.php:200
@@ -21766,7 +23663,9 @@ msgid "Remote Database SSL Information"
 msgstr ""
 
 #: pollers.php:201
-msgid "Starting in MariaDB 11.4 and above, SSL is autonegotiated between the client and server.  So, this option may not be required"
+msgid ""
+"Starting in MariaDB 11.4 and above, SSL is autonegotiated between the client "
+"and server.  So, this option may not be required"
 msgstr ""
 
 #: pollers.php:205 pollers.php:248
@@ -21774,7 +23673,9 @@ msgid "Remote Database SSL"
 msgstr ""
 
 #: pollers.php:206
-msgid "If the remote database uses SSL to connect, and it's prior to MariaDB 11.4, check the checkbox below to enter the details."
+msgid ""
+"If the remote database uses SSL to connect, and it's prior to MariaDB 11.4, "
+"check the checkbox below to enter the details."
 msgstr ""
 
 #: pollers.php:212
@@ -21790,7 +23691,9 @@ msgid "Remote Database SSL Certificate"
 msgstr ""
 
 #: pollers.php:222
-msgid "The file holding the SSL Certificate to use to connect to the remote database."
+msgid ""
+"The file holding the SSL Certificate to use to connect to the remote "
+"database."
 msgstr ""
 
 #: pollers.php:230
@@ -21798,7 +23701,11 @@ msgid "Remote Database SSL Authority"
 msgstr ""
 
 #: pollers.php:231
-msgid "The file holding the SSL Certificate Authority to use to connect to the remote database.  This is an optional parameter that can be required by the database provider if they have started SSL using the --ssl-mode=VERIFY_CA option."
+msgid ""
+"The file holding the SSL Certificate Authority to use to connect to the "
+"remote database.  This is an optional parameter that can be required by the "
+"database provider if they have started SSL using the --ssl-mode=VERIFY_CA "
+"option."
 msgstr ""
 
 #: pollers.php:239
@@ -21806,21 +23713,33 @@ msgid "Remote Database SSL Authorities directory"
 msgstr ""
 
 #: pollers.php:240
-msgid "The file path to the directory that contains the trusted SSL Certificate Authority certificates. This is an optional parameter that can used instead of giving the path to an individual Certificate Authority file. This parameter can be required by the database provider if they have started SSL using the --ssl-mode=VERIFY_CA option."
+msgid ""
+"The file path to the directory that contains the trusted SSL Certificate "
+"Authority certificates. This is an optional parameter that can used instead "
+"of giving the path to an individual Certificate Authority file. This "
+"parameter can be required by the database provider if they have started SSL "
+"using the --ssl-mode=VERIFY_CA option."
 msgstr ""
 
 #: pollers.php:249
-msgid "Provides a way to disable verification of the server's SSL certificate Common Name against the server's hostname when connecting. This verification is enabled by default."
+msgid ""
+"Provides a way to disable verification of the server's SSL certificate "
+"Common Name against the server's hostname when connecting. This verification "
+"is enabled by default."
 msgstr ""
 
 #: pollers.php:347
 #, php-format
-msgid "You have already used this hostname '%s'.  Please enter a non-duplicate hostname."
+msgid ""
+"You have already used this hostname '%s'.  Please enter a non-duplicate "
+"hostname."
 msgstr ""
 
 #: pollers.php:353
 #, php-format
-msgid "You have already used this database hostname '%s'.  Please enter a non-duplicate database hostname."
+msgid ""
+"You have already used this database hostname '%s'.  Please enter a non-"
+"duplicate database hostname."
 msgstr ""
 
 #: pollers.php:576
@@ -21876,11 +23795,15 @@ msgid "Enable Data Collectors"
 msgstr ""
 
 #: pollers.php:628
-msgid "Click 'Continue' to Synchronize the Remote Data Collector for Offline Operation."
+msgid ""
+"Click 'Continue' to Synchronize the Remote Data Collector for Offline "
+"Operation."
 msgstr ""
 
 #: pollers.php:629
-msgid "Click 'Continue' to Synchronize the Remote Data Collectors for Offline Operation."
+msgid ""
+"Click 'Continue' to Synchronize the Remote Data Collectors for Offline "
+"Operation."
 msgstr ""
 
 #: pollers.php:630 pollers.php:642
@@ -21892,11 +23815,15 @@ msgid "Resync Data Collectors"
 msgstr ""
 
 #: pollers.php:634
-msgid "Click 'Continue' to Synchronize the Authentication Data to Remote Data Collector."
+msgid ""
+"Click 'Continue' to Synchronize the Authentication Data to Remote Data "
+"Collector."
 msgstr ""
 
 #: pollers.php:635
-msgid "Click 'Continue' to Synchronize the Authentication Data to Remote Data Collectors."
+msgid ""
+"Click 'Continue' to Synchronize the Authentication Data to Remote Data "
+"Collectors."
 msgstr ""
 
 #: pollers.php:636
@@ -21925,7 +23852,10 @@ msgid "Site [new]"
 msgstr ""
 
 #: pollers.php:710
-msgid "Remote Data Collectors must be able to communicate to the Main Data Collector, and vice versa.  Use this button to verify that the Main Data Collector can communicate to this Remote Data Collector."
+msgid ""
+"Remote Data Collectors must be able to communicate to the Main Data "
+"Collector, and vice versa.  Use this button to verify that the Main Data "
+"Collector can communicate to this Remote Data Collector."
 msgstr ""
 
 #: pollers.php:718
@@ -22045,7 +23975,8 @@ msgid "RRD check"
 msgstr ""
 
 #: rrdcheck.php:36
-msgid "RRD check is disabled, please enable in Configuration -> Settings -> Data"
+msgid ""
+"RRD check is disabled, please enable in Configuration -> Settings -> Data"
 msgstr ""
 
 #: rrdcheck.php:120
@@ -22195,11 +24126,17 @@ msgid "Changing Permission Model Warning"
 msgstr ""
 
 #: settings.php:265
-msgid "Changing Permission Model will alter a users effective Graph permissions."
+msgid ""
+"Changing Permission Model will alter a users effective Graph permissions."
 msgstr ""
 
 #: settings.php:266
-msgid "After you change the Graph Permission Model you should audit your Users and User Groups Effective Graph permission to ensure that you still have adequate control of your Graphs.  NOTE: If you want to restrict all Graphs at the Device or Graph Template Graph Permission Model, the default Graph Policy should be set to 'Deny'."
+msgid ""
+"After you change the Graph Permission Model you should audit your Users and "
+"User Groups Effective Graph permission to ensure that you still have "
+"adequate control of your Graphs.  NOTE: If you want to restrict all Graphs "
+"at the Device or Graph Template Graph Permission Model, the default Graph "
+"Policy should be set to 'Deny'."
 msgstr ""
 
 #: settings.php:294
@@ -22387,7 +24324,9 @@ msgid "Zoom"
 msgstr ""
 
 #: sites.php:161
-msgid "The default Map Zoom for this Site.  Values can be from 0 to 23. Note that some regions of the planet have a max Zoom of 15."
+msgid ""
+"The default Map Zoom for this Site.  Values can be from 0 to 23. Note that "
+"some regions of the planet have a max Zoom of 15."
 msgstr ""
 
 #: sites.php:163
@@ -22514,12 +24453,12 @@ msgstr ""
 msgid "No Sites Found"
 msgstr ""
 
-#: spikekill.php:39
+#: spikekill.php:38
 #, php-format
 msgid "FATAL: Spike Kill method '%s' is Invalid"
 msgstr ""
 
-#: spikekill.php:118
+#: spikekill.php:117
 msgid "FATAL: Spike Kill Not Allowed"
 msgstr ""
 
@@ -22530,12 +24469,16 @@ msgstr ""
 
 #: support.php:54
 #, php-format
-msgid "Cacti has been locked out by '%s'.  Press the button again after Cacti maintenance is over."
+msgid ""
+"Cacti has been locked out by '%s'.  Press the button again after Cacti "
+"maintenance is over."
 msgstr ""
 
 #: support.php:58
 #, php-format
-msgid "Cacti maintenance lockout has been cleared by '%s'.  Press the button again after Cacti maintenance is over."
+msgid ""
+"Cacti maintenance lockout has been cleared by '%s'.  Press the button again "
+"after Cacti maintenance is over."
 msgstr ""
 
 #: support.php:83
@@ -22706,7 +24649,9 @@ msgid "Collector"
 msgstr ""
 
 #: support.php:743
-msgid "The Type of Task.  Generally represents the plugin and task within the plugin."
+msgid ""
+"The Type of Task.  Generally represents the plugin and task within the "
+"plugin."
 msgstr ""
 
 #: support.php:746
@@ -22722,7 +24667,9 @@ msgid "Task ID"
 msgstr ""
 
 #: support.php:755
-msgid "The ID of the Task which is often times the LSF clusterid or the License Service ID, but can be other metrics as well."
+msgid ""
+"The ID of the Task which is often times the LSF clusterid or the License "
+"Service ID, but can be other metrics as well."
 msgstr ""
 
 #: support.php:758
@@ -22738,7 +24685,9 @@ msgid "The Process ID for the task."
 msgstr ""
 
 #: support.php:771
-msgid "The background process timeout in seconds when a Cacti process.  Otherwise controlled by the individual plugins."
+msgid ""
+"The background process timeout in seconds when a Cacti process.  Otherwise "
+"controlled by the individual plugins."
 msgstr ""
 
 #: support.php:774
@@ -22746,7 +24695,9 @@ msgid "Start Time"
 msgstr ""
 
 #: support.php:777
-msgid "Time the background process started for a Cacti process.  The start time may or may not be supported for various plugins."
+msgid ""
+"Time the background process started for a Cacti process.  The start time may "
+"or may not be supported for various plugins."
 msgstr ""
 
 #: support.php:783
@@ -22822,7 +24773,9 @@ msgid "Permission Name"
 msgstr ""
 
 #: support.php:1153
-msgid "NET-SNMP Not Installed or its paths are not set.  Please install if you wish to monitor SNMP enabled devices."
+msgid ""
+"NET-SNMP Not Installed or its paths are not set.  Please install if you wish "
+"to monitor SNMP enabled devices."
 msgstr ""
 
 #: support.php:1160
@@ -22831,12 +24784,16 @@ msgstr ""
 
 #: support.php:1160
 #, php-format
-msgid "ERROR: Installed RRDtool version does not exceed configured version.<br>Please visit the %s and select the correct RRDtool Utility Version."
+msgid ""
+"ERROR: Installed RRDtool version does not exceed configured version."
+"<br>Please visit the %s and select the correct RRDtool Utility Version."
 msgstr ""
 
 #: support.php:1166
 #, php-format
-msgid "ERROR: RRDtool 1.2.x+ does not support the GIF images format, but %d\" graph(s) and/or templates have GIF set as the image format."
+msgid ""
+"ERROR: RRDtool 1.2.x+ does not support the GIF images format, but %d\" "
+"graph(s) and/or templates have GIF set as the image format."
 msgstr ""
 
 #: support.php:1181
@@ -22949,11 +24906,15 @@ msgid "Minimum Connections:"
 msgstr ""
 
 #: support.php:1401
-msgid "Assumes 100 spare connections for Web page users and other various connections."
+msgid ""
+"Assumes 100 spare connections for Web page users and other various "
+"connections."
 msgstr ""
 
 #: support.php:1402
-msgid "The minimum required can vary greatly if there is heavy user Graph viewing activity."
+msgid ""
+"The minimum required can vary greatly if there is heavy user Graph viewing "
+"activity."
 msgstr ""
 
 #: support.php:1403
@@ -22992,8 +24953,11 @@ msgid "Max Total Memory Possible"
 msgstr ""
 
 #: support.php:1598
-#, php-format
-msgid "Reduce MySQL/MariaDB Memory to less than 80% of System Memory.  Preserve additional Cache Memory for RRDfiles if the Database is on the same system as the RRDfiles.  See Core and Client Totals below for explanation of calculation method."
+msgid ""
+"Reduce MySQL/MariaDB Memory to less than 80% of System Memory.  Preserve "
+"additional Cache Memory for RRDfiles if the Database is on the same system "
+"as the RRDfiles.  See Core and Client Totals below for explanation of "
+"calculation method."
 msgstr ""
 
 #: support.php:1616 support.php:1621 support.php:1649
@@ -23037,7 +25001,9 @@ msgid "PHP SNMP"
 msgstr ""
 
 #: support.php:1698
-msgid "Installed. <span class=\"deviceDown\">Note: If you are planning on using SNMPv3, you must remove php-snmp and use the Net-SNMP toolset.</span>"
+msgid ""
+"Installed. <span class=\"deviceDown\">Note: If you are planning on using "
+"SNMPv3, you must remove php-snmp and use the Net-SNMP toolset.</span>"
 msgstr ""
 
 #: support.php:1734
@@ -23046,11 +25012,16 @@ msgstr ""
 
 #: support.php:1737
 #, php-format
-msgid "It is highly suggested that you alter you php.ini memory_limit to %s or higher."
+msgid ""
+"It is highly suggested that you alter you php.ini memory_limit to %s or "
+"higher."
 msgstr ""
 
 #: support.php:1738
-msgid "This suggested memory value is calculated based on the number of data source present and is only to be used as a suggestion, actual values may vary system to system based on requirements."
+msgid ""
+"This suggested memory value is calculated based on the number of data source "
+"present and is only to be used as a suggestion, actual values may vary "
+"system to system based on requirements."
 msgstr ""
 
 #: templates_export.php:107
@@ -23099,7 +25070,9 @@ msgstr ""
 
 #: templates_import.php:146
 #, php-format
-msgid "See the cacti.log for more information, and review the XML file for proper syntax.  The error details are shown below.<br><br><b>Errors:</b><br>%s"
+msgid ""
+"See the cacti.log for more information, and review the XML file for proper "
+"syntax.  The error details are shown below.<br><br><b>Errors:</b><br>%s"
 msgstr ""
 
 #: templates_import.php:146
@@ -23120,7 +25093,8 @@ msgid "Not Readable"
 msgstr ""
 
 #: templates_import.php:253
-msgid "Import Templates [ None selected imports all, Check to import selectively ]"
+msgid ""
+"Import Templates [ None selected imports all, Check to import selectively ]"
 msgstr ""
 
 #: templates_import.php:266
@@ -23142,7 +25116,9 @@ msgid "Unmet: %d"
 msgstr ""
 
 #: templates_import.php:334
-msgid "Some CDEF Items will not import due to an export error! Contact Template provider for an updated export."
+msgid ""
+"Some CDEF Items will not import due to an export error! Contact Template "
+"provider for an updated export."
 msgstr ""
 
 #: templates_import.php:375 templates_import.php:462
@@ -23275,7 +25251,8 @@ msgid "Edit Tree"
 msgstr ""
 
 #: tree.php:795
-msgid "To Edit this tree, you must first lock it by pressing the Edit Tree button."
+msgid ""
+"To Edit this tree, you must first lock it by pressing the Edit Tree button."
 msgstr ""
 
 #: tree.php:801
@@ -23365,7 +25342,9 @@ msgid "The name by which this Tree will be referred to as."
 msgstr ""
 
 #: tree.php:2122
-msgid "The internal database ID for this Tree.  Useful when performing automation or debugging."
+msgid ""
+"The internal database ID for this Tree.  Useful when performing automation "
+"or debugging."
 msgstr ""
 
 #: tree.php:2125
@@ -23385,7 +25364,9 @@ msgid "The original author of this Tree."
 msgstr ""
 
 #: tree.php:2146
-msgid "To change the order of the trees, first sort by this column, press the up or down arrows once they appear."
+msgid ""
+"To change the order of the trees, first sort by this column, press the up or "
+"down arrows once they appear."
 msgstr ""
 
 #: tree.php:2149
@@ -23505,11 +25486,19 @@ msgid "Disable Users"
 msgstr ""
 
 #: user_admin.php:415
-msgid "Click 'Continue' to Overwrite the User settings with the selected Template User settings and permissions.  The original User Full Name, Password, Realm and Enable status will be retained, all other fields will be overwritten from the Template User."
+msgid ""
+"Click 'Continue' to Overwrite the User settings with the selected Template "
+"User settings and permissions.  The original User Full Name, Password, Realm "
+"and Enable status will be retained, all other fields will be overwritten "
+"from the Template User."
 msgstr ""
 
 #: user_admin.php:416
-msgid "Click 'Continue' to Overwrite the Users settings with the selected Template User settings and permissions.  The original Users Full Name, Password, Realm and Enable status will be retained, all other fields will be overwritten from the Template User."
+msgid ""
+"Click 'Continue' to Overwrite the Users settings with the selected Template "
+"User settings and permissions.  The original Users Full Name, Password, "
+"Realm and Enable status will be retained, all other fields will be "
+"overwritten from the Template User."
 msgstr ""
 
 #: user_admin.php:417
@@ -23545,19 +25534,29 @@ msgid "Deny"
 msgstr ""
 
 #: user_admin.php:777 user_group_admin.php:746
-msgid "<b>Note:</b> System Graph Policy is 'Permissive' meaning the User must have access to at least one of Graph, Device, or Graph Template to gain access to the Graph"
+msgid ""
+"<b>Note:</b> System Graph Policy is 'Permissive' meaning the User must have "
+"access to at least one of Graph, Device, or Graph Template to gain access to "
+"the Graph"
 msgstr ""
 
 #: user_admin.php:779 user_group_admin.php:748
-msgid "<b>Note:</b> System Graph Policy is 'Restrictive' meaning the User must have access to either the Graph or the Device and Graph Template to gain access to the Graph"
+msgid ""
+"<b>Note:</b> System Graph Policy is 'Restrictive' meaning the User must have "
+"access to either the Graph or the Device and Graph Template to gain access "
+"to the Graph"
 msgstr ""
 
 #: user_admin.php:781 user_group_admin.php:750
-msgid "<b>Note:</b> System Graph Policy is 'Device' meaning the User must have access to the Graph or Device to gain access to the Graph"
+msgid ""
+"<b>Note:</b> System Graph Policy is 'Device' meaning the User must have "
+"access to the Graph or Device to gain access to the Graph"
 msgstr ""
 
 #: user_admin.php:783 user_group_admin.php:752
-msgid "<b>Note:</b> System Graph Policy is 'Graph Template' meaning the User must have access to the Graph or Graph Template to gain access to the Graph"
+msgid ""
+"<b>Note:</b> System Graph Policy is 'Graph Template' meaning the User must "
+"have access to the Graph or Graph Template to gain access to the Graph"
 msgstr ""
 
 #: user_admin.php:787 user_group_admin.php:760
@@ -23597,7 +25596,7 @@ msgstr ""
 msgid "Grant Access"
 msgstr ""
 
-#: user_admin.php:1015 user_admin.php:2423 user_group_admin.php:1852
+#: user_admin.php:1015 user_admin.php:2425 user_group_admin.php:1852
 #: user_group_admin.php:1922
 msgid "Groups"
 msgstr ""
@@ -23614,14 +25613,14 @@ msgstr ""
 msgid "Non Member"
 msgstr ""
 
-#: user_admin.php:1035 user_admin.php:2311 user_admin.php:2312
-#: user_admin.php:2313 user_group_admin.php:1945 user_group_admin.php:1946
+#: user_admin.php:1035 user_admin.php:2313 user_admin.php:2314
+#: user_admin.php:2315 user_group_admin.php:1945 user_group_admin.php:1946
 #: user_group_admin.php:1947
 msgid "ALLOW"
 msgstr ""
 
-#: user_admin.php:1035 user_admin.php:2311 user_admin.php:2312
-#: user_admin.php:2313 user_group_admin.php:1945 user_group_admin.php:1946
+#: user_admin.php:1035 user_admin.php:2313 user_admin.php:2314
+#: user_admin.php:2315 user_group_admin.php:1945 user_group_admin.php:1946
 #: user_group_admin.php:1947
 msgid "DENY"
 msgstr ""
@@ -23715,138 +25714,138 @@ msgstr ""
 msgid "User Settings %s"
 msgstr ""
 
-#: user_admin.php:1851 user_group_admin.php:1715
+#: user_admin.php:1853 user_group_admin.php:1715
 msgid "Permissions"
 msgstr ""
 
-#: user_admin.php:1852
+#: user_admin.php:1854
 msgid "Group Membership"
 msgstr ""
 
-#: user_admin.php:1853 user_group_admin.php:1716
+#: user_admin.php:1855 user_group_admin.php:1716
 msgid "Graph Perms"
 msgstr ""
 
-#: user_admin.php:1854 user_group_admin.php:1717
+#: user_admin.php:1856 user_group_admin.php:1717
 msgid "Device Perms"
 msgstr ""
 
-#: user_admin.php:1855 user_group_admin.php:1718
+#: user_admin.php:1857 user_group_admin.php:1718
 msgid "Template Perms"
 msgstr ""
 
-#: user_admin.php:1856 user_group_admin.php:1719
+#: user_admin.php:1858 user_group_admin.php:1719
 msgid "Tree Perms"
 msgstr ""
 
-#: user_admin.php:1906
+#: user_admin.php:1908
 #, php-format
 msgid "User Management %s"
 msgstr ""
 
-#: user_admin.php:2044
+#: user_admin.php:2046
 msgid "< 1 Week Ago"
 msgstr ""
 
-#: user_admin.php:2045
+#: user_admin.php:2047
 msgid "< 1 Month Ago"
 msgstr ""
 
-#: user_admin.php:2046
+#: user_admin.php:2048
 msgid "> 1 Month Ago"
 msgstr ""
 
-#: user_admin.php:2047
+#: user_admin.php:2049
 msgid "> 2 Months Ago"
 msgstr ""
 
-#: user_admin.php:2048
+#: user_admin.php:2050
 msgid "> 4 Months Ago"
 msgstr ""
 
-#: user_admin.php:2055
+#: user_admin.php:2057
 msgid "Basic"
 msgstr ""
 
-#: user_admin.php:2056
+#: user_admin.php:2058
 msgid "LDAP/AD"
 msgstr ""
 
-#: user_admin.php:2057
+#: user_admin.php:2059
 msgid "Domain"
 msgstr ""
 
-#: user_admin.php:2076
+#: user_admin.php:2078
 msgid "Group"
 msgstr ""
 
-#: user_admin.php:2085 user_admin.php:2260
+#: user_admin.php:2087 user_admin.php:2262
 msgid "Last Login"
 msgstr ""
 
-#: user_admin.php:2137
+#: user_admin.php:2139
 msgid "User Management"
 msgstr ""
 
-#: user_admin.php:2232
+#: user_admin.php:2234
 msgid "User ID"
 msgstr ""
 
-#: user_admin.php:2248 user_group_admin.php:1905
+#: user_admin.php:2250 user_group_admin.php:1905
 msgid "Graph Policy"
 msgstr ""
 
-#: user_admin.php:2252 user_group_admin.php:1909
+#: user_admin.php:2254 user_group_admin.php:1909
 msgid "Device Policy"
 msgstr ""
 
-#: user_admin.php:2256 user_group_admin.php:1913
+#: user_admin.php:2258 user_group_admin.php:1913
 msgid "Template Policy"
 msgstr ""
 
-#: user_admin.php:2294 user_group_admin.php:674
+#: user_admin.php:2296 user_group_admin.php:674
 msgid "Unavailable"
 msgstr ""
 
-#: user_admin.php:2321
+#: user_admin.php:2323
 msgid "No Users Found"
 msgstr ""
 
-#: user_admin.php:2405 user_group_admin.php:2039
+#: user_admin.php:2407 user_group_admin.php:2039
 #, php-format
 msgid "Graph Permissions %s"
 msgstr ""
 
-#: user_admin.php:2409 user_admin.php:2505 user_admin.php:2521
-#: user_admin.php:2535 user_group_admin.php:2043 user_group_admin.php:2125
+#: user_admin.php:2411 user_admin.php:2507 user_admin.php:2523
+#: user_admin.php:2537 user_group_admin.php:2043 user_group_admin.php:2125
 #: user_group_admin.php:2141 user_group_admin.php:2155
 msgid "Only Show Exceptions"
 msgstr ""
 
-#: user_admin.php:2421
+#: user_admin.php:2423
 #, php-format
 msgid "Group Membership %s"
 msgstr ""
 
-#: user_admin.php:2425
+#: user_admin.php:2427
 msgid "Show All"
 msgstr ""
 
-#: user_admin.php:2501 user_group_admin.php:2121
+#: user_admin.php:2503 user_group_admin.php:2121
 #, php-format
 msgid "Device Permissions %s"
 msgstr ""
 
-#: user_admin.php:2517 user_group_admin.php:2137
+#: user_admin.php:2519 user_group_admin.php:2137
 #, php-format
 msgid "Template Permissions %s"
 msgstr ""
 
-#: user_admin.php:2519 user_group_admin.php:2139
+#: user_admin.php:2521 user_group_admin.php:2139
 msgid "Templatee"
 msgstr ""
 
-#: user_admin.php:2531 user_group_admin.php:2151
+#: user_admin.php:2533 user_group_admin.php:2151
 #, php-format
 msgid "Tree Permissions %s"
 msgstr ""
@@ -23900,7 +25899,9 @@ msgid "Enable User Domains"
 msgstr ""
 
 #: user_domains.php:249
-msgid "Click 'Continue' to make the following the following User Domain the default one."
+msgid ""
+"Click 'Continue' to make the following the following User Domain the default "
+"one."
 msgstr ""
 
 #: user_domains.php:250
@@ -23917,7 +25918,9 @@ msgid "User Domain [new]"
 msgstr ""
 
 #: user_domains.php:296
-msgid "Enter a meaningful name for this domain. This will be the name that appears in the Login Realm during login."
+msgid ""
+"Enter a meaningful name for this domain. This will be the name that appears "
+"in the Login Realm during login."
 msgstr ""
 
 #: user_domains.php:302
@@ -23929,15 +25932,19 @@ msgid "Choose what type of domain this is."
 msgstr ""
 
 #: user_domains.php:310
-msgid "The name of the user that Cacti will use as a template for new user accounts."
+msgid ""
+"The name of the user that Cacti will use as a template for new user accounts."
 msgstr ""
 
 #: user_domains.php:320
-msgid "If this checkbox is checked, users will be able to login using this domain."
+msgid ""
+"If this checkbox is checked, users will be able to login using this domain."
 msgstr ""
 
 #: user_domains.php:327
-msgid "If testing the LDAP connection and your desire more details in your Cacti log, check this box."
+msgid ""
+"If testing the LDAP connection and your desire more details in your Cacti "
+"log, check this box."
 msgstr ""
 
 #: user_domains.php:343
@@ -23945,7 +25952,10 @@ msgid "Server(s)"
 msgstr ""
 
 #: user_domains.php:344
-msgid "A space delimited list of DNS hostnames or IP address of for valid LDAP servers.  Cacti will attempt to use the LDAP servers from left to right to authenticate a user."
+msgid ""
+"A space delimited list of DNS hostnames or IP address of for valid LDAP "
+"servers.  Cacti will attempt to use the LDAP servers from left to right to "
+"authenticate a user."
 msgstr ""
 
 #: user_domains.php:352
@@ -23993,7 +26003,9 @@ msgid "Encryption"
 msgstr ""
 
 #: user_domains.php:396
-msgid "Encryption that the server supports. TLS is only supported by Protocol Version 3."
+msgid ""
+"Encryption that the server supports. TLS is only supported by Protocol "
+"Version 3."
 msgstr ""
 
 #: user_domains.php:402
@@ -24009,7 +26021,9 @@ msgid "Referrals"
 msgstr ""
 
 #: user_domains.php:411
-msgid "Enable or Disable LDAP referrals.  If disabled, it may increase the speed of searches."
+msgid ""
+"Enable or Disable LDAP referrals.  If disabled, it may increase the speed of "
+"searches."
 msgstr ""
 
 #: user_domains.php:417
@@ -24017,7 +26031,15 @@ msgid "Mode"
 msgstr ""
 
 #: user_domains.php:418
-msgid "Mode which cacti will attempt to authenticate against the LDAP server.<blockquote><i>No Searching</i> - No Distinguished Name (DN) searching occurs, just attempt to bind with the provided Distinguished Name (DN) format.<br><br><i>Anonymous Searching</i> - Attempts to search for username against LDAP directory via anonymous binding to locate the users Distinguished Name (DN).<br><br><i>Specific Searching</i> - Attempts search for username against LDAP directory via Specific Distinguished Name (DN) and Specific Password for binding to locate the users Distinguished Name (DN)."
+msgid ""
+"Mode which cacti will attempt to authenticate against the LDAP server."
+"<blockquote><i>No Searching</i> - No Distinguished Name (DN) searching "
+"occurs, just attempt to bind with the provided Distinguished Name (DN) "
+"format.<br><br><i>Anonymous Searching</i> - Attempts to search for username "
+"against LDAP directory via anonymous binding to locate the users "
+"Distinguished Name (DN).<br><br><i>Specific Searching</i> - Attempts search "
+"for username against LDAP directory via Specific Distinguished Name (DN) and "
+"Specific Password for binding to locate the users Distinguished Name (DN)."
 msgstr ""
 
 #: user_domains.php:424
@@ -24025,7 +26047,16 @@ msgid "Distinguished Name (DN)"
 msgstr ""
 
 #: user_domains.php:425
-msgid "The \"Distinguished Name\" syntax, applicable for both OpenLDAP and Windows AD configurations, offers flexibility in defining user identity. For OpenLDAP, the format follows this structure: <i>\"uid=&lt;username&gt;,ou=people,dc=domain,dc=local\"</i>. Windows AD provides an alternative syntax: <i>\"&lt;username&gt;@win2kdomain.local\"</i>, commonly known as \"userPrincipalName (UPN)\". In this context, \"&lt;username&gt;\" represents the specific username provided during the login prompt. This is particularly pertinent when operating in \"No Searching\" mode, or \"Require Group Membership\" enabled."
+msgid ""
+"The \"Distinguished Name\" syntax, applicable for both OpenLDAP and Windows "
+"AD configurations, offers flexibility in defining user identity. For "
+"OpenLDAP, the format follows this structure: "
+"<i>\"uid=&lt;username&gt;,ou=people,dc=domain,dc=local\"</i>. Windows AD "
+"provides an alternative syntax: <i>\"&lt;username&gt;@win2kdomain.local\"</"
+"i>, commonly known as \"userPrincipalName (UPN)\". In this context, "
+"\"&lt;username&gt;\" represents the specific username provided during the "
+"login prompt. This is particularly pertinent when operating in \"No "
+"Searching\" mode, or \"Require Group Membership\" enabled."
 msgstr ""
 
 #: user_domains.php:432
@@ -24033,7 +26064,10 @@ msgid "Require Group Membership"
 msgstr ""
 
 #: user_domains.php:433
-msgid "Require user to be member of group to authenticate. Group settings must be set for this to work, enabling without proper group settings will cause authentication failure."
+msgid ""
+"Require user to be member of group to authenticate. Group settings must be "
+"set for this to work, enabling without proper group settings will cause "
+"authentication failure."
 msgstr ""
 
 #: user_domains.php:438
@@ -24053,7 +26087,12 @@ msgid "Group Member Attribute"
 msgstr ""
 
 #: user_domains.php:450
-msgid "This refers to the specific attribute within the LDAP directory that holds the usernames of group members. It is crucial to ensure that the attribute value aligns with the configuration specified in the \"Distinguished Name\" or that the actual attribute value is searchable using the settings outlined in the \"Distinguished Name\"."
+msgid ""
+"This refers to the specific attribute within the LDAP directory that holds "
+"the usernames of group members. It is crucial to ensure that the attribute "
+"value aligns with the configuration specified in the \"Distinguished Name\" "
+"or that the actual attribute value is searchable using the settings outlined "
+"in the \"Distinguished Name\"."
 msgstr ""
 
 #: user_domains.php:456
@@ -24061,7 +26100,9 @@ msgid "Group Member Type"
 msgstr ""
 
 #: user_domains.php:457
-msgid "Defines if users use full Distinguished Name or just Username in the defined Group Member Attribute."
+msgid ""
+"Defines if users use full Distinguished Name or just Username in the defined "
+"Group Member Attribute."
 msgstr ""
 
 #: user_domains.php:463
@@ -24073,7 +26114,10 @@ msgid "Search Base"
 msgstr ""
 
 #: user_domains.php:468
-msgid "Search base for searching the LDAP directory, such as <i>\"dc=win2kdomain,dc=local\"</i> or <i>\"ou=people,dc=domain,dc=local\"</i>."
+msgid ""
+"Search base for searching the LDAP directory, such as "
+"<i>\"dc=win2kdomain,dc=local\"</i> or <i>\"ou=people,dc=domain,dc=local\"</"
+"i>."
 msgstr ""
 
 #: user_domains.php:474
@@ -24081,7 +26125,13 @@ msgid "Search Filter"
 msgstr ""
 
 #: user_domains.php:475
-msgid "Search filter to use to locate the user in the LDAP directory, such as for windows: <i>\"(&amp;(objectclass=user)(objectcategory=user)(userPrincipalName=&lt;username&gt;*))\"</i> or for OpenLDAP: <i>\"(&(objectClass=account)(uid=&lt;username&gt))\"</i>.  \"&lt;username&gt\" is replaced with the username that was supplied at the login prompt."
+msgid ""
+"Search filter to use to locate the user in the LDAP directory, such as for "
+"windows: <i>\"(&amp;(objectclass=user)(objectcategory=user)"
+"(userPrincipalName=&lt;username&gt;*))\"</i> or for OpenLDAP: "
+"<i>\"(&(objectClass=account)(uid=&lt;username&gt))\"</i>.  "
+"\"&lt;username&gt\" is replaced with the username that was supplied at the "
+"login prompt."
 msgstr ""
 
 #: user_domains.php:481
@@ -24089,7 +26139,8 @@ msgid "Search Distinguished Name (DN)"
 msgstr ""
 
 #: user_domains.php:482
-msgid "Distinguished Name for Specific Searching binding to the LDAP directory."
+msgid ""
+"Distinguished Name for Specific Searching binding to the LDAP directory."
 msgstr ""
 
 #: user_domains.php:488
@@ -24105,7 +26156,9 @@ msgid "LDAP CN Settings"
 msgstr ""
 
 #: user_domains.php:500
-msgid "Field that will replace the Full Name when creating a new user, taken from LDAP. (on windows: displayname) "
+msgid ""
+"Field that will replace the Full Name when creating a new user, taken from "
+"LDAP. (on windows: displayname) "
 msgstr ""
 
 #: user_domains.php:506
@@ -24185,7 +26238,9 @@ msgid "Group Description"
 msgstr ""
 
 #: user_group_admin.php:81
-msgid "A more descriptive name for this group, that can include spaces or special characters."
+msgid ""
+"A more descriptive name for this group, that can include spaces or special "
+"characters."
 msgstr ""
 
 #: user_group_admin.php:93
@@ -24398,7 +26453,9 @@ msgid "Success - Token"
 msgstr ""
 
 #: user_log.php:212
-msgid "Click 'Continue' to purge the User Log.<br><br><br>Note: If logging is set to both Cacti and Syslog, the log information will remain in Syslog."
+msgid ""
+"Click 'Continue' to purge the User Log.<br><br><br>Note: If logging is set "
+"to both Cacti and Syslog, the log information will remain in Syslog."
 msgstr ""
 
 #: user_log.php:247
@@ -24503,7 +26560,9 @@ msgid "Poller Cache Items"
 msgstr ""
 
 #: utilities.php:847
-msgid "Poller Cache Items [ <span class=\"blink deviceUp\">Rebuild In Process - Press Go to Check Status</span> ]"
+msgid ""
+"Poller Cache Items [ <span class=\"blink deviceUp\">Rebuild In Process - "
+"Press Go to Check Status</span> ]"
 msgstr ""
 
 #: utilities.php:851
@@ -24519,15 +26578,23 @@ msgid "Poller Cache Items [ Rebuild Timed out and Crashed ]"
 msgstr ""
 
 #: utilities.php:883
-msgid "Cacti technical support page.  Used by developers and technical support persons to assist with issues in Cacti.  Includes checks for common configuration issues."
+msgid ""
+"Cacti technical support page.  Used by developers and technical support "
+"persons to assist with issues in Cacti.  Includes checks for common "
+"configuration issues."
 msgstr ""
 
 #: utilities.php:887
-msgid "The Cacti Log stores statistic, error and other message depending on system settings.  This information can be used to identify problems with the poller and application."
+msgid ""
+"The Cacti Log stores statistic, error and other message depending on system "
+"settings.  This information can be used to identify problems with the poller "
+"and application."
 msgstr ""
 
 #: utilities.php:891
-msgid "Allows Administrators to browse the user log.  Administrators can filter and export the log as well."
+msgid ""
+"Allows Administrators to browse the user log.  Administrators can filter and "
+"export the log as well."
 msgstr ""
 
 #: utilities.php:895
@@ -24535,11 +26602,17 @@ msgid "Poller Cache Administration"
 msgstr ""
 
 #: utilities.php:898
-msgid "This is the data that is being passed to the poller each time it runs. This data is then in turn executed/interpreted and the results are fed into the RRDfiles for graphing or the database for display."
+msgid ""
+"This is the data that is being passed to the poller each time it runs. This "
+"data is then in turn executed/interpreted and the results are fed into the "
+"RRDfiles for graphing or the database for display."
 msgstr ""
 
 #: utilities.php:902
-msgid "The Data Query Cache stores information gathered from Data Query input types. The values from these fields can be used in the text area of Graphs for Legends, Vertical Labels, and GPRINTS as well as in CDEF's."
+msgid ""
+"The Data Query Cache stores information gathered from Data Query input "
+"types. The values from these fields can be used in the text area of Graphs "
+"for Legends, Vertical Labels, and GPRINTS as well as in CDEF's."
 msgstr ""
 
 #: utilities.php:904
@@ -24547,11 +26620,21 @@ msgid "Rebuild Poller Cache"
 msgstr ""
 
 #: utilities.php:907
-msgid "The Poller Cache will be re-generated if you select this option. Use this option only in the event of a database crash if you are experiencing issues after the crash and have already run the database repair tools.  Alternatively, if you are having problems with a specific Device, simply re-save that Device to rebuild its Poller Cache.  There is also a command line interface equivalent to this command that is recommended for large systems."
+msgid ""
+"The Poller Cache will be re-generated if you select this option. Use this "
+"option only in the event of a database crash if you are experiencing issues "
+"after the crash and have already run the database repair tools.  "
+"Alternatively, if you are having problems with a specific Device, simply re-"
+"save that Device to rebuild its Poller Cache.  There is also a command line "
+"interface equivalent to this command that is recommended for large systems."
 msgstr ""
 
 #: utilities.php:909
-msgid "NOTE: On large systems, this command may take several minutes to hours to complete and therefore should not be run from the Cacti UI.  You can simply run 'php -q cli/rebuild_poller_cache.php --help' at the command line for more information."
+msgid ""
+"NOTE: On large systems, this command may take several minutes to hours to "
+"complete and therefore should not be run from the Cacti UI.  You can simply "
+"run 'php -q cli/rebuild_poller_cache.php --help' at the command line for "
+"more information."
 msgstr ""
 
 #: utilities.php:913
@@ -24559,7 +26642,13 @@ msgid "Rebuild Resource Cache"
 msgstr ""
 
 #: utilities.php:916
-msgid "When operating multiple Data Collectors in Cacti, Cacti will attempt to maintain state for key files on all Data Collectors.  This includes all core, non-install related website and plugin files.  When you force a Resource Cache rebuild, Cacti will clear the local Resource Cache, and then rebuild it at the next scheduled poller start.  This will trigger all Remote Data Collectors to recheck their website and plugin files for consistency."
+msgid ""
+"When operating multiple Data Collectors in Cacti, Cacti will attempt to "
+"maintain state for key files on all Data Collectors.  This includes all "
+"core, non-install related website and plugin files.  When you force a "
+"Resource Cache rebuild, Cacti will clear the local Resource Cache, and then "
+"rebuild it at the next scheduled poller start.  This will trigger all Remote "
+"Data Collectors to recheck their website and plugin files for consistency."
 msgstr ""
 
 #: utilities.php:920
@@ -24571,7 +26660,9 @@ msgid "View Boost Status"
 msgstr ""
 
 #: utilities.php:923
-msgid "This menu pick allows you to view various boost settings and statistics associated with the current running Boost configuration."
+msgid ""
+"This menu pick allows you to view various boost settings and statistics "
+"associated with the current running Boost configuration."
 msgstr ""
 
 #: utilities.php:927
@@ -24583,7 +26674,10 @@ msgid "Purge Data Source Statistics"
 msgstr ""
 
 #: utilities.php:931
-msgid "This menu pick will purge all existing Data Source Statistics from the Database.  If Data Source Statistics is enabled, the Data Sources Statistics will start collection again on the next Data Collector pass."
+msgid ""
+"This menu pick will purge all existing Data Source Statistics from the "
+"Database.  If Data Source Statistics is enabled, the Data Sources Statistics "
+"will start collection again on the next Data Collector pass."
 msgstr ""
 
 #: utilities.php:936
@@ -24599,11 +26693,15 @@ msgid "Rebuild SNMP Agent Cache"
 msgstr ""
 
 #: utilities.php:945
-msgid "The SNMP cache will be cleared and re-generated if you select this option. Note that it takes another poller run to restore the SNMP cache completely."
+msgid ""
+"The SNMP cache will be cleared and re-generated if you select this option. "
+"Note that it takes another poller run to restore the SNMP cache completely."
 msgstr ""
 
 #: utilities.php:950
-msgid "This menu pick allows you to view the latest events SNMP Agent has handled in relation to the registered notification receivers."
+msgid ""
+"This menu pick allows you to view the latest events SNMP Agent has handled "
+"in relation to the registered notification receivers."
 msgstr ""
 
 #: utilities.php:957
@@ -24764,7 +26862,10 @@ msgstr ""
 
 #: utilities.php:1403
 #, php-format
-msgid "Records: %s (ds rows), Time: %s (secs), GetRows: %s (secs), ResultsCycle: %s (secs), FileAndTemplate: %s (secs), LastUpdate: %s (secs), RRDUpdate: %s (secs), Delete: %s (secs)"
+msgid ""
+"Records: %s (ds rows), Time: %s (secs), GetRows: %s (secs), ResultsCycle: %s "
+"(secs), FileAndTemplate: %s (secs), LastUpdate: %s (secs), RRDUpdate: %s "
+"(secs), Delete: %s (secs)"
 msgstr ""
 
 #: utilities.php:1414
@@ -24778,12 +26879,17 @@ msgstr ""
 
 #: utilities.php:1449
 #, php-format
-msgid "Status: <span class=\"deviceUp\"><b>Running</b></span>, Remaining: %s (dses), CurrentRuntime: %s (secs), PrevRuntime: %s (secs), PrevProcessed: %10s (ds rows)"
+msgid ""
+"Status: <span class=\"deviceUp\"><b>Running</b></span>, Remaining: %s "
+"(dses), CurrentRuntime: %s (secs), PrevRuntime: %s (secs), PrevProcessed: "
+"%10s (ds rows)"
 msgstr ""
 
 #: utilities.php:1451
 #, php-format
-msgid "Status: <span class=\"deviceRecovering\"><b>Idle</b></span>, PrevRuntime: %s (secs), PrevProcessed: %10s (ds rows)"
+msgid ""
+"Status: <span class=\"deviceRecovering\"><b>Idle</b></span>, PrevRuntime: %s "
+"(secs), PrevProcessed: %10s (ds rows)"
 msgstr ""
 
 #: utilities.php:1457
@@ -24967,7 +27073,9 @@ msgid "The name of this VDEF."
 msgstr ""
 
 #: vdef.php:757
-msgid "VDEFs that are in use cannot be Deleted. In use is defined as being referenced by a Graph or a Graph Template."
+msgid ""
+"VDEFs that are in use cannot be Deleted. In use is defined as being "
+"referenced by a Graph or a Graph Template."
 msgstr ""
 
 #: vdef.php:763

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -840,7 +840,7 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 		// we are going to blow away all record if ok
 		$vals_in_buffer = 0;
 
-		// innitialize some variables
+		// initialize some variables
 		$rrd_tmpl           = '';
 		$rrd_tmplp          = [];
 		$rrd_tmplpts        = 0;

--- a/poller_dsstats.php
+++ b/poller_dsstats.php
@@ -445,7 +445,7 @@ function display_help() : void {
 
 	print PHP_EOL . 'usage: poller_dsstats.php [--force] [--debug]' . PHP_EOL . PHP_EOL;
 
-	print 'Cacti\'s Data Source Statics poller.  This poller will periodically' . PHP_EOL;
+	print 'Cacti\'s Data Source Statistics poller.  This poller will periodically' . PHP_EOL;
 	print 'to calculate Data Source statistics for Cacti and works in conjunction' . PHP_EOL;
 	print 'with Cacti\'s performance boosting poller as required.' . PHP_EOL . PHP_EOL;
 

--- a/scripts/ss_apache_stats.php
+++ b/scripts/ss_apache_stats.php
@@ -2,7 +2,7 @@
 
 /**
  * Original Template by ApacheStats 0.8.2 by RCK - http://forums.cacti.net/about25227.html
- * Tested and packged for Cacti 1.2.x  by Sean Mancini - bmfmancini - www.seanmancini.com
+ * Tested and packaged for Cacti 1.2.x  by Sean Mancini - bmfmancini - www.seanmancini.com
  */
 
 if (!isset($called_by_script_server)) {

--- a/tree.php
+++ b/tree.php
@@ -215,7 +215,7 @@ function tree_check_sequences() : void {
 
 	if ($bad_seq > 0 || $dup_seq > 0) {
 		// resequence the list so it has no gaps, and 0 values will appear at the top
-		// since thats where they would have been displayed
+		// since that's where they would have been displayed
 		db_execute('SET @seq = 0; UPDATE graph_tree SET sequence = (@seq:=@seq+1) ORDER BY sequence, id;');
 	}
 }
@@ -1007,7 +1007,7 @@ function tree_edit(bool $partial = false) : void {
 				.done(function(data) {
 					$('#graphs').jstree('destroy');
 					$('#graphs').html(data);
-					dragable('graphs');
+					draggable('graphs');
 				})
 				.fail(function(data) {
 					getPresentHTTPError(data);
@@ -1020,8 +1020,8 @@ function tree_edit(bool $partial = false) : void {
 				.done(function(data) {
 					$('#hosts').jstree('destroy');
 					$('#hosts').html(data);
-					dragable('hosts');
-					dragable('graphs');
+					draggable('hosts');
+					draggable('graphs');
 				})
 				.fail(function(data) {
 					getPresentHTTPError(data);
@@ -1032,9 +1032,9 @@ function tree_edit(bool $partial = false) : void {
 			$.get('tree.php?action=sites&filter='+$('#sfilter').val(), function(data) {
 				$('#sites').jstree('destroy');
 				$('#sites').html(data);
-				dragable('sites');
-				dragable('hosts');
-				dragable('graphs');
+				draggable('sites');
+				draggable('hosts');
+				draggable('graphs');
 				enableKeyups();
 			});
 		}
@@ -1122,9 +1122,9 @@ function tree_edit(bool $partial = false) : void {
 
 				drawTree();
 
-				dragable('graphs');
-				dragable('hosts');
-				dragable('sites');
+				draggable('graphs');
+				draggable('hosts');
+				draggable('sites');
 
 				enableKeyups();
 			});
@@ -1147,9 +1147,9 @@ function tree_edit(bool $partial = false) : void {
 
 				drawTree();
 
-				dragable('graphs');
-				dragable('hosts');
-				dragable('sites');
+				draggable('graphs');
+				draggable('hosts');
+				draggable('sites');
 
 				enableKeyups();
 			});
@@ -1448,12 +1448,12 @@ function tree_edit(bool $partial = false) : void {
 
 			$('#ctree').css('height', height).css('overflow','auto');;
 
-			dragable('graphs');
-			dragable('hosts');
-			dragable('sites');
+			draggable('graphs');
+			draggable('hosts');
+			draggable('sites');
 		});
 
-		function dragable(element) {
+		function draggable(element) {
 			var id = '#'+element;
 			var divdata = '';
 


### PR DESCRIPTION
## Summary

- Fixes 63 spelling errors in comments, docblocks, and string literals across 23 files
- Detected by automated `codespell` scan of the `develop` branch
- No logic changes; all edits are in non-executable text

## Corrections (selected)

| Before | After | Files affected |
|--------|-------|----------------|
| `accomodate` | `accommodate` | 5 files |
| `dragable` | `draggable` | `tree.php` (14 occurrences) |
| `dependant` | `dependent` | `graphs.php`, `lib/installer.php` |
| `immediatly` | `immediately` | `lib/installer.php` |
| `$flage[PDO` | `$flags[PDO` | `lib/database.php` (dead assignment) |
| `Statics` | `Statistics` | `poller_dsstats.php` |
| `sqlLite` | `SQLite` | `cli/splice_rrd.php` |
| `innitialize` | `initialize` | `poller_boost.php` |

Full correction table in #6803.

## Exclusions

- `parms`/`PARMS` — Cacti CLI variable name convention
- `tht`, `ot` — SQL table aliases
- `CurrOS`, `hasTables` — PHP variable names
- `pring` — internal Cacti function
- `realy`/`realx` — image coordinate variables
- `alues`/`alue` — RRD XML element notation (`<V>alues`)

## Test plan

- [ ] No PHP parse errors: `php -l <file>` on each modified file
- [ ] No functional regression: codespell-only changes with no logic impact
- [ ] `codespell` scan passes clean after merge

Fixes #6803