### PR TITLE
fix(i18n): clear 885 format-string-unsafe translations

### DIFF
--- a/locales/po/bg-BG.po
+++ b/locales/po/bg-BG.po
@@ -1,3 +1,4 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Cacti\n"
@@ -20820,12 +20821,12 @@ msgstr ""
 #: poller.php:1253
 #, php-format
 msgid "WARNING: 24 hours Poller[%d] avg. run time is %f seconds (more than %d &#37; of time limit)"
-msgstr "ВНИМАНИЕ: 24 часа Poller[%d] средно време на работа е %f секунди (повече от %d % от ограничението във времето)"
+msgstr ""
 
 #: poller.php:1269
 #, php-format
 msgid "WARNING: In last hour Poller[%d] run time %d times reached more than %d &#37; of time limit"
-msgstr "ПРЕДУПРЕЖДЕНИЕ: В последния час Poller[%d] време на работа %d пъти достигна повече от %d % от срока"
+msgstr ""
 
 #: poller.php:1291
 msgid "Cacti System Notification"

--- a/locales/po/el-GR.po
+++ b/locales/po/el-GR.po
@@ -63,7 +63,7 @@ msgstr "Ευχαριστούμε"
 #: about.php:88
 #, php-format
 msgid "A very special thanks to %sTobi Oetiker%s, the creator of %sRRDtool%s and the very popular %sMRTG%s."
-msgstr "Ένα πολύ ιδιαίτερο ευχαριστώ στον %s Tobi Oetiker %s, τον δημιουργό των %sRRDtool% και των πολύ δημοφιλών %sMRTG%."
+msgstr ""
 
 #: about.php:91
 msgid "The users of Cacti"
@@ -336,7 +336,7 @@ msgstr "Κλάδος Προορισμού:"
 #: user_admin.php:1876
 #, php-format
 msgid "[edit: %s]"
-msgstr "Επεξεργασία"
+msgstr ""
 
 #: aggregate_graphs.php:1054 aggregate_graphs.php:1164
 #: aggregate_graphs.php:1166
@@ -1999,7 +1999,7 @@ msgstr "Καθορίστε τον αριθμό των νημάτων που θα
 #: automation_networks.php:747
 #, php-format
 msgid "%d Thread"
-msgstr "κλώσμα διχτυού χωρίς κόμπους"
+msgstr ""
 
 #: automation_networks.php:748 automation_networks.php:749
 #: automation_networks.php:750 automation_networks.php:751
@@ -2013,7 +2013,7 @@ msgstr "κλώσμα διχτυού χωρίς κόμπους"
 #: include/global_arrays.php:917 include/global_arrays.php:918
 #, php-format
 msgid "%d Threads"
-msgstr "Συζητήσεις"
+msgstr ""
 
 #: automation_networks.php:764 lib/api_scheduler.php:148
 #: lib/html_reports.php:2210
@@ -2027,7 +2027,7 @@ msgstr "Μετά το επιλεγμένο Όριο Εκτέλεσης, η δι�
 #: automation_networks.php:768 lib/html_filter.php:94
 #, php-format
 msgid "%d Minute"
-msgstr "${ 0 } λεπτό"
+msgstr ""
 
 #: automation_networks.php:769 automation_networks.php:770
 #: automation_networks.php:771 automation_networks.php:772
@@ -2053,13 +2053,13 @@ msgstr "${ 0 } λεπτό"
 #: lib/html_filter.php:95 lib/html_filter.php:96
 #, php-format
 msgid "%d Minutes"
-msgstr "${ 0 } λεπτά"
+msgstr ""
 
 #: automation_networks.php:773 include/global_arrays.php:800
 #: include/global_arrays.php:810 include/global_arrays.php:1606
 #, php-format
 msgid "%d Hour"
-msgstr "${ 0 } ώρα"
+msgstr ""
 
 #: automation_networks.php:774 automation_networks.php:775
 #: automation_networks.php:776 data_source_profiles.php:1335
@@ -2083,7 +2083,7 @@ msgstr "${ 0 } ώρα"
 #: include/global_settings.php:3380
 #, php-format
 msgid "%d Hours"
-msgstr " 0 Hours"
+msgstr ""
 
 #: automation_networks.php:783
 msgid "Enable this Network Range."
@@ -3277,7 +3277,7 @@ msgstr "Πλήρης"
 #: changelog.php:99
 #, php-format
 msgid "Change Log [%s]"
-msgstr "Αρχείο καταγραφής Αλλαγών"
+msgstr ""
 
 #: changelog.php:160 support.php:1010
 #, php-format
@@ -3963,12 +3963,12 @@ msgstr "Κάντε κλικ στην επιλογή «Συνέχεια» για 
 #: data_input.php:294
 #, php-format
 msgid "Field Name: %s"
-msgstr "Όνομα Πεδίου"
+msgstr ""
 
 #: data_input.php:295
 #, php-format
 msgid "Friendly Name: %s"
-msgstr "Φιλική Ονομασία:"
+msgstr ""
 
 #: data_input.php:301
 msgid "Remove Data Input Field"
@@ -4548,7 +4548,7 @@ msgstr "Κάντε κλικ στην επιλογή «Συνέχεια» για 
 #: data_source_profiles.php:878
 #, php-format
 msgid "Profile Name: %s"
-msgstr "Όνομα προφίλ:"
+msgstr ""
 
 #: data_source_profiles.php:884
 msgid "Remove Data Source Profile RRA"
@@ -4673,7 +4673,7 @@ msgstr "% d Μήνας"
 #: include/global_settings.php:2003 rrdcleaner.php:462 rrdcleaner.php:463
 #, php-format
 msgid "%d Week"
-msgstr "Εβδομάδα 0"
+msgstr ""
 
 #: data_source_profiles.php:1318 include/global_arrays.php:819
 #: include/global_arrays.php:820 include/global_arrays.php:840
@@ -4683,14 +4683,14 @@ msgstr "Εβδομάδα 0"
 #: include/global_settings.php:3385 rrdcleaner.php:464 rrdcleaner.php:465
 #, php-format
 msgid "%d Weeks"
-msgstr "0 εβδομάδες"
+msgstr ""
 
 #: data_source_profiles.php:1327 include/global_arrays.php:761
 #: include/global_arrays.php:805 include/global_arrays.php:815
 #: include/global_arrays.php:1611 include/global_settings.php:1997
 #, php-format
 msgid "%d Day"
-msgstr "Ημέρα 0"
+msgstr ""
 
 #: data_source_profiles.php:1327 include/global_arrays.php:806
 #: include/global_arrays.php:816 include/global_arrays.php:817
@@ -5069,7 +5069,7 @@ msgstr "Εξωτερικός"
 #: support.php:493
 #, php-format
 msgid "%d Seconds"
-msgstr "${ 0 } δευτερόλεπτα"
+msgstr ""
 
 #: data_sources.php:1388 include/global_arrays.php:750
 #: include/global_arrays.php:1352 include/global_arrays.php:1731
@@ -5154,7 +5154,7 @@ msgstr "Πηγές δεδομένων [ Μη βασισμένες στη συσ�
 #: data_sources.php:1949
 #, php-format
 msgid "Data Sources [ %s ]"
-msgstr "Data Sources"
+msgstr ""
 
 #: data_templates.php:36
 msgid "Change Profile"
@@ -5795,7 +5795,7 @@ msgstr "Πηγές δεδομένων [Χωρίς συσκευή]"
 #: graphs.php:902 graphs.php:938
 #, php-format
 msgid "Data Sources [%s]"
-msgstr "Data Sources"
+msgstr ""
 
 #: graphs.php:976
 #, php-format
@@ -6229,7 +6229,7 @@ msgstr "Σφάλμα κατά την ανάλυση του αρχείου πόρ
 #: graphs_new.php:743
 #, php-format
 msgid "Data Query [%s]"
-msgstr "Ερώτηση Δεδομένων"
+msgstr ""
 
 #: graphs_new.php:746 host.php:1111
 msgid "Reload Query"
@@ -7828,7 +7828,7 @@ msgstr "Κάθε %d ημέρα"
 #: include/global_arrays.php:793
 #, php-format
 msgid "%0.1f Minutes"
-msgstr "${ 0 } λεπτά"
+msgstr ""
 
 #: include/global_arrays.php:826 include/global_arrays.php:846
 #: include/global_arrays.php:858 include/global_arrays.php:859
@@ -8626,7 +8626,7 @@ msgstr "Προηγούμενος Χρόνος"
 #: include/global_arrays.php:1605
 #, php-format
 msgid "%d Min"
-msgstr "Λεπτό"
+msgstr ""
 
 #: include/global_arrays.php:1660
 msgid "Month Number, Day, Year"
@@ -8662,7 +8662,7 @@ msgstr "Μετά την Ενίσχυση"
 #: include/global_arrays.php:1752
 #, php-format
 msgid "%d MBytes"
-msgstr "MBytes"
+msgstr ""
 
 #: include/global_arrays.php:1690
 msgid "1 GByte"
@@ -8735,12 +8735,12 @@ msgstr "6 Ώρες"
 #: include/global_settings.php:1850 include/global_settings.php:1851
 #, php-format
 msgid "%s Hours"
-msgstr " 0 Hours"
+msgstr ""
 
 #: include/global_arrays.php:1753
 #, php-format
 msgid "%d GByte"
-msgstr "GByte"
+msgstr ""
 
 #: include/global_arrays.php:1761 utilities.php:1321 utilities.php:1322
 #: utilities.php:1376
@@ -8773,7 +8773,7 @@ msgstr "Mbyte"
 #: include/global_arrays.php:1795 include/global_arrays.php:1796
 #, php-format
 msgid "%d Megabytes"
-msgstr " megabytes"
+msgstr ""
 
 #: include/global_arrays.php:1804
 msgid "Send Now"
@@ -9786,7 +9786,7 @@ msgstr "Αυτόματη ανίχνευση/ρύθμιση στο πρώτο Re-
 #: include/global_form.php:204
 #, php-format
 msgid "%d Repetition"
-msgstr "υποτροπή"
+msgstr ""
 
 #: include/global_form.php:205 include/global_form.php:206
 #: include/global_form.php:207 include/global_form.php:208
@@ -9798,7 +9798,7 @@ msgstr "υποτροπή"
 #: include/global_form.php:219
 #, php-format
 msgid "%d Repetitions"
-msgstr "Repeticiones"
+msgstr ""
 
 #: include/global_form.php:228
 msgid "The maximum number of attempts to reach a device via an SNMP readstring prior to giving up."
@@ -11953,7 +11953,7 @@ msgstr "Ο προεπιλεγμένος αριθμός νημάτων συσκε
 #: include/global_settings.php:874
 #, php-format
 msgid "%s Thread"
-msgstr "κλώσμα διχτυού χωρίς κόμπους"
+msgstr ""
 
 #: include/global_settings.php:875 include/global_settings.php:876
 #: include/global_settings.php:877 include/global_settings.php:878
@@ -11962,7 +11962,7 @@ msgstr "κλώσμα διχτυού χωρίς κόμπους"
 #: include/global_settings.php:883
 #, php-format
 msgid "%s Threads"
-msgstr "Συζητήσεις"
+msgstr ""
 
 #: include/global_settings.php:887
 msgid "Re-index Method for Data Queries"
@@ -12826,7 +12826,7 @@ msgstr "Το μέγιστο χρονικό διάστημα που μπορεί 
 #: include/global_settings.php:1843
 #, php-format
 msgid "%s Minute"
-msgstr "${ 0 } λεπτό"
+msgstr ""
 
 #: include/global_settings.php:1749
 msgid "Miscelanious Task Parallelism and Timeouts"
@@ -12856,7 +12856,7 @@ msgstr "Το μέγιστο χρονικό διάστημα που μπορεί 
 #: include/global_settings.php:1848
 #, php-format
 msgid "%s Hour"
-msgstr "${ 0 } ώρα"
+msgstr ""
 
 #: include/global_settings.php:1783
 msgid "Poller Commands Timeout"
@@ -12919,7 +12919,7 @@ msgstr "1 Διαδικασία"
 #: include/global_settings.php:2764 include/global_settings.php:2765
 #, php-format
 msgid "%d Processes"
-msgstr "Διαδικασίες"
+msgstr ""
 
 #: include/global_settings.php:1824
 msgid "Maintenance Background Generation Timeout"
@@ -13035,7 +13035,7 @@ msgstr "1 προσπάθεια"
 #: include/global_settings.php:1937
 #, php-format
 msgid "%d Attempts"
-msgstr "Προσπαθειών"
+msgstr ""
 
 #: include/global_settings.php:1941
 msgid "Auto Unlock"
@@ -13987,7 +13987,7 @@ msgstr "Οποιαδήποτε τιμή που είναι τόσο πολλές 
 #: include/global_settings.php:2925
 #, php-format
 msgid "%d Standard Deviations"
-msgstr "τυπικές αποκλίσεις"
+msgstr ""
 
 #: include/global_settings.php:2929
 msgid "Max Kills Per RRA"
@@ -14005,7 +14005,7 @@ msgstr "Αυτή η τιμή αντιπροσωπεύει τον μέγιστο 
 #: include/global_settings.php:2944 include/global_settings.php:2945
 #, php-format
 msgid "%d Spikes"
-msgstr "Κορυφές"
+msgstr ""
 
 #: include/global_settings.php:2949
 msgid "Absolute Maximum Value"
@@ -15336,7 +15336,7 @@ msgstr "Ο διαχειριστής του Cacti έχει εξαναγκάσει
 #: lib/auth.php:4175
 #, php-format
 msgid "Password must be at least %d characters!"
-msgstr "La contraseña debe tener por lo menos  caracteres"
+msgstr ""
 
 #: lib/auth.php:4181
 msgid "Your password must contain at least 1 numerical character!"
@@ -15397,17 +15397,17 @@ msgstr "Το 2FA έχει ενεργοποιηθεί και επαληθευτε
 #: lib/boost.php:82 utilities.php:1378
 #, php-format
 msgid "%s MBytes"
-msgstr "MBytes"
+msgstr ""
 
 #: lib/boost.php:85
 #, php-format
 msgid "%s KBytes"
-msgstr "KBytes"
+msgstr ""
 
 #: lib/boost.php:88
 #, php-format
 msgid "%s Bytes"
-msgstr "bytes"
+msgstr ""
 
 #: lib/clog_webapi.php:139
 #, php-format
@@ -15601,7 +15601,7 @@ msgstr "Βρέθηκε τύπος = '%s' [%s]."
 #: lib/data_query.php:154
 #, php-format
 msgid "Unknown Type = '%s'."
-msgstr "Άγνωστος τύπος"
+msgstr ""
 
 #: lib/data_query.php:211
 msgid "WARNING: Sort Field Association has Changed.  Re-mapping issues may occur!"
@@ -16180,7 +16180,7 @@ msgstr "Σφάλμα Mailer: Δεν έχει οριστεί διεύθυνση �
 #: lib/functions.php:6027
 #, php-format
 msgid "Authentication failed: %s"
-msgstr "Η ταυτοποίηση απέτυχε"
+msgstr ""
 
 #: lib/functions.php:6031
 #, php-format
@@ -16190,7 +16190,7 @@ msgstr "Αποτυχία HELO: %s"
 #: lib/functions.php:6034
 #, php-format
 msgid "Connect failed: %s"
-msgstr "Αποτυχία σύνδεσης"
+msgstr ""
 
 #: lib/functions.php:6037
 msgid "SMTP error: "
@@ -16280,12 +16280,12 @@ msgstr ""
 #: lib/functions.php:7524
 #, php-format
 msgid "- Dev %s"
-msgstr "ΔΕΕ"
+msgstr ""
 
 #: lib/functions.php:7526
 #, php-format
 msgid "- Beta %s"
-msgstr "Beta"
+msgstr ""
 
 #: lib/functions.php:7594
 #, php-format
@@ -16362,7 +16362,7 @@ msgstr "Όλα %d %s"
 #: lib/html.php:654
 #, php-format
 msgid "Current Page: %s"
-msgstr "Τρέχουσα σελίδα"
+msgstr ""
 
 #: lib/html.php:685
 #, php-format
@@ -17533,7 +17533,7 @@ msgstr "Λεπτομέρειες αντικειμένου"
 #: lib/html_reports.php:1681
 #, php-format
 msgid "Graph: %s"
-msgstr "Γράφημα:"
+msgstr ""
 
 #: lib/html_reports.php:1684 lib/html_reports.php:1711
 #: lib/html_reports.php:1724 lib/html_reports.php:1725
@@ -17563,7 +17563,7 @@ msgstr ", Χρήση του RegEx: \"%s\""
 #: lib/html_reports.php:1751
 #, php-format
 msgid "Tree: %s"
-msgstr "Δέντρο:"
+msgstr ""
 
 #: lib/html_reports.php:1761
 #, php-format
@@ -17573,7 +17573,7 @@ msgstr ", Συσκευή: %s"
 #: lib/html_reports.php:1763
 #, php-format
 msgid ", Branch: %s"
-msgstr "Υποκατάστημα "
+msgstr ""
 
 #: lib/html_reports.php:1766
 msgid "(All Branches)"
@@ -17940,7 +17940,7 @@ msgstr "Παρακαλείσθε να το αναφέρετε στον Όμιλ�
 #: lib/installer.php:1885
 #, php-format
 msgid "Unknown Reason: %s"
-msgstr "Άγνωστη αιτία"
+msgstr ""
 
 #: lib/installer.php:1893
 #, php-format
@@ -18252,12 +18252,12 @@ msgstr "Βάση δεδομένων: <b>%s</b>"
 #: lib/installer.php:2488 lib/installer.php:2500
 #, php-format
 msgid "Database User: <b>%s</b>"
-msgstr "Χρήστης βάσης δεδομένων"
+msgstr ""
 
 #: lib/installer.php:2489 lib/installer.php:2501
 #, php-format
 msgid "Database Hostname: <b>%s</b>"
-msgstr "Όνομα κεντρικού υπολογιστή βάσης δεδομένων"
+msgstr ""
 
 #: lib/installer.php:2490 lib/installer.php:2502
 #, php-format
@@ -18919,7 +18919,7 @@ msgstr "Η προεπιλεγμένη συσκευή προστέθηκε στο
 #: lib/installer.php:3862
 #, php-format
 msgid "Output: %s."
-msgstr "Έξοδος:"
+msgstr ""
 
 #: lib/installer.php:3882
 msgid "Creating Graphs for Default Device"
@@ -19013,12 +19013,12 @@ msgstr "Και τα δυο"
 #: lib/installer.php:4179
 #, php-format
 msgid "No - %s"
-msgstr "Όχι (0)"
+msgstr ""
 
 #: lib/installer.php:4187
 #, php-format
 msgid "%s - N/A"
-msgstr "Α/Α"
+msgstr ""
 
 #: lib/installer.php:4187 lib/installer.php:4189
 msgid "Web"
@@ -19027,7 +19027,7 @@ msgstr "Ιστότοπος"
 #: lib/installer.php:4189 lib/installer.php:4192
 #, php-format
 msgid "%s - No"
-msgstr "0 Όχι"
+msgstr ""
 
 #: lib/installer.php:4192
 msgid "Cli"
@@ -19091,7 +19091,7 @@ msgstr "Σφάλμα πρωτοκόλλου, Αδυναμία σύνδεσης, 
 #: lib/ldap.php:428
 #, php-format
 msgid "Unable to Connect to Server (%s)"
-msgstr "Δεν ήταν δυνατή η σύνδεση με τον διακομιστή"
+msgstr ""
 
 #: lib/ldap.php:429
 #, php-format
@@ -19462,7 +19462,7 @@ msgstr "Προβλήματα κατά την αποστολή της αναφο�
 #: lib/reports.php:644
 #, php-format
 msgid "Report '%s' Sent Successfully"
-msgstr "Η αναφορά στάλθηκε με επιτυχία"
+msgstr ""
 
 #: lib/reports.php:851
 #, php-format
@@ -19980,7 +19980,7 @@ msgstr "Προσπάθεια δημιουργίας γραφήματος από 
 #: lib/template.php:2308 lib/template.php:2342
 #, php-format
 msgid "Created: %s"
-msgstr "Δημιουργήθηκε:"
+msgstr ""
 
 #: lib/template.php:2324 lib/template.php:2353
 msgid "ERROR: Whitelist Validation Failed. Check Data Input Method"
@@ -20157,7 +20157,7 @@ msgstr "Όταν χρησιμοποιείτε MariaDB 10.2.4 και άνω, μπ
 #: lib/utility.php:1378
 #, php-format
 msgid "%s Tuning"
-msgstr "πρόγραμμα \"Tuning educational structures in Europe\""
+msgstr ""
 
 #: lib/utility.php:1378
 msgid "Note: Many changes below require a database restart"
@@ -20627,7 +20627,7 @@ msgstr "Πακέτο ερωτήματος δεδομένων %s"
 #: package.php:314 templates_export.php:168
 #, php-format
 msgid "Available Templates [%s]"
-msgstr "Διαθέσιμα Πρότυπα"
+msgstr ""
 
 #: package.php:319
 msgid "Available Templates"
@@ -21516,7 +21516,7 @@ msgstr "Δεν βρέθηκαν πρόσθετα"
 #: plugins.php:1397 plugins.php:1431
 #, php-format
 msgid "Not Compatible, '%s'"
-msgstr "Μη συμβατό."
+msgstr ""
 
 #: plugins.php:1399 plugins.php:1433
 msgid "Plugin Error"
@@ -22798,7 +22798,7 @@ msgstr "Τεχνική υποστήριξη "
 #: support.php:258
 #, php-format
 msgid "%d Chars"
-msgstr "σαλβελίνος"
+msgstr ""
 
 #: support.php:286
 msgid "Include Poller"
@@ -23200,7 +23200,7 @@ msgstr "Μνήμη συστήματος"
 #: support.php:1650 support.php:1660
 #, php-format
 msgid "%s GB"
-msgstr "EL"
+msgstr ""
 
 #: support.php:1588
 msgid "MySQL/MariaDB Memory Statistics (Source: MySQL Tuner)"
@@ -23353,7 +23353,7 @@ msgstr "Με ζημιά"
 #: templates_import.php:321
 #, php-format
 msgid "Met: %d"
-msgstr "Διάβρωση"
+msgstr ""
 
 #: templates_import.php:325
 #, php-format
@@ -23936,7 +23936,7 @@ msgstr "Άδειες παλαιού τύπου"
 #: user_admin.php:1768 user_group_admin.php:1632
 #, php-format
 msgid "User Settings %s"
-msgstr "Ρυθμίσεις Χρήστη"
+msgstr ""
 
 #: user_admin.php:1853 user_group_admin.php:1715
 msgid "Permissions"
@@ -23965,7 +23965,7 @@ msgstr "Πέρμες δέντρων"
 #: user_admin.php:1908
 #, php-format
 msgid "User Management %s"
-msgstr "Διαχείριση Χρηστών"
+msgstr ""
 
 #: user_admin.php:2046
 msgid "< 1 Week Ago"
@@ -24049,7 +24049,7 @@ msgstr "Εμφάνιση μόνο εξαιρέσεων"
 #: user_admin.php:2423
 #, php-format
 msgid "Group Membership %s"
-msgstr "Συμμετοχή σε μια Ομάδα"
+msgstr ""
 
 #: user_admin.php:2427
 msgid "Show All"
@@ -24929,7 +24929,7 @@ msgstr "Μέσος όρος bytes/εγγραφής:"
 #: utilities.php:1314
 #, php-format
 msgid "%d Bytes"
-msgstr "bytes"
+msgstr ""
 
 #: utilities.php:1314
 msgid "Max Record Length:"
@@ -25106,7 +25106,7 @@ msgstr "Καταχωρίσεις στο ημερολόγιο του πλοίου
 #: utilities.php:1867
 #, php-format
 msgid "Severity Level: %s"
-msgstr "Βαθμός αυστηρότητας"
+msgstr ""
 
 #: vdef.php:257
 msgid "Click 'Continue' to Delete the following VDEF."

--- a/locales/po/fr-FR.po
+++ b/locales/po/fr-FR.po
@@ -1,3 +1,4 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Cacti\n"
@@ -2657,7 +2658,7 @@ msgstr "Option SNMP :"
 #: automation_snmp.php:537
 #, php-format
 msgid "SNMP Version: <b>%s</b>"
-msgstr "Version SNMP"
+msgstr ""
 
 #: automation_snmp.php:538
 #, php-format
@@ -11635,7 +11636,7 @@ msgstr "Le nombre par défaut de threads de périphérique.  Ceci s'applique uni
 #: include/global_settings.php:816
 #, php-format
 msgid "%s Thread"
-msgstr "sécurité"
+msgstr ""
 
 #: include/global_settings.php:817 include/global_settings.php:818
 #: include/global_settings.php:819 include/global_settings.php:820
@@ -21491,7 +21492,7 @@ msgstr "Changelog"
 #: support.php:81
 #, php-format
 msgid "Technical Support [%s]"
-msgstr "Support technique"
+msgstr ""
 
 #: support.php:288
 msgid "Include Poller"
@@ -23997,7 +23998,6 @@ msgstr "Pas de VDEF"
 #~ msgstr "Cliquez sur 'Continuer' pour copier l'utilisateur sélectionné vers un nouvel utilisateur ci-dessous."
 
 #, fuzzy
-#~| msgid "Click 'Continue' to delete the folling Automation Template(s)."
 #~ msgid "Click 'Continue' to delete the following Automation Template(s)."
 #~ msgstr "Cliquez sur 'Continuer' pour supprimer le(s) modèle(s) d'automatisation suivant(s)."
 
@@ -24107,7 +24107,6 @@ msgstr "Pas de VDEF"
 #~ msgstr "Convertir en graphique(s) normal(aux)"
 
 #, fuzzy
-#~| msgid "DES"
 #~ msgid "DS"
 #~ msgstr "DES"
 
@@ -24188,7 +24187,6 @@ msgstr "Pas de VDEF"
 #~ msgstr "Hauteur du Graphique"
 
 #, fuzzy
-#~| msgid "Graph, Data Source"
 #~ msgid "Graph Source"
 #~ msgstr "Graphique, Source des données"
 

--- a/locales/po/he-IL.po
+++ b/locales/po/he-IL.po
@@ -309,12 +309,12 @@ msgstr "להתנתק עם צבירה"
 #: aggregate_graphs.php:970
 #, php-format
 msgid "Click 'Continue' to Place the following Aggregate Graph on Tree %s."
-msgstr "לחץ על &#39;המשך&#39; כדי למחוק את התבניות הבאות של גרף מצטבר."
+msgstr ""
 
 #: aggregate_graphs.php:971
 #, php-format
 msgid "Click 'Continue' to Duplicate following Aggregate Graphs on Tree %s."
-msgstr "לחץ על &#39;המשך&#39; כדי להציב את הגרפים המצטברים הבאים מתחת לעץ העץ."
+msgstr ""
 
 #: aggregate_graphs.php:972
 msgid "Place Aggregate Graph on Tree"
@@ -959,7 +959,7 @@ msgstr "המשתמש אומת, אך חשבון התבנית מושבת. שימו
 #: auth_login.php:141
 #, php-format
 msgid "Access Denied!  Guest user id %s does not exist.  Please contact your Administrator."
-msgstr "הגישה נדחתה, אנא צור קשר עם מנהל Cacti."
+msgstr ""
 
 #: auth_login.php:180
 msgid "Access Denied!  User account disabled."
@@ -1243,12 +1243,12 @@ msgstr "נוסף ידנית דרך ממשק אוטומציה המכשיר."
 #: automation_devices.php:125
 #, php-format
 msgid "Device %s Added to Cacti"
-msgstr "נוסף ל- Cacti"
+msgstr ""
 
 #: automation_devices.php:127
 #, php-format
 msgid "Device %s Not Added to Cacti"
-msgstr "לא נוספו ל- Cacti"
+msgstr ""
 
 #: automation_devices.php:137
 msgid "Devices Removed from Cacti Automation database"
@@ -2969,7 +2969,7 @@ msgstr "לחץ על &#39;המשך&#39; כדי למחוק את שאילתות ה�
 #: automation_templates.php:791
 #, php-format
 msgid "Tree Rule Name: '%s'"
-msgstr "עץ כלל פריטים"
+msgstr ""
 
 #: automation_templates.php:798
 msgid "Remove Tree Rule"
@@ -3482,7 +3482,7 @@ msgstr "מלא"
 #: changelog.php:99
 #, php-format
 msgid "Change Log [%s]"
-msgstr "ChangeLogLanguage"
+msgstr ""
 
 #: changelog.php:160 support.php:1018
 #, php-format
@@ -4650,7 +4650,7 @@ msgstr "% d חודש"
 #: rrdcleaner.php:527
 #, php-format
 msgid "%d Months"
-msgstr "% חודשים"
+msgstr ""
 
 #: data_source_profiles.php:842 include/global_arrays.php:752
 #: include/global_arrays.php:808 include/global_arrays.php:829
@@ -4945,7 +4945,7 @@ msgstr "הפעל מצב מידע על מקור הנתונים."
 #: data_sources.php:864
 #, php-format
 msgid "Edit Graph: '%s'."
-msgstr "ערוך תבנית גרף."
+msgstr ""
 
 #: data_sources.php:869 graphs.php:2280
 msgid "Edit Device."
@@ -5113,7 +5113,7 @@ msgstr "ערוך פרופיל"
 #: data_templates.php:261
 #, php-format
 msgid "Field \"%s\" is missing an Output Field.  Select the Output Field associated with this Data Source, and press Save again."
-msgstr "בשדה \"{ 0 }\" חסר שדה פלט.  בחר את שדה הפלט המשויך למקור נתונים זה ולחץ שוב על שמור."
+msgstr ""
 
 #: data_templates.php:447
 #, php-format
@@ -5368,7 +5368,7 @@ msgstr "הגרף אינו קיים"
 #: graph.php:115 graph.php:409
 #, php-format
 msgid "Graph Utility View for Graph: %s"
-msgstr "תצוגת השירות גרף"
+msgstr ""
 
 #: graph.php:160 lib/html.php:585
 msgid "Graph Details, Zooming and Debugging Utilities"
@@ -6089,12 +6089,12 @@ msgstr "מקום גרפים על הדו&quot;ח"
 #: graphs.php:1912
 #, php-format
 msgid "Click 'Continue' to Place the following Graph on Tree %s."
-msgstr "לחץ על &#39;המשך&#39; כדי למחוק את העץ הבא."
+msgstr ""
 
 #: graphs.php:1913
 #, php-format
 msgid "Click 'Continue' to Duplicate following Graphs on Tree %s."
-msgstr "לחץ על &#39;המשך&#39; כדי למחוק את העץ הבא."
+msgstr ""
 
 #: graphs.php:1914
 msgid "Place Graph on Tree"
@@ -6195,7 +6195,7 @@ msgstr "ניהול קבוצת משתמשים [עריכה: %s]"
 #: graphs.php:2688
 #, php-format
 msgid "Graph Management [ %s ]"
-msgstr "ניהול גרפים"
+msgstr ""
 
 #: graphs.php:2756 graphs.php:2759
 msgid "Source"
@@ -6224,7 +6224,7 @@ msgstr "הגדרות ברירת המחדל נשמרו"
 #: graphs_new.php:338
 #, php-format
 msgid "New Graphs for [ %s ] (%s %s)"
-msgstr "גרפים חדשים עבור [ %s]"
+msgstr ""
 
 #: graphs_new.php:340
 msgid "New Graphs for [ All Devices ]"
@@ -6285,7 +6285,7 @@ msgstr "שגיאה בניתוח קובץ XML של משאב שאילתת נתונ
 #: graphs_new.php:695
 #, php-format
 msgid "Error Parsing Data Query Resource XML file for Data Query '%s' with id '%s'.  Field Name '%s' missing a 'direction' attribute"
-msgstr "שגיאה בניתוח קובץ XML של משאב שאילתת נתונים עבור שאילתת נתונים '%s' עם המזהה '%s'"
+msgstr ""
 
 #: graphs_new.php:699
 #, php-format
@@ -6341,7 +6341,7 @@ msgstr "אזהרה: דף קקטוסים:%s למשתמש:%s יצר שגיאה ח�
 #: help.php:74
 #, php-format
 msgid "The Document page '%s' count not be reached.  The Cacti Documentation site is not reachable.  The http error was '%s'.  Consider downloading an official release to obtain the latest documentation and hosting the documentation locally."
-msgstr "הספירה של דף המסמך '{ 0 }' לא הושגה. לא ניתן להגיע לאתר התיעוד של קקטוסים. שגיאת ה - http הייתה '{ 1 }'. מומלץ להוריד גרסה רשמית כדי לקבל את המסמכים העדכניים ביותר ולארח את המסמכים באופן מקומי."
+msgstr ""
 
 #: help.php:88
 msgid "Cacti GitHub Site"
@@ -6359,7 +6359,7 @@ msgstr "קובץ העזרה %s לא נמצא באתר התיעוד של קקטו
 #: help.php:102
 #, php-format
 msgid "The Document page '%s' count not be reached locally."
-msgstr "הספירה של דף המסמך '{ 0 }' לא מגיעה באופן מקומי."
+msgstr ""
 
 #: host.php:44
 msgid "Change Device Settings"
@@ -6404,12 +6404,12 @@ msgstr "שגיאה: התקן ["
 #: host.php:217
 #, php-format
 msgid "Device Reindex Completed in %0.2f seconds.  There were %d items updated."
-msgstr "ריינדקס מכשיר הושלם ב-% 0.2f שניות. %% פריטים עודכנו."
+msgstr ""
 
 #: host.php:360
 #, php-format
 msgid "Unable to add some Devices to Report '%s'"
-msgstr "לא יכול להתחבר לשרת"
+msgstr ""
 
 #: host.php:479
 msgid "Click 'Continue' to Delete the following Device."
@@ -6522,12 +6522,12 @@ msgstr "מקום התקנים על עץ"
 #: host.php:564
 #, php-format
 msgid "Click 'Continue' to Place the following Device on Tree %s."
-msgstr "לחץ על &#39;המשך&#39; כדי למחוק את תבניות המכשיר הבאות."
+msgstr ""
 
 #: host.php:565
 #, php-format
 msgid "Click 'Continue' to Duplicate following Devices on Tree %s."
-msgstr "לחץ על &#39;המשך&#39; כדי למחוק את העץ הבא."
+msgstr ""
 
 #: host.php:566
 msgid "Place Device on Tree"
@@ -6566,7 +6566,7 @@ msgstr "הצג מטמון פולר"
 #: host.php:733
 #, php-format
 msgid " [ In state since '%s', Uptime since '%s' ]"
-msgstr "[ במצב מאז '{ 0 }', זמן פעולה משופר מאז '{ 1 }']"
+msgstr ""
 
 #: host.php:748
 msgid "Create Graphs for this Device"
@@ -7699,12 +7699,12 @@ msgstr "כל% d שעות"
 #: include/global_arrays.php:771
 #, php-format
 msgid "Every %d Day"
-msgstr "כל יום אחד"
+msgstr ""
 
 #: include/global_arrays.php:783
 #, php-format
 msgid "%0.1f Minutes"
-msgstr "דקות %d"
+msgstr ""
 
 #: include/global_arrays.php:816 include/global_arrays.php:836
 #: include/global_arrays.php:848 include/global_arrays.php:849
@@ -8435,7 +8435,7 @@ msgstr "סוף היום"
 #: include/global_arrays.php:1572
 #, php-format
 msgid "Last %d Days"
-msgstr "% D האחרון"
+msgstr ""
 
 #: include/global_arrays.php:1573
 msgid "Last Week"
@@ -8454,7 +8454,7 @@ msgstr "חודש קודם"
 #: include/global_arrays.php:1578 include/global_arrays.php:1579
 #, php-format
 msgid "Last %d Months"
-msgstr "% D האחרון"
+msgstr ""
 
 #: include/global_arrays.php:1580
 msgid "Last Year"
@@ -8463,7 +8463,7 @@ msgstr "בשנה שעברה"
 #: include/global_arrays.php:1581
 #, php-format
 msgid "Last %d Years"
-msgstr "% D האחרון"
+msgstr ""
 
 #: include/global_arrays.php:1582
 msgid "Day Shift"
@@ -9509,7 +9509,7 @@ msgstr "ציין את מספר ה- OIDs שניתן להשיג ב- SNMP יחיד 
 #: include/global_form.php:161
 #, php-format
 msgid "%d OID"
-msgstr "מקסימום OID"
+msgstr ""
 
 #: include/global_form.php:162 include/global_form.php:163
 #: include/global_form.php:164 include/global_form.php:165
@@ -9542,7 +9542,7 @@ msgstr "זיהוי אוטומטי/הגדרה באינדקס מחדש הראשו�
 #: include/global_form.php:188
 #, php-format
 msgid "%d Repetition"
-msgstr "אפשרויות רשת"
+msgstr ""
 
 #: include/global_form.php:189 include/global_form.php:190
 #: include/global_form.php:191 include/global_form.php:192
@@ -9554,7 +9554,7 @@ msgstr "אפשרויות רשת"
 #: include/global_form.php:203
 #, php-format
 msgid "%d Repetitions"
-msgstr "אפשרויות רשת"
+msgstr ""
 
 #: include/global_form.php:212
 msgid "The maximum number of attempts to reach a device via an SNMP readstring prior to giving up."
@@ -11662,7 +11662,7 @@ msgstr "מספר ברירת המחדל של שרשורי המכשיר. אפשר�
 #: include/global_settings.php:816
 #, php-format
 msgid "%s Thread"
-msgstr "% d Thread"
+msgstr ""
 
 #: include/global_settings.php:817 include/global_settings.php:818
 #: include/global_settings.php:819 include/global_settings.php:820
@@ -11671,7 +11671,7 @@ msgstr "% d Thread"
 #: include/global_settings.php:825
 #, php-format
 msgid "%s Threads"
-msgstr "% d Threads"
+msgstr ""
 
 #: include/global_settings.php:829
 msgid "Re-index Method for Data Queries"
@@ -14323,7 +14323,7 @@ msgstr "סיומת קובץ לא חוקית."
 #: lib/api_automation.php:5273 lib/api_automation.php:5275
 #, php-format
 msgid "Automation Network SNMP Rule '%s' %s!"
-msgstr "כלל SNMP של רשת האוטומציה '{ 0 }' %s!"
+msgstr ""
 
 #: lib/api_automation.php:5273 lib/api_automation.php:5275
 #: lib/api_automation.php:5309 lib/api_automation.php:5311
@@ -14341,7 +14341,7 @@ msgstr "עודכן"
 #: lib/api_automation.php:5279 lib/api_automation.php:5281
 #, php-format
 msgid "Automation Network SNMP Rule '%s' %s Failed!"
-msgstr "כלל SNMP של רשת האוטומציה '{ 0 }' %s נכשל!"
+msgstr ""
 
 #: lib/api_automation.php:5279 lib/api_automation.php:5281
 #: lib/api_automation.php:5315 lib/api_automation.php:5317
@@ -14355,12 +14355,12 @@ msgstr "עדכון"
 #: lib/api_automation.php:5309 lib/api_automation.php:5311
 #, php-format
 msgid "Automation Network SNMP Option %s!"
-msgstr "אוטומציה של אפשרויות SNMP"
+msgstr ""
 
 #: lib/api_automation.php:5315 lib/api_automation.php:5317
 #, php-format
 msgid "Automation Network SNMP Option %s Failed!"
-msgstr "אוטומציה של אפשרויות SNMP"
+msgstr ""
 
 #: lib/api_automation.php:5351
 msgid "The Automation Network Rule does not include any SNMP Options!"
@@ -14381,12 +14381,12 @@ msgstr "תבנית לא ידועה"
 #: lib/api_automation.php:5404 lib/api_automation.php:5406
 #, php-format
 msgid "Automation Network Rule '%s' %s!"
-msgstr "ברירת מחדל רשת אוטומציה"
+msgstr ""
 
 #: lib/api_automation.php:5410 lib/api_automation.php:5412
 #, php-format
 msgid "Automation Network Rule '%s' %s Failed!"
-msgstr "כלל רשת האוטומציה '{ 0 }' %s נכשל!"
+msgstr ""
 
 #: lib/api_automation.php:5418
 msgid "Automation Network Rule Import data is either for another object type or not JSON formatted."
@@ -14502,29 +14502,29 @@ msgstr "המכשיר מושבת"
 #: lib/auth.php:2355 lib/auth.php:2357 lib/auth.php:2363 lib/auth.php:2365
 #, php-format
 msgid "Graph:(%s%s)"
-msgstr "תרשים:"
+msgstr ""
 
 #: lib/auth.php:2378 lib/auth.php:2384 lib/auth.php:2451 lib/auth.php:2453
 #: lib/auth.php:2457 lib/auth.php:2459
 #, php-format
 msgid "Device:(%s%s)"
-msgstr "התקן"
+msgstr ""
 
 #: lib/auth.php:2392 lib/auth.php:2398 lib/auth.php:2467 lib/auth.php:2469
 #: lib/auth.php:2473 lib/auth.php:2475
 #, php-format
 msgid "Template:(%s%s)"
-msgstr "תבניות"
+msgstr ""
 
 #: lib/auth.php:2405
 #, php-format
 msgid "Graph+Device+Template:(%s%s)"
-msgstr "תבנית מכשיר:"
+msgstr ""
 
 #: lib/auth.php:2442 lib/auth.php:2444
 #, php-format
 msgid "Device+Template:(%s%s)"
-msgstr "תבנית מכשיר:"
+msgstr ""
 
 #: lib/auth.php:2488 lib/auth.php:2495 lib/auth.php:2504
 msgid "Restricted By: "
@@ -14595,7 +14595,7 @@ msgstr "שגיאה בחיפוש LDAP: %s"
 #: lib/auth.php:4094 lib/auth.php:5105
 #, php-format
 msgid "Access Denied!  Template user id %s does not exist.  Please contact your Administrator."
-msgstr "הגישה נדחתה, אנא צור קשר עם מנהל Cacti."
+msgstr ""
 
 #: lib/auth.php:4479
 msgid "Access Denied! Login failed."
@@ -14673,7 +14673,7 @@ msgstr "2FA הופעל ואומת"
 #: lib/boost.php:64 utilities.php:1708
 #, php-format
 msgid "%s MBytes"
-msgstr "% d MBtes"
+msgstr ""
 
 #: lib/boost.php:67
 #, php-format
@@ -14844,12 +14844,12 @@ msgstr "הפעלת שאילתת נתונים [ %s]."
 #: lib/data_query.php:113
 #, php-format
 msgid "Found Type = '%s' [%s]."
-msgstr "נמצא סוג = &#39;%&#39; [ %s]."
+msgstr ""
 
 #: lib/data_query.php:135
 #, php-format
 msgid "Unknown Type = '%s'."
-msgstr "סוג לא ידוע = &#39;%&#39;."
+msgstr ""
 
 #: lib/data_query.php:172
 msgid "WARNING: Sort Field Association has Changed.  Re-mapping issues may occur!"
@@ -14882,7 +14882,7 @@ msgstr "הסרת אינדקס זוהתה! הקודם Endex: %s"
 #: lib/data_query.php:360
 #, php-format
 msgid "Verification of %s Local Data ID's Complete"
-msgstr "איגוד המדדים עם נתונים מקומיים הושלם"
+msgstr ""
 
 #: lib/data_query.php:363
 #, php-format
@@ -14908,7 +14908,7 @@ msgstr "איגוד המדדים עם נתונים מקומיים הושלם"
 #: lib/data_query.php:392
 #, php-format
 msgid "Update Re-Index Cache complete. There were %s index changes, and %s orphaned indexes."
-msgstr "עדכן את המטמון מחדש של אינדקס מחדש. היו"
+msgstr ""
 
 #: lib/data_query.php:396
 msgid "Update Poller Cache for Query complete"
@@ -15022,7 +15022,7 @@ msgstr "לחץ כדי להציג פלט שאילתת נתונים עבור הש�
 #: lib/data_query.php:741
 #, php-format
 msgid "Sort field returned no data for field name %s, skipping"
-msgstr "שדה מיון לא החזיר נתונים. לא ניתן להמשיך באינדקס מחדש."
+msgstr ""
 
 #: lib/data_query.php:743
 #, php-format
@@ -15132,7 +15132,7 @@ msgstr "שדה קלט ממוקם &#39; %s&#39; [get]"
 #: lib/data_query.php:1032
 #, php-format
 msgid "Found OID rewrite rule: 's/%s/%s/'"
-msgstr "נמצא OID לשכתב כלל: &#39;s /% / %s /&#39;"
+msgstr ""
 
 #: lib/data_query.php:1043
 #, php-format
@@ -15208,7 +15208,7 @@ msgstr "נמצא פריט [ %s = &#39; %s&#39;] אינדקס: %s [מ- %s]"
 #: lib/data_query.php:1386
 #, php-format
 msgid "Found OCTET STRING '%s' decoded value: '%s'"
-msgstr "נמצא ערך פענוח של% OCTET STRING &#39;%&#39;: &#39; %s&#39;"
+msgstr ""
 
 #: lib/data_query.php:1392 lib/data_query.php:1443
 #, php-format
@@ -15223,7 +15223,7 @@ msgstr "נמצא פריט [ %s = &#39; %s&#39;] index: %s [מתוך rexxp oid va
 #: lib/data_query.php:1710
 #, php-format
 msgid "Bogus rewrite_value item found, index='%s'"
-msgstr "נמצא פריט REWRITE_VALUE מזויף, INDEX='{ 0 }'"
+msgstr ""
 
 #: lib/data_query.php:1724
 msgid "Could not parse translation map (rewrite_value)"
@@ -15266,7 +15266,7 @@ msgstr "נכשל שינוי אורך השדה סיסמה, לא יכול להמש
 #: lib/dsdebug.php:175
 #, php-format
 msgid "Data Source ID %s does not exist"
-msgstr "מקור הנתונים אינו קיים"
+msgstr ""
 
 #: lib/dsdebug.php:259
 msgid "Debug not completed after 5 pollings"
@@ -15283,12 +15283,12 @@ msgstr "מקור הנתונים אינו מוגדר כ- Active"
 #: lib/dsdebug.php:277
 #, php-format
 msgid "RRDfile Folder (rra) is not writable by Poller.  Folder owner: %s.  Poller runs as: %s"
-msgstr "תיקיית RRD אינה ניתנת לכתיבה על ידי Poller. RRD בעלים:"
+msgstr ""
 
 #: lib/dsdebug.php:282
 #, php-format
 msgid "RRDfile is not writable by Poller.  RRDfile owner: %s.  Poller runs as %s"
-msgstr "קובץ RRD אינו ניתן לכתיבה על ידי Poller. RRD בעלים:"
+msgstr ""
 
 #: lib/dsdebug.php:291
 msgid "RRDfile does not match Data Source"
@@ -15327,12 +15327,12 @@ msgstr "הגדרות שמור ל - Data Collector% d נכשל."
 #: lib/functions.php:896
 #, php-format
 msgid "Form Validation Failed: Variable '%s' does not allow nulls and variable is null"
-msgstr "אימות הטופס נכשל: המשתנה '{ 0 }' אינו מאפשר nulls והמשתנה הוא null"
+msgstr ""
 
 #: lib/functions.php:898
 #, php-format
 msgid "Form Validation Failed: Variable '%s' with Value '%s' Failed REGEX '%s'"
-msgstr "אימות הטופס נכשל: משתנה '{ 0 }' עם ערך '{ 1 }' רג'קס נכשל '{ 2 }'"
+msgstr ""
 
 #: lib/functions.php:914
 msgid "One or more fields failed validation"
@@ -15499,7 +15499,7 @@ msgstr "Cacti מושבת plugin %s עקב השגיאה הבאה: %s! לקבלת 
 #: lib/functions.php:6752
 #, php-format
 msgid "WARNING: PollerID:%s has an invalid hostname:%s.  Is it not reachable via DNS!"
-msgstr "אזהרה: ל - PollerID: ל -{ 0} יש שם מארח לא חוקי:%s.  האם לא ניתן להגיע אליו באמצעות DNS!"
+msgstr ""
 
 #: lib/functions.php:6781
 #, php-format
@@ -15525,12 +15525,12 @@ msgstr "- ביטא %s"
 #: lib/functions.php:7309
 #, php-format
 msgid "Version %s %s"
-msgstr "%s %s %s"
+msgstr ""
 
 #: lib/functions.php:7852
 #, php-format
 msgid "WARNING: Key Cacti Include File \"%s\" missing.  Please locate and replace this file as we checked in \"%s\""
-msgstr "אזהרה: מפתח קקטוסים כולל קובץ \"{ 0 }\" חסר.  אנא אתר והחלף קובץ זה בעת שביצענו צ'ק - אין \"{ 1 }\""
+msgstr ""
 
 #: lib/functions.php:8996
 msgid "System Device"
@@ -15605,7 +15605,7 @@ msgstr "כל% d %s"
 #: lib/html.php:700
 #, php-format
 msgid "Current Page: %s"
-msgstr "ערך נוכחי"
+msgstr ""
 
 #: lib/html.php:731
 #, php-format
@@ -16686,22 +16686,22 @@ msgstr "[חדש]"
 #: lib/html_reports.php:1572
 #, php-format
 msgid "Details %s"
-msgstr "פרטים"
+msgstr ""
 
 #: lib/html_reports.php:1618
 #, php-format
 msgid "Report Items %s"
-msgstr "אין פריטי דוח"
+msgstr ""
 
 #: lib/html_reports.php:1664
 #, php-format
 msgid "Scheduled Events %s"
-msgstr "אירועים מתוזמנים"
+msgstr ""
 
 #: lib/html_reports.php:1676
 #, php-format
 msgid "Report Preview %s"
-msgstr "תצוגה מקדימה של דוח"
+msgstr ""
 
 #: lib/html_reports.php:1712
 msgid "Item Details"
@@ -16710,7 +16710,7 @@ msgstr "פרטי פריט"
 #: lib/html_reports.php:1727
 #, php-format
 msgid "Graph: %s"
-msgstr "Symbol for file attachment annotations"
+msgstr ""
 
 #: lib/html_reports.php:1730 lib/html_reports.php:1758
 #: lib/html_reports.php:1771 lib/html_reports.php:1772
@@ -16740,7 +16740,7 @@ msgstr ", באמצעות RegEx: \"%s\""
 #: lib/html_reports.php:1800
 #, php-format
 msgid "Tree: %s"
-msgstr "עץ"
+msgstr ""
 
 #: lib/html_reports.php:1811
 #, php-format
@@ -16750,7 +16750,7 @@ msgstr "(מהמכשיר: %s)"
 #: lib/html_reports.php:1813
 #, php-format
 msgid ", Branch: %s"
-msgstr "ענף:"
+msgstr ""
 
 #: lib/html_reports.php:1816
 msgid "(All Branches)"
@@ -17009,7 +17009,7 @@ msgstr "הנתיב לא ניתן לכתיבה"
 #: lib/installer.php:786
 #, php-format
 msgid "Failed to set specified %sRRDTool version: %s"
-msgstr "נכשל בהגדרת %sRRDTool גרסה %s: %s"
+msgstr ""
 
 #: lib/installer.php:837
 msgid "Invalid Theme Specified"
@@ -17053,7 +17053,7 @@ msgstr "החלת מרווח ה- cron שצוין נכשלה"
 #: lib/installer.php:1107
 #, php-format
 msgid "Failed to apply '%s' as Automation Range"
-msgstr "החלת טווח אוטומציה מוגדר נכשלה"
+msgstr ""
 
 #: lib/installer.php:1190
 msgid "No matching snmp option exists"
@@ -17205,7 +17205,7 @@ msgstr "תצורת ה- Cacti שלך כוללת את הנתיב הנכון (url_p
 #: lib/installer.php:2037
 #, php-format
 msgid "PHP - Recommendations (%s)"
-msgstr "PHP - המלצות"
+msgstr ""
 
 #: lib/installer.php:2041
 msgid "PHP Recommendations ("
@@ -17763,7 +17763,7 @@ msgstr "שרת Cacti שלך מוכן כמעט. בדוק כי אתה שמח לה�
 #: lib/installer.php:2936
 #, php-format
 msgid "Press '%s' then click '%s' to complete the installation process after selecting your Device Templates."
-msgstr "לחץ על &#39; %s&#39; ולאחר מכן לחץ על &#39;%&#39; כדי להשלים את תהליך ההתקנה לאחר בחירת תבניות המכשיר."
+msgstr ""
 
 #: lib/installer.php:2964
 msgid "The following General Install Options will be applied."
@@ -17814,7 +17814,7 @@ msgstr "אין חבילות התקן להתקנה"
 #: lib/installer.php:3012
 #, php-format
 msgid "%d Tables to be Upgraded"
-msgstr "סוג פריט שיש להוסיף."
+msgstr ""
 
 #: lib/installer.php:3012 lib/installer.php:3014 lib/installer.php:3056
 msgid "Table Upgrades"
@@ -17949,7 +17949,7 @@ msgstr "ייבוא החבילה #%s '%s' תחת הפרופיל '%s' נכשל"
 #: lib/installer.php:3469
 #, php-format
 msgid "Mapping Automation Template for Device Template '%s'"
-msgstr "תבניות אוטומציה עבור [תבנית נמחקה]"
+msgstr ""
 
 #: lib/installer.php:3490
 msgid "No templates were selected for import"
@@ -17962,12 +17962,12 @@ msgstr "ממתין לתצורה"
 #: lib/installer.php:3532
 #, php-format
 msgid "Setting default data source profile to %s (%s)"
-msgstr "ברירת המחדל של פרופיל מקור הנתונים עבור תבנית נתונים זו."
+msgstr ""
 
 #: lib/installer.php:3557
 #, php-format
 msgid "Failed to find selected profile (%s), no changes were made"
-msgstr "החלת הפרופיל שצוין %s! = %s נכשלה"
+msgstr ""
 
 #: lib/installer.php:3568
 #, php-format
@@ -17985,12 +17985,12 @@ msgstr "הוספת הגדרות snmp נוספות לאוטומציה"
 #: lib/installer.php:3593
 #, php-format
 msgid "Selecting Automation Option Set %s"
-msgstr "מחק תבניות אוטומציה"
+msgstr ""
 
 #: lib/installer.php:3607
 #, php-format
 msgid "Updating Automation Option Set %s"
-msgstr "אוטומציה של אפשרויות SNMP"
+msgstr ""
 
 #: lib/installer.php:3611
 #, php-format
@@ -18000,12 +18000,12 @@ msgstr "מערך אפשרויות אוטומציה שעודכן בהצלחה%s"
 #: lib/installer.php:3613
 #, php-format
 msgid "Resequencing Automation Option Set %s"
-msgstr "הפעלת אוטומציה בהתקנים"
+msgstr ""
 
 #: lib/installer.php:3620
 #, php-format
 msgid "Failed to updated Automation Option Set %s"
-msgstr "החלת טווח אוטומציה מוגדר נכשלה"
+msgstr ""
 
 #: lib/installer.php:3623
 msgid "Failed to find any automation option set"
@@ -18019,7 +18019,7 @@ msgstr "תבניות מכשיר [עריכה: %s]"
 #: lib/installer.php:3665
 #, php-format
 msgid "The Add Default Device Command is: '%s'"
-msgstr "פקודת הוספת התקן ברירת המחדל היא: '{ 0 }'"
+msgstr ""
 
 #: lib/installer.php:3673
 msgid "WARNING: Default Device Failed to be Added error to follow."
@@ -18032,7 +18032,7 @@ msgstr "נוסף ל- Cacti"
 #: lib/installer.php:3680
 #, php-format
 msgid "Output: %s."
-msgstr "שדות תפוקה"
+msgstr ""
 
 #: lib/installer.php:3700
 msgid "Creating Graphs for Default Device"
@@ -18112,7 +18112,7 @@ msgstr "הרקע כבר התחיל ב-%s, ניסיון זה ב-%s דילג"
 #: lib/installer.php:3946
 #, php-format
 msgid "Exception occurred during installation: #%s - %s"
-msgstr "חריגה אירעה במהלך ההתקנה: #"
+msgstr ""
 
 #: lib/installer.php:3956
 #, php-format
@@ -18126,12 +18126,12 @@ msgstr "שניהם"
 #: lib/installer.php:3997
 #, php-format
 msgid "No - %s"
-msgstr "עבר מ-%s ל-%s"
+msgstr ""
 
 #: lib/installer.php:4005
 #, php-format
 msgid "%s - N/A"
-msgstr "עבר מ-%s ל-%s"
+msgstr ""
 
 #: lib/installer.php:4005 lib/installer.php:4007
 msgid "Web"
@@ -18140,7 +18140,7 @@ msgstr "אתר אינטרנט"
 #: lib/installer.php:4007 lib/installer.php:4010
 #, php-format
 msgid "%s - No"
-msgstr "עבר מ-%s ל-%s"
+msgstr ""
 
 #: lib/installer.php:4010
 msgid "Cli"
@@ -18179,17 +18179,17 @@ msgstr "לא הוגדר שם משתמש"
 #: lib/ldap.php:412
 #, php-format
 msgid "Protocol Error, Unable to set version (%s) on Server (%s)"
-msgstr "שגיאת פרוטוקול, לא ניתן להגדיר גרסה"
+msgstr ""
 
 #: lib/ldap.php:416
 #, php-format
 msgid "Protocol Error, Unable to set referrals option (%s) on Server (%s)"
-msgstr "שגיאת פרוטוקול, לא ניתן להגדיר אפשרות הפניות"
+msgstr ""
 
 #: lib/ldap.php:420
 #, php-format
 msgid "Protocol Error, unable to start TLS communications (%s) on Server (%s)"
-msgstr "שגיאת פרוטוקול, אין אפשרות להפעיל תקשורת TLS"
+msgstr ""
 
 #: lib/ldap.php:424
 #, php-format
@@ -18199,27 +18199,27 @@ msgstr "שגיאת פרוטוקול, כשל כללי ( %s)"
 #: lib/ldap.php:428
 #, php-format
 msgid "Protocol Error, Unable to bind, LDAP result: (%s) on Server (%s)"
-msgstr "שגיאת פרוטוקול, לא ניתן לקשור, התוצאה LDAP: %s"
+msgstr ""
 
 #: lib/ldap.php:432
 #, php-format
 msgid "Unable to Connect to Server (%s)"
-msgstr "לא יכול להתחבר לשרת"
+msgstr ""
 
 #: lib/ldap.php:436
 #, php-format
 msgid "Connection Timeout to Server (%s)"
-msgstr "זמן הקצאת חיבור"
+msgstr ""
 
 #: lib/ldap.php:440
 #, php-format
 msgid "Insufficient Access to Server (%s)"
-msgstr "אין גישה מספקת"
+msgstr ""
 
 #: lib/ldap.php:444
 #, php-format
 msgid "Group DN could not be found to compare on Server (%s)"
-msgstr "לא ניתן היה להשוות את DN בקבוצה כדי להשוות"
+msgstr ""
 
 #: lib/ldap.php:448
 msgid "More than one matching user found"
@@ -18236,7 +18236,7 @@ msgstr "לא ניתן למצוא את המשתמשים DN"
 #: lib/ldap.php:460
 #, php-format
 msgid "Unable to create LDAP connection object to Server (%s)"
-msgstr "לא ניתן ליצור אובייקט חיבור LDAP"
+msgstr ""
 
 #: lib/ldap.php:464
 msgid "Specific DN and Password required"
@@ -18249,7 +18249,7 @@ msgstr "סיסמה לא חוקית סופקה. ההתחברות נכשלה."
 #: lib/ldap.php:473
 #, php-format
 msgid "Unexpected error %s (Ldap Error: %s) on Server (%s)"
-msgstr "שגיאה %s לא צפויה (שגיאת Ldap: %s)"
+msgstr ""
 
 #: lib/ping.php:149
 msgid "ICMP Ping timed out"
@@ -18335,17 +18335,17 @@ msgstr "אין אפשרות להתקין את הפלאגין."
 #: lib/plugins.php:748
 #, php-format
 msgid "The Plugin directory '%s' needs to be renamed to remove 'plugin_' from the name before it can be installed."
-msgstr "יש לשנות את שם ספריית התוספים '{ 0 }' כדי להסיר את 'plugin _' מהשם לפני שניתן יהיה להתקין אותה."
+msgstr ""
 
 #: lib/plugins.php:751
 #, php-format
 msgid "The Plugin in the directory '%s' does not include an version function '%s()'.  This function must exist for the plugin to be installed."
-msgstr "התוסף בספריה '{ 0 }' אינו כולל פונקציית גרסה '{1 }()'. פונקציה זו חייבת להתקיים כדי שהתוסף יותקן."
+msgstr ""
 
 #: lib/plugins.php:784
 #, php-format
 msgid "The Plugin in the directory '%s' does not include an install function '%s()'.  This function must exist for the plugin to be installed."
-msgstr "התוסף בספריה '{ 0 }' אינו כולל פונקציית התקנה '{1 }()'. פונקציה זו חייבת להתקיים כדי שהתוסף יותקן."
+msgstr ""
 
 #: lib/plugins.php:982
 #, php-format
@@ -18360,72 +18360,72 @@ msgstr "נתונים עבור התוסף %s כולל טבלאות והגדרות
 #: lib/plugins.php:1441
 #, php-format
 msgid "The Archive for Plugin '%s' has been removed."
-msgstr "הארכיון עבור התוסף '{ 0 }' הוסר."
+msgstr ""
 
 #: lib/plugins.php:1491
 #, php-format
 msgid "Restore failed!  The Plugin '%s' archive Restore failed.  Unable to create directory '%s'."
-msgstr "השחזור נכשל! שחזור הארכיון של התוסף '{ 0 }' נכשל.  לא ניתן ליצור את הספרייה '{ 1 }'."
+msgstr ""
 
 #: lib/plugins.php:1493
 #, php-format
 msgid "Restore failed!  The available Plugin '%s' Load failed.  Unable to create directory '%s'."
-msgstr "השחזור נכשל! הטעינה הזמינה של התוסף '{ 0 }' נכשלה.  לא ניתן ליצור את הספרייה '{ 1 }'."
+msgstr ""
 
 #: lib/plugins.php:1592
 #, php-format
 msgid "Restore failed!  The archived Plugin '%s' Restore failed. Unable to create directory %s"
-msgstr "השחזור נכשל!  השחזור של התוסף '{ 0 }' בארכיון נכשל. לא ניתן ליצור ספרייה %s"
+msgstr ""
 
 #: lib/plugins.php:1594
 #, php-format
 msgid "Load failed!  The available Plugin '%s' Load failed. Unable to create directory %s"
-msgstr "הטעינה נכשלה! הטעינה הזמינה של התוסף '{ 0 }' נכשלה. לא ניתן ליצור ספרייה %s"
+msgstr ""
 
 #: lib/plugins.php:1614
 #, php-format
 msgid "Restore succeeded!  The archived Plugin '%s' Restore succeeded."
-msgstr "השחזור הצליח!  השחזור בארכיון של התוסף '{ 0 }' הצליח."
+msgstr ""
 
 #: lib/plugins.php:1621
 #, php-format
 msgid "Load succeeded!  The available Plugin '%s' Load succeeded."
-msgstr "הטעינה הצליחה! הטעינה הזמינה של התוסף '{ 0 }' הצליחה."
+msgstr ""
 
 #: lib/plugins.php:1639
 #, php-format
 msgid "Restore failed!  The archived Plugin '%s' Restore failed.  Check the cacti.log for warnings."
-msgstr "השחזור נכשל!  השחזור של התוסף '{ 0 }' בארכיון נכשל.  בדוק את cacti.log לאזהרות."
+msgstr ""
 
 #: lib/plugins.php:1641
 #, php-format
 msgid "Load failed!  The available Plugin '%s' Load failed.  Check the cacti.log for warnings."
-msgstr "הטעינה נכשלה! הטעינה הזמינה של התוסף '{ 0 }' נכשלה.  בדוק את cacti.log לאזהרות."
+msgstr ""
 
 #: lib/plugins.php:1648
 #, php-format
 msgid "Restore failed!  Unable to locate the archive record for Plugin '%s' in the database."
-msgstr "השחזור נכשל!  לא ניתן לאתר את רשומת הארכיון עבור התוסף '{ 0 }' במסד הנתונים."
+msgstr ""
 
 #: lib/plugins.php:1650
 #, php-format
 msgid "Load failed!  Unable to locate the available record for Plugin '%s' in the database."
-msgstr "הטעינה נכשלה!  לא ניתן לאתר את הרשומה הזמינה עבור התוסף '{ 0 }' במסד הנתונים."
+msgstr ""
 
 #: lib/plugins.php:1717
 #, php-format
 msgid "The Plugin '%s' has been archived successfully."
-msgstr "יומן Cacti טוהר בהצלחה"
+msgstr ""
 
 #: lib/plugins.php:1719
 #, php-format
 msgid "The Plugin '%s' archiving process has failed.  Check the Cacti log for errors."
-msgstr "תיקיה אחת או יותר של RRDfile נכשלה. ראה יומן Cacti עבור שגיאות."
+msgstr ""
 
 #: lib/plugins.php:1722
 #, php-format
 msgid "The Plugin '%s' archiving process has failed due to the plugin directory being missing."
-msgstr "תהליך האחסון בארכיון של התוסף '{ 0 }' נכשל מכיוון שספריית התוסף חסרה."
+msgstr ""
 
 #: lib/plugins.php:1730 lib/plugins.php:1737 plugins.php:638 plugins.php:641
 #: plugins.php:1043
@@ -18456,7 +18456,7 @@ msgstr "לא נמצאו תוספים במיקום GitHub/GitLab."
 #: lib/plugins.php:1956
 #, php-format
 msgid "The Cacti plugin %s has not releases"
-msgstr "Cacti Poller עדיין לא רץ."
+msgstr ""
 
 #: lib/plugins.php:2011 lib/plugins.php:2149
 msgid "Unable to get archive from GitHub/GitLab location."
@@ -18475,7 +18475,7 @@ msgstr "לא ניתן לקבל נתוני ריפו עבור תוסף %s ממיק
 #: lib/plugins.php:2238
 #, php-format
 msgid "There were '%s' Plugins found at The Cacti Groups GitHub site and '%s' Plugins Tags/Releases were retrieved and updated in %0.2f seconds."
-msgstr "נמצאו '{ 0 }' תוספים באתר GitHub של קבוצות Cacti והתוספים/שחרורים '{ 1 }' אוחזרו ועודכנו תוך %0.2f שניות."
+msgstr ""
 
 #: lib/plugins.php:2240
 #, php-format
@@ -18485,7 +18485,7 @@ msgstr "לא ניתן להגיע לאתר GitHub של קבוצות Cacti.  אי�
 #: lib/reports.php:144
 #, php-format
 msgid "Device '%s' successfully added to Report."
-msgstr "נוסף ל- Cacti"
+msgstr ""
 
 #: lib/reports.php:147
 msgid "Device not found! Unable to add to Report"
@@ -18561,7 +18561,7 @@ msgstr "הפקודה RRDtool:"
 #: lib/rrd.php:3299
 #, php-format
 msgid "The required RRDfile step size is '%s' but observed step is '%s'"
-msgstr "הגודל הנדרש של RRD הוא &#39; %s&#39;"
+msgstr ""
 
 #: lib/rrd.php:3359
 #, php-format
@@ -18596,7 +18596,7 @@ msgstr "קובץ ה- RRA &#39; %s&#39; כולל אותו CF / שלבים ( %s, %
 #: lib/rrd.php:3450
 #, php-format
 msgid "The pdp_per_row of '%s' is invalid for RRA '%s' should be '%s'.  Consider deleting and allowing Cacti to re-create RRDfile."
-msgstr "ה - pdp_per_row של '{ 0 }' אינו חוקי עבור RRA '{ 1 }' צריך להיות '{ 2 }'. שקול למחוק ולאפשר ל - Cacti ליצור מחדש RRDfile."
+msgstr ""
 
 #: lib/rrd.php:3454
 #, php-format
@@ -18606,12 +18606,12 @@ msgstr "XFF עבור cacti RRA id &#39; %s&#39; צריך להיות &#39; %s&#39
 #: lib/rrd.php:3458
 #, php-format
 msgid "The number of rows for Cacti RRA id '%s' is incorrect.  The number of rows are '%s' but should be '%s'"
-msgstr "מספר השורות עבור Cacti RRA id &#39; %s&#39; צריך להיות &#39; %s&#39;"
+msgstr ""
 
 #: lib/rrd.php:3476
 #, php-format
 msgid "The RRA '%s' missing in the existing Cacti RRDfile"
-msgstr "RRA &#39;%&#39; חסר ב- RRDfile"
+msgstr ""
 
 #: lib/rrd.php:3483
 #, php-format
@@ -18700,12 +18700,12 @@ msgstr "שגיאה בעת ניתוח XML של DDR"
 #: lib/rrd.php:4159
 #, php-format
 msgid "RRA (CF=%s, ROWS=%d, PDP_PER_ROW=%d, XFF=%1.2f) removed from RRD file"
-msgstr "RRA (CF = %s, ROWS =% d, PDP_PER_ROW =% d, XFF = 1.2f) הוסר מקובץ RRD"
+msgstr ""
 
 #: lib/rrd.php:4199
 #, php-format
 msgid "RRA (CF=%s, ROWS=%d, PDP_PER_ROW=%d, XFF=%1.2f) adding to RRD file"
-msgstr "RRA (CF = %s, ROWS =% d, PDP_PER_ROW =% d, XFF = 1.2f) הוספת לקובץ RRD"
+msgstr ""
 
 #: lib/rrd.php:4291 lib/rrd.php:4305
 #, php-format
@@ -18752,7 +18752,7 @@ msgstr "שגיאה: ההיתרים נכשלו. בדוק שיטת קלט נתונ
 #: lib/template.php:2267
 #, php-format
 msgid "Graph Not created for %s due to bad data"
-msgstr "יצירת גרפים"
+msgstr ""
 
 #: lib/template.php:2296
 #, php-format
@@ -18762,12 +18762,12 @@ msgstr "הערה: הגרף לא נוסף עבור שאילתת נתונים %s �
 #: lib/timespan_settings.php:136
 #, php-format
 msgid "Your Start Date '%s' is before January 1993.  Please pick a more recent Start Date."
-msgstr "תאריך ההתחלה שלך '{ 0 }' הוא לפני ינואר 1993.  יש לבחור תאריך התחלה עדכני יותר."
+msgstr ""
 
 #: lib/timespan_settings.php:141
 #, php-format
 msgid "Your End Date '%s' is before January 1993.  Please pick a more recent End Date."
-msgstr "תאריך הסיום שלך '{ 0 }' הוא לפני ינואר 1993.  יש לבחור תאריך סיום עדכני יותר."
+msgstr ""
 
 #: lib/utility.php:1113
 msgid "MySQL 5.6+ and MariaDB 10.0+ are great releases, and are very good versions to choose. Make sure you run the very latest release though which fixes a long standing low level networking issue that was causing spine many issues with reliability."
@@ -18838,7 +18838,7 @@ msgstr "אם לטבלאות שלכם יש אינדקסים גדולים מאוד
 #: lib/utility.php:1254
 #, php-format
 msgid "InnoDB will hold as much tables and indexes in system memory as is possible.  Therefore, you should make the innodb_buffer_pool large enough to hold as much of the tables and index in memory.  Checking the size of the /var/lib/mysql/cacti directory will help in determining this value.  We are recommending 25%% of your systems total memory, but your requirements will vary depending on your systems size.  If you database is very large or remote, you can consider increasing this size.  If remote, it can by as high as 80% of the systems memory.  However, cautions must be taken to reduce the swappiness of the system, or to remove swap to keep the system from swapping."
-msgstr "InnoDB תקיים כמה טבלאות ואינדקסים בזיכרון המערכת ככל האפשר. לכן, אתה צריך לעשות את innodb_buffer_pool גדול מספיק כדי להחזיק כמה שיותר שולחנות ואינדקס בזיכרון. בדיקת גודל הספרייה / var / lib / mysql / cacti תסייע בקביעת ערך זה. אנו ממליצים על 25 %% מהמערכת הכוללת של הזיכרון, אך הדרישות שלך ישתנו בהתאם לגודל המערכות שלך."
+msgstr ""
 
 #: lib/utility.php:1260
 msgid "This settings should remain ON unless your Cacti instances is running on either ZFS or FusionI/O which both have internal journaling to accommodate abrupt system crashes.  However, if you have very good power, and your systems rarely go down and you have backups, turning this setting to OFF can net you almost a 50% increase in database performance."
@@ -18954,7 +18954,7 @@ msgstr "מינימום של %s MB זיכרון מגבלה"
 #: lib/utility.php:2007
 #, php-format
 msgid "A minimum of %s m execution time"
-msgstr "מינימום של% זמן ביצוע sm"
+msgstr ""
 
 #: lib/utility.php:2009
 msgid "A valid timezone that matches MySQL and the system"
@@ -18967,7 +18967,7 @@ msgstr "שם שימושי עבור VDEF זה."
 #: link.php:79
 #, php-format
 msgid "External Link ID '%s' with Title '%s' attempted to inject an invalid URL and was blocked!"
-msgstr "מזהה קישור חיצוני '{ 0 }' עם הכותרת '{ 1 }' ניסה להזריק כתובת URL לא חוקית ונחסם!"
+msgstr ""
 
 #: links.php:76
 msgid "Your contentfile is not a valid URL.  Please enter a value URL"
@@ -19173,7 +19173,7 @@ msgstr "התנתקות של Cacti"
 #: logout.php:60
 #, php-format
 msgid "You have been logged out of Cacti due to %s."
-msgstr "אתה כבר מחובר מתוך Cacti עקב פסק זמן הפגישה."
+msgstr ""
 
 #: logout.php:61
 #, php-format
@@ -19358,7 +19358,7 @@ msgstr "אירעו שגיאות באריזת התבניות שלך.  שגיאו�
 #: package.php:221
 #, php-format
 msgid "A Critical Template file '%s' is missing.  Please locate this file before packaging"
-msgstr "קובץ תבנית קריטי '{ 0 }' חסר.  אנא אתר קובץ זה לפני האריזה"
+msgstr ""
 
 #: package.php:562
 msgid "Package Templates"
@@ -19371,17 +19371,17 @@ msgstr "מה תרצה לייצא?"
 #: package.php:667
 #, php-format
 msgid "%s Device Package"
-msgstr "שם ההתקן:% 1"
+msgstr ""
 
 #: package.php:670
 #, php-format
 msgid "%s Graph Template Package"
-msgstr "שם תבנית גרף"
+msgstr ""
 
 #: package.php:673
 #, php-format
 msgid "%s Data Query Package"
-msgstr "שם שאילתה של נתונים"
+msgstr ""
 
 #: package.php:700 templates_export.php:168
 #, php-format
@@ -19395,7 +19395,7 @@ msgstr "תבניות זמינות [ %s]"
 #: package.php:709
 #, php-format
 msgid "%s to Export"
-msgstr "ייצא"
+msgstr ""
 
 #: package.php:710
 msgid "Choose the exact items to export in the Package."
@@ -19465,7 +19465,7 @@ msgstr "תכולת החבילה כלולה"
 #: package.php:898
 #, php-format
 msgid "Script or Resource File '%s' does not exist.  Please repackage after locating and installing this file"
-msgstr "קובץ סקריפט או משאב '{ 0 }' אינו קיים.  יש לארוז מחדש לאחר איתור והתקנת קובץ זה"
+msgstr ""
 
 #: package.php:912 package_import.php:82
 msgid "Key Generation Required to Use Tool"
@@ -19482,7 +19482,7 @@ msgstr "על מנת להשתמש בכלי אריזה זה, תחילה עליך �
 #: package.php:964
 #, php-format
 msgid "The Web Server must have write access to the '%s' directory"
-msgstr "לשרת האינטרנט חייבת להיות גישה לכתיבה לספרייה '{ 0 }'"
+msgstr ""
 
 #: package.php:986
 msgid "Unable to initialize SQLite3"
@@ -19512,7 +19512,7 @@ msgstr "לא ניתן ליצור תיקיית חבילה זמנית %s."
 #: package_import.php:203 package_import.php:527
 #, php-format
 msgid "The Package %s Imported Successfully"
-msgstr "יומן Cacti טוהר בהצלחה"
+msgstr ""
 
 #: package_import.php:205 package_import.php:529
 #, php-format
@@ -19522,7 +19522,7 @@ msgstr "הייבוא של החבילה %s נכשל"
 #: package_import.php:298
 #, php-format
 msgid "Package %s"
-msgstr "חבילת קבצים"
+msgstr ""
 
 #: package_import.php:305
 msgid "Click 'Continue' to Import the following Package."
@@ -19575,7 +19575,7 @@ msgstr "לא ניתן להשיג את המפתח הציבורי לחבילה ז�
 #: package_import.php:427
 #, php-format
 msgid "You have not Trusted this Package Author '%s'.  If you wish to import, check the Automatically Trust Author checkbox.  Otherwise, feel free to reach the author at the following Email address '%s'."
-msgstr "לא בטחת במחבר חבילה זה '{ 0 }'. אם ברצונך לייבא, יש לסמן את תיבת הסימון 'מחבר אמון אוטומטי '.  אחרת, אל תהסס לפנות למחבר בכתובת הדוא\"ל הבאה '{ 1 }'."
+msgstr ""
 
 #: package_import.php:738
 msgid "Repo File Missing or Damaged"
@@ -19584,7 +19584,7 @@ msgstr "קובץ ריפו חסר או פגום"
 #: package_import.php:739
 #, php-format
 msgid "The Repo '%s' is NOT Reachable at the URL Location in the package.manifest."
-msgstr "לא ניתן להשיג את ה - Repo '{ 0 }' במיקום כתובת ה - URL ב - package.manifest."
+msgstr ""
 
 #: package_import.php:740
 msgid "Something is wrong with your Package Repository"
@@ -19597,12 +19597,12 @@ msgstr "לא ניתן לסמוך על החתימה עבור חבילה אחת א
 #: package_import.php:762
 #, php-format
 msgid "<b>Author:</b> &lt;%s&gt; %s.<br>"
-msgstr "<b>מחבר:</b> <{ 0}> %s.<br>"
+msgstr ""
 
 #: package_import.php:766
 #, php-format
 msgid "<b>Package</b> %s"
-msgstr "חבילת קבצים"
+msgstr ""
 
 #: package_import.php:769
 msgid "Press 'Ok' to start Trusting the Signer, or escape to cancel."
@@ -19623,7 +19623,7 @@ msgstr "כל חתימות החבילה אומתו"
 #: package_import.php:823 package_import.php:1963 package_repos.php:123
 #, php-format
 msgid "The Repo '%s' is NOT Reachable at the URL Location or the package.manifest file is missing."
-msgstr "לא ניתן להשיג את ה - Repo '{ 0 }' במיקום כתובת ה - URL או שקובץ package.manifest חסר."
+msgstr ""
 
 #: package_import.php:880 package_import.php:886 package_import.php:981
 #: package_import.php:984
@@ -19637,7 +19637,7 @@ msgstr "לקבלת מידע נוסף, ניתן לעיין באתר cacti.log.  �
 #: package_import.php:880
 #, php-format
 msgid "The package \"%s\" download or validation failed"
-msgstr "הורדת או אימות החבילה \"{ 0 }\" נכשלה"
+msgstr ""
 
 #: package_import.php:886
 msgid "See the cacti.log for more information.  It could be that you had either an API Key error or the package was tamered with, or the location is not available"
@@ -19778,17 +19778,17 @@ msgstr "לא נמצאו עמודים"
 #: package_import.php:1946
 #, php-format
 msgid "The Repo '%s' is NOT Reachable on GitHub or the '%s' file is missing or it could be an invalid branch.  Valid Package Locations are normally: https://github.com/Author/RepoName/."
-msgstr "לא ניתן להשיג את קובץ הריפו '{ 0 }' ב - GitHub או שהקובץ '{ 1 }' חסר או שהוא יכול להיות ענף לא חוקי. מיקומי חבילות חוקיים הם בדרך כלל: https://github.com/Author/RepoName/."
+msgstr ""
 
 #: package_import.php:1974
 #, php-format
 msgid "The Repo '%s' is Reachable on the Local Cacti Server.  But not data returned from the manifest file."
-msgstr "ניתן להשיג את הריפו '{ 0 }' בשרת הקקטוסים המקומי.  אבל לא נתונים שהוחזרו מקובץ המניפסט."
+msgstr ""
 
 #: package_import.php:1977 package_repos.php:131
 #, php-format
 msgid "The Repo '%s' is NOT Reachable on the Local Cacti Server or the package.manifest file is missing."
-msgstr "לא ניתן להשיג את ה - Repo '{ 0 }' בשרת הקקטוסים המקומי או שקובץ package.manifest חסר."
+msgstr ""
 
 #: package_keys.php:95 package_repos.php:206
 msgid "Click 'Continue' to delete the following ."
@@ -19846,22 +19846,22 @@ msgstr "כתובת URL ישירה"
 #: package_repos.php:104
 #, php-format
 msgid "The Repo '%s' is Reachable on GitHub."
-msgstr "ניתן להשיג את הריפו '{ 0 }' ב - GitHub."
+msgstr ""
 
 #: package_repos.php:106
 #, php-format
 msgid "The Repo '%s' is NOT Reachable on GitHub or the package.manifest file is missing or it could be an invalid branch.  Valid Package Locations are normally: https://github.com/Author/RepoName/."
-msgstr "לא ניתן להשיג את ה - Repo '{ 0 }' ב - GitHub או שקובץ package.manifest חסר או שהוא יכול להיות ענף לא חוקי. מיקומי חבילות חוקיים הם בדרך כלל: https://github.com/Author/RepoName/."
+msgstr ""
 
 #: package_repos.php:121
 #, php-format
 msgid "The Repo '%s' is Reachable at the URL Location."
-msgstr "ניתן להשיג את ה - Repo '{ 0 }' במיקום כתובת ה - URL."
+msgstr ""
 
 #: package_repos.php:129
 #, php-format
 msgid "The Repo '%s' is Reachable on the Local Cacti Server."
-msgstr "ניתן להשיג את הריפו '{ 0 }' בשרת הקקטוסים המקומי."
+msgstr ""
 
 #: package_repos.php:211
 msgid "Delete Package Repository"
@@ -20079,12 +20079,12 @@ msgstr "עבר לארכיון"
 #: plugins.php:165
 #, php-format
 msgid "The action '%s' on Plugin '%s' can not be performed due to the Plugin in it's current state."
-msgstr "לא ניתן לבצע את הפעולה '{ 0 }' בתוסף '{ 1 }' עקב התוסף במצבו הנוכחי."
+msgstr ""
 
 #: plugins.php:169
 #, php-format
 msgid "The action '%s' '%s' on Plugin '%s' can not be taken as the Plugin is integrated."
-msgstr "לא ניתן לבצע את הפעולה '{ 0 }' '{ 1 }' בתוסף '{ 2 }' מכיוון שהתוסף משולב."
+msgstr ""
 
 #: plugins.php:218
 msgid "The fetch latest plugins process has been launched into background."
@@ -20097,12 +20097,12 @@ msgstr "תהליך הבאת התוספים האחרונים כבר החל."
 #: plugins.php:276
 #, php-format
 msgid "Plugin '%s' has passed it's Configuration Check test and can not be Installed"
-msgstr "התוסף '{ 0 }' עבר את בדיקת התצורה שלו ולא ניתן להתקין אותו"
+msgstr ""
 
 #: plugins.php:278
 #, php-format
 msgid "Plugin '%s' Check Configuration function returned a null response which is invalid.  Please check with Plugin Developer for an update."
-msgstr "הפונקציה '{ 0 }' בדוק את התצורה החזירה תגובה אפס שאינה חוקית.  אנא בדוק עם Plugin Developer לעדכון."
+msgstr ""
 
 #: plugins.php:580
 msgid "Uninstalling this Plugin and may remove all Plugin Data and Settings.  If you really want to Uninstall the Plugin, click 'Uninstall' below.  Otherwise click 'Cancel'."
@@ -20482,7 +20482,7 @@ msgstr "התקנת תוסף"
 #: plugins.php:1760
 #, php-format
 msgid "Plugin '%s' can not be archived before it's been Installed."
-msgstr "אין אפשרות להתקין את הפלאגין."
+msgstr ""
 
 #: plugins.php:1771
 msgid "Remove Plugin Data Tables and Settings"
@@ -20565,27 +20565,27 @@ msgstr "הפעל פלאגין"
 #: poller.php:405
 #, php-format
 msgid "WARNING: %s is out of sync with the Poller Interval for Poller[%d]!  The Poller Interval is %d seconds, with a maximum of a %d seconds, but %d seconds have passed since the last poll!"
-msgstr "אזהרה: %s אינו מסונכרן עם מרווח הפוליר! מרווח הפולרים הוא &#39;% d&#39; שניות, עם מקסימום של% d שניות, אך% d שניות חלפו מאז הסקר האחרון!"
+msgstr ""
 
 #: poller.php:579
 #, php-format
 msgid "WARNING: There are %d processes detected as overrunning a polling cycle for Poller[%d], please investigate."
-msgstr "אזהרה: יש% d &#39;שזוהו כעקוף את מחזור הסקרים, אנא חקרו."
+msgstr ""
 
 #: poller.php:637
 #, php-format
 msgid "WARNING: Poller Output Table not empty for Poller[%d].  Issues: %d, %s."
-msgstr "אזהרה: טבלת הפלט לא ריקה. בעיות:% d, %s."
+msgstr ""
 
 #: poller.php:671
 #, php-format
 msgid "ERROR: The spine path: %s is invalid for Poller[%d].  Poller can not continue!"
-msgstr "שגיאה: נתיב השדרה: %s אינו חוקי. פולר לא יכול להמשיך!"
+msgstr ""
 
 #: poller.php:819
 #, php-format
 msgid "Maximum runtime of %d seconds exceeded for Poller[%d]. Exiting."
-msgstr "זמן ריצה מרבי של% d שניות חרג. יציאה."
+msgstr ""
 
 #: poller.php:944
 msgid "WARNING: Cacti Polling Cycle Exceeded Poller Interval by "
@@ -20603,12 +20603,12 @@ msgstr "פולר במצב פעימות לב"
 #: poller.php:1253
 #, php-format
 msgid "WARNING: 24 hours Poller[%d] avg. run time is %f seconds (more than %d &#37; of time limit)"
-msgstr "אזהרה: 24 שעות סוקר [%d] זמן ריצה ממוצע הוא %f שניות (יותר מ -{ 2 }% ממגבלת הזמן)"
+msgstr ""
 
 #: poller.php:1269
 #, php-format
 msgid "WARNING: In last hour Poller[%d] run time %d times reached more than %d &#37; of time limit"
-msgstr "אזהרה: בשעה האחרונה זמן הריצה [%d] של הסוקר %d פעמים הגיע ליותר מ -{ 2 }% ממגבלת הזמן"
+msgstr ""
 
 #: poller.php:1291
 msgid "Cacti System Notification"
@@ -20621,7 +20621,7 @@ msgstr "הערה: נוסף אספן נתונים של קקטוסים. לפיכך
 #: poller_automation.php:54
 #, php-format
 msgid "WARNING: Main Cacti database %s offline or in recovery"
-msgstr "אזהרה: מסד הנתונים הראשי של קקטוסים לא מקוון או בשחזור"
+msgstr ""
 
 #: poller_automation.php:1037 poller_automation.php:1091
 msgid "Cacti Primary Admin"
@@ -21174,7 +21174,7 @@ msgstr "הערה: הגדרות הנתיב בכרטיסייה זו נשמרות �
 #: settings.php:138
 #, php-format
 msgid "Cacti Settings (%s)%s"
-msgstr "הגדרות Cacti ( %s)"
+msgstr ""
 
 #: settings.php:248
 msgid "Changing Permission Model Warning"
@@ -22047,7 +22047,7 @@ msgstr "עיין ב -cacti.log לקבלת מידע נוסף, ובדוק את ק�
 #: templates_import.php:143
 #, php-format
 msgid "The Template XML file \"%s\" validation failed"
-msgstr "אימות קובץ ה - XML של התבנית \"{ 0 }\" נכשל"
+msgstr ""
 
 #: templates_import.php:216
 msgid "Import Files [ If Files are missing, locate and install before using ]"
@@ -22076,7 +22076,7 @@ msgstr "פגום"
 #: templates_import.php:320
 #, php-format
 msgid "Met: %d"
-msgstr "MET"
+msgstr ""
 
 #: templates_import.php:324
 #, php-format
@@ -23694,7 +23694,7 @@ msgstr "מפורטת טיימרים Runtime:"
 #: utilities.php:1779 utilities.php:1781
 #, php-format
 msgid "Process: %d"
-msgstr "תהליך"
+msgstr ""
 
 #: utilities.php:1779
 #, php-format

--- a/locales/po/hi-IN.po
+++ b/locales/po/hi-IN.po
@@ -309,12 +309,12 @@ msgstr "एग्रीगेट से अलग होना"
 #: aggregate_graphs.php:970
 #, php-format
 msgid "Click 'Continue' to Place the following Aggregate Graph on Tree %s."
-msgstr "निम्नलिखित एग्रीगेट ग्राफ टेम्पलेट (ओं) को हटाने के लिए &#39;जारी रखें&#39; पर क्लिक करें।"
+msgstr ""
 
 #: aggregate_graphs.php:971
 #, php-format
 msgid "Click 'Continue' to Duplicate following Aggregate Graphs on Tree %s."
-msgstr "ट्री शाखा के तहत निम्नलिखित एग्रीगेट ग्राफ (ओं) को रखने के लिए &#39;जारी रखें&#39; पर क्लिक करें।"
+msgstr ""
 
 #: aggregate_graphs.php:972
 msgid "Place Aggregate Graph on Tree"
@@ -894,7 +894,7 @@ msgstr "कम से कम 1 विशेष वर्ण शामिल क�
 #: auth_changepassword.php:348 auth_resetpassword.php:253
 #, php-format
 msgid "Cannot be reused for %d password changes"
-msgstr "% D पासवर्ड परिवर्तन के लिए पुन: उपयोग नहीं किया जा सकता है"
+msgstr ""
 
 #: auth_changepassword.php:403
 msgid "There are problems with the Change Password page.  Contact your Cacti administrator right away."
@@ -959,7 +959,7 @@ msgstr "उपयोगकर्ता को प्रमाणित किय
 #: auth_login.php:141
 #, php-format
 msgid "Access Denied!  Guest user id %s does not exist.  Please contact your Administrator."
-msgstr "पहुँच निषेध, कृपया आप कैक्टि प्रशासक से संपर्क करें।"
+msgstr ""
 
 #: auth_login.php:180
 msgid "Access Denied!  User account disabled."
@@ -1243,12 +1243,12 @@ msgstr "डिवाइस स्वचालन इंटरफ़ेस के
 #: automation_devices.php:125
 #, php-format
 msgid "Device %s Added to Cacti"
-msgstr "कैक्टि में जोड़ा गया"
+msgstr ""
 
 #: automation_devices.php:127
 #, php-format
 msgid "Device %s Not Added to Cacti"
-msgstr "कैक्टि में नहीं जोड़ा गया"
+msgstr ""
 
 #: automation_devices.php:137
 msgid "Devices Removed from Cacti Automation database"
@@ -2969,7 +2969,7 @@ msgstr "निम्न डेटा क्वेरी को हटाने �
 #: automation_templates.php:791
 #, php-format
 msgid "Tree Rule Name: '%s'"
-msgstr "ट्री नियम आइटम"
+msgstr ""
 
 #: automation_templates.php:798
 msgid "Remove Tree Rule"
@@ -3482,7 +3482,7 @@ msgstr "पूरा नाम"
 #: changelog.php:99
 #, php-format
 msgid "Change Log [%s]"
-msgstr "चेंजलॉग"
+msgstr ""
 
 #: changelog.php:160 support.php:1018
 #, php-format
@@ -4599,7 +4599,7 @@ msgstr "डेटा स्रोत प्रोफ़ाइल आइटम �
 #: data_source_profiles.php:799
 #, php-format
 msgid "%s KBytes per Data Sources and %s Bytes for the Header"
-msgstr "% डेटा स्रोतों के अनुसार केबीटीज़ और हैडर के लिए %s बाइट्स"
+msgstr ""
 
 #: data_source_profiles.php:808
 #, php-format
@@ -4668,14 +4668,14 @@ msgstr "% d वीक"
 #: include/global_settings.php:3228 rrdcleaner.php:522 rrdcleaner.php:523
 #, php-format
 msgid "%d Weeks"
-msgstr "% द वीक"
+msgstr ""
 
 #: data_source_profiles.php:851 include/global_arrays.php:751
 #: include/global_arrays.php:795 include/global_arrays.php:805
 #: include/global_arrays.php:1601 include/global_settings.php:1863
 #, php-format
 msgid "%d Day"
-msgstr "% द डे"
+msgstr ""
 
 #: data_source_profiles.php:851 include/global_arrays.php:796
 #: include/global_arrays.php:806 include/global_arrays.php:807
@@ -4689,7 +4689,7 @@ msgstr "% द डे"
 #: include/global_settings.php:1974 include/global_settings.php:1975
 #, php-format
 msgid "%d Days"
-msgstr "% ड डय"
+msgstr ""
 
 #: data_source_profiles.php:859 include/global_arrays.php:745
 #: include/global_arrays.php:1666 include/global_arrays.php:1687
@@ -4935,7 +4935,7 @@ msgstr "डेटा स्रोत जानकारी मोड चाल�
 #: data_sources.php:864
 #, php-format
 msgid "Edit Graph: '%s'."
-msgstr "ग्राफ़ टेम्पलेट संपादित करें।"
+msgstr ""
 
 #: data_sources.php:869 graphs.php:2280
 msgid "Edit Device."
@@ -5103,7 +5103,7 @@ msgstr "प्रोफ़ाइल बदलें"
 #: data_templates.php:261
 #, php-format
 msgid "Field \"%s\" is missing an Output Field.  Select the Output Field associated with this Data Source, and press Save again."
-msgstr "फ़ील्ड \"{ 0 }\" में एक आउटपुट फ़ील्ड नहीं है। इस डेटा स्रोत से जुड़े आउटपुट फ़ील्ड का चयन करें, और फिर से सहेजें दबाएं।"
+msgstr ""
 
 #: data_templates.php:447
 #, php-format
@@ -5358,7 +5358,7 @@ msgstr "ग्राफ मौजूद नहीं है"
 #: graph.php:115 graph.php:409
 #, php-format
 msgid "Graph Utility View for Graph: %s"
-msgstr "ग्राफ उपयोगिता देखें"
+msgstr ""
 
 #: graph.php:160 lib/html.php:585
 msgid "Graph Details, Zooming and Debugging Utilities"
@@ -6067,12 +6067,12 @@ msgstr "रिपोर्ट पर ग्राफ़ रखें"
 #: graphs.php:1912
 #, php-format
 msgid "Click 'Continue' to Place the following Graph on Tree %s."
-msgstr "निम्नलिखित ट्री को हटाने के लिए &#39;जारी रखें&#39; पर क्लिक करें।"
+msgstr ""
 
 #: graphs.php:1913
 #, php-format
 msgid "Click 'Continue' to Duplicate following Graphs on Tree %s."
-msgstr "निम्नलिखित ट्री को हटाने के लिए &#39;जारी रखें&#39; पर क्लिक करें।"
+msgstr ""
 
 #: graphs.php:1914
 msgid "Place Graph on Tree"
@@ -6140,7 +6140,7 @@ msgstr "चयनित ग्राफ़ टेम्पलेट"
 #: graphs.php:2320
 #, php-format
 msgid "Choose a Graph Template to apply to this Graph. Please note that you may only change Graph Templates to a 100%% compatible Graph Template, which means that it includes identical Data Sources."
-msgstr "इस ग्राफ़ पर लागू करने के लिए एक ग्राफ़ टेम्पलेट चुनें। कृपया ध्यान दें कि आप केवल ग्राफ़ टेम्पलेट को 100% प्रति संगत ग्राफ़ टेम्पलेट में बदल सकते हैं, जिसका अर्थ है कि इसमें समान डेटा स्रोत शामिल हैं।"
+msgstr ""
 
 #: graphs.php:2328
 msgid "Choose the Device that this Graph belongs to."
@@ -6173,7 +6173,7 @@ msgstr "उपयोगकर्ता समूह प्रबंधन [स�
 #: graphs.php:2688
 #, php-format
 msgid "Graph Management [ %s ]"
-msgstr "ग्राफ प्रबंधन"
+msgstr ""
 
 #: graphs.php:2756 graphs.php:2759
 msgid "Source"
@@ -6202,7 +6202,7 @@ msgstr "डिफ़ॉल्ट सेटिंग्स सहेजे गए
 #: graphs_new.php:338
 #, php-format
 msgid "New Graphs for [ %s ] (%s %s)"
-msgstr "[ %s] के लिए नए रेखांकन"
+msgstr ""
 
 #: graphs_new.php:340
 msgid "New Graphs for [ All Devices ]"
@@ -6263,7 +6263,7 @@ msgstr "आईडी '%s' के साथ डेटा क्वेरी '%s' 
 #: graphs_new.php:695
 #, php-format
 msgid "Error Parsing Data Query Resource XML file for Data Query '%s' with id '%s'.  Field Name '%s' missing a 'direction' attribute"
-msgstr "आईडी '%s' के साथ डेटा क्वेरी '%s' के लिए डेटा क्वेरी संसाधन XML फ़ाइल को पार्स करने में त्रुटि"
+msgstr ""
 
 #: graphs_new.php:699
 #, php-format
@@ -6319,7 +6319,7 @@ msgstr "चेतावनी: कैक्टि पेज:%s यूज़र �
 #: help.php:74
 #, php-format
 msgid "The Document page '%s' count not be reached.  The Cacti Documentation site is not reachable.  The http error was '%s'.  Consider downloading an official release to obtain the latest documentation and hosting the documentation locally."
-msgstr "दस्तावेज़ पृष्ठ '{ 0 }' गणना तक नहीं पहुंचा जा सकता है। कैक्टि डॉक्यूमेंटेशन साइट से संपर्क नहीं हो पा रहा है। HTTP त्रुटि '{ 1 }' थी। नवीनतम दस्तावेज़ प्राप्त करने और स्थानीय रूप से दस्तावेज़ों की मेज़बानी करने के लिए आधिकारिक रिलीज़ डाउनलोड करने पर विचार करें।"
+msgstr ""
 
 #: help.php:88
 msgid "Cacti GitHub Site"
@@ -6337,7 +6337,7 @@ msgstr "सहायता फ़ाइल %s कैक्टि दस्ता
 #: help.php:102
 #, php-format
 msgid "The Document page '%s' count not be reached locally."
-msgstr "दस्तावेज़ पृष्ठ '{ 0 }' पर स्थानीय रूप से नहीं पहुँचा जा सकता है।"
+msgstr ""
 
 #: host.php:44
 msgid "Change Device Settings"
@@ -6382,12 +6382,12 @@ msgstr "त्रुटि: डिवाइस ["
 #: host.php:217
 #, php-format
 msgid "Device Reindex Completed in %0.2f seconds.  There were %d items updated."
-msgstr "डिवाइस रिइंडेक्स% 0.2f सेकंड में पूरा हुआ। % D आइटम अपडेट किए गए थे।"
+msgstr ""
 
 #: host.php:360
 #, php-format
 msgid "Unable to add some Devices to Report '%s'"
-msgstr "सर्वर से संपर्क करने में असमर्थ"
+msgstr ""
 
 #: host.php:479
 msgid "Click 'Continue' to Delete the following Device."
@@ -6500,12 +6500,12 @@ msgstr "ट्री पर डिवाइस (ओं) को रखें"
 #: host.php:564
 #, php-format
 msgid "Click 'Continue' to Place the following Device on Tree %s."
-msgstr "निम्नलिखित डिवाइस टेम्पलेट (ओं) को हटाने के लिए &#39;जारी रखें&#39; पर क्लिक करें"
+msgstr ""
 
 #: host.php:565
 #, php-format
 msgid "Click 'Continue' to Duplicate following Devices on Tree %s."
-msgstr "निम्नलिखित ट्री को हटाने के लिए &#39;जारी रखें&#39; पर क्लिक करें।"
+msgstr ""
 
 #: host.php:566
 msgid "Place Device on Tree"
@@ -6544,7 +6544,7 @@ msgstr "देखें पोलर कैश"
 #: host.php:733
 #, php-format
 msgid " [ In state since '%s', Uptime since '%s' ]"
-msgstr "['{ 0 }' के बाद से राज्य में, '{ 1 }' के बाद से अपटाइम]"
+msgstr ""
 
 #: host.php:748
 msgid "Create Graphs for this Device"
@@ -7672,17 +7672,17 @@ msgstr "प्रत्येक घंटे"
 #: include/global_settings.php:2849
 #, php-format
 msgid "Every %d Hours"
-msgstr "हर द% ख ड"
+msgstr ""
 
 #: include/global_arrays.php:771
 #, php-format
 msgid "Every %d Day"
-msgstr "हर% 1 दन"
+msgstr ""
 
 #: include/global_arrays.php:783
 #, php-format
 msgid "%0.1f Minutes"
-msgstr "% d मिनट"
+msgstr ""
 
 #: include/global_arrays.php:816 include/global_arrays.php:836
 #: include/global_arrays.php:848 include/global_arrays.php:849
@@ -9487,7 +9487,7 @@ msgstr "एक एकल SNMP प्राप्त अनुरोध में
 #: include/global_form.php:161
 #, php-format
 msgid "%d OID"
-msgstr "मैक्स ओआईडी"
+msgstr ""
 
 #: include/global_form.php:162 include/global_form.php:163
 #: include/global_form.php:164 include/global_form.php:165
@@ -9520,7 +9520,7 @@ msgstr "ऑटो डिटेक्ट/पहले री-इंडेक्�
 #: include/global_form.php:188
 #, php-format
 msgid "%d Repetition"
-msgstr "ग्रिड विकल्प"
+msgstr ""
 
 #: include/global_form.php:189 include/global_form.php:190
 #: include/global_form.php:191 include/global_form.php:192
@@ -9532,7 +9532,7 @@ msgstr "ग्रिड विकल्प"
 #: include/global_form.php:203
 #, php-format
 msgid "%d Repetitions"
-msgstr "ग्रिड विकल्प"
+msgstr ""
 
 #: include/global_form.php:212
 msgid "The maximum number of attempts to reach a device via an SNMP readstring prior to giving up."
@@ -9673,7 +9673,7 @@ msgstr "विशिष्ट इनपुट विधि के लिए व�
 #: include/global_form.php:451 include/global_form.php:462
 #, php-format
 msgid "Field [%s]"
-msgstr "खेत]"
+msgstr ""
 
 #: include/global_form.php:452
 #, php-format
@@ -11640,7 +11640,7 @@ msgstr "डिवाइस थ्रेड्स की डिफ़ॉल्ट
 #: include/global_settings.php:816
 #, php-format
 msgid "%s Thread"
-msgstr "% d थ्रेड"
+msgstr ""
 
 #: include/global_settings.php:817 include/global_settings.php:818
 #: include/global_settings.php:819 include/global_settings.php:820
@@ -11649,7 +11649,7 @@ msgstr "% d थ्रेड"
 #: include/global_settings.php:825
 #, php-format
 msgid "%s Threads"
-msgstr "% d थ्रेड्स"
+msgstr ""
 
 #: include/global_settings.php:829
 msgid "Re-index Method for Data Queries"
@@ -13514,7 +13514,7 @@ msgstr "भिन्नता का प्रतिशत"
 #: include/global_settings.php:2734
 #, php-format
 msgid "This value represents the percentage above the adjusted sample average once outliers have been removed from the sample.  For example, a Variance Percentage of 100%% on an adjusted average of 50 would remove any sample above the quantity of 100 from the graph."
-msgstr "यह मान समायोजित नमूना औसत से ऊपर प्रतिशत का प्रतिनिधित्व करता है जब एक बार आउटलेर को नमूने से हटा दिया जाता है। उदाहरण के लिए, 50 के समायोजित औसत पर 100% प्रति वर्ष का एक भिन्न प्रतिशत ग्राफ से 100 की मात्रा के ऊपर किसी भी नमूने को हटा देगा।"
+msgstr ""
 
 #: include/global_settings.php:2757
 msgid "Variance Number of Outliers"
@@ -14301,7 +14301,7 @@ msgstr "अमान्य फ़ाइल एक्सटेंशन।"
 #: lib/api_automation.php:5273 lib/api_automation.php:5275
 #, php-format
 msgid "Automation Network SNMP Rule '%s' %s!"
-msgstr "स्वचालन नेटवर्क SNMP नियम '{ 0 }' %s!"
+msgstr ""
 
 #: lib/api_automation.php:5273 lib/api_automation.php:5275
 #: lib/api_automation.php:5309 lib/api_automation.php:5311
@@ -14319,7 +14319,7 @@ msgstr "अपडेट करें"
 #: lib/api_automation.php:5279 lib/api_automation.php:5281
 #, php-format
 msgid "Automation Network SNMP Rule '%s' %s Failed!"
-msgstr "स्वचालन नेटवर्क SNMP नियम '{ 0 }'{ 1} विफल!"
+msgstr ""
 
 #: lib/api_automation.php:5279 lib/api_automation.php:5281
 #: lib/api_automation.php:5315 lib/api_automation.php:5317
@@ -14333,12 +14333,12 @@ msgstr "अपडेट करें"
 #: lib/api_automation.php:5309 lib/api_automation.php:5311
 #, php-format
 msgid "Automation Network SNMP Option %s!"
-msgstr "स्वचालन SNMP विकल्प"
+msgstr ""
 
 #: lib/api_automation.php:5315 lib/api_automation.php:5317
 #, php-format
 msgid "Automation Network SNMP Option %s Failed!"
-msgstr "स्वचालन SNMP विकल्प"
+msgstr ""
 
 #: lib/api_automation.php:5351
 msgid "The Automation Network Rule does not include any SNMP Options!"
@@ -14359,12 +14359,12 @@ msgstr "अज्ञात टेम्पलेट"
 #: lib/api_automation.php:5404 lib/api_automation.php:5406
 #, php-format
 msgid "Automation Network Rule '%s' %s!"
-msgstr "डिफ़ॉल्ट स्वचालन नेटवर्क"
+msgstr ""
 
 #: lib/api_automation.php:5410 lib/api_automation.php:5412
 #, php-format
 msgid "Automation Network Rule '%s' %s Failed!"
-msgstr "स्वचालन नेटवर्क नियम '{ 0 }' %s विफल!"
+msgstr ""
 
 #: lib/api_automation.php:5418
 msgid "Automation Network Rule Import data is either for another object type or not JSON formatted."
@@ -14480,29 +14480,29 @@ msgstr "डिवाइस अक्षम है"
 #: lib/auth.php:2355 lib/auth.php:2357 lib/auth.php:2363 lib/auth.php:2365
 #, php-format
 msgid "Graph:(%s%s)"
-msgstr "ग्राफ़:"
+msgstr ""
 
 #: lib/auth.php:2378 lib/auth.php:2384 lib/auth.php:2451 lib/auth.php:2453
 #: lib/auth.php:2457 lib/auth.php:2459
 #, php-format
 msgid "Device:(%s%s)"
-msgstr "डिवाइस:"
+msgstr ""
 
 #: lib/auth.php:2392 lib/auth.php:2398 lib/auth.php:2467 lib/auth.php:2469
 #: lib/auth.php:2473 lib/auth.php:2475
 #, php-format
 msgid "Template:(%s%s)"
-msgstr "टेम्पलेट्स"
+msgstr ""
 
 #: lib/auth.php:2405
 #, php-format
 msgid "Graph+Device+Template:(%s%s)"
-msgstr "डिवाइस टेम्पलेट:"
+msgstr ""
 
 #: lib/auth.php:2442 lib/auth.php:2444
 #, php-format
 msgid "Device+Template:(%s%s)"
-msgstr "डिवाइस टेम्पलेट:"
+msgstr ""
 
 #: lib/auth.php:2488 lib/auth.php:2495 lib/auth.php:2504
 msgid "Restricted By: "
@@ -14573,7 +14573,7 @@ msgstr "LDAP खोज त्रुटि: %s"
 #: lib/auth.php:4094 lib/auth.php:5105
 #, php-format
 msgid "Access Denied!  Template user id %s does not exist.  Please contact your Administrator."
-msgstr "पहुँच निषेध, कृपया आप कैक्टि प्रशासक से संपर्क करें।"
+msgstr ""
 
 #: lib/auth.php:4479
 msgid "Access Denied! Login failed."
@@ -14651,7 +14651,7 @@ msgstr "2FA सक्षम और सत्यापित किया गय�
 #: lib/boost.php:64 utilities.php:1708
 #, php-format
 msgid "%s MBytes"
-msgstr "% d एमबीटीज़"
+msgstr ""
 
 #: lib/boost.php:67
 #, php-format
@@ -14860,7 +14860,7 @@ msgstr "सूचकांक हटाने का पता चला! पि
 #: lib/data_query.php:360
 #, php-format
 msgid "Verification of %s Local Data ID's Complete"
-msgstr "स्थानीय डेटा के साथ अनुक्रमणिका एसोसिएशन"
+msgstr ""
 
 #: lib/data_query.php:363
 #, php-format
@@ -14886,7 +14886,7 @@ msgstr "स्थानीय डेटा के साथ अनुक्र�
 #: lib/data_query.php:392
 #, php-format
 msgid "Update Re-Index Cache complete. There were %s index changes, and %s orphaned indexes."
-msgstr "अद्यतन पुनः अनुक्रमणिका कैश पूरा करें। वहां थे"
+msgstr ""
 
 #: lib/data_query.php:396
 msgid "Update Poller Cache for Query complete"
@@ -15000,7 +15000,7 @@ msgstr "फ़ील्ड &#39; %s&#39; के लिए डेटा क्व
 #: lib/data_query.php:741
 #, php-format
 msgid "Sort field returned no data for field name %s, skipping"
-msgstr "सॉर्ट फ़ील्ड ने कोई डेटा नहीं दिया। री-इंडेक्स जारी नहीं रख सकता।"
+msgstr ""
 
 #: lib/data_query.php:743
 #, php-format
@@ -15145,7 +15145,7 @@ msgstr "डेटा के लिए परिणाम मिले @ &#39; %s
 #: lib/data_query.php:1179
 #, php-format
 msgid "Setting result for data @ '%s' [key='%s', value='%s']"
-msgstr "डेटा के लिए परिणाम सेट करना"
+msgstr ""
 
 #: lib/data_query.php:1183
 #, php-format
@@ -15155,7 +15155,7 @@ msgstr "डेटा @ &#39; %s&#39; [कुंजी = &#39; %s&#39;, मान
 #: lib/data_query.php:1197
 #, php-format
 msgid "Got SNMP get result for data @ '%s' [value='%s'] (index: %s)"
-msgstr "एसएनएमपी को डेटा @ &#39; %s&#39; [मूल्य = &#39; %s&#39;] के लिए परिणाम मिलता है"
+msgstr ""
 
 #: lib/data_query.php:1227
 #, php-format
@@ -15201,7 +15201,7 @@ msgstr "पाया गया आइटम [ %s = &#39; %s&#39;] सूचक�
 #: lib/data_query.php:1710
 #, php-format
 msgid "Bogus rewrite_value item found, index='%s'"
-msgstr "फर्जी rewrite_value आइटम मिला, index='{ 0 }'"
+msgstr ""
 
 #: lib/data_query.php:1724
 msgid "Could not parse translation map (rewrite_value)"
@@ -15244,7 +15244,7 @@ msgstr "पासवर्ड फ़ील्ड की लंबाई बद�
 #: lib/dsdebug.php:175
 #, php-format
 msgid "Data Source ID %s does not exist"
-msgstr "डेटा स्रोत मौजूद नहीं है"
+msgstr ""
 
 #: lib/dsdebug.php:259
 msgid "Debug not completed after 5 pollings"
@@ -15261,12 +15261,12 @@ msgstr "डेटा स्रोत को सक्रिय के रूप 
 #: lib/dsdebug.php:277
 #, php-format
 msgid "RRDfile Folder (rra) is not writable by Poller.  Folder owner: %s.  Poller runs as: %s"
-msgstr "आरआरडी फोल्डर पोलर द्वारा लिखने योग्य नहीं है। RRD Owner:"
+msgstr ""
 
 #: lib/dsdebug.php:282
 #, php-format
 msgid "RRDfile is not writable by Poller.  RRDfile owner: %s.  Poller runs as %s"
-msgstr "आरआरडी फ़ाइल पोलर द्वारा लिखने योग्य नहीं है। RRD Owner:"
+msgstr ""
 
 #: lib/dsdebug.php:291
 msgid "RRDfile does not match Data Source"
@@ -15305,12 +15305,12 @@ msgstr "सेटिंग्स डेटा कलेक्टर में �
 #: lib/functions.php:896
 #, php-format
 msgid "Form Validation Failed: Variable '%s' does not allow nulls and variable is null"
-msgstr "फ़ॉर्म सत्यापन विफल: वेरिएबल '{ 0 }' नल की अनुमति नहीं देता है और वेरिएबल नल है"
+msgstr ""
 
 #: lib/functions.php:898
 #, php-format
 msgid "Form Validation Failed: Variable '%s' with Value '%s' Failed REGEX '%s'"
-msgstr "फ़ॉर्म सत्यापन विफल: वैल्यू '{ 0 }' के साथ वेरिएबल '{ 1 }' विफल रेगेक्स '{ 2 }'"
+msgstr ""
 
 #: lib/functions.php:914
 msgid "One or more fields failed validation"
@@ -15508,7 +15508,7 @@ msgstr "संस्करण %s %s"
 #: lib/functions.php:7852
 #, php-format
 msgid "WARNING: Key Cacti Include File \"%s\" missing.  Please locate and replace this file as we checked in \"%s\""
-msgstr "चेतावनी: कुंजी कैक्टि फ़ाइल \"{ 0 }\" लापता शामिल करें।  कृपया इस फ़ाइल को ढूँढें और बदलें जैसा कि हमने \"{ 1 }\" में चेक इन किया है"
+msgstr ""
 
 #: lib/functions.php:8996
 msgid "System Device"
@@ -15569,7 +15569,7 @@ msgstr "पिछला"
 #: lib/html.php:671
 #, php-format
 msgid "%d to %d of %s [ %s ]"
-msgstr "% d% से% d %s [ %s]"
+msgstr ""
 
 #: lib/html.php:674 lib/html.php:703 lib/installer.php:1778
 msgid "Next"
@@ -15583,7 +15583,7 @@ msgstr "सभी% d %s"
 #: lib/html.php:700
 #, php-format
 msgid "Current Page: %s"
-msgstr "वर्तमान मूल्य"
+msgstr ""
 
 #: lib/html.php:731
 #, php-format
@@ -16664,22 +16664,22 @@ msgstr "[नया]"
 #: lib/html_reports.php:1572
 #, php-format
 msgid "Details %s"
-msgstr "विवरण"
+msgstr ""
 
 #: lib/html_reports.php:1618
 #, php-format
 msgid "Report Items %s"
-msgstr "कोई रिपोर्ट आइटम नहीं"
+msgstr ""
 
 #: lib/html_reports.php:1664
 #, php-format
 msgid "Scheduled Events %s"
-msgstr "अनुसूचित घटना"
+msgstr ""
 
 #: lib/html_reports.php:1676
 #, php-format
 msgid "Report Preview %s"
-msgstr "रिपोर्ट का पूर्वावलोकन करें"
+msgstr ""
 
 #: lib/html_reports.php:1712
 msgid "Item Details"
@@ -16688,7 +16688,7 @@ msgstr "आइटम विवरण"
 #: lib/html_reports.php:1727
 #, php-format
 msgid "Graph: %s"
-msgstr "काल ग्राफ"
+msgstr ""
 
 #: lib/html_reports.php:1730 lib/html_reports.php:1758
 #: lib/html_reports.php:1771 lib/html_reports.php:1772
@@ -16718,7 +16718,7 @@ msgstr ", RegEx का उपयोग करना: \"%s\""
 #: lib/html_reports.php:1800
 #, php-format
 msgid "Tree: %s"
-msgstr "वृक्षugiou"
+msgstr ""
 
 #: lib/html_reports.php:1811
 #, php-format
@@ -16728,7 +16728,7 @@ msgstr "(डिवाइस से: %s)"
 #: lib/html_reports.php:1813
 #, php-format
 msgid ", Branch: %s"
-msgstr "शाखा:"
+msgstr ""
 
 #: lib/html_reports.php:1816
 msgid "(All Branches)"
@@ -16888,7 +16888,7 @@ msgstr "डाउनलोड"
 #: lib/html_validate.php:97
 #, php-format
 msgid "Validation error for variable %s with a value of %s.  See backtrace below for more details."
-msgstr "चर %s के मान के साथ सत्यापन त्रुटि। अधिक विवरण के लिए नीचे देखें।"
+msgstr ""
 
 #: lib/html_validate.php:115
 msgid "Validation Error"
@@ -17031,7 +17031,7 @@ msgstr "निर्दिष्ट क्रोन अंतराल लाग
 #: lib/installer.php:1107
 #, php-format
 msgid "Failed to apply '%s' as Automation Range"
-msgstr "निर्दिष्ट ऑटोमेशन रेंज को लागू करने में विफल"
+msgstr ""
 
 #: lib/installer.php:1190
 msgid "No matching snmp option exists"
@@ -17183,7 +17183,7 @@ msgstr "आपके Cacti कॉन्फ़िगरेशन को config.ph
 #: lib/installer.php:2037
 #, php-format
 msgid "PHP - Recommendations (%s)"
-msgstr "PHP - सिफारिशें"
+msgstr ""
 
 #: lib/installer.php:2041
 msgid "PHP Recommendations ("
@@ -17317,7 +17317,7 @@ msgstr "यदि आपके कैश को साफ़ करने और
 #: lib/installer.php:2250
 #, php-format
 msgid "Downgrade from <strong>%s</strong> to <strong>%s</strong>"
-msgstr "<strong>% <strong>S%</strong></strong> <strong>s</strong> से डाउनग्रेड"
+msgstr ""
 
 #: lib/installer.php:2251
 msgid "You appear to be downgrading to a previous version.  Database changes made for the newer version will not be reversed and <i>could</i> cause issues."
@@ -17792,7 +17792,7 @@ msgstr "कोई डिवाइस पैकेज इंस्टॉल न�
 #: lib/installer.php:3012
 #, php-format
 msgid "%d Tables to be Upgraded"
-msgstr "आइटम प्रकार जोड़ा जाना है।"
+msgstr ""
 
 #: lib/installer.php:3012 lib/installer.php:3014 lib/installer.php:3056
 msgid "Table Upgrades"
@@ -17927,7 +17927,7 @@ msgstr "प्रोफ़ाइल '%s' के तहत पैकेज #%s '%
 #: lib/installer.php:3469
 #, php-format
 msgid "Mapping Automation Template for Device Template '%s'"
-msgstr "[हटाए गए टेम्पलेट] के लिए ऑटोमेशन टेम्प्लेट"
+msgstr ""
 
 #: lib/installer.php:3490
 msgid "No templates were selected for import"
@@ -17940,12 +17940,12 @@ msgstr "कॉन्फ़िगरेशन की प्रतीक्षा 
 #: lib/installer.php:3532
 #, php-format
 msgid "Setting default data source profile to %s (%s)"
-msgstr "इस डेटा टेम्प्लेट के लिए डिफ़ॉल्ट डेटा स्रोत प्रोफ़ाइल।"
+msgstr ""
 
 #: lib/installer.php:3557
 #, php-format
 msgid "Failed to find selected profile (%s), no changes were made"
-msgstr "निर्दिष्ट प्रोफ़ाइल %s लागू करने में विफल! = %s"
+msgstr ""
 
 #: lib/installer.php:3568
 #, php-format
@@ -17963,12 +17963,12 @@ msgstr "स्वचालन के लिए अतिरिक्त स्�
 #: lib/installer.php:3593
 #, php-format
 msgid "Selecting Automation Option Set %s"
-msgstr "स्वचालन खाका हटाएं"
+msgstr ""
 
 #: lib/installer.php:3607
 #, php-format
 msgid "Updating Automation Option Set %s"
-msgstr "स्वचालन SNMP विकल्प"
+msgstr ""
 
 #: lib/installer.php:3611
 #, php-format
@@ -17978,12 +17978,12 @@ msgstr "सफलतापूर्वक अपडेट किया गया
 #: lib/installer.php:3613
 #, php-format
 msgid "Resequencing Automation Option Set %s"
-msgstr "डिवाइस पर स्वचालन चलाएं"
+msgstr ""
 
 #: lib/installer.php:3620
 #, php-format
 msgid "Failed to updated Automation Option Set %s"
-msgstr "निर्दिष्ट ऑटोमेशन रेंज को लागू करने में विफल"
+msgstr ""
 
 #: lib/installer.php:3623
 msgid "Failed to find any automation option set"
@@ -17997,7 +17997,7 @@ msgstr "डिवाइस टेम्पलेट [संपादित क�
 #: lib/installer.php:3665
 #, php-format
 msgid "The Add Default Device Command is: '%s'"
-msgstr "डिफ़ॉल्ट डिवाइस कमांड जोड़ें: '{ 0 }'"
+msgstr ""
 
 #: lib/installer.php:3673
 msgid "WARNING: Default Device Failed to be Added error to follow."
@@ -18010,7 +18010,7 @@ msgstr "कैक्टि में जोड़ा गया"
 #: lib/installer.php:3680
 #, php-format
 msgid "Output: %s."
-msgstr "आउटपुट फील्ड्स"
+msgstr ""
 
 #: lib/installer.php:3700
 msgid "Creating Graphs for Default Device"
@@ -18090,7 +18090,7 @@ msgstr "पृष्ठभूमि को%s पर पहले ही शु�
 #: lib/installer.php:3946
 #, php-format
 msgid "Exception occurred during installation: #%s - %s"
-msgstr "स्थापना के दौरान अपवाद हुआ: #"
+msgstr ""
 
 #: lib/installer.php:3956
 #, php-format
@@ -18157,17 +18157,17 @@ msgstr "कोई उपयोगकर्ता नाम निर्धार
 #: lib/ldap.php:412
 #, php-format
 msgid "Protocol Error, Unable to set version (%s) on Server (%s)"
-msgstr "प्रोटोकॉल त्रुटि, संस्करण सेट करने में असमर्थ"
+msgstr ""
 
 #: lib/ldap.php:416
 #, php-format
 msgid "Protocol Error, Unable to set referrals option (%s) on Server (%s)"
-msgstr "प्रोटोकॉल त्रुटि, रेफरल विकल्प सेट करने में असमर्थ"
+msgstr ""
 
 #: lib/ldap.php:420
 #, php-format
 msgid "Protocol Error, unable to start TLS communications (%s) on Server (%s)"
-msgstr "प्रोटोकॉल त्रुटि, टीएलएस संचार शुरू करने में असमर्थ"
+msgstr ""
 
 #: lib/ldap.php:424
 #, php-format
@@ -18177,27 +18177,27 @@ msgstr "प्रोटोकॉल त्रुटि, सामान्य �
 #: lib/ldap.php:428
 #, php-format
 msgid "Protocol Error, Unable to bind, LDAP result: (%s) on Server (%s)"
-msgstr "प्रोटोकॉल त्रुटि, बांधने में असमर्थ, LDAP परिणाम: %s"
+msgstr ""
 
 #: lib/ldap.php:432
 #, php-format
 msgid "Unable to Connect to Server (%s)"
-msgstr "सर्वर से संपर्क करने में असमर्थ"
+msgstr ""
 
 #: lib/ldap.php:436
 #, php-format
 msgid "Connection Timeout to Server (%s)"
-msgstr "कनेक्शन का समय समाप्त"
+msgstr ""
 
 #: lib/ldap.php:440
 #, php-format
 msgid "Insufficient Access to Server (%s)"
-msgstr "अपर्याप्त पहुंच"
+msgstr ""
 
 #: lib/ldap.php:444
 #, php-format
 msgid "Group DN could not be found to compare on Server (%s)"
-msgstr "ग्रुप डीएन की तुलना करने के लिए नहीं मिला"
+msgstr ""
 
 #: lib/ldap.php:448
 msgid "More than one matching user found"
@@ -18214,7 +18214,7 @@ msgstr "उपयोगकर्ता DN खोजने में असमर
 #: lib/ldap.php:460
 #, php-format
 msgid "Unable to create LDAP connection object to Server (%s)"
-msgstr "LDAP कनेक्शन ऑब्जेक्ट बनाने में असमर्थ"
+msgstr ""
 
 #: lib/ldap.php:464
 msgid "Specific DN and Password required"
@@ -18227,7 +18227,7 @@ msgstr "अमान्य पासवर्ड प्रदान किया
 #: lib/ldap.php:473
 #, php-format
 msgid "Unexpected error %s (Ldap Error: %s) on Server (%s)"
-msgstr "अनपेक्षित त्रुटि %s (Ldap त्रुटि: %s)"
+msgstr ""
 
 #: lib/ping.php:149
 msgid "ICMP Ping timed out"
@@ -18313,17 +18313,17 @@ msgstr "प्लगइन स्थापित नहीं किया ज�
 #: lib/plugins.php:748
 #, php-format
 msgid "The Plugin directory '%s' needs to be renamed to remove 'plugin_' from the name before it can be installed."
-msgstr "प्लगइन निर्देशिका '{ 0 }' को स्थापित करने से पहले नाम से 'plugin_' को हटाने के लिए नाम बदलने की आवश्यकता है।"
+msgstr ""
 
 #: lib/plugins.php:751
 #, php-format
 msgid "The Plugin in the directory '%s' does not include an version function '%s()'.  This function must exist for the plugin to be installed."
-msgstr "'{ 0 }' निर्देशिका में प्लगइन में '{ 1}()' संस्करण फ़ंक्शन शामिल नहीं है। प्लगइन को इंस्टॉल करने के लिए यह फ़ंक्शन मौजूद होना चाहिए।"
+msgstr ""
 
 #: lib/plugins.php:784
 #, php-format
 msgid "The Plugin in the directory '%s' does not include an install function '%s()'.  This function must exist for the plugin to be installed."
-msgstr "'{ 0 }' निर्देशिका में प्लगइन में '{ 1}()' इंस्टॉल फ़ंक्शन शामिल नहीं है। प्लगइन को इंस्टॉल करने के लिए यह फ़ंक्शन मौजूद होना चाहिए।"
+msgstr ""
 
 #: lib/plugins.php:982
 #, php-format
@@ -18338,72 +18338,72 @@ msgstr "अनुपस्थित निष्कासन फ़ंक्श�
 #: lib/plugins.php:1441
 #, php-format
 msgid "The Archive for Plugin '%s' has been removed."
-msgstr "प्लगइन '{ 0 }' के लिए संग्रह हटा दिया गया है।"
+msgstr ""
 
 #: lib/plugins.php:1491
 #, php-format
 msgid "Restore failed!  The Plugin '%s' archive Restore failed.  Unable to create directory '%s'."
-msgstr "पुनर्स्थापना विफल! प्लगइन '{ 0 }' संग्रह पुनर्स्थापना विफल। '{ 1 }' निर्देशिका बनाने में असमर्थ।"
+msgstr ""
 
 #: lib/plugins.php:1493
 #, php-format
 msgid "Restore failed!  The available Plugin '%s' Load failed.  Unable to create directory '%s'."
-msgstr "पुनर्स्थापना विफल! उपलब्ध प्लगइन '{ 0 }' लोड विफल रहा। '{ 1 }' निर्देशिका बनाने में असमर्थ।"
+msgstr ""
 
 #: lib/plugins.php:1592
 #, php-format
 msgid "Restore failed!  The archived Plugin '%s' Restore failed. Unable to create directory %s"
-msgstr "पुनर्स्थापना विफल! संग्रहीत प्लगइन '{ 0 }' पुनर्स्थापना विफल। %s निर्देशिका बनाने में असमर्थ"
+msgstr ""
 
 #: lib/plugins.php:1594
 #, php-format
 msgid "Load failed!  The available Plugin '%s' Load failed. Unable to create directory %s"
-msgstr "लोड नहीं हो सका! उपलब्ध प्लगइन '{ 0 }' लोड विफल रहा। %s निर्देशिका बनाने में असमर्थ"
+msgstr ""
 
 #: lib/plugins.php:1614
 #, php-format
 msgid "Restore succeeded!  The archived Plugin '%s' Restore succeeded."
-msgstr "पुनर्स्थापना सफल! संग्रहीत प्लगइन '{ 0 }' पुनर्स्थापना सफल."
+msgstr ""
 
 #: lib/plugins.php:1621
 #, php-format
 msgid "Load succeeded!  The available Plugin '%s' Load succeeded."
-msgstr "लोड सफल रहा! उपलब्ध प्लगइन '{ 0 }' लोड सफल रहा।"
+msgstr ""
 
 #: lib/plugins.php:1639
 #, php-format
 msgid "Restore failed!  The archived Plugin '%s' Restore failed.  Check the cacti.log for warnings."
-msgstr "पुनर्स्थापना विफल! संग्रहीत प्लगइन '{ 0 }' पुनर्स्थापना विफल। चेतावनियों के लिए cacti.log देखें।"
+msgstr ""
 
 #: lib/plugins.php:1641
 #, php-format
 msgid "Load failed!  The available Plugin '%s' Load failed.  Check the cacti.log for warnings."
-msgstr "लोड नहीं हो सका! उपलब्ध प्लगइन '{ 0 }' लोड विफल रहा। चेतावनियों के लिए cacti.log देखें।"
+msgstr ""
 
 #: lib/plugins.php:1648
 #, php-format
 msgid "Restore failed!  Unable to locate the archive record for Plugin '%s' in the database."
-msgstr "पुनर्स्थापित करने में विफल! डेटाबेस में प्लगइन '{ 0 }' के लिए संग्रह रिकॉर्ड का पता लगाने में असमर्थ।"
+msgstr ""
 
 #: lib/plugins.php:1650
 #, php-format
 msgid "Load failed!  Unable to locate the available record for Plugin '%s' in the database."
-msgstr "लोड नहीं हो सका! डेटाबेस में प्लगइन '{ 0 }' के लिए उपलब्ध रिकॉर्ड का पता लगाने में असमर्थ।"
+msgstr ""
 
 #: lib/plugins.php:1717
 #, php-format
 msgid "The Plugin '%s' has been archived successfully."
-msgstr "Cacti लॉग सफलतापूर्वक पूर्ण हुआ"
+msgstr ""
 
 #: lib/plugins.php:1719
 #, php-format
 msgid "The Plugin '%s' archiving process has failed.  Check the Cacti log for errors."
-msgstr "एक या अधिक RRDfile मरम्मत विफल। त्रुटियों के लिए कैक्टि लॉग देखें।"
+msgstr ""
 
 #: lib/plugins.php:1722
 #, php-format
 msgid "The Plugin '%s' archiving process has failed due to the plugin directory being missing."
-msgstr "प्लगइन निर्देशिका गायब होने के कारण प्लगइन '{ 0 }' संग्रहण प्रक्रिया विफल हो गई है।"
+msgstr ""
 
 #: lib/plugins.php:1730 lib/plugins.php:1737 plugins.php:638 plugins.php:641
 #: plugins.php:1043
@@ -18434,7 +18434,7 @@ msgstr "GitHub/GitLab स्थान पर कोई प्लगइन नह
 #: lib/plugins.php:1956
 #, php-format
 msgid "The Cacti plugin %s has not releases"
-msgstr "कैक्टि पोलर अभी तक नहीं चला है।"
+msgstr ""
 
 #: lib/plugins.php:2011 lib/plugins.php:2149
 msgid "Unable to get archive from GitHub/GitLab location."
@@ -18453,7 +18453,7 @@ msgstr "GitHub/GitLab स्थान से प्लगइन %s के लि
 #: lib/plugins.php:2238
 #, php-format
 msgid "There were '%s' Plugins found at The Cacti Groups GitHub site and '%s' Plugins Tags/Releases were retrieved and updated in %0.2f seconds."
-msgstr "The Cacti Groups GitHub साइट पर '{ 0 }' प्लगइन्स मिले थे और '{ 1 }' प्लगइन्स टैग/रिलीज़ %0.2f सेकंड में पुनर्प्राप्त और अपडेट किए गए थे।"
+msgstr ""
 
 #: lib/plugins.php:2240
 #, php-format
@@ -18463,7 +18463,7 @@ msgstr "The Cacti Groups GitHub साइट तक पहुँचने मे
 #: lib/reports.php:144
 #, php-format
 msgid "Device '%s' successfully added to Report."
-msgstr "कैक्टि में जोड़ा गया"
+msgstr ""
 
 #: lib/reports.php:147
 msgid "Device not found! Unable to add to Report"
@@ -18539,7 +18539,7 @@ msgstr "RRDtool कमांड:"
 #: lib/rrd.php:3299
 #, php-format
 msgid "The required RRDfile step size is '%s' but observed step is '%s'"
-msgstr "आवश्यक RRD चरण का आकार &#39; %s&#39; है"
+msgstr ""
 
 #: lib/rrd.php:3359
 #, php-format
@@ -18574,7 +18574,7 @@ msgstr "फ़ाइल RRA &#39; %s&#39; में &#39; %s&#39; के सम�
 #: lib/rrd.php:3450
 #, php-format
 msgid "The pdp_per_row of '%s' is invalid for RRA '%s' should be '%s'.  Consider deleting and allowing Cacti to re-create RRDfile."
-msgstr "'{ 0 }' का pdp_per_row RRA '{ 1 }' के लिए अमान्य है '{ 2 }' होना चाहिए। कैक्टि को RRDfile को फिर से बनाने के लिए हटाने और अनुमति देने पर विचार करें।"
+msgstr ""
 
 #: lib/rrd.php:3454
 #, php-format
@@ -18584,7 +18584,7 @@ msgstr "Cacti RRA आईडी &#39; %s&#39; के लिए XFF &#39; %s&#39; 
 #: lib/rrd.php:3458
 #, php-format
 msgid "The number of rows for Cacti RRA id '%s' is incorrect.  The number of rows are '%s' but should be '%s'"
-msgstr "Cacti RRA आईडी &#39; %s&#39; के लिए पंक्तियों की संख्या &#39; %s&#39; होनी चाहिए"
+msgstr ""
 
 #: lib/rrd.php:3476
 #, php-format
@@ -18669,7 +18669,7 @@ msgstr "XML फ़ाइल लिखते समय ERROR: %s"
 #: lib/rrd.php:3815 lib/rrd.php:3877 lib/rrd.php:3940
 #, php-format
 msgid "ERROR: RRDfile %s not writeable"
-msgstr "त्रुटि: RRDfile% लेखन योग्य नहीं है"
+msgstr ""
 
 #: lib/rrd.php:3847 lib/rrd.php:3910
 msgid "Error while parsing the XML of RRDtool dump"
@@ -18730,7 +18730,7 @@ msgstr "त्रुटि: श्वेतसूची मान्यता �
 #: lib/template.php:2267
 #, php-format
 msgid "Graph Not created for %s due to bad data"
-msgstr "ग्राफ निर्माण"
+msgstr ""
 
 #: lib/template.php:2296
 #, php-format
@@ -18740,12 +18740,12 @@ msgstr "नोट: डेटा स्रोत सत्यापन विफ�
 #: lib/timespan_settings.php:136
 #, php-format
 msgid "Your Start Date '%s' is before January 1993.  Please pick a more recent Start Date."
-msgstr "आपकी शुरू होने की तारीख '{ 0 }' जनवरी 1993 से पहले की है।  कृपया एक और हालिया शुरू होने की तारीख चुनें।"
+msgstr ""
 
 #: lib/timespan_settings.php:141
 #, php-format
 msgid "Your End Date '%s' is before January 1993.  Please pick a more recent End Date."
-msgstr "आपकी अंतिम तिथि '{ 0 }' जनवरी 1993 से पहले है।  कृपया हाल ही में खत्म होने की कोई और तारीख चुनें।"
+msgstr ""
 
 #: lib/utility.php:1113
 msgid "MySQL 5.6+ and MariaDB 10.0+ are great releases, and are very good versions to choose. Make sure you run the very latest release though which fixes a long standing low level networking issue that was causing spine many issues with reliability."
@@ -18816,7 +18816,7 @@ msgstr "यदि आपकी तालिकाओं में बहुत �
 #: lib/utility.php:1254
 #, php-format
 msgid "InnoDB will hold as much tables and indexes in system memory as is possible.  Therefore, you should make the innodb_buffer_pool large enough to hold as much of the tables and index in memory.  Checking the size of the /var/lib/mysql/cacti directory will help in determining this value.  We are recommending 25%% of your systems total memory, but your requirements will vary depending on your systems size.  If you database is very large or remote, you can consider increasing this size.  If remote, it can by as high as 80% of the systems memory.  However, cautions must be taken to reduce the swappiness of the system, or to remove swap to keep the system from swapping."
-msgstr "InnoDB जितना संभव हो उतना सिस्टम मेमोरी में टेबल और इंडेक्स रखेगा। इसलिए, आपको innodb_buffer_pool को पर्याप्त रूप से बड़ा करना चाहिए ताकि स्मृति में तालिकाओं और अनुक्रमणिका को पकड़ सकें। / Var / lib / mysql / cacti निर्देशिका के आकार की जाँच करने से इस मान को निर्धारित करने में मदद मिलेगी। हम आपके सिस्टम की कुल मेमोरी के 25%% की अनुशंसा कर रहे हैं, लेकिन आपकी आवश्यकताओं को आपके सिस्टम के आकार के आधार पर अलग-अलग किया जाएगा।"
+msgstr ""
 
 #: lib/utility.php:1260
 msgid "This settings should remain ON unless your Cacti instances is running on either ZFS or FusionI/O which both have internal journaling to accommodate abrupt system crashes.  However, if you have very good power, and your systems rarely go down and you have backups, turning this setting to OFF can net you almost a 50% increase in database performance."
@@ -18945,7 +18945,7 @@ msgstr "इस VDEF के लिए एक उपयोगी नाम।"
 #: link.php:79
 #, php-format
 msgid "External Link ID '%s' with Title '%s' attempted to inject an invalid URL and was blocked!"
-msgstr "शीर्षक '{ 1 }' के साथ बाहरी लिंक आईडी '{ 0 }' ने एक अमान्य URL इंजेक्ट करने का प्रयास किया और इसे अवरुद्ध कर दिया गया!"
+msgstr ""
 
 #: links.php:76
 msgid "Your contentfile is not a valid URL.  Please enter a value URL"
@@ -19151,7 +19151,7 @@ msgstr "कैक्टि का लॉगआउट"
 #: logout.php:60
 #, php-format
 msgid "You have been logged out of Cacti due to %s."
-msgstr "सत्र समय समाप्त होने के कारण आप कैक्टि से लॉग आउट हो गए हैं।"
+msgstr ""
 
 #: logout.php:61
 #, php-format
@@ -19336,7 +19336,7 @@ msgstr "आपके टेम्प्लेट की पैकेजिंग
 #: package.php:221
 #, php-format
 msgid "A Critical Template file '%s' is missing.  Please locate this file before packaging"
-msgstr "एक क्रिटिकल टेम्पलेट फ़ाइल '{ 0 }' गुम है। पैकेजिंग से पहले कृपया इस फ़ाइल का पता लगाएँ"
+msgstr ""
 
 #: package.php:562
 msgid "Package Templates"
@@ -19349,17 +19349,17 @@ msgstr "आप क्या निर्यात करना चाहें�
 #: package.php:667
 #, php-format
 msgid "%s Device Package"
-msgstr "उपकरण नामः% 1"
+msgstr ""
 
 #: package.php:670
 #, php-format
 msgid "%s Graph Template Package"
-msgstr "ग्राफ टेम्पलेट का नाम"
+msgstr ""
 
 #: package.php:673
 #, php-format
 msgid "%s Data Query Package"
-msgstr "डेटा क्वेरी नाम"
+msgstr ""
 
 #: package.php:700 templates_export.php:168
 #, php-format
@@ -19373,7 +19373,7 @@ msgstr "उपलब्ध टेम्पलेट [ %s]"
 #: package.php:709
 #, php-format
 msgid "%s to Export"
-msgstr "एक्सपोर्ट"
+msgstr ""
 
 #: package.php:710
 msgid "Choose the exact items to export in the Package."
@@ -19443,7 +19443,7 @@ msgstr "पैकेज सामग्री शामिल करें"
 #: package.php:898
 #, php-format
 msgid "Script or Resource File '%s' does not exist.  Please repackage after locating and installing this file"
-msgstr "स्क्रिप्ट या रिसोर्स फ़ाइल '{ 0 }' मौजूद नहीं है।  कृपया इस फ़ाइल का पता लगाने और इंस्टॉल करने के बाद रीपैकेज करें"
+msgstr ""
 
 #: package.php:912 package_import.php:82
 msgid "Key Generation Required to Use Tool"
@@ -19460,7 +19460,7 @@ msgstr "इस पैकेजिंग टूल का उपयोग कर�
 #: package.php:964
 #, php-format
 msgid "The Web Server must have write access to the '%s' directory"
-msgstr "वेब सर्वर के पास '{ 0 }' निर्देशिका तक लेखन पहुंच होनी चाहिए"
+msgstr ""
 
 #: package.php:986
 msgid "Unable to initialize SQLite3"
@@ -19490,7 +19490,7 @@ msgstr "पैकेज अस्थायी निर्देशिका %s 
 #: package_import.php:203 package_import.php:527
 #, php-format
 msgid "The Package %s Imported Successfully"
-msgstr "Cacti लॉग सफलतापूर्वक पूर्ण हुआ"
+msgstr ""
 
 #: package_import.php:205 package_import.php:529
 #, php-format
@@ -19500,7 +19500,7 @@ msgstr "पैकेज %s इम्पोर्ट नहीं हो सक�
 #: package_import.php:298
 #, php-format
 msgid "Package %s"
-msgstr "पैकेज फ़ाइलें"
+msgstr ""
 
 #: package_import.php:305
 msgid "Click 'Continue' to Import the following Package."
@@ -19547,7 +19547,7 @@ msgstr "इस पैकेज के लिए सार्वजनिक क�
 #: package_import.php:427
 #, php-format
 msgid "You have not Trusted this Package Author '%s'.  If you wish to import, check the Automatically Trust Author checkbox.  Otherwise, feel free to reach the author at the following Email address '%s'."
-msgstr "आपने इस पैकेज लेखक '{ 0 }' पर भरोसा नहीं किया है।  अगर आप इम्पोर्ट करना चाहते हैं, तो ऑटोमैटिकली ट्रस्ट ऑथर चेकबॉक्स पर जाएँ।  अन्यथा, नीचे दिए गए ईमेल पते '{ 1 }' पर लेखक से बेझिझक संपर्क करें।"
+msgstr ""
 
 #: package_import.php:738
 msgid "Repo File Missing or Damaged"
@@ -19556,7 +19556,7 @@ msgstr "रेपो फ़ाइल मौजूद नहीं है या 
 #: package_import.php:739
 #, php-format
 msgid "The Repo '%s' is NOT Reachable at the URL Location in the package.manifest."
-msgstr "रेपो '{ 0 }' पैकेज.मैनिफ़ेस्ट में URL स्थान पर पहुँच योग्य नहीं है।"
+msgstr ""
 
 #: package_import.php:740
 msgid "Something is wrong with your Package Repository"
@@ -19569,12 +19569,12 @@ msgstr "एक या अधिक पैकेजों के लिए हस
 #: package_import.php:762
 #, php-format
 msgid "<b>Author:</b> &lt;%s&gt; %s.<br>"
-msgstr "<b>लेखक:</b> <{ 0 }> %s ।<br>"
+msgstr ""
 
 #: package_import.php:766
 #, php-format
 msgid "<b>Package</b> %s"
-msgstr "पैकेज फ़ाइलें"
+msgstr ""
 
 #: package_import.php:769
 msgid "Press 'Ok' to start Trusting the Signer, or escape to cancel."
@@ -19595,7 +19595,7 @@ msgstr "पैकेज के सभी हस्ताक्षर मान�
 #: package_import.php:823 package_import.php:1963 package_repos.php:123
 #, php-format
 msgid "The Repo '%s' is NOT Reachable at the URL Location or the package.manifest file is missing."
-msgstr "रेपो '{ 0 }' URL स्थान पर पहुंच योग्य नहीं है या पैकेज.मैनिफ़ेस्ट फ़ाइल गायब है।"
+msgstr ""
 
 #: package_import.php:880 package_import.php:886 package_import.php:981
 #: package_import.php:984
@@ -19609,7 +19609,7 @@ msgstr "अधिक जानकारी के लिए cacti.log देख�
 #: package_import.php:880
 #, php-format
 msgid "The package \"%s\" download or validation failed"
-msgstr "पैकेज \"{ 0 }\" डाउनलोड या सत्यापन विफल रहा"
+msgstr ""
 
 #: package_import.php:886
 msgid "See the cacti.log for more information.  It could be that you had either an API Key error or the package was tamered with, or the location is not available"
@@ -19750,17 +19750,17 @@ msgstr "कोई पृष्ठ नहीं मिला"
 #: package_import.php:1946
 #, php-format
 msgid "The Repo '%s' is NOT Reachable on GitHub or the '%s' file is missing or it could be an invalid branch.  Valid Package Locations are normally: https://github.com/Author/RepoName/."
-msgstr "रेपो '{ 0 }' GitHub पर पहुंच योग्य नहीं है या '{ 1 }' फ़ाइल गायब है या यह एक अमान्य शाखा हो सकती है।  मान्य पैकेज स्थान सामान्य रूप से होते हैं: https://github.com/Author/RepoName/।"
+msgstr ""
 
 #: package_import.php:1974
 #, php-format
 msgid "The Repo '%s' is Reachable on the Local Cacti Server.  But not data returned from the manifest file."
-msgstr "रेपो '{ 0 }' लोकल कैक्टि सर्वर पर पहुंच योग्य है।  लेकिन मैनिफ़ेस्ट फ़ाइल से डेटा नहीं लौटाया गया।"
+msgstr ""
 
 #: package_import.php:1977 package_repos.php:131
 #, php-format
 msgid "The Repo '%s' is NOT Reachable on the Local Cacti Server or the package.manifest file is missing."
-msgstr "रेपो '{ 0 }' लोकल कैक्टि सर्वर पर उपलब्ध नहीं है या पैकेज.मैनिफ़ेस्ट फ़ाइल गुम है।"
+msgstr ""
 
 #: package_keys.php:95 package_repos.php:206
 msgid "Click 'Continue' to delete the following ."
@@ -19814,22 +19814,22 @@ msgstr "डायरेक्ट यूआरएल"
 #: package_repos.php:104
 #, php-format
 msgid "The Repo '%s' is Reachable on GitHub."
-msgstr "रेपो '{ 0 }' GitHub पर पहुंच योग्य है।"
+msgstr ""
 
 #: package_repos.php:106
 #, php-format
 msgid "The Repo '%s' is NOT Reachable on GitHub or the package.manifest file is missing or it could be an invalid branch.  Valid Package Locations are normally: https://github.com/Author/RepoName/."
-msgstr "रेपो '{ 0 }' GitHub पर पहुंच योग्य नहीं है या पैकेज.मैनिफ़ेस्ट फ़ाइल गायब है या यह एक अमान्य शाखा हो सकती है।  मान्य पैकेज स्थान सामान्य रूप से होते हैं: https://github.com/Author/RepoName/।"
+msgstr ""
 
 #: package_repos.php:121
 #, php-format
 msgid "The Repo '%s' is Reachable at the URL Location."
-msgstr "रेपो '{ 0 }' URL स्थान पर पहुंच योग्य है।"
+msgstr ""
 
 #: package_repos.php:129
 #, php-format
 msgid "The Repo '%s' is Reachable on the Local Cacti Server."
-msgstr "रेपो '{ 0 }' लोकल कैक्टि सर्वर पर पहुंच योग्य है।"
+msgstr ""
 
 #: package_repos.php:211
 msgid "Delete Package Repository"
@@ -20039,12 +20039,12 @@ msgstr "संग्रहीत"
 #: plugins.php:165
 #, php-format
 msgid "The action '%s' on Plugin '%s' can not be performed due to the Plugin in it's current state."
-msgstr "प्लगइन '{ 1 }' पर क्रिया '{ 0 }' इसकी वर्तमान स्थिति में प्लगइन के कारण नहीं की जा सकती है।"
+msgstr ""
 
 #: plugins.php:169
 #, php-format
 msgid "The action '%s' '%s' on Plugin '%s' can not be taken as the Plugin is integrated."
-msgstr "प्लगइन '{ 2 }' पर '{ 0 }''{ 1 }' कार्रवाई नहीं की जा सकती क्योंकि प्लगइन एकीकृत है।"
+msgstr ""
 
 #: plugins.php:218
 msgid "The fetch latest plugins process has been launched into background."
@@ -20057,12 +20057,12 @@ msgstr "लाने की नवीनतम प्लगइन्स प्�
 #: plugins.php:276
 #, php-format
 msgid "Plugin '%s' has passed it's Configuration Check test and can not be Installed"
-msgstr "प्लगइन '{ 0 }' ने अपनी कॉन्फ़िगरेशन जाँच परीक्षा पास कर ली है और इसे इंस्टॉल नहीं किया जा सकता है"
+msgstr ""
 
 #: plugins.php:278
 #, php-format
 msgid "Plugin '%s' Check Configuration function returned a null response which is invalid.  Please check with Plugin Developer for an update."
-msgstr "प्लगइन '{ 0 }' चेक कॉन्फ़िगरेशन फ़ंक्शन ने एक शून्य प्रतिक्रिया लौटाई जो अमान्य है। अपडेट के लिए कृपया प्लगइन डेवलपर से संपर्क करें।"
+msgstr ""
 
 #: plugins.php:580
 msgid "Uninstalling this Plugin and may remove all Plugin Data and Settings.  If you really want to Uninstall the Plugin, click 'Uninstall' below.  Otherwise click 'Cancel'."
@@ -20442,7 +20442,7 @@ msgstr "प्लग मैं स्थापित"
 #: plugins.php:1760
 #, php-format
 msgid "Plugin '%s' can not be archived before it's been Installed."
-msgstr "प्लगइन स्थापित नहीं किया जा सकता है।"
+msgstr ""
 
 #: plugins.php:1771
 msgid "Remove Plugin Data Tables and Settings"
@@ -20525,27 +20525,27 @@ msgstr "प्लगिन सक्षम करें"
 #: poller.php:405
 #, php-format
 msgid "WARNING: %s is out of sync with the Poller Interval for Poller[%d]!  The Poller Interval is %d seconds, with a maximum of a %d seconds, but %d seconds have passed since the last poll!"
-msgstr "चेतावनी: पोलर इंटरवल के साथ सिंक के बाहर %s है! पोलर इंटरवल &#39;% d ’सेकंड है, जिसमें अधिकतम,% d’ सेकंड हैं, लेकिन अंतिम मतदान के बाद% d सेकंड बीत चुके हैं!"
+msgstr ""
 
 #: poller.php:579
 #, php-format
 msgid "WARNING: There are %d processes detected as overrunning a polling cycle for Poller[%d], please investigate."
-msgstr "चेतावनी: मतदान चक्र को ओवररनिंग करने के रूप में &#39;% d&#39; का पता चला है, कृपया जाँच करें।"
+msgstr ""
 
 #: poller.php:637
 #, php-format
 msgid "WARNING: Poller Output Table not empty for Poller[%d].  Issues: %d, %s."
-msgstr "चेतावनी: पोलर आउटपुट तालिका खाली नहीं है। मुद्दे:% d, %s"
+msgstr ""
 
 #: poller.php:671
 #, php-format
 msgid "ERROR: The spine path: %s is invalid for Poller[%d].  Poller can not continue!"
-msgstr "त्रुटि: रीढ़ पथ: %s अमान्य है। जारी नहीं रख सकते पोल!"
+msgstr ""
 
 #: poller.php:819
 #, php-format
 msgid "Maximum runtime of %d seconds exceeded for Poller[%d]. Exiting."
-msgstr "% D सेकंड का अधिकतम क्रम पार हो गया। बाहर निकल रहा है।"
+msgstr ""
 
 #: poller.php:944
 msgid "WARNING: Cacti Polling Cycle Exceeded Poller Interval by "
@@ -20563,12 +20563,12 @@ msgstr "दिल की धड़कन मोड में पोलर"
 #: poller.php:1253
 #, php-format
 msgid "WARNING: 24 hours Poller[%d] avg. run time is %f seconds (more than %d &#37; of time limit)"
-msgstr "चेतावनी: 24 घंटे Poller [%d] औसत रन टाइम %f सेकंड है (समय सीमा के {2 }% से अधिक)"
+msgstr ""
 
 #: poller.php:1269
 #, php-format
 msgid "WARNING: In last hour Poller[%d] run time %d times reached more than %d &#37; of time limit"
-msgstr "चेतावनी: अंतिम घंटे में Poller[%d] रन टाइम %d बार समय सीमा के {2 }% से अधिक तक पहुंच गया"
+msgstr ""
 
 #: poller.php:1291
 msgid "Cacti System Notification"
@@ -20581,7 +20581,7 @@ msgstr "नोट: एक दूसरा कैक्टि डेटा कल
 #: poller_automation.php:54
 #, php-format
 msgid "WARNING: Main Cacti database %s offline or in recovery"
-msgstr "चेतावनी: मुख्य कैक्टि डेटाबेस ऑफ़लाइन या पुनर्प्राप्ति में है"
+msgstr ""
 
 #: poller_automation.php:1037 poller_automation.php:1091
 msgid "Cacti Primary Admin"
@@ -21031,7 +21031,7 @@ msgstr "दिन %d"
 #: rrdcheck.php:240 rrdcheck.php:241
 #, php-format
 msgid "%d days"
-msgstr "दिन"
+msgstr ""
 
 #: rrdcheck.php:245 rrdcheck.php:248
 msgid "Messages"
@@ -21134,7 +21134,7 @@ msgstr "नोट: इस टैब पर पथ सेटिंग केव�
 #: settings.php:138
 #, php-format
 msgid "Cacti Settings (%s)%s"
-msgstr "कैक्टि सेटिंग्स ( %s)"
+msgstr ""
 
 #: settings.php:248
 msgid "Changing Permission Model Warning"
@@ -22007,7 +22007,7 @@ msgstr "अधिक जानकारी के लिए cacti.log देख�
 #: templates_import.php:143
 #, php-format
 msgid "The Template XML file \"%s\" validation failed"
-msgstr "टेम्पलेट XML फ़ाइल \"{ 0 }\" सत्यापन विफल रहा"
+msgstr ""
 
 #: templates_import.php:216
 msgid "Import Files [ If Files are missing, locate and install before using ]"
@@ -22036,7 +22036,7 @@ msgstr "डेटा स्रोत, ग्राफ़"
 #: templates_import.php:320
 #, php-format
 msgid "Met: %d"
-msgstr "मिले। "
+msgstr ""
 
 #: templates_import.php:324
 #, php-format
@@ -23654,7 +23654,7 @@ msgstr "विस्तृत रनटाइम टाइमर:"
 #: utilities.php:1779 utilities.php:1781
 #, php-format
 msgid "Process: %d"
-msgstr "1 प्रक्रिया"
+msgstr ""
 
 #: utilities.php:1779
 #, php-format

--- a/locales/po/it-IT.po
+++ b/locales/po/it-IT.po
@@ -29,7 +29,7 @@ msgstr "Cacti è stato progettato per essere una soluzione grafica completa basa
 #: about.php:46
 #, php-format
 msgid "Please see the official %sCacti website%s for information on how to use Cacti, get support, and updates."
-msgstr "Si prega di consultare il sito ufficiale %sCacti%s%s per informazioni, supporto e aggiornamenti."
+msgstr ""
 
 #: about.php:50
 msgid "Active Developers"
@@ -313,12 +313,12 @@ msgstr "Dissociazione con Aggregato"
 #: aggregate_graphs.php:985
 #, php-format
 msgid "Click 'Continue' to Place the following Aggregate Graph on Tree %s."
-msgstr "Fare clic su \"Continua\" per eliminare i seguenti modelli di grafici aggregati."
+msgstr ""
 
 #: aggregate_graphs.php:986
 #, php-format
 msgid "Click 'Continue' to Duplicate following Aggregate Graphs on Tree %s."
-msgstr "Fare clic su \"Continua\" per posizionare i seguenti grafici aggregati sotto il ramo degli alberi."
+msgstr ""
 
 #: aggregate_graphs.php:987
 msgid "Place Aggregate Graph on Tree"
@@ -926,7 +926,7 @@ msgstr "L'utente è stato autenticato, ma l'account modello è disabilitato. Uti
 #: auth_login.php:135
 #, php-format
 msgid "Access Denied!  Guest user id %s does not exist.  Please contact your Administrator."
-msgstr "Accesso negato, si prega di contattare l'amministratore di Cacti."
+msgstr ""
 
 #: auth_login.php:173
 msgid "Access Denied!  User account disabled."
@@ -1210,12 +1210,12 @@ msgstr "Aggiunto manualmente attraverso l'interfaccia di automazione del disposi
 #: automation_devices.php:122
 #, php-format
 msgid "Device %s Added to Cacti"
-msgstr "Aggiunto a Cacti"
+msgstr ""
 
 #: automation_devices.php:124
 #, php-format
 msgid "Device %s Not Added to Cacti"
-msgstr "Non aggiunto a Cacti"
+msgstr ""
 
 #: automation_devices.php:134
 msgid "Devices Removed from Cacti Automation database"
@@ -2725,7 +2725,7 @@ msgstr "Fare clic su 'Continua' per eliminare le seguenti Richieste di dati sara
 #: automation_templates.php:915
 #, php-format
 msgid "Tree Rule Name: '%s'"
-msgstr "Articoli della regola dell'albero"
+msgstr ""
 
 #: automation_templates.php:922
 msgid "Remove Tree Rule"
@@ -3277,7 +3277,7 @@ msgstr "Pieno"
 #: changelog.php:99
 #, php-format
 msgid "Change Log [%s]"
-msgstr "1 Cambiamento"
+msgstr ""
 
 #: changelog.php:160 support.php:1010
 #, php-format
@@ -4565,7 +4565,7 @@ msgstr "(Alcuni elementi di sola lettura)"
 #: data_source_profiles.php:999
 #, php-format
 msgid "RRA [edit: %s %s]"
-msgstr "RRA [modifica: %s %s %s]."
+msgstr ""
 
 #: data_source_profiles.php:1089
 #, php-format
@@ -5991,12 +5991,12 @@ msgstr "Grafici dei luoghi sul rapporto"
 #: graphs.php:2005
 #, php-format
 msgid "Click 'Continue' to Place the following Graph on Tree %s."
-msgstr "Fare clic su 'Continua' per eliminare il seguente albero."
+msgstr ""
 
 #: graphs.php:2006
 #, php-format
 msgid "Click 'Continue' to Duplicate following Graphs on Tree %s."
-msgstr "Fare clic su 'Continua' per eliminare il seguente albero."
+msgstr ""
 
 #: graphs.php:2007
 msgid "Place Graph on Tree"
@@ -6048,7 +6048,7 @@ msgstr "Template grafico selezionato"
 #: graphs.php:2402
 #, php-format
 msgid "Choose a Graph Template to apply to this Graph. Please note that you may only change Graph Templates to a 100%% compatible Graph Template, which means that it includes identical Data Sources."
-msgstr "Scegliere un modello di grafico da applicare a questo grafico. Si prega di notare che è possibile modificare i modelli grafici solo per ottenere un modello grafico compatibile al 100%, il che significa che include sorgenti di dati identiche."
+msgstr "Scegliere un modello di grafico da applicare a questo grafico. Si prega di notare che è possibile modificare i modelli grafici solo per ottenere un modello grafico compatibile al 100%%, il che significa che include sorgenti di dati identiche."
 
 #: graphs.php:2411
 msgid "Choose the Device that this Graph belongs to."
@@ -6150,7 +6150,7 @@ msgstr "Gestione gruppi utenti [modifica: %s]."
 #: graphs.php:3231
 #, php-format
 msgid "Graph Management [ %s ]"
-msgstr "Gestione dei grafici"
+msgstr ""
 
 #: graphs_new.php:82
 msgid "Default Settings Saved"
@@ -6219,7 +6219,7 @@ msgstr "Errore durante l'analisi del file XML della risorsa della query di dati 
 #: graphs_new.php:698
 #, php-format
 msgid "Error Parsing Data Query Resource XML file for Data Query '%s' with id '%s'.  Field Name '%s' missing a 'direction' attribute"
-msgstr "Errore durante l'analisi del file XML della risorsa della query di dati per la query di dati \"%s\" con ID \"%s\""
+msgstr ""
 
 #: graphs_new.php:702
 #, php-format
@@ -6347,7 +6347,7 @@ msgstr "Reindice dispositivo completato in% 0.2f secondi. Sono stati aggiornati%
 #: host.php:359
 #, php-format
 msgid "Unable to add some Devices to Report '%s'"
-msgstr "Impossibile connettersi al server"
+msgstr ""
 
 #: host.php:478
 msgid "Click 'Continue' to Delete the following Device."
@@ -6461,7 +6461,7 @@ msgstr "Posizionare il dispositivo o i dispositivi sull'albero"
 #: host.php:580
 #, php-format
 msgid "Click 'Continue' to Place the following Device on Tree %s."
-msgstr "Fare clic su 'Continua' per eliminare i seguenti modelli di dispositivo."
+msgstr ""
 
 #: host.php:581
 #, fuzzy, php-format
@@ -7823,12 +7823,12 @@ msgstr "Ogni % di ore"
 #: include/global_arrays.php:781
 #, php-format
 msgid "Every %d Day"
-msgstr "Ogni %1 giorno"
+msgstr ""
 
 #: include/global_arrays.php:793
 #, php-format
 msgid "%0.1f Minutes"
-msgstr "%d Minuti"
+msgstr ""
 
 #: include/global_arrays.php:826 include/global_arrays.php:846
 #: include/global_arrays.php:858 include/global_arrays.php:859
@@ -8585,7 +8585,7 @@ msgstr "Anno scorso"
 #: include/global_arrays.php:1591
 #, php-format
 msgid "Last %d Years"
-msgstr "Ultimi anni"
+msgstr ""
 
 #: include/global_arrays.php:1592
 msgid "Day Shift"
@@ -9753,7 +9753,7 @@ msgstr "Specificato il numero di OID che possono essere ottenuti in una singola 
 #: include/global_form.php:177
 #, php-format
 msgid "%d OID"
-msgstr "Max OID"
+msgstr ""
 
 #: include/global_form.php:178 include/global_form.php:179
 #: include/global_form.php:180 include/global_form.php:181
@@ -9786,7 +9786,7 @@ msgstr "Rileva/Imposta automaticamente al primo reindicizzazione"
 #: include/global_form.php:204
 #, php-format
 msgid "%d Repetition"
-msgstr "Opzioni della griglia"
+msgstr ""
 
 #: include/global_form.php:205 include/global_form.php:206
 #: include/global_form.php:207 include/global_form.php:208
@@ -9798,7 +9798,7 @@ msgstr "Opzioni della griglia"
 #: include/global_form.php:219
 #, php-format
 msgid "%d Repetitions"
-msgstr "Opzioni della griglia"
+msgstr ""
 
 #: include/global_form.php:228
 msgid "The maximum number of attempts to reach a device via an SNMP readstring prior to giving up."
@@ -11953,7 +11953,7 @@ msgstr "Il numero predefinito di Device Threads.  Questo è applicabile solo qua
 #: include/global_settings.php:874
 #, php-format
 msgid "%s Thread"
-msgstr "%d Filettatura"
+msgstr ""
 
 #: include/global_settings.php:875 include/global_settings.php:876
 #: include/global_settings.php:877 include/global_settings.php:878
@@ -11962,7 +11962,7 @@ msgstr "%d Filettatura"
 #: include/global_settings.php:883
 #, php-format
 msgid "%s Threads"
-msgstr "%d Filettature"
+msgstr ""
 
 #: include/global_settings.php:887
 msgid "Re-index Method for Data Queries"
@@ -14759,12 +14759,12 @@ msgstr "Regola SNMP di rete di automazione '%s' %s non riuscita!"
 #: lib/api_automation.php:5525 lib/api_automation.php:5527
 #, php-format
 msgid "Automation Network SNMP Option %s!"
-msgstr "Opzioni SNMP di automazione"
+msgstr ""
 
 #: lib/api_automation.php:5531 lib/api_automation.php:5533
 #, php-format
 msgid "Automation Network SNMP Option %s Failed!"
-msgstr "Opzioni SNMP di automazione"
+msgstr ""
 
 #: lib/api_automation.php:5573
 msgid "The Automation Network Rule does not include any SNMP Options!"
@@ -14785,7 +14785,7 @@ msgstr "Modello Sconosciuto"
 #: lib/api_automation.php:5629 lib/api_automation.php:5631
 #, php-format
 msgid "Automation Network Rule '%s' %s!"
-msgstr "Rete di automazione predefinita"
+msgstr ""
 
 #: lib/api_automation.php:5635 lib/api_automation.php:5637
 #, php-format
@@ -15225,29 +15225,29 @@ msgstr "Il dispositivo è disabilitato"
 #: lib/auth.php:2302 lib/auth.php:2304 lib/auth.php:2310 lib/auth.php:2312
 #, php-format
 msgid "Graph:(%s%s)"
-msgstr "Grafico"
+msgstr ""
 
 #: lib/auth.php:2325 lib/auth.php:2331 lib/auth.php:2398 lib/auth.php:2400
 #: lib/auth.php:2404 lib/auth.php:2406
 #, php-format
 msgid "Device:(%s%s)"
-msgstr "Dispositivo"
+msgstr ""
 
 #: lib/auth.php:2339 lib/auth.php:2345 lib/auth.php:2414 lib/auth.php:2416
 #: lib/auth.php:2420 lib/auth.php:2422
 #, php-format
 msgid "Template:(%s%s)"
-msgstr "Modelli"
+msgstr ""
 
 #: lib/auth.php:2352
 #, php-format
 msgid "Graph+Device+Template:(%s%s)"
-msgstr "Modello del dispositivo:"
+msgstr ""
 
 #: lib/auth.php:2389 lib/auth.php:2391
 #, php-format
 msgid "Device+Template:(%s%s)"
-msgstr "Modello del dispositivo:"
+msgstr ""
 
 #: lib/auth.php:2435 lib/auth.php:2442 lib/auth.php:2451
 msgid "Restricted By: "
@@ -15304,7 +15304,7 @@ msgstr "Errore di ricerca LDAP: %s"
 #: lib/auth.php:3862 lib/auth.php:4717
 #, php-format
 msgid "Access Denied!  Template user id %s does not exist.  Please contact your Administrator."
-msgstr "Accesso negato, si prega di contattare l'amministratore di Cacti."
+msgstr ""
 
 #: lib/auth.php:3870
 #, php-format
@@ -15397,7 +15397,7 @@ msgstr "La 2FA è stata abilitata e verificata"
 #: lib/boost.php:82 utilities.php:1378
 #, php-format
 msgid "%s MBytes"
-msgstr "%d MByte"
+msgstr ""
 
 #: lib/boost.php:85
 #, php-format
@@ -15473,12 +15473,12 @@ msgstr " - Ammin vista"
 #: lib/clog_webapi.php:358
 #, php-format
 msgid "Log [Total Lines: %d %s - Filter active]"
-msgstr "Log [Linee totali: %d %s %s - Filtro attivo]."
+msgstr ""
 
 #: lib/clog_webapi.php:360
 #, php-format
 msgid "Log [Total Lines: %d %s - Unfiltered]"
-msgstr "Log [Linee totali: %d %s %s - non filtrato]."
+msgstr ""
 
 #: lib/clog_webapi.php:365 managers.php:323 managers.php:515 managers.php:550
 #: utilities.php:336 utilities.php:375 utilities.php:466 utilities.php:607
@@ -15634,7 +15634,7 @@ msgstr "Rimozione dell'indice rilevato! Indizio precedente: %s"
 #: lib/data_query.php:403
 #, php-format
 msgid "Verification of %s Local Data ID's Complete"
-msgstr "Indice di associazione con i dati locali completo"
+msgstr ""
 
 #: lib/data_query.php:406
 #, php-format
@@ -15660,7 +15660,7 @@ msgstr "Indice di associazione con i dati locali completo"
 #: lib/data_query.php:435
 #, php-format
 msgid "Update Re-Index Cache complete. There were %s index changes, and %s orphaned indexes."
-msgstr "Aggiornare Re-Index Cache completa. C'erano"
+msgstr ""
 
 #: lib/data_query.php:439
 msgid "Update Poller Cache for Query complete"
@@ -15774,7 +15774,7 @@ msgstr "Fare clic per visualizzare l'output di Data Query per il campo '%s'."
 #: lib/data_query.php:848
 #, php-format
 msgid "Sort field returned no data for field name %s, skipping"
-msgstr "Ordina campo restituito nessun dato.  Non è possibile continuare Re-Index."
+msgstr ""
 
 #: lib/data_query.php:850
 #, php-format
@@ -15884,7 +15884,7 @@ msgstr "Campo di inserimento localizzato '%s' [get]"
 #: lib/data_query.php:1174
 #, php-format
 msgid "Found OID rewrite rule: 's/%s/%s/'"
-msgstr "Trovato OID riscrivere la regola: 's/%s/%s/%s/'."
+msgstr ""
 
 #: lib/data_query.php:1185
 #, php-format
@@ -16023,7 +16023,7 @@ msgstr "Impossibile modificare la lunghezza del campo password, non può continu
 #: lib/dsdebug.php:190
 #, php-format
 msgid "Data Source ID %s does not exist"
-msgstr "Fonte dei dati non esiste"
+msgstr ""
 
 #: lib/dsdebug.php:275
 msgid "Debug not completed after 5 pollings"
@@ -16040,12 +16040,12 @@ msgstr "La sorgente dati non è impostata come attiva"
 #: lib/dsdebug.php:293
 #, php-format
 msgid "RRDfile Folder (rra) is not writable by Poller.  Folder owner: %s.  Poller runs as: %s"
-msgstr "La cartella RRD non è scrivibile da Poller.  RRD Proprietario:"
+msgstr ""
 
 #: lib/dsdebug.php:298
 #, php-format
 msgid "RRDfile is not writable by Poller.  RRDfile owner: %s.  Poller runs as %s"
-msgstr "Il file RRD non è scrivibile da Poller.  RRD Proprietario:"
+msgstr ""
 
 #: lib/dsdebug.php:307
 msgid "RRDfile does not match Data Source"
@@ -16362,7 +16362,7 @@ msgstr "Tutti %d %s"
 #: lib/html.php:654
 #, php-format
 msgid "Current Page: %s"
-msgstr "Valore Attuale"
+msgstr ""
 
 #: lib/html.php:685
 #, php-format
@@ -17136,7 +17136,7 @@ msgstr "IL GRAFICO NON ESISTE"
 #: lib/html_graph.php:1733 lib/html_graph.php:2065
 #, php-format
 msgid "Graph Utility View for Graph: %s"
-msgstr "Vista Grafico Utilità"
+msgstr ""
 
 #: lib/html_graph.php:1784
 msgid "CSV Export"
@@ -17519,12 +17519,12 @@ msgstr "new"
 #: lib/html_reports.php:1530
 #, php-format
 msgid "Details %s"
-msgstr "Dettagli"
+msgstr ""
 
 #: lib/html_reports.php:1572
 #, php-format
 msgid "Report Items %s"
-msgstr "Nessuna voce del report"
+msgstr ""
 
 #: lib/html_reports.php:1666
 msgid "Item Details"
@@ -17533,7 +17533,7 @@ msgstr "Articolo"
 #: lib/html_reports.php:1681
 #, php-format
 msgid "Graph: %s"
-msgstr "Grafico:"
+msgstr ""
 
 #: lib/html_reports.php:1684 lib/html_reports.php:1711
 #: lib/html_reports.php:1724 lib/html_reports.php:1725
@@ -17563,7 +17563,7 @@ msgstr ", Usando RegEx: \"%s\""
 #: lib/html_reports.php:1751
 #, php-format
 msgid "Tree: %s"
-msgstr "Albero"
+msgstr ""
 
 #: lib/html_reports.php:1761
 #, php-format
@@ -17573,7 +17573,7 @@ msgstr "(Dal dispositivo: %s)"
 #: lib/html_reports.php:1763
 #, php-format
 msgid ", Branch: %s"
-msgstr "Organizzazione:"
+msgstr ""
 
 #: lib/html_reports.php:1766
 msgid "(All Branches)"
@@ -17610,7 +17610,7 @@ msgstr "Ricostruzione"
 #: lib/html_reports.php:1931
 #, php-format
 msgid "Report Preview %s"
-msgstr "Anteprima del rapporto"
+msgstr ""
 
 #: lib/html_reports.php:1954 lib/html_reports.php:2248
 #, fuzzy
@@ -17914,7 +17914,7 @@ msgstr "Impossibile applicare l'intervallo di cron specificato"
 #: lib/installer.php:1208
 #, php-format
 msgid "Failed to apply '%s' as Automation Range"
-msgstr "Impossibile applicare la gamma di automazione specificata"
+msgstr ""
 
 #: lib/installer.php:1300
 msgid "No matching snmp option exists"
@@ -18071,7 +18071,7 @@ msgstr "La tua configurazione Cacti ha il relativo percorso corretto (url_path) 
 #: lib/installer.php:2199
 #, php-format
 msgid "PHP - Recommendations (%s)"
-msgstr "PHP - Raccomandazioni"
+msgstr ""
 
 #: lib/installer.php:2203
 msgid "PHP Recommendations ("
@@ -18749,7 +18749,7 @@ msgstr "Aggiorna"
 #: lib/installer.php:3248
 #, php-format
 msgid "%d Tables to be Upgraded"
-msgstr "Voce Tipo di elemento da aggiungere."
+msgstr ""
 
 #: lib/installer.php:3249
 msgid "The following Tables will be Upgraded to InnoDB and Converted to utf8mb4 for performance and internationalization."
@@ -18836,7 +18836,7 @@ msgstr "L'importazione del pacchetto #%s '%s' nel profilo '%s' non è riuscita"
 #: lib/installer.php:3653
 #, php-format
 msgid "Mapping Automation Template for Device Template '%s'"
-msgstr "Modelli di automazione per [Modelli eliminati]."
+msgstr ""
 
 #: lib/installer.php:3674
 msgid "No templates were selected for import"
@@ -18849,12 +18849,12 @@ msgstr "In attesa di configurazione"
 #: lib/installer.php:3714
 #, php-format
 msgid "Setting default data source profile to %s (%s)"
-msgstr "Il profilo sorgente dati predefinito per questo modello dati."
+msgstr ""
 
 #: lib/installer.php:3739
 #, php-format
 msgid "Failed to find selected profile (%s), no changes were made"
-msgstr "Impossibile applicare il profilo specificato %s != %s"
+msgstr ""
 
 #: lib/installer.php:3750
 #, php-format
@@ -18872,12 +18872,12 @@ msgstr "Aggiunta di ulteriori impostazioni snmp per l'automazione"
 #: lib/installer.php:3775
 #, php-format
 msgid "Selecting Automation Option Set %s"
-msgstr "Eliminazione dei modelli di automazione"
+msgstr ""
 
 #: lib/installer.php:3789
 #, php-format
 msgid "Updating Automation Option Set %s"
-msgstr "Opzioni SNMP di automazione"
+msgstr ""
 
 #: lib/installer.php:3793
 #, php-format
@@ -18887,12 +18887,12 @@ msgstr "Set di opzioni di automazione aggiornato correttamente%s"
 #: lib/installer.php:3795
 #, php-format
 msgid "Resequencing Automation Option Set %s"
-msgstr "Eseguire l'automazione su dispositivi"
+msgstr ""
 
 #: lib/installer.php:3802
 #, php-format
 msgid "Failed to updated Automation Option Set %s"
-msgstr "Impossibile applicare la gamma di automazione specificata"
+msgstr ""
 
 #: lib/installer.php:3805
 msgid "Failed to find any automation option set"
@@ -18919,7 +18919,7 @@ msgstr "Aggiunto a Cacti"
 #: lib/installer.php:3862
 #, php-format
 msgid "Output: %s."
-msgstr "Campi di Emissione"
+msgstr ""
 
 #: lib/installer.php:3882
 msgid "Creating Graphs for Default Device"
@@ -18999,7 +18999,7 @@ msgstr "Lo sfondo era già stato avviato da%s, questo tentativo di%s è stato ig
 #: lib/installer.php:4130
 #, php-format
 msgid "Exception occurred during installation: #%s - %s"
-msgstr "Eccezione durante l'installazione:  #"
+msgstr ""
 
 #: lib/installer.php:4140
 #, php-format
@@ -19013,12 +19013,12 @@ msgstr "Entrambi"
 #: lib/installer.php:4179
 #, php-format
 msgid "No - %s"
-msgstr "Versione %s %s"
+msgstr ""
 
 #: lib/installer.php:4187
 #, php-format
 msgid "%s - N/A"
-msgstr "Versione %s %s"
+msgstr ""
 
 #: lib/installer.php:4187 lib/installer.php:4189
 msgid "Web"
@@ -19027,7 +19027,7 @@ msgstr "Web"
 #: lib/installer.php:4189 lib/installer.php:4192
 #, php-format
 msgid "%s - No"
-msgstr "Versione %s %s"
+msgstr ""
 
 #: lib/installer.php:4192
 msgid "Cli"
@@ -19066,17 +19066,17 @@ msgstr "Nessun nome utente definito"
 #: lib/ldap.php:423
 #, php-format
 msgid "Protocol Error, Unable to set version (%s) on Server (%s)"
-msgstr "Errore di protocollo, Impossibile impostare la versione"
+msgstr ""
 
 #: lib/ldap.php:424
 #, php-format
 msgid "Protocol Error, Unable to set referrals option (%s) on Server (%s)"
-msgstr "Errore di protocollo, Impossibile impostare l'opzione dei riferimenti"
+msgstr ""
 
 #: lib/ldap.php:425
 #, php-format
 msgid "Protocol Error, unable to start TLS communications (%s) on Server (%s)"
-msgstr "Errore di protocollo, impossibilità di avviare le comunicazioni TLS"
+msgstr ""
 
 #: lib/ldap.php:426
 #, php-format
@@ -19086,27 +19086,27 @@ msgstr "Errore di protocollo, Guasto generale (%s)"
 #: lib/ldap.php:427
 #, php-format
 msgid "Protocol Error, Unable to bind, LDAP result: (%s) on Server (%s)"
-msgstr "Errore di protocollo, Impossibile legare, risultato LDAP: %s"
+msgstr ""
 
 #: lib/ldap.php:428
 #, php-format
 msgid "Unable to Connect to Server (%s)"
-msgstr "Impossibile connettersi al server"
+msgstr ""
 
 #: lib/ldap.php:429
 #, php-format
 msgid "Connection Timeout to Server (%s)"
-msgstr "Timeout connessione"
+msgstr ""
 
 #: lib/ldap.php:430
 #, php-format
 msgid "Insufficient Access to Server (%s)"
-msgstr "Autorizzazioni di accesso insufficienti."
+msgstr ""
 
 #: lib/ldap.php:431
 #, php-format
 msgid "Group DN could not be found to compare on Server (%s)"
-msgstr "Gruppo DN non è stato trovato per confrontare"
+msgstr ""
 
 #: lib/ldap.php:432
 msgid "More than one matching user found"
@@ -19123,7 +19123,7 @@ msgstr "Impossibile trovare gli utenti DN"
 #: lib/ldap.php:435
 #, php-format
 msgid "Unable to create LDAP connection object to Server (%s)"
-msgstr "Impossibile creare un oggetto di connessione LDAP"
+msgstr ""
 
 #: lib/ldap.php:436
 msgid "Specific DN and Password required"
@@ -19136,7 +19136,7 @@ msgstr "Password fornita non valida. Accesso fallito."
 #: lib/ldap.php:438
 #, php-format
 msgid "Unexpected error %s (Ldap Error: %s) on Server (%s)"
-msgstr "Errore imprevisto %s (Errore Ldap: %s)"
+msgstr ""
 
 #: lib/package.php:115 package_import.php:82
 msgid "Key Generation Required to Use Tool"
@@ -19369,12 +19369,12 @@ msgstr "Caricamento non riuscito!  Impossibile individuare il record disponibile
 #: lib/plugins.php:1728
 #, php-format
 msgid "The Plugin '%s' has been archived successfully."
-msgstr "Cacti log spurgato con successo"
+msgstr ""
 
 #: lib/plugins.php:1730
 #, php-format
 msgid "The Plugin '%s' archiving process has failed.  Check the Cacti log for errors."
-msgstr "Una o più riparazioni del file RRD hanno fallito.  Vedere il registro Cacti per gli errori."
+msgstr ""
 
 #: lib/plugins.php:1733
 #, php-format
@@ -19443,7 +19443,7 @@ msgstr ""
 #: lib/reports.php:146
 #, php-format
 msgid "Device '%s' successfully added to Report."
-msgstr "Aggiunto a Cacti"
+msgstr ""
 
 #: lib/reports.php:149
 msgid "Device not found! Unable to add to Report"
@@ -19544,7 +19544,7 @@ msgstr "Comando RRDtool:"
 #: lib/rrd.php:3415
 #, php-format
 msgid "The required RRDfile step size is '%s' but observed step is '%s'"
-msgstr "La dimensione del passo RRD richiesta è \"%s\"."
+msgstr ""
 
 #: lib/rrd.php:3475
 #, php-format
@@ -19589,7 +19589,7 @@ msgstr "XFF per i cactus RRA id \"%s\" dovrebbe essere \"%s\"."
 #: lib/rrd.php:3574
 #, php-format
 msgid "The number of rows for Cacti RRA id '%s' is incorrect.  The number of rows are '%s' but should be '%s'"
-msgstr "Numero di righe per Cacti RRA id \"%s\" dovrebbe essere \"%s\"."
+msgstr ""
 
 #: lib/rrd.php:3593
 #, php-format
@@ -19989,7 +19989,7 @@ msgstr "Convalida Whitelist fallita. Metodo di inserimento dei dati di controllo
 #: lib/template.php:2332
 #, php-format
 msgid "Graph Not created for %s due to bad data"
-msgstr "Creazione di grafici"
+msgstr ""
 
 #: lib/template.php:2361
 #, php-format
@@ -20045,7 +20045,7 @@ msgstr "Grazie alle funzionalità di polling remoto, grandi quantità di dati sa
 #: lib/utility.php:1185
 #, php-format
 msgid "If using the Cacti Performance Booster and choosing a memory storage engine, you have to be careful to flush your Performance Booster buffer before the system runs out of memory table space.  This is done two ways, first reducing the size of your output column to just the right size.  This column is in the tables poller_output, and poller_output_boost.  The second thing you can do is allocate more memory to memory tables.  We have arbitrarily chosen a recommended value of 10%% of system memory, but if you are using SSD disk drives, or have a smaller system, you may ignore this recommendation or choose a different storage engine.  You may see the expected consumption of the Performance Booster tables under Console -> System Utilities -> View Boost Status."
-msgstr "Se si utilizza il Cacti Performance Booster e si sceglie un motore di memoria, è necessario fare attenzione a risciacquare il buffer Performance Booster prima che il sistema esaurisca lo spazio della tabella di memoria.  Questo viene fatto in due modi, riducendo prima di tutto la dimensione della colonna di uscita alla dimensione giusta.  Questa colonna è nelle tabelle poller_output, e poller_output_boost.  La seconda cosa da fare è allocare più memoria alle tabelle di memoria.  Abbiamo scelto arbitrariamente un valore raccomandato del 10% della memoria di sistema, ma se si utilizzano unità disco SSD o si dispone di un sistema più piccolo, è possibile ignorare questa raccomandazione o scegliere un motore di archiviazione diverso.  È possibile visualizzare il consumo previsto delle tabelle del Performance Booster in Console -> System Utilities -> View Boost Status."
+msgstr ""
 
 #: lib/utility.php:1191
 msgid "When executing subqueries, having a larger temporary table size, keep those temporary tables in memory."
@@ -20075,7 +20075,7 @@ msgstr "Se le tue tabelle hanno indici molto grandi, devi operare con Barracuda 
 #: lib/utility.php:1227
 #, php-format
 msgid "InnoDB will hold as much tables and indexes in system memory as is possible.  Therefore, you should make the innodb_buffer_pool large enough to hold as much of the tables and index in memory.  Checking the size of the /var/lib/mysql/cacti directory will help in determining this value.  We are recommending 25%% of your systems total memory, but your requirements will vary depending on your systems size.  If you database is very large or remote, you can consider increasing this size.  If remote, it can by as high as 80% of the systems memory.  However, cautions must be taken to reduce the swappiness of the system, or to remove swap to keep the system from swapping."
-msgstr "InnoDB contiene quante più tabelle e indici possibili nella memoria di sistema.  Pertanto, si dovrebbe rendere il innodb_buffer_pool abbastanza grande da contenere la stessa quantità di tabelle e indici in memoria.  Controllare la dimensione della cartella /var/lib/mysql/cacti aiuterà a determinare questo valore.  Vi raccomandiamo il 25% della memoria totale del vostro sistema, ma le vostre esigenze variano a seconda delle dimensioni del sistema."
+msgstr ""
 
 #: lib/utility.php:1233
 #, fuzzy
@@ -20106,7 +20106,7 @@ msgstr "Con la moderna memorizzazione di tipo SSD, avere più filettature io è 
 #: lib/utility.php:1271 lib/utility.php:1313
 #, php-format
 msgid "As of %s %s, the you can control how often %s flushes transactions to disk.  The default is 1 second, but in high I/O systems setting to a value greater than 1 can allow disk I/O to be more sequential"
-msgstr "A partire da %s %s %s, è possibile controllare la frequenza con cui %s scarica le transazioni su disco.  Il valore predefinito è 1 secondo, ma nei sistemi di I/O elevati, l'impostazione di un valore superiore a 1 può consentire all'I/O del disco di essere più sequenziale."
+msgstr ""
 
 #: lib/utility.php:1276
 msgid "With modern SSD type storage, having multiple read io threads is advantageous for applications with high io characteristics.  Depending on your MariaDB/MySQL versions, this value can go as high as 64.  But try to keep the number less than your total SMT threads on the database server."
@@ -20403,12 +20403,12 @@ msgstr "Logout di Cacti"
 #: logout.php:70
 #, php-format
 msgid "You have been logged out of Cacti due to %s."
-msgstr "Sei stato disconnesso da Cacti a causa di un timeout della sessione."
+msgstr ""
 
 #: logout.php:71
 #, php-format
 msgid "Please close your browser or %sLogin Again%s"
-msgstr "Per favore chiudi il tuo browser o accedi di nuovo%s"
+msgstr ""
 
 #: logout.php:72
 msgid "Cookies have been cleared"
@@ -20612,17 +20612,17 @@ msgstr "Cosa vorresti esportare?"
 #: package.php:278
 #, php-format
 msgid "%s Device Package"
-msgstr "Nome dispositivo"
+msgstr ""
 
 #: package.php:282
 #, php-format
 msgid "%s Graph Template Package"
-msgstr "Nome del modello grafico"
+msgstr ""
 
 #: package.php:286
 #, php-format
 msgid "%s Data Query Package"
-msgstr "Nome della query di dati"
+msgstr ""
 
 #: package.php:314 templates_export.php:168
 #, php-format
@@ -20636,7 +20636,7 @@ msgstr "Modelli disponibili"
 #: package.php:323
 #, php-format
 msgid "%s to Export"
-msgstr "Esporta"
+msgstr ""
 
 #: package.php:324
 msgid "Choose the exact items to export in the Package."
@@ -20711,12 +20711,12 @@ msgstr "Impossibile creare la directory temporanea del pacchetto %s."
 #: package_import.php:208 package_import.php:529
 #, php-format
 msgid "The Package %s Imported Successfully"
-msgstr "Cacti log spurgato con successo"
+msgstr ""
 
 #: package_import.php:210 package_import.php:531
 #, php-format
 msgid "The Package %s Import Failed"
-msgstr "Importazione del pacchetto non riuscita."
+msgstr ""
 
 #: package_import.php:308
 #, php-format
@@ -21663,7 +21663,7 @@ msgstr "Installa il Plugin"
 #: plugins.php:1816
 #, php-format
 msgid "Plugin '%s' can not be archived before it's been Installed."
-msgstr "Il plugin non può essere installato."
+msgstr ""
 
 #: plugins.php:1827
 msgid "Remove Plugin Data Tables and Settings"
@@ -21751,27 +21751,27 @@ msgstr "Abilita plugin"
 #: poller.php:405
 #, php-format
 msgid "WARNING: %s is out of sync with the Poller Interval for Poller[%d]!  The Poller Interval is %d seconds, with a maximum of a %d seconds, but %d seconds have passed since the last poll!"
-msgstr "ATTENZIONE: %s non è sincronizzato con l'intervallo di polling!  L'intervallo di polling è '%d' secondi, con un massimo di '%d' secondi, ma sono passati %d secondi dall'ultimo sondaggio!"
+msgstr ""
 
 #: poller.php:594
 #, php-format
 msgid "WARNING: There are %d processes detected as overrunning a polling cycle for Poller[%d], please investigate."
-msgstr "ATTENZIONE: Ci sono '%d' rilevati come superamento di un ciclo di sondaggi, si prega di indagare."
+msgstr ""
 
 #: poller.php:652
 #, php-format
 msgid "WARNING: Poller Output Table not empty for Poller[%d].  Issues: %d, %s."
-msgstr "AVVERTENZA: Poller Output Table non vuoto.  Questioni: %d, %s."
+msgstr ""
 
 #: poller.php:693
 #, php-format
 msgid "ERROR: The spine path: %s is invalid for Poller[%d].  Poller can not continue!"
-msgstr "ERROR: Il percorso della colonna vertebrale: %s non è valido.  Poller non può continuare!"
+msgstr ""
 
 #: poller.php:842
 #, php-format
 msgid "Maximum runtime of %d seconds exceeded for Poller[%d]. Exiting."
-msgstr "Tempo di esecuzione massimo di %d secondi superato. Esce."
+msgstr ""
 
 #: poller.php:1022
 #, php-format
@@ -21803,7 +21803,7 @@ msgstr "NOTA: è stato aggiunto un secondo raccoglitore di dati di cactus. Perta
 #: poller_automation.php:57
 #, php-format
 msgid "WARNING: Main Cacti database %s offline or in recovery"
-msgstr "ATTENZIONE: database principale Cacti offline o in recovery"
+msgstr ""
 
 #: poller_automation.php:1071 poller_automation.php:1125
 msgid "Cacti Primary Admin"
@@ -22402,7 +22402,7 @@ msgstr "NOTA: le impostazioni del percorso in questa scheda vengono salvate solo
 #: settings.php:140
 #, php-format
 msgid "Cacti Settings (%s)%s"
-msgstr "Impostazioni Cacti (%s)"
+msgstr ""
 
 #: settings.php:264
 msgid "Changing Permission Model Warning"
@@ -23353,12 +23353,12 @@ msgstr "Danneggiato"
 #: templates_import.php:321
 #, php-format
 msgid "Met: %d"
-msgstr "MET"
+msgstr ""
 
 #: templates_import.php:325
 #, php-format
 msgid "Unmet: %d"
-msgstr "Non vengono soddisfatti"
+msgstr ""
 
 #: templates_import.php:334
 msgid "Some CDEF Items will not import due to an export error! Contact Template provider for an updated export."
@@ -25010,7 +25010,7 @@ msgstr "Timer di runtime dettagliati:"
 #: utilities.php:1449 utilities.php:1451
 #, php-format
 msgid "Process: %d"
-msgstr "1 Processo"
+msgstr ""
 
 #: utilities.php:1449
 #, php-format
@@ -25404,10 +25404,6 @@ msgstr "Nessun VDEF"
 #~ msgstr[0] "Fare clic su 'Continua' per eliminare il seguente sito.  Nota, tutti i dispositivi saranno dissociati da questo sito."
 #~ msgstr[1] "Fare clic su 'Continua' per eliminare tutti i seguenti siti.  Nota, tutti i dispositivi saranno dissociati da questo sito."
 
-#, php-format
-#~ msgid "Click 'Continue' to Duplicate following Devices on Tree %s."
-#~ msgstr "Fare clic su 'Continua' per eliminare il seguente albero."
-
 #, fuzzy
 #~ msgid "Click 'Continue' to Synchronize Devices associated with the selected Device Template(s).  Note that this action may take some time depending on the number of Devices mapped to the Device Template."
 #~ msgstr "Fare clic su 'Continua' per sincronizzare i dispositivi associati ai modelli di dispositivi selezionati.  Si noti che questa azione potrebbe richiedere un certo tempo a seconda del numero di dispositivi mappati sul modello del dispositivo."
@@ -25573,7 +25569,6 @@ msgstr "Nessun VDEF"
 #~ msgstr "Alberi creati"
 
 #, fuzzy
-#~| msgid "DES"
 #~ msgid "DS"
 #~ msgstr "DES"
 

--- a/locales/po/ja-JP.po
+++ b/locales/po/ja-JP.po
@@ -1,3 +1,4 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: cacti\n"
@@ -304,12 +305,12 @@ msgstr "集約との関連付け解除"
 #: aggregate_graphs.php:970
 #, php-format
 msgid "Click 'Continue' to Place the following Aggregate Graph on Tree %s."
-msgstr "次の集計グラフテンプレートを削除するには、[続行]をクリックします。"
+msgstr ""
 
 #: aggregate_graphs.php:971
 #, php-format
 msgid "Click 'Continue' to Duplicate following Aggregate Graphs on Tree %s."
-msgstr "[続行]をクリックして、次の集計グラフをツリーブランチの下に配置します。"
+msgstr ""
 
 #: aggregate_graphs.php:972
 msgid "Place Aggregate Graph on Tree"
@@ -954,7 +955,7 @@ msgstr "ユーザーは認証されましたが、テンプレートアカウン
 #: auth_login.php:141
 #, php-format
 msgid "Access Denied!  Guest user id %s does not exist.  Please contact your Administrator."
-msgstr "アクセス拒否されました。Cacti 管理者に連絡してください。"
+msgstr ""
 
 #: auth_login.php:180
 msgid "Access Denied!  User account disabled."
@@ -1238,12 +1239,12 @@ msgstr "デバイス自動化インターフェースを介して手動で追加
 #: automation_devices.php:125
 #, php-format
 msgid "Device %s Added to Cacti"
-msgstr "サボテンに追加"
+msgstr ""
 
 #: automation_devices.php:127
 #, php-format
 msgid "Device %s Not Added to Cacti"
-msgstr "サボテンに加えられなかった"
+msgstr ""
 
 #: automation_devices.php:137
 msgid "Devices Removed from Cacti Automation database"
@@ -2964,7 +2965,7 @@ msgstr "[続行]をクリックして、以下のデータクエリを削除し�
 #: automation_templates.php:791
 #, php-format
 msgid "Tree Rule Name: '%s'"
-msgstr "ツリールール項目"
+msgstr ""
 
 #: automation_templates.php:798
 msgid "Remove Tree Rule"
@@ -3477,7 +3478,7 @@ msgstr "フル"
 #: changelog.php:99
 #, php-format
 msgid "Change Log [%s]"
-msgstr "ChangeLogLanguage"
+msgstr ""
 
 #: changelog.php:160 support.php:1018
 #, php-format
@@ -5093,7 +5094,7 @@ msgstr "プロファイルを変更(G)"
 #: data_templates.php:261
 #, php-format
 msgid "Field \"%s\" is missing an Output Field.  Select the Output Field associated with this Data Source, and press Save again."
-msgstr "フィールド\"%s\"には出力フィールドがありません。このデータソースに関連付けられている出力フィールドを選択し、もう一度[保存]を押します。"
+msgstr ""
 
 #: data_templates.php:447
 #, php-format
@@ -5348,7 +5349,7 @@ msgstr "グラフが存在しない"
 #: graph.php:115 graph.php:409
 #, php-format
 msgid "Graph Utility View for Graph: %s"
-msgstr "グラフユーティリティビュー"
+msgstr ""
 
 #: graph.php:160 lib/html.php:585
 msgid "Graph Details, Zooming and Debugging Utilities"
@@ -6051,12 +6052,12 @@ msgstr "レポートにグラフを配置する"
 #: graphs.php:1912
 #, php-format
 msgid "Click 'Continue' to Place the following Graph on Tree %s."
-msgstr "次のツリーを削除するには、[続行]をクリックしてください。"
+msgstr ""
 
 #: graphs.php:1913
 #, php-format
 msgid "Click 'Continue' to Duplicate following Graphs on Tree %s."
-msgstr "次のツリーを削除するには、[続行]をクリックしてください。"
+msgstr ""
 
 #: graphs.php:1914
 msgid "Place Graph on Tree"
@@ -6124,7 +6125,7 @@ msgstr "選択済グラフテンプレート"
 #: graphs.php:2320
 #, php-format
 msgid "Choose a Graph Template to apply to this Graph. Please note that you may only change Graph Templates to a 100%% compatible Graph Template, which means that it includes identical Data Sources."
-msgstr "このグラフに適用するグラフテンプレートを選択します。グラフテンプレートは、互換性のある100%のグラフテンプレートにしか変更できないため、同一のデータソースが含まれることになります。"
+msgstr "このグラフに適用するグラフテンプレートを選択します。グラフテンプレートは、互換性のある100%%のグラフテンプレートにしか変更できないため、同一のデータソースが含まれることになります。"
 
 #: graphs.php:2328
 msgid "Choose the Device that this Graph belongs to."
@@ -6157,7 +6158,7 @@ msgstr "ユーザグループ管理[編集：%s]"
 #: graphs.php:2688
 #, php-format
 msgid "Graph Management [ %s ]"
-msgstr "グラフ管理"
+msgstr ""
 
 #: graphs.php:2756 graphs.php:2759
 msgid "Source"
@@ -6298,7 +6299,7 @@ msgstr "デフォルト設定"
 #: help.php:44
 #, php-format
 msgid "WARNING: Cacti Page:%s for User:%s Generated a Fatal Error %d!"
-msgstr "警告：ユーザー：%sのCactiページ：%sが致命的なエラー %d を生成しました！"
+msgstr ""
 
 #: help.php:74
 #, php-format
@@ -6484,12 +6485,12 @@ msgstr "ツリーにデバイスを配置"
 #: host.php:564
 #, php-format
 msgid "Click 'Continue' to Place the following Device on Tree %s."
-msgstr "次のデバイステンプレートを削除するには、[続行]をクリックしてください。"
+msgstr ""
 
 #: host.php:565
 #, php-format
 msgid "Click 'Continue' to Duplicate following Devices on Tree %s."
-msgstr "次のツリーを削除するには、[続行]をクリックしてください。"
+msgstr ""
 
 #: host.php:566
 msgid "Place Device on Tree"
@@ -6528,7 +6529,7 @@ msgstr "ポーラーキャッシュの表示"
 #: host.php:733
 #, php-format
 msgid " [ In state since '%s', Uptime since '%s' ]"
-msgstr "['%s'以降の状態、'%s'以降の稼働時間]"
+msgstr ""
 
 #: host.php:748
 msgid "Create Graphs for this Device"
@@ -7661,7 +7662,7 @@ msgstr "%d時間ごと"
 #: include/global_arrays.php:771
 #, php-format
 msgid "Every %d Day"
-msgstr "%1日ごと"
+msgstr ""
 
 #: include/global_arrays.php:783
 #, php-format
@@ -9504,7 +9505,7 @@ msgstr "最初の再インデックスでの自動検出/設定"
 #: include/global_form.php:188
 #, php-format
 msgid "%d Repetition"
-msgstr "グリッドオプション"
+msgstr ""
 
 #: include/global_form.php:189 include/global_form.php:190
 #: include/global_form.php:191 include/global_form.php:192
@@ -13498,7 +13499,7 @@ msgstr "差異の割合"
 #: include/global_settings.php:2734
 #, php-format
 msgid "This value represents the percentage above the adjusted sample average once outliers have been removed from the sample.  For example, a Variance Percentage of 100%% on an adjusted average of 50 would remove any sample above the quantity of 100 from the graph."
-msgstr "この値は、異常値がサンプルから削除された後の調整済みサンプルの平均を上回るパーセンテージを表します。たとえば、50の調整済み平均に対して100%のVariance Percentageを指定すると、グラフから100の数量を超えるサンプルが削除されます。"
+msgstr "この値は、異常値がサンプルから削除された後の調整済みサンプルの平均を上回るパーセンテージを表します。たとえば、50の調整済み平均に対して100%%のVariance Percentageを指定すると、グラフから100の数量を超えるサンプルが削除されます。"
 
 #: include/global_settings.php:2757
 msgid "Variance Number of Outliers"
@@ -13970,12 +13971,12 @@ msgstr "これで<a href=\"%s\"><b>Cactiに</b></a>ログインしました。�
 #: index.php:71
 #, php-format
 msgid "<a href=\"%s\">Create devices</a> for network"
-msgstr "ネットワーク用の<a href=\"%s\">デバイス</a>を<a href=\"%s\">作成する</a>"
+msgstr ""
 
 #: index.php:72
 #, php-format
 msgid "<a href=\"%s\">Create graphs</a> for your new devices"
-msgstr "新しいデバイス用に<a href=\"%s\">グラフ</a>を<a href=\"%s\">作成</a>する"
+msgstr ""
 
 #: index.php:73
 #, php-format
@@ -14285,7 +14286,7 @@ msgstr "ファイル拡張子が無効です。"
 #: lib/api_automation.php:5273 lib/api_automation.php:5275
 #, php-format
 msgid "Automation Network SNMP Rule '%s' %s!"
-msgstr "オートメーションネットワークSNMPルール'%s' %s！"
+msgstr ""
 
 #: lib/api_automation.php:5273 lib/api_automation.php:5275
 #: lib/api_automation.php:5309 lib/api_automation.php:5311
@@ -14303,7 +14304,7 @@ msgstr "更新しました"
 #: lib/api_automation.php:5279 lib/api_automation.php:5281
 #, php-format
 msgid "Automation Network SNMP Rule '%s' %s Failed!"
-msgstr "オートメーションネットワークSNMPルール'%s' %s が失敗しました！"
+msgstr ""
 
 #: lib/api_automation.php:5279 lib/api_automation.php:5281
 #: lib/api_automation.php:5315 lib/api_automation.php:5317
@@ -14317,12 +14318,12 @@ msgstr "更新"
 #: lib/api_automation.php:5309 lib/api_automation.php:5311
 #, php-format
 msgid "Automation Network SNMP Option %s!"
-msgstr "自動化SNMPオプション"
+msgstr ""
 
 #: lib/api_automation.php:5315 lib/api_automation.php:5317
 #, php-format
 msgid "Automation Network SNMP Option %s Failed!"
-msgstr "自動化SNMPオプション"
+msgstr ""
 
 #: lib/api_automation.php:5351
 msgid "The Automation Network Rule does not include any SNMP Options!"
@@ -14343,12 +14344,12 @@ msgstr "未知のテンプレート"
 #: lib/api_automation.php:5404 lib/api_automation.php:5406
 #, php-format
 msgid "Automation Network Rule '%s' %s!"
-msgstr "デフォルトの自動化ネットワーク"
+msgstr ""
 
 #: lib/api_automation.php:5410 lib/api_automation.php:5412
 #, php-format
 msgid "Automation Network Rule '%s' %s Failed!"
-msgstr "オートメーションネットワークルール'%s' %s に失敗しました！"
+msgstr ""
 
 #: lib/api_automation.php:5418
 msgid "Automation Network Rule Import data is either for another object type or not JSON formatted."
@@ -14557,7 +14558,7 @@ msgstr "LDAP検索エラー：%s"
 #: lib/auth.php:4094 lib/auth.php:5105
 #, php-format
 msgid "Access Denied!  Template user id %s does not exist.  Please contact your Administrator."
-msgstr "アクセス拒否されました。Cacti 管理者に連絡してください。"
+msgstr ""
 
 #: lib/auth.php:4479
 msgid "Access Denied! Login failed."
@@ -14844,7 +14845,7 @@ msgstr "インデックスの削除が検出されました！ PreviousIndex ：
 #: lib/data_query.php:360
 #, php-format
 msgid "Verification of %s Local Data ID's Complete"
-msgstr "ローカルデータとのインデックスの関連付けが完了しました"
+msgstr ""
 
 #: lib/data_query.php:363
 #, php-format
@@ -14870,7 +14871,7 @@ msgstr "ローカルデータとのインデックスの関連付けが完了し
 #: lib/data_query.php:392
 #, php-format
 msgid "Update Re-Index Cache complete. There were %s index changes, and %s orphaned indexes."
-msgstr "再インデックスキャッシュの更新が完了しました。あった"
+msgstr ""
 
 #: lib/data_query.php:396
 msgid "Update Poller Cache for Query complete"
@@ -14984,7 +14985,7 @@ msgstr "フィールド'%s'のデータクエリ出力を表示するにはク�
 #: lib/data_query.php:741
 #, php-format
 msgid "Sort field returned no data for field name %s, skipping"
-msgstr "ソートフィールドからデータが返されませんでした。再索引付けを続行できません。"
+msgstr ""
 
 #: lib/data_query.php:743
 #, php-format
@@ -15017,7 +15018,7 @@ msgstr "SNMPセッションを読み込めませんでした。"
 #: lib/data_query.php:886
 #, php-format
 msgid "Tested Bulk Walk Size %d with a response of %2.4f."
-msgstr "%2.4fの応答でバルクウォークサイズ%dをテストしました。"
+msgstr ""
 
 #: lib/data_query.php:898
 #, php-format
@@ -15228,7 +15229,7 @@ msgstr "パスワードフィールド長の変更に失敗しました。パス
 #: lib/dsdebug.php:175
 #, php-format
 msgid "Data Source ID %s does not exist"
-msgstr "データソースが存在しません"
+msgstr ""
 
 #: lib/dsdebug.php:259
 msgid "Debug not completed after 5 pollings"
@@ -15289,12 +15290,12 @@ msgstr "設定をデータコレクタに保存します%d失敗しました。"
 #: lib/functions.php:896
 #, php-format
 msgid "Form Validation Failed: Variable '%s' does not allow nulls and variable is null"
-msgstr "フォームの検証に失敗しました:変数'%s'はNULLを許可しておらず、変数はNULLです"
+msgstr ""
 
 #: lib/functions.php:898
 #, php-format
 msgid "Form Validation Failed: Variable '%s' with Value '%s' Failed REGEX '%s'"
-msgstr "フォームの検証に失敗しました:値'%s'の変数'%s'は正規表現'%s'に失敗しました"
+msgstr ""
 
 #: lib/functions.php:914
 msgid "One or more fields failed validation"
@@ -15461,7 +15462,7 @@ msgstr "次のエラーのため、Cactiはプラグイン%sを無効にしま�
 #: lib/functions.php:6752
 #, php-format
 msgid "WARNING: PollerID:%s has an invalid hostname:%s.  Is it not reachable via DNS!"
-msgstr "警告： PollerID ：%sに無効なホスト名：%sがあります。DNS経由では到達できませんか？"
+msgstr ""
 
 #: lib/functions.php:6781
 #, php-format
@@ -15470,9 +15471,6 @@ msgid ""
 "Reason: %s.\n"
 "See Cacti Log for details."
 msgstr ""
-"リモートエージェント %s への連絡に失敗しました\n"
-"理由：%s。\n"
-"詳細については、Cactiログを参照してください。"
 
 #: lib/functions.php:7247
 #, php-format
@@ -15492,7 +15490,7 @@ msgstr "バージョン%s%s"
 #: lib/functions.php:7852
 #, php-format
 msgid "WARNING: Key Cacti Include File \"%s\" missing.  Please locate and replace this file as we checked in \"%s\""
-msgstr "警告：キーCactiインクルードファイル\"%s\"がありません。\"%s\"をチェックインしたので、このファイルを見つけて交換してください"
+msgstr ""
 
 #: lib/functions.php:8996
 msgid "System Device"
@@ -16653,7 +16651,7 @@ msgstr "詳細： %s"
 #: lib/html_reports.php:1618
 #, php-format
 msgid "Report Items %s"
-msgstr "レポート項目なし"
+msgstr ""
 
 #: lib/html_reports.php:1664
 #, php-format
@@ -16663,7 +16661,7 @@ msgstr "予定されたイベント %s"
 #: lib/html_reports.php:1676
 #, php-format
 msgid "Report Preview %s"
-msgstr "レポートプレビュー"
+msgstr ""
 
 #: lib/html_reports.php:1712
 msgid "Item Details"
@@ -17347,7 +17345,7 @@ msgstr "データベース<b>：%s</b>"
 #: lib/installer.php:2329 lib/installer.php:2341
 #, php-format
 msgid "Database User: <b>%s</b>"
-msgstr "あなたのデータベースユーザがテーブルを作成する権限がありません。私たちは、単にテーブルを空にすることによって復元しようとします。これは、a）あなたは同じデータベース構造でWordPressのバージョンから復元しているのように動作する必要があり、およびb）あなたのインポートされたデータベースは、すでにインポートサイトに存在しない任意のテーブルが含まれていません。"
+msgstr ""
 
 #: lib/installer.php:2330 lib/installer.php:2342
 #, php-format
@@ -17776,7 +17774,7 @@ msgstr "インストールするデバイスパッケージがありません"
 #: lib/installer.php:3012
 #, php-format
 msgid "%d Tables to be Upgraded"
-msgstr "追加するアイテムの種類。"
+msgstr ""
 
 #: lib/installer.php:3012 lib/installer.php:3014 lib/installer.php:3056
 msgid "Table Upgrades"
@@ -17924,7 +17922,7 @@ msgstr "設定待ち"
 #: lib/installer.php:3532
 #, php-format
 msgid "Setting default data source profile to %s (%s)"
-msgstr "このデータテンプレートのデフォルトのデータソースプロファイル。"
+msgstr ""
 
 #: lib/installer.php:3557
 #, php-format
@@ -17947,12 +17945,12 @@ msgstr "自動化のための追加のSNMP設定の追加"
 #: lib/installer.php:3593
 #, php-format
 msgid "Selecting Automation Option Set %s"
-msgstr "自動化テンプレートを削除"
+msgstr ""
 
 #: lib/installer.php:3607
 #, php-format
 msgid "Updating Automation Option Set %s"
-msgstr "自動化SNMPオプション"
+msgstr ""
 
 #: lib/installer.php:3611
 #, php-format
@@ -17962,12 +17960,12 @@ msgstr "オートメーションオプションセット%sを更新しました"
 #: lib/installer.php:3613
 #, php-format
 msgid "Resequencing Automation Option Set %s"
-msgstr "デバイスでオートメーションを実行する"
+msgstr ""
 
 #: lib/installer.php:3620
 #, php-format
 msgid "Failed to updated Automation Option Set %s"
-msgstr "指定された自動化範囲を適用できませんでした"
+msgstr ""
 
 #: lib/installer.php:3623
 msgid "Failed to find any automation option set"
@@ -17981,7 +17979,7 @@ msgstr "デバイステンプレート[編集：%s]"
 #: lib/installer.php:3665
 #, php-format
 msgid "The Add Default Device Command is: '%s'"
-msgstr "デフォルトのデバイスの追加コマンドは次のとおりです: '%s'"
+msgstr ""
 
 #: lib/installer.php:3673
 msgid "WARNING: Default Device Failed to be Added error to follow."
@@ -17994,7 +17992,7 @@ msgstr "サボテンに追加"
 #: lib/installer.php:3680
 #, php-format
 msgid "Output: %s."
-msgstr "出力項目"
+msgstr ""
 
 #: lib/installer.php:3700
 msgid "Creating Graphs for Default Device"
@@ -18171,7 +18169,7 @@ msgstr "サーバーに接続できない(%s)"
 #: lib/ldap.php:436
 #, php-format
 msgid "Connection Timeout to Server (%s)"
-msgstr "接続タイムアウト"
+msgstr ""
 
 #: lib/ldap.php:440
 #, php-format
@@ -18198,7 +18196,7 @@ msgstr "ユーザーDNが見つかりません"
 #: lib/ldap.php:460
 #, php-format
 msgid "Unable to create LDAP connection object to Server (%s)"
-msgstr "LDAP接続オブジェクトを作成できません"
+msgstr ""
 
 #: lib/ldap.php:464
 msgid "Specific DN and Password required"
@@ -18322,72 +18320,72 @@ msgstr "削除機能がないため、テーブルと設定を含むプラグイ
 #: lib/plugins.php:1441
 #, php-format
 msgid "The Archive for Plugin '%s' has been removed."
-msgstr "プラグイン'%s'のアーカイブが削除されました。"
+msgstr ""
 
 #: lib/plugins.php:1491
 #, php-format
 msgid "Restore failed!  The Plugin '%s' archive Restore failed.  Unable to create directory '%s'."
-msgstr "復元に失敗しました！プラグイン'%s'アーカイブの復元に失敗しました。ディレクトリ'%s'を作成できません。"
+msgstr ""
 
 #: lib/plugins.php:1493
 #, php-format
 msgid "Restore failed!  The available Plugin '%s' Load failed.  Unable to create directory '%s'."
-msgstr "復元に失敗しました！利用可能なプラグイン'%s'の読み込みに失敗しました。ディレクトリ'%s'を作成できません。"
+msgstr ""
 
 #: lib/plugins.php:1592
 #, php-format
 msgid "Restore failed!  The archived Plugin '%s' Restore failed. Unable to create directory %s"
-msgstr "復元に失敗しました！アーカイブされたプラグイン'%s'の復元に失敗しました。ディレクトリ %s を作成できません"
+msgstr ""
 
 #: lib/plugins.php:1594
 #, php-format
 msgid "Load failed!  The available Plugin '%s' Load failed. Unable to create directory %s"
-msgstr "読み込みに失敗しました！利用可能なプラグイン'%s'の読み込みに失敗しました。ディレクトリ %s を作成できません"
+msgstr ""
 
 #: lib/plugins.php:1614
 #, php-format
 msgid "Restore succeeded!  The archived Plugin '%s' Restore succeeded."
-msgstr "復元に成功しました！アーカイブされたプラグイン'%s'の復元に成功しました。"
+msgstr ""
 
 #: lib/plugins.php:1621
 #, php-format
 msgid "Load succeeded!  The available Plugin '%s' Load succeeded."
-msgstr "読み込みに成功しました！利用可能なプラグイン'%s'の読み込みに成功しました。"
+msgstr ""
 
 #: lib/plugins.php:1639
 #, php-format
 msgid "Restore failed!  The archived Plugin '%s' Restore failed.  Check the cacti.log for warnings."
-msgstr "復元に失敗しました！アーカイブされたプラグイン'%s'の復元に失敗しました。cacti.logで警告を確認します。"
+msgstr ""
 
 #: lib/plugins.php:1641
 #, php-format
 msgid "Load failed!  The available Plugin '%s' Load failed.  Check the cacti.log for warnings."
-msgstr "読み込みに失敗しました！利用可能なプラグイン'%s'の読み込みに失敗しました。cacti.logで警告を確認します。"
+msgstr ""
 
 #: lib/plugins.php:1648
 #, php-format
 msgid "Restore failed!  Unable to locate the archive record for Plugin '%s' in the database."
-msgstr "復元に失敗しました！データベースでプラグイン'%s'のアーカイブレコードを見つけることができません。"
+msgstr ""
 
 #: lib/plugins.php:1650
 #, php-format
 msgid "Load failed!  Unable to locate the available record for Plugin '%s' in the database."
-msgstr "読み込みに失敗しました！データベースでプラグイン'%s'の利用可能なレコードを見つけることができません。"
+msgstr ""
 
 #: lib/plugins.php:1717
 #, php-format
 msgid "The Plugin '%s' has been archived successfully."
-msgstr "サボテンログは正常に削除されました"
+msgstr ""
 
 #: lib/plugins.php:1719
 #, php-format
 msgid "The Plugin '%s' archiving process has failed.  Check the Cacti log for errors."
-msgstr "1つ以上のRRDファイルの修復に失敗しました。エラーについてはCactiログを参照してください。"
+msgstr ""
 
 #: lib/plugins.php:1722
 #, php-format
 msgid "The Plugin '%s' archiving process has failed due to the plugin directory being missing."
-msgstr "プラグインディレクトリが見つからないため、プラグイン'%s'のアーカイブプロセスが失敗しました。"
+msgstr ""
 
 #: lib/plugins.php:1730 lib/plugins.php:1737 plugins.php:638 plugins.php:641
 #: plugins.php:1043
@@ -18418,7 +18416,7 @@ msgstr "GitHub/GitLabの場所にプラグインが見つかりませんでし�
 #: lib/plugins.php:1956
 #, php-format
 msgid "The Cacti plugin %s has not releases"
-msgstr "Cacti Pollerはまだ実行されていません。"
+msgstr ""
 
 #: lib/plugins.php:2011 lib/plugins.php:2149
 msgid "Unable to get archive from GitHub/GitLab location."
@@ -18437,7 +18435,7 @@ msgstr "GitHub/GitLabの場所からプラグイン %s の開発リポジトリ�
 #: lib/plugins.php:2238
 #, php-format
 msgid "There were '%s' Plugins found at The Cacti Groups GitHub site and '%s' Plugins Tags/Releases were retrieved and updated in %0.2f seconds."
-msgstr "The Cacti Groups GitHubサイトに'%s'個のプラグインがあり、'%s'個のプラグインタグ/リリースが %0.2f 秒で取得および更新されました。"
+msgstr ""
 
 #: lib/plugins.php:2240
 #, php-format
@@ -18714,7 +18712,7 @@ msgstr "エラー：ホワイトリストの検証に失敗しました。デー
 #: lib/template.php:2267
 #, php-format
 msgid "Graph Not created for %s due to bad data"
-msgstr "グラフ作成"
+msgstr ""
 
 #: lib/template.php:2296
 #, php-format
@@ -18724,12 +18722,12 @@ msgstr "注：データソースの検証に失敗したため、データクエ
 #: lib/timespan_settings.php:136
 #, php-format
 msgid "Your Start Date '%s' is before January 1993.  Please pick a more recent Start Date."
-msgstr "開始日'%s'は1993年1月以前です。より最近の開始日を選択してください。"
+msgstr ""
 
 #: lib/timespan_settings.php:141
 #, php-format
 msgid "Your End Date '%s' is before January 1993.  Please pick a more recent End Date."
-msgstr "終了日'%s'は1993年1月以前です。より最近の終了日を選択してください。"
+msgstr ""
 
 #: lib/utility.php:1113
 msgid "MySQL 5.6+ and MariaDB 10.0+ are great releases, and are very good versions to choose. Make sure you run the very latest release though which fixes a long standing low level networking issue that was causing spine many issues with reliability."
@@ -18800,7 +18798,7 @@ msgstr "テーブルに非常に大きなインデックスがある場合、Bar
 #: lib/utility.php:1254
 #, php-format
 msgid "InnoDB will hold as much tables and indexes in system memory as is possible.  Therefore, you should make the innodb_buffer_pool large enough to hold as much of the tables and index in memory.  Checking the size of the /var/lib/mysql/cacti directory will help in determining this value.  We are recommending 25%% of your systems total memory, but your requirements will vary depending on your systems size.  If you database is very large or remote, you can consider increasing this size.  If remote, it can by as high as 80% of the systems memory.  However, cautions must be taken to reduce the swappiness of the system, or to remove swap to keep the system from swapping."
-msgstr "InnoDBはできるだけ多くのテーブルとインデックスをシステムメモリに保持します。そのため、innodb_buffer_poolを、メモリ内にできるだけ多くのテーブルとインデックスを保持できる大きさにする必要があります。 / var / lib / mysql / cactiディレクトリのサイズを確認すると、この値を決定するのに役立ちます。システム全体のメモリの25%を推奨していますが、要件はシステムのサイズによって異なります。"
+msgstr ""
 
 #: lib/utility.php:1260
 msgid "This settings should remain ON unless your Cacti instances is running on either ZFS or FusionI/O which both have internal journaling to accommodate abrupt system crashes.  However, if you have very good power, and your systems rarely go down and you have backups, turning this setting to OFF can net you almost a 50% increase in database performance."
@@ -18929,7 +18927,7 @@ msgstr "このVDEFの便利な名前。"
 #: link.php:79
 #, php-format
 msgid "External Link ID '%s' with Title '%s' attempted to inject an invalid URL and was blocked!"
-msgstr "タイトル'%s'の外部リンクID '%s'が無効なURLを挿入しようとしましたが、ブロックされました！"
+msgstr ""
 
 #: links.php:76
 msgid "Your contentfile is not a valid URL.  Please enter a value URL"
@@ -19135,7 +19133,7 @@ msgstr "サボテンのログアウト"
 #: logout.php:60
 #, php-format
 msgid "You have been logged out of Cacti due to %s."
-msgstr "セッションタイムアウトによりCactiからログアウトしました。"
+msgstr ""
 
 #: logout.php:61
 #, php-format
@@ -19320,7 +19318,7 @@ msgstr "テンプレートのパッケージ化中にエラーが発生しまし
 #: package.php:221
 #, php-format
 msgid "A Critical Template file '%s' is missing.  Please locate this file before packaging"
-msgstr "重要なテンプレートファイル'%s'がありません。パッケージングする前にこのファイルを見つけてください"
+msgstr ""
 
 #: package.php:562
 msgid "Package Templates"
@@ -19333,17 +19331,17 @@ msgstr "何をエクスポートしますか？"
 #: package.php:667
 #, php-format
 msgid "%s Device Package"
-msgstr "デバイス名"
+msgstr ""
 
 #: package.php:670
 #, php-format
 msgid "%s Graph Template Package"
-msgstr "グラフテンプレート名"
+msgstr ""
 
 #: package.php:673
 #, php-format
 msgid "%s Data Query Package"
-msgstr "データ照会名"
+msgstr ""
 
 #: package.php:700 templates_export.php:168
 #, php-format
@@ -19357,7 +19355,7 @@ msgstr "利用可能なテンプレート"
 #: package.php:709
 #, php-format
 msgid "%s to Export"
-msgstr "エクスポート"
+msgstr ""
 
 #: package.php:710
 msgid "Choose the exact items to export in the Package."
@@ -19427,7 +19425,7 @@ msgstr "パッケージ内容に含まれるもの"
 #: package.php:898
 #, php-format
 msgid "Script or Resource File '%s' does not exist.  Please repackage after locating and installing this file"
-msgstr "スクリプトまたはリソースファイル'%s'は存在しません。このファイルを見つけてインストールした後、再パッケージしてください"
+msgstr ""
 
 #: package.php:912 package_import.php:82
 msgid "Key Generation Required to Use Tool"
@@ -19444,7 +19442,7 @@ msgstr "このパッケージングツールを使用するには、まずcliデ
 #: package.php:964
 #, php-format
 msgid "The Web Server must have write access to the '%s' directory"
-msgstr "Webサーバーは'%s'ディレクトリへの書き込みアクセス権を持っている必要があります"
+msgstr ""
 
 #: package.php:986
 msgid "Unable to initialize SQLite3"
@@ -19474,7 +19472,7 @@ msgstr "パッケージ一時ディレクトリ %s を作成できません。"
 #: package_import.php:203 package_import.php:527
 #, php-format
 msgid "The Package %s Imported Successfully"
-msgstr "サボテンログは正常に削除されました"
+msgstr ""
 
 #: package_import.php:205 package_import.php:529
 #, php-format
@@ -19484,7 +19482,7 @@ msgstr "パッケージ %s のインポートに失敗しました"
 #: package_import.php:298
 #, php-format
 msgid "Package %s"
-msgstr "パッケージファイル"
+msgstr ""
 
 #: package_import.php:305
 msgid "Click 'Continue' to Import the following Package."
@@ -19528,7 +19526,7 @@ msgstr "このパッケージの公開鍵を取得できません。新しいパ
 #: package_import.php:427
 #, php-format
 msgid "You have not Trusted this Package Author '%s'.  If you wish to import, check the Automatically Trust Author checkbox.  Otherwise, feel free to reach the author at the following Email address '%s'."
-msgstr "このパッケージ作成者'%s'を信頼していません。インポートする場合は、[作成者を自動的に信頼する]チェックボックスをオンにします。それ以外の場合は、次のメールアドレス'%s'までお気軽にご連絡ください。"
+msgstr ""
 
 #: package_import.php:738
 msgid "Repo File Missing or Damaged"
@@ -19537,7 +19535,7 @@ msgstr "レポファイルが見つからないか破損しています"
 #: package_import.php:739
 #, php-format
 msgid "The Repo '%s' is NOT Reachable at the URL Location in the package.manifest."
-msgstr "リポジトリ'%s'は、package.manifestのURLロケーションに到達できません。"
+msgstr ""
 
 #: package_import.php:740
 msgid "Something is wrong with your Package Repository"
@@ -19550,12 +19548,12 @@ msgstr "1つ以上のパッケージの署名が信頼されていません。<b
 #: package_import.php:762
 #, php-format
 msgid "<b>Author:</b> &lt;%s&gt; %s.<br>"
-msgstr "<b>投稿者</b>：<%s>%s。<br>"
+msgstr ""
 
 #: package_import.php:766
 #, php-format
 msgid "<b>Package</b> %s"
-msgstr "パッケージファイル"
+msgstr ""
 
 #: package_import.php:769
 msgid "Press 'Ok' to start Trusting the Signer, or escape to cancel."
@@ -19576,7 +19574,7 @@ msgstr "すべてのパッケージ署名が検証されました"
 #: package_import.php:823 package_import.php:1963 package_repos.php:123
 #, php-format
 msgid "The Repo '%s' is NOT Reachable at the URL Location or the package.manifest file is missing."
-msgstr "リポジトリ'%s'はURLロケーションで到達できないか、package.manifestファイルがありません。"
+msgstr ""
 
 #: package_import.php:880 package_import.php:886 package_import.php:981
 #: package_import.php:984
@@ -19731,17 +19729,17 @@ msgstr "パッケージが見つかりません"
 #: package_import.php:1946
 #, php-format
 msgid "The Repo '%s' is NOT Reachable on GitHub or the '%s' file is missing or it could be an invalid branch.  Valid Package Locations are normally: https://github.com/Author/RepoName/."
-msgstr "レポジトリ'%s'はGitHubでアクセスできないか、'%s'ファイルが見つからないか、無効なブランチの可能性があります。有効なパッケージの場所は通常、https://github.com/Author/RepoName/です。"
+msgstr ""
 
 #: package_import.php:1974
 #, php-format
 msgid "The Repo '%s' is Reachable on the Local Cacti Server.  But not data returned from the manifest file."
-msgstr "レポジトリ'%s'はローカルCactiサーバーで到達可能です。しかし、マニフェストファイルから返されるデータはありません。"
+msgstr ""
 
 #: package_import.php:1977 package_repos.php:131
 #, php-format
 msgid "The Repo '%s' is NOT Reachable on the Local Cacti Server or the package.manifest file is missing."
-msgstr "レポジトリ'%s'はローカルCactiサーバーで到達できないか、package.manifestファイルがありません。"
+msgstr ""
 
 #: package_keys.php:95 package_repos.php:206
 msgid "Click 'Continue' to delete the following ."
@@ -19793,22 +19791,22 @@ msgstr "ダイレクトURL"
 #: package_repos.php:104
 #, php-format
 msgid "The Repo '%s' is Reachable on GitHub."
-msgstr "リポジトリ'%s'はGitHubで到達可能です。"
+msgstr ""
 
 #: package_repos.php:106
 #, php-format
 msgid "The Repo '%s' is NOT Reachable on GitHub or the package.manifest file is missing or it could be an invalid branch.  Valid Package Locations are normally: https://github.com/Author/RepoName/."
-msgstr "リポジトリ'%s'はGitHubでアクセスできないか、package.manifestファイルが見つからないか、無効なブランチである可能性があります。有効なパッケージの場所は通常、https://github.com/Author/RepoName/です。"
+msgstr ""
 
 #: package_repos.php:121
 #, php-format
 msgid "The Repo '%s' is Reachable at the URL Location."
-msgstr "リポジトリ'%s'はURLロケーションで到達可能です。"
+msgstr ""
 
 #: package_repos.php:129
 #, php-format
 msgid "The Repo '%s' is Reachable on the Local Cacti Server."
-msgstr "レポジトリ'%s'はローカルCactiサーバーで到達可能です。"
+msgstr ""
 
 #: package_repos.php:211
 msgid "Delete Package Repository"
@@ -20014,12 +20012,12 @@ msgstr "アーカイブ"
 #: plugins.php:165
 #, php-format
 msgid "The action '%s' on Plugin '%s' can not be performed due to the Plugin in it's current state."
-msgstr "プラグイン'%s'のアクション'%s'は、プラグインが現在の状態であるため実行できません。"
+msgstr ""
 
 #: plugins.php:169
 #, php-format
 msgid "The action '%s' '%s' on Plugin '%s' can not be taken as the Plugin is integrated."
-msgstr "プラグイン'%s'のアクション'%s''%s'は、プラグインが統合されているため実行できません。"
+msgstr ""
 
 #: plugins.php:218
 msgid "The fetch latest plugins process has been launched into background."
@@ -20032,12 +20030,12 @@ msgstr "最新のプラグインの取得プロセスはすでに開始されて
 #: plugins.php:276
 #, php-format
 msgid "Plugin '%s' has passed it's Configuration Check test and can not be Installed"
-msgstr "プラグイン'%s'は構成チェックテストに合格しており、インストールできません"
+msgstr ""
 
 #: plugins.php:278
 #, php-format
 msgid "Plugin '%s' Check Configuration function returned a null response which is invalid.  Please check with Plugin Developer for an update."
-msgstr "プラグイン'%s'構成チェック関数は無効なNULL応答を返しました。アップデートについては、プラグイン開発者に確認してください。"
+msgstr ""
 
 #: plugins.php:580
 msgid "Uninstalling this Plugin and may remove all Plugin Data and Settings.  If you really want to Uninstall the Plugin, click 'Uninstall' below.  Otherwise click 'Cancel'."
@@ -20417,7 +20415,7 @@ msgstr "プラグインをインストール"
 #: plugins.php:1760
 #, php-format
 msgid "Plugin '%s' can not be archived before it's been Installed."
-msgstr "プラグインをインストールできません。"
+msgstr ""
 
 #: plugins.php:1771
 msgid "Remove Plugin Data Tables and Settings"
@@ -20500,27 +20498,27 @@ msgstr "プラグインを有効にする"
 #: poller.php:405
 #, php-format
 msgid "WARNING: %s is out of sync with the Poller Interval for Poller[%d]!  The Poller Interval is %d seconds, with a maximum of a %d seconds, but %d seconds have passed since the last poll!"
-msgstr "警告：%sはポーラー間隔と同期していません。ポーリング間隔は &#39;%d&#39;秒で、最大 &#39;%d&#39;秒ですが、最後のポーリングから%d秒が経過しました。"
+msgstr ""
 
 #: poller.php:579
 #, php-format
 msgid "WARNING: There are %d processes detected as overrunning a polling cycle for Poller[%d], please investigate."
-msgstr "警告：ポーリングサイクルのオーバーランとして &#39;%d&#39;が検出されました。調べてください。"
+msgstr ""
 
 #: poller.php:637
 #, php-format
 msgid "WARNING: Poller Output Table not empty for Poller[%d].  Issues: %d, %s."
-msgstr "警告：ポーラー出力テーブルが空ではありません。問題：%d、%s。"
+msgstr ""
 
 #: poller.php:671
 #, php-format
 msgid "ERROR: The spine path: %s is invalid for Poller[%d].  Poller can not continue!"
-msgstr "エラー：スパインパス：%sが無効です。ポーラーは続けることができません！"
+msgstr ""
 
 #: poller.php:819
 #, php-format
 msgid "Maximum runtime of %d seconds exceeded for Poller[%d]. Exiting."
-msgstr "最大実行時間%d秒を超えました。終了しています。"
+msgstr ""
 
 #: poller.php:944
 msgid "WARNING: Cacti Polling Cycle Exceeded Poller Interval by "
@@ -20529,7 +20527,7 @@ msgstr "警告：サボテンのポーリングサイクルがポーラー間隔
 #: poller.php:970
 #, php-format
 msgid "WARNING: PollerID:%s with Name:%s is in Heartbeat Status"
-msgstr "警告：名前：%sのPollerID ：%sはハートビート状態です"
+msgstr ""
 
 #: poller.php:972
 msgid "Poller in Heartbeat Mode"
@@ -20538,12 +20536,12 @@ msgstr "ハートビートモードのポーラー"
 #: poller.php:1253
 #, php-format
 msgid "WARNING: 24 hours Poller[%d] avg. run time is %f seconds (more than %d &#37; of time limit)"
-msgstr "警告： 24時間ポーラー[%d]の平均実行時間は %f 秒です（制限時間の%d%を超えています）"
+msgstr ""
 
 #: poller.php:1269
 #, php-format
 msgid "WARNING: In last hour Poller[%d] run time %d times reached more than %d &#37; of time limit"
-msgstr "警告：直前の1時間に、ポーラー[%d]の実行時間 %d 回が制限時間の%d%を超えました"
+msgstr ""
 
 #: poller.php:1291
 msgid "Cacti System Notification"
@@ -20556,7 +20554,7 @@ msgstr "注：2番目のCactiデータコレクターが追加されました。
 #: poller_automation.php:54
 #, php-format
 msgid "WARNING: Main Cacti database %s offline or in recovery"
-msgstr "警告：メインのCactiデータベースはオフラインまたはリカバリ中です"
+msgstr ""
 
 #: poller_automation.php:1037 poller_automation.php:1091
 msgid "Cacti Primary Admin"
@@ -23595,7 +23593,7 @@ msgstr "%d 秒"
 #: utilities.php:1688
 #, php-format
 msgid "%0.2f percent of update frequency)"
-msgstr "更新頻度の%0.2f%）"
+msgstr "更新頻度の%0.2f%%）"
 
 #: utilities.php:1696
 msgid "RRD Updates:"
@@ -24094,7 +24092,6 @@ msgstr "VDEFなし"
 #~ msgstr "LINE1グラフに変換"
 
 #, fuzzy
-#~| msgid "DES"
 #~ msgid "DS"
 #~ msgstr "不均衡症候群"
 

--- a/locales/po/ko-KR.po
+++ b/locales/po/ko-KR.po
@@ -309,12 +309,12 @@ msgstr "집계와의 연관성 해제"
 #: aggregate_graphs.php:970
 #, php-format
 msgid "Click 'Continue' to Place the following Aggregate Graph on Tree %s."
-msgstr "다음 집계 그래프 템플릿을 삭제하려면 &#39;계속&#39;을 클릭하십시오."
+msgstr ""
 
 #: aggregate_graphs.php:971
 #, php-format
 msgid "Click 'Continue' to Duplicate following Aggregate Graphs on Tree %s."
-msgstr "트리 분기 아래에 다음 집계 그래프를 배치하려면 &#39;계속&#39;을 클릭하십시오."
+msgstr ""
 
 #: aggregate_graphs.php:972
 msgid "Place Aggregate Graph on Tree"
@@ -959,7 +959,7 @@ msgstr "사용자가 인증되었지만 템플릿 계정이 비활성화되었�
 #: auth_login.php:141
 #, php-format
 msgid "Access Denied!  Guest user id %s does not exist.  Please contact your Administrator."
-msgstr "액세스가 거부되었습니다. Cacti 관리자에게 연락하십시오."
+msgstr ""
 
 #: auth_login.php:180
 msgid "Access Denied!  User account disabled."
@@ -1243,12 +1243,12 @@ msgstr "장치 자동화 인터페이스를 통해 수동으로 추가되었습�
 #: automation_devices.php:125
 #, php-format
 msgid "Device %s Added to Cacti"
-msgstr "선인장에 추가됨"
+msgstr ""
 
 #: automation_devices.php:127
 #, php-format
 msgid "Device %s Not Added to Cacti"
-msgstr "선인장에 추가되지 않음"
+msgstr ""
 
 #: automation_devices.php:137
 msgid "Devices Removed from Cacti Automation database"
@@ -2969,7 +2969,7 @@ msgstr "&#39;계속&#39;을 클릭하여 다음 데이터를 삭제하면 장치
 #: automation_templates.php:791
 #, php-format
 msgid "Tree Rule Name: '%s'"
-msgstr "트리 규칙 항목"
+msgstr ""
 
 #: automation_templates.php:798
 msgid "Remove Tree Rule"
@@ -3482,7 +3482,7 @@ msgstr "전체"
 #: changelog.php:99
 #, php-format
 msgid "Change Log [%s]"
-msgstr "ChangeLogLanguage"
+msgstr ""
 
 #: changelog.php:160 support.php:1018
 #, php-format
@@ -4930,7 +4930,7 @@ msgstr "데이터 소스 정보 모드를 켭니다."
 #: data_sources.php:864
 #, php-format
 msgid "Edit Graph: '%s'."
-msgstr "그래프 템플릿 편집."
+msgstr ""
 
 #: data_sources.php:869 graphs.php:2280
 msgid "Edit Device."
@@ -5353,7 +5353,7 @@ msgstr "그래프가 존재하지 않습니다"
 #: graph.php:115 graph.php:409
 #, php-format
 msgid "Graph Utility View for Graph: %s"
-msgstr "그래프 유틸리티보기"
+msgstr ""
 
 #: graph.php:160 lib/html.php:585
 msgid "Graph Details, Zooming and Debugging Utilities"
@@ -6056,12 +6056,12 @@ msgstr "보고서에 그래프 놓기"
 #: graphs.php:1912
 #, php-format
 msgid "Click 'Continue' to Place the following Graph on Tree %s."
-msgstr "다음 트리를 삭제하려면 &#39;계속&#39;을 클릭하십시오."
+msgstr ""
 
 #: graphs.php:1913
 #, php-format
 msgid "Click 'Continue' to Duplicate following Graphs on Tree %s."
-msgstr "다음 트리를 삭제하려면 &#39;계속&#39;을 클릭하십시오."
+msgstr ""
 
 #: graphs.php:1914
 msgid "Place Graph on Tree"
@@ -6162,7 +6162,7 @@ msgstr "사용자 그룹 관리 [편집 :  %s]"
 #: graphs.php:2688
 #, php-format
 msgid "Graph Management [ %s ]"
-msgstr "그래프 관리"
+msgstr ""
 
 #: graphs.php:2756 graphs.php:2759
 msgid "Source"
@@ -6191,7 +6191,7 @@ msgstr "저장된 기본 설정"
 #: graphs_new.php:338
 #, php-format
 msgid "New Graphs for [ %s ] (%s %s)"
-msgstr "[ %s]에 대한 새로운 그래프"
+msgstr ""
 
 #: graphs_new.php:340
 msgid "New Graphs for [ All Devices ]"
@@ -6252,7 +6252,7 @@ msgstr "ID가 '%s'인 데이터 쿼리 '%s'에 대한 데이터 쿼리 리소스
 #: graphs_new.php:695
 #, php-format
 msgid "Error Parsing Data Query Resource XML file for Data Query '%s' with id '%s'.  Field Name '%s' missing a 'direction' attribute"
-msgstr "ID가 '%s'인 데이터 쿼리 '%s'에 대한 데이터 쿼리 리소스 XML 파일을 구문 분석하는 동안 오류가 발생했습니다."
+msgstr ""
 
 #: graphs_new.php:699
 #, php-format
@@ -6376,7 +6376,7 @@ msgstr "장치 재 색인이 % 0.2f 초 안에 완료되었습니다. % d 개의
 #: host.php:360
 #, php-format
 msgid "Unable to add some Devices to Report '%s'"
-msgstr "서버에 연결할 수 없습니다."
+msgstr ""
 
 #: host.php:479
 msgid "Click 'Continue' to Delete the following Device."
@@ -6489,12 +6489,12 @@ msgstr "트리에 장치 놓기"
 #: host.php:564
 #, php-format
 msgid "Click 'Continue' to Place the following Device on Tree %s."
-msgstr "다음 장치 템플릿을 삭제하려면 &#39;계속&#39;을 클릭하십시오."
+msgstr ""
 
 #: host.php:565
 #, php-format
 msgid "Click 'Continue' to Duplicate following Devices on Tree %s."
-msgstr "다음 트리를 삭제하려면 &#39;계속&#39;을 클릭하십시오."
+msgstr ""
 
 #: host.php:566
 msgid "Place Device on Tree"
@@ -7666,12 +7666,12 @@ msgstr "% d 시간마다"
 #: include/global_arrays.php:771
 #, php-format
 msgid "Every %d Day"
-msgstr "% 1 일마다"
+msgstr ""
 
 #: include/global_arrays.php:783
 #, php-format
 msgid "%0.1f Minutes"
-msgstr "%d 분"
+msgstr ""
 
 #: include/global_arrays.php:816 include/global_arrays.php:836
 #: include/global_arrays.php:848 include/global_arrays.php:849
@@ -9476,7 +9476,7 @@ msgstr "단일 SNMP 가져 오기 요청에서 얻을 수있는 OID 수를 지�
 #: include/global_form.php:161
 #, php-format
 msgid "%d OID"
-msgstr "최대 OID"
+msgstr ""
 
 #: include/global_form.php:162 include/global_form.php:163
 #: include/global_form.php:164 include/global_form.php:165
@@ -9509,7 +9509,7 @@ msgstr "첫 번째 Re-Index에서 자동 감지/설정"
 #: include/global_form.php:188
 #, php-format
 msgid "%d Repetition"
-msgstr "그리드 옵션"
+msgstr ""
 
 #: include/global_form.php:189 include/global_form.php:190
 #: include/global_form.php:191 include/global_form.php:192
@@ -9521,7 +9521,7 @@ msgstr "그리드 옵션"
 #: include/global_form.php:203
 #, php-format
 msgid "%d Repetitions"
-msgstr "그리드 옵션"
+msgstr ""
 
 #: include/global_form.php:212
 msgid "The maximum number of attempts to reach a device via an SNMP readstring prior to giving up."
@@ -11629,7 +11629,7 @@ msgstr "기본 장치 스레드 수입니다. 이것은 척추 데이터 수집�
 #: include/global_settings.php:816
 #, php-format
 msgid "%s Thread"
-msgstr "스레드 % d 개"
+msgstr ""
 
 #: include/global_settings.php:817 include/global_settings.php:818
 #: include/global_settings.php:819 include/global_settings.php:820
@@ -11638,7 +11638,7 @@ msgstr "스레드 % d 개"
 #: include/global_settings.php:825
 #, php-format
 msgid "%s Threads"
-msgstr "스레드 % d 개"
+msgstr ""
 
 #: include/global_settings.php:829
 msgid "Re-index Method for Data Queries"
@@ -14322,12 +14322,12 @@ msgstr "업데이트"
 #: lib/api_automation.php:5309 lib/api_automation.php:5311
 #, php-format
 msgid "Automation Network SNMP Option %s!"
-msgstr "자동화 SNMP 옵션"
+msgstr ""
 
 #: lib/api_automation.php:5315 lib/api_automation.php:5317
 #, php-format
 msgid "Automation Network SNMP Option %s Failed!"
-msgstr "자동화 SNMP 옵션"
+msgstr ""
 
 #: lib/api_automation.php:5351
 msgid "The Automation Network Rule does not include any SNMP Options!"
@@ -14348,7 +14348,7 @@ msgstr "알 수없는 템플릿"
 #: lib/api_automation.php:5404 lib/api_automation.php:5406
 #, php-format
 msgid "Automation Network Rule '%s' %s!"
-msgstr "기본 자동화 네트워크"
+msgstr ""
 
 #: lib/api_automation.php:5410 lib/api_automation.php:5412
 #, php-format
@@ -14469,29 +14469,29 @@ msgstr "기기가 사용 중지되었습니다."
 #: lib/auth.php:2355 lib/auth.php:2357 lib/auth.php:2363 lib/auth.php:2365
 #, php-format
 msgid "Graph:(%s%s)"
-msgstr "그래프:"
+msgstr ""
 
 #: lib/auth.php:2378 lib/auth.php:2384 lib/auth.php:2451 lib/auth.php:2453
 #: lib/auth.php:2457 lib/auth.php:2459
 #, php-format
 msgid "Device:(%s%s)"
-msgstr "장치"
+msgstr ""
 
 #: lib/auth.php:2392 lib/auth.php:2398 lib/auth.php:2467 lib/auth.php:2469
 #: lib/auth.php:2473 lib/auth.php:2475
 #, php-format
 msgid "Template:(%s%s)"
-msgstr "템플릿"
+msgstr ""
 
 #: lib/auth.php:2405
 #, php-format
 msgid "Graph+Device+Template:(%s%s)"
-msgstr "기기 템플릿 :"
+msgstr ""
 
 #: lib/auth.php:2442 lib/auth.php:2444
 #, php-format
 msgid "Device+Template:(%s%s)"
-msgstr "기기 템플릿 :"
+msgstr ""
 
 #: lib/auth.php:2488 lib/auth.php:2495 lib/auth.php:2504
 msgid "Restricted By: "
@@ -14562,7 +14562,7 @@ msgstr "LDAP 검색 오류 :  %s"
 #: lib/auth.php:4094 lib/auth.php:5105
 #, php-format
 msgid "Access Denied!  Template user id %s does not exist.  Please contact your Administrator."
-msgstr "액세스가 거부되었습니다. Cacti 관리자에게 연락하십시오."
+msgstr ""
 
 #: lib/auth.php:4479
 msgid "Access Denied! Login failed."
@@ -14640,7 +14640,7 @@ msgstr "2FA가 활성화되고 검증되었습니다"
 #: lib/boost.php:64 utilities.php:1708
 #, php-format
 msgid "%s MBytes"
-msgstr "% d MBytes"
+msgstr ""
 
 #: lib/boost.php:67
 #, php-format
@@ -14849,7 +14849,7 @@ msgstr "색인 제거가 감지되었습니다! 이전 색인 :  %s"
 #: lib/data_query.php:360
 #, php-format
 msgid "Verification of %s Local Data ID's Complete"
-msgstr "로컬 데이터와 색인 연관 완료"
+msgstr ""
 
 #: lib/data_query.php:363
 #, php-format
@@ -14875,7 +14875,7 @@ msgstr "로컬 데이터와 색인 연관 완료"
 #: lib/data_query.php:392
 #, php-format
 msgid "Update Re-Index Cache complete. There were %s index changes, and %s orphaned indexes."
-msgstr "업데이트 색인 다시 캐시 완료. 있었다"
+msgstr ""
 
 #: lib/data_query.php:396
 msgid "Update Poller Cache for Query complete"
@@ -14989,7 +14989,7 @@ msgstr "&#39; %s&#39;필드에 대한 데이터 쿼리 출력을 표시하려면
 #: lib/data_query.php:741
 #, php-format
 msgid "Sort field returned no data for field name %s, skipping"
-msgstr "정렬 필드에서 데이터가 반환되지 않았습니다. 다시 색인 생성을 계속할 수 없습니다."
+msgstr ""
 
 #: lib/data_query.php:743
 #, php-format
@@ -15022,7 +15022,7 @@ msgstr "SNMP 세션을로드하지 못했습니다."
 #: lib/data_query.php:886
 #, php-format
 msgid "Tested Bulk Walk Size %d with a response of %2.4f."
-msgstr "%2.4f 응답으로 Bulk Walk Size %d를 테스트했습니다."
+msgstr ""
 
 #: lib/data_query.php:898
 #, php-format
@@ -15175,7 +15175,7 @@ msgstr "발견 된 항목 [ %s = &#39; %s&#39;] 색인 :  %s [from  %s]"
 #: lib/data_query.php:1386
 #, php-format
 msgid "Found OCTET STRING '%s' decoded value: '%s'"
-msgstr "% OCTET STRING &#39; %s&#39;디코딩 된 값을 발견했습니다 : &#39; %s&#39;"
+msgstr ""
 
 #: lib/data_query.php:1392 lib/data_query.php:1443
 #, php-format
@@ -15233,7 +15233,7 @@ msgstr "암호 필드 길이를 변경하는 데 실패했으며 암호를 손�
 #: lib/dsdebug.php:175
 #, php-format
 msgid "Data Source ID %s does not exist"
-msgstr "데이터 소스가 존재하지 않습니다."
+msgstr ""
 
 #: lib/dsdebug.php:259
 msgid "Debug not completed after 5 pollings"
@@ -15250,12 +15250,12 @@ msgstr "데이터 소스가 활성으로 설정되지 않았습니다."
 #: lib/dsdebug.php:277
 #, php-format
 msgid "RRDfile Folder (rra) is not writable by Poller.  Folder owner: %s.  Poller runs as: %s"
-msgstr "RRD 폴더는 폴러가 쓸 수 없습니다. RRD 소유자 :"
+msgstr ""
 
 #: lib/dsdebug.php:282
 #, php-format
 msgid "RRDfile is not writable by Poller.  RRDfile owner: %s.  Poller runs as %s"
-msgstr "RRD 파일에 폴러가 쓸 수 없습니다. RRD 소유자 :"
+msgstr ""
 
 #: lib/dsdebug.php:291
 msgid "RRDfile does not match Data Source"
@@ -15558,7 +15558,7 @@ msgstr "이전"
 #: lib/html.php:671
 #, php-format
 msgid "%d to %d of %s [ %s ]"
-msgstr "% d ~  %s [ %s]"
+msgstr ""
 
 #: lib/html.php:674 lib/html.php:703 lib/installer.php:1778
 msgid "Next"
@@ -15572,7 +15572,7 @@ msgstr "전체 % d  %s"
 #: lib/html.php:700
 #, php-format
 msgid "Current Page: %s"
-msgstr "현재 가치"
+msgstr ""
 
 #: lib/html.php:731
 #, php-format
@@ -16653,22 +16653,22 @@ msgstr "[새로운]"
 #: lib/html_reports.php:1572
 #, php-format
 msgid "Details %s"
-msgstr "상세정보"
+msgstr ""
 
 #: lib/html_reports.php:1618
 #, php-format
 msgid "Report Items %s"
-msgstr "보고서 항목 없음"
+msgstr ""
 
 #: lib/html_reports.php:1664
 #, php-format
 msgid "Scheduled Events %s"
-msgstr "예정된 일정"
+msgstr ""
 
 #: lib/html_reports.php:1676
 #, php-format
 msgid "Report Preview %s"
-msgstr "보고서 미리보기"
+msgstr ""
 
 #: lib/html_reports.php:1712
 msgid "Item Details"
@@ -16677,7 +16677,7 @@ msgstr "아이템 세부내역"
 #: lib/html_reports.php:1727
 #, php-format
 msgid "Graph: %s"
-msgstr "그래프:"
+msgstr ""
 
 #: lib/html_reports.php:1730 lib/html_reports.php:1758
 #: lib/html_reports.php:1771 lib/html_reports.php:1772
@@ -16707,7 +16707,7 @@ msgstr ", 정규식 사용: \"%s\""
 #: lib/html_reports.php:1800
 #, php-format
 msgid "Tree: %s"
-msgstr "트리:"
+msgstr ""
 
 #: lib/html_reports.php:1811
 #, php-format
@@ -16717,7 +16717,7 @@ msgstr "(장치에서 :  %s)"
 #: lib/html_reports.php:1813
 #, php-format
 msgid ", Branch: %s"
-msgstr "분기:"
+msgstr ""
 
 #: lib/html_reports.php:1816
 msgid "(All Branches)"
@@ -17020,7 +17020,7 @@ msgstr "지정된 cron 간격을 적용하지 못했습니다."
 #: lib/installer.php:1107
 #, php-format
 msgid "Failed to apply '%s' as Automation Range"
-msgstr "지정된 자동화 범위를 적용하지 못했습니다."
+msgstr ""
 
 #: lib/installer.php:1190
 msgid "No matching snmp option exists"
@@ -17172,7 +17172,7 @@ msgstr "Cacti 구성은 config.php에 상대 경로 (url_path)가 있습니다."
 #: lib/installer.php:2037
 #, php-format
 msgid "PHP - Recommendations (%s)"
-msgstr "PHP - 권장 사항"
+msgstr ""
 
 #: lib/installer.php:2041
 msgid "PHP Recommendations ("
@@ -17289,7 +17289,7 @@ msgstr "설치 유형"
 #: lib/installer.php:2239
 #, php-format
 msgid "Upgrade from <strong>%s</strong> to <strong>%s</strong>"
-msgstr "<strong> %s의</strong> <strong>%의에서</strong> 업그레이드"
+msgstr ""
 
 #: lib/installer.php:2241
 msgid "In the event of issues, It is highly recommended that you clear your browser cache, closing then reopening your browser (not just the tab Cacti is on) and retrying, before raising an issue with The Cacti Group"
@@ -17781,7 +17781,7 @@ msgstr "설치할 장치 패키지가 없습니다"
 #: lib/installer.php:3012
 #, php-format
 msgid "%d Tables to be Upgraded"
-msgstr "추가 할 항목 유형입니다."
+msgstr ""
 
 #: lib/installer.php:3012 lib/installer.php:3014 lib/installer.php:3056
 msgid "Table Upgrades"
@@ -17916,7 +17916,7 @@ msgstr "프로필 '%s'에서 패키지 # %s '%s'을 (를) 가져 오지 못했�
 #: lib/installer.php:3469
 #, php-format
 msgid "Mapping Automation Template for Device Template '%s'"
-msgstr "[Deleted Template]에 대한 자동화 템플릿"
+msgstr ""
 
 #: lib/installer.php:3490
 msgid "No templates were selected for import"
@@ -17929,12 +17929,12 @@ msgstr "구성 대기 중"
 #: lib/installer.php:3532
 #, php-format
 msgid "Setting default data source profile to %s (%s)"
-msgstr "이 데이터 템플릿의 기본 데이터 소스 프로필입니다."
+msgstr ""
 
 #: lib/installer.php:3557
 #, php-format
 msgid "Failed to find selected profile (%s), no changes were made"
-msgstr "지정한 프로필  %s! =  %s을 적용하지 못했습니다."
+msgstr ""
 
 #: lib/installer.php:3568
 #, php-format
@@ -17952,12 +17952,12 @@ msgstr "자동화를위한 추가 snmp 설정 추가"
 #: lib/installer.php:3593
 #, php-format
 msgid "Selecting Automation Option Set %s"
-msgstr "자동화 템플릿 삭제"
+msgstr ""
 
 #: lib/installer.php:3607
 #, php-format
 msgid "Updating Automation Option Set %s"
-msgstr "자동화 SNMP 옵션"
+msgstr ""
 
 #: lib/installer.php:3611
 #, php-format
@@ -17967,12 +17967,12 @@ msgstr "자동화 옵션 세트 %s을 (를) 성공적으로 업데이트했습�
 #: lib/installer.php:3613
 #, php-format
 msgid "Resequencing Automation Option Set %s"
-msgstr "장치에서 자동화 실행"
+msgstr ""
 
 #: lib/installer.php:3620
 #, php-format
 msgid "Failed to updated Automation Option Set %s"
-msgstr "지정된 자동화 범위를 적용하지 못했습니다."
+msgstr ""
 
 #: lib/installer.php:3623
 msgid "Failed to find any automation option set"
@@ -17999,7 +17999,7 @@ msgstr "선인장에 추가됨"
 #: lib/installer.php:3680
 #, php-format
 msgid "Output: %s."
-msgstr "출력 필드"
+msgstr ""
 
 #: lib/installer.php:3700
 msgid "Creating Graphs for Default Device"
@@ -18079,7 +18079,7 @@ msgstr "백그라운드가 이미 %s에서 시작되었습니다. %s에서의이
 #: lib/installer.php:3946
 #, php-format
 msgid "Exception occurred during installation: #%s - %s"
-msgstr "설치 중에 예외가 발생했습니다 : #"
+msgstr ""
 
 #: lib/installer.php:3956
 #, php-format
@@ -18093,12 +18093,12 @@ msgstr "모두"
 #: lib/installer.php:3997
 #, php-format
 msgid "No - %s"
-msgstr "분"
+msgstr ""
 
 #: lib/installer.php:4005
 #, php-format
 msgid "%s - N/A"
-msgstr "분"
+msgstr ""
 
 #: lib/installer.php:4005 lib/installer.php:4007
 msgid "Web"
@@ -18107,7 +18107,7 @@ msgstr "웹"
 #: lib/installer.php:4007 lib/installer.php:4010
 #, php-format
 msgid "%s - No"
-msgstr "분"
+msgstr ""
 
 #: lib/installer.php:4010
 msgid "Cli"
@@ -18146,17 +18146,17 @@ msgstr "사용자 이름이 정의되지 않았습니다."
 #: lib/ldap.php:412
 #, php-format
 msgid "Protocol Error, Unable to set version (%s) on Server (%s)"
-msgstr "프로토콜 오류, 버전을 설정할 수 없습니다."
+msgstr ""
 
 #: lib/ldap.php:416
 #, php-format
 msgid "Protocol Error, Unable to set referrals option (%s) on Server (%s)"
-msgstr "프로토콜 오류, 추천 옵션을 설정할 수 없습니다."
+msgstr ""
 
 #: lib/ldap.php:420
 #, php-format
 msgid "Protocol Error, unable to start TLS communications (%s) on Server (%s)"
-msgstr "프로토콜 오류, TLS 통신을 시작할 수 없음"
+msgstr ""
 
 #: lib/ldap.php:424
 #, php-format
@@ -18166,27 +18166,27 @@ msgstr "프로토콜 오류, 일반 오류 ( %s)"
 #: lib/ldap.php:428
 #, php-format
 msgid "Protocol Error, Unable to bind, LDAP result: (%s) on Server (%s)"
-msgstr "프로토콜 오류, 바인딩 할 수 없습니다. LDAP 결과 :  %s"
+msgstr ""
 
 #: lib/ldap.php:432
 #, php-format
 msgid "Unable to Connect to Server (%s)"
-msgstr "서버에 연결할 수 없습니다."
+msgstr ""
 
 #: lib/ldap.php:436
 #, php-format
 msgid "Connection Timeout to Server (%s)"
-msgstr "접속 시간 초과"
+msgstr ""
 
 #: lib/ldap.php:440
 #, php-format
 msgid "Insufficient Access to Server (%s)"
-msgstr "불충분 한 액세스"
+msgstr ""
 
 #: lib/ldap.php:444
 #, php-format
 msgid "Group DN could not be found to compare on Server (%s)"
-msgstr "그룹 DN을 (를) 찾을 수 없습니다."
+msgstr ""
 
 #: lib/ldap.php:448
 msgid "More than one matching user found"
@@ -18203,7 +18203,7 @@ msgstr "사용자 DN을 찾을 수 없습니다."
 #: lib/ldap.php:460
 #, php-format
 msgid "Unable to create LDAP connection object to Server (%s)"
-msgstr "LDAP 연결 개체를 만들 수 없습니다."
+msgstr ""
 
 #: lib/ldap.php:464
 msgid "Specific DN and Password required"
@@ -18216,7 +18216,7 @@ msgstr "잘못된 비밀번호가 제공되었습니다. 로그인 실패."
 #: lib/ldap.php:473
 #, php-format
 msgid "Unexpected error %s (Ldap Error: %s) on Server (%s)"
-msgstr "예기치 않은 오류  %s (Ldap 오류 :  %s)"
+msgstr ""
 
 #: lib/ping.php:149
 msgid "ICMP Ping timed out"
@@ -18288,7 +18288,7 @@ msgstr "설정으로 인해 핑이 수행되지 않았습니다."
 #: lib/plugins.php:681
 #, php-format
 msgid "'%s' versions '%s' above or in range are required to install '%s'. "
-msgstr "%s 버전  %s 이상이 필요합니다."
+msgstr ""
 
 #: lib/plugins.php:685
 #, php-format
@@ -18382,12 +18382,12 @@ msgstr "로드 실패! 데이터베이스에서 플러그인 '%s' 에 사용할 
 #: lib/plugins.php:1717
 #, php-format
 msgid "The Plugin '%s' has been archived successfully."
-msgstr "Cacti 로그가 성공적으로 제거되었습니다."
+msgstr ""
 
 #: lib/plugins.php:1719
 #, php-format
 msgid "The Plugin '%s' archiving process has failed.  Check the Cacti log for errors."
-msgstr "하나 이상의 RRDfile 복구가 실패했습니다. Cacti 로그에서 오류를 확인하십시오."
+msgstr ""
 
 #: lib/plugins.php:1722
 #, php-format
@@ -18423,7 +18423,7 @@ msgstr "GitHub/GitLab 위치에서 플러그인을 찾을 수 없습니다."
 #: lib/plugins.php:1956
 #, php-format
 msgid "The Cacti plugin %s has not releases"
-msgstr "Cacti Poller는 아직 운영되지 않았습니다."
+msgstr ""
 
 #: lib/plugins.php:2011 lib/plugins.php:2149
 msgid "Unable to get archive from GitHub/GitLab location."
@@ -18452,7 +18452,7 @@ msgstr "Cacti Groups GitHub 사이트에 연결할 수 없습니다. %0.2f 초 �
 #: lib/reports.php:144
 #, php-format
 msgid "Device '%s' successfully added to Report."
-msgstr "선인장에 추가됨"
+msgstr ""
 
 #: lib/reports.php:147
 msgid "Device not found! Unable to add to Report"
@@ -18528,7 +18528,7 @@ msgstr "RRDtool 명령 :"
 #: lib/rrd.php:3299
 #, php-format
 msgid "The required RRDfile step size is '%s' but observed step is '%s'"
-msgstr "필수 RRD 단계 크기는 &#39; %s&#39;입니다."
+msgstr ""
 
 #: lib/rrd.php:3359
 #, php-format
@@ -18573,7 +18573,7 @@ msgstr "선인장에 대한 XFF RRA id &#39; %s&#39;은 (는) &#39; %s&#39;이�
 #: lib/rrd.php:3458
 #, php-format
 msgid "The number of rows for Cacti RRA id '%s' is incorrect.  The number of rows are '%s' but should be '%s'"
-msgstr "Cacti RRA id &#39; %s&#39;의 행 수는 &#39; %s&#39;이어야합니다."
+msgstr ""
 
 #: lib/rrd.php:3476
 #, php-format
@@ -18719,7 +18719,7 @@ msgstr "오류 : 화이트리스트 검증에 실패했습니다. 데이터 입�
 #: lib/template.php:2267
 #, php-format
 msgid "Graph Not created for %s due to bad data"
-msgstr "그래프 생성"
+msgstr ""
 
 #: lib/template.php:2296
 #, php-format
@@ -18743,7 +18743,7 @@ msgstr "MySQL 5.6+와 MariaDB 10.0+는 훌륭한 릴리스이며 선택할 수�
 #: lib/utility.php:1125
 #, php-format
 msgid "It is STRONGLY recommended that you enable InnoDB in any %s version greater than 5.5.3."
-msgstr "5.1보다 큰 모든 버전에서 InnoDB를 활성화하는 것이 좋습니다."
+msgstr ""
 
 #: lib/utility.php:1138 lib/utility.php:1175
 msgid "When using Cacti with languages other than English, it is important to use the utf8mb4_unicode_ci collation type as some characters take more than a single byte."
@@ -18757,7 +18757,7 @@ msgstr "영어 이외의 언어로 Cacti를 사용하는 경우 일부 문자는
 #: lib/utility.php:1163
 #, php-format
 msgid "It is recommended that you enable InnoDB in any %s version greater than 5.1."
-msgstr "5.1보다 큰 모든 버전에서 InnoDB를 활성화하는 것이 좋습니다."
+msgstr ""
 
 #: lib/utility.php:1196
 #, php-format
@@ -18805,7 +18805,7 @@ msgstr "테이블에 인덱스가 매우 큰 경우 Barracuda innodb_file_format
 #: lib/utility.php:1254
 #, php-format
 msgid "InnoDB will hold as much tables and indexes in system memory as is possible.  Therefore, you should make the innodb_buffer_pool large enough to hold as much of the tables and index in memory.  Checking the size of the /var/lib/mysql/cacti directory will help in determining this value.  We are recommending 25%% of your systems total memory, but your requirements will vary depending on your systems size.  If you database is very large or remote, you can consider increasing this size.  If remote, it can by as high as 80% of the systems memory.  However, cautions must be taken to reduce the swappiness of the system, or to remove swap to keep the system from swapping."
-msgstr "InnoDB는 가능한 많은 테이블과 인덱스를 시스템 메모리에 보유합니다. 그러므로, innodb_buffer_pool을 메모리에서 많은 테이블과 인덱스를 저장할만큼 충분히 크게 만들어야한다. / var / lib / mysql / cacti 디렉토리의 크기를 확인하면이 값을 결정하는 데 도움이됩니다. 시스템 총 메모리의 25 %%를 권장하지만 사용자의 요구 사항은 시스템 크기에 따라 다릅니다."
+msgstr ""
 
 #: lib/utility.php:1260
 msgid "This settings should remain ON unless your Cacti instances is running on either ZFS or FusionI/O which both have internal journaling to accommodate abrupt system crashes.  However, if you have very good power, and your systems rarely go down and you have backups, turning this setting to OFF can net you almost a 50% increase in database performance."
@@ -19140,7 +19140,7 @@ msgstr "선인장 로그 아웃"
 #: logout.php:60
 #, php-format
 msgid "You have been logged out of Cacti due to %s."
-msgstr "Cacti에서 세션 시간 초과로 인해 로그 아웃되었습니다."
+msgstr ""
 
 #: logout.php:61
 #, php-format
@@ -19338,17 +19338,17 @@ msgstr "무엇을 수출 하시겠습니까?"
 #: package.php:667
 #, php-format
 msgid "%s Device Package"
-msgstr "장치 이름"
+msgstr ""
 
 #: package.php:670
 #, php-format
 msgid "%s Graph Template Package"
-msgstr "그래프 템플릿 이름"
+msgstr ""
 
 #: package.php:673
 #, php-format
 msgid "%s Data Query Package"
-msgstr "데이터 쿼리 이름"
+msgstr ""
 
 #: package.php:700 templates_export.php:168
 #, php-format
@@ -19362,7 +19362,7 @@ msgstr "사용 가능한 템플릿"
 #: package.php:709
 #, php-format
 msgid "%s to Export"
-msgstr "내보내기"
+msgstr ""
 
 #: package.php:710
 msgid "Choose the exact items to export in the Package."
@@ -19479,7 +19479,7 @@ msgstr "패키지 임시 디렉터리 %s 을 (를) 생성할 수 없습니다."
 #: package_import.php:203 package_import.php:527
 #, php-format
 msgid "The Package %s Imported Successfully"
-msgstr "Cacti 로그가 성공적으로 제거되었습니다."
+msgstr ""
 
 #: package_import.php:205 package_import.php:529
 #, php-format
@@ -19489,7 +19489,7 @@ msgstr "패키지 %s 가져오기 실패"
 #: package_import.php:298
 #, php-format
 msgid "Package %s"
-msgstr "패키지 파일"
+msgstr ""
 
 #: package_import.php:305
 msgid "Click 'Continue' to Import the following Package."
@@ -19560,7 +19560,7 @@ msgstr "<b>작성자:</b> < %s > %s.<br>"
 #: package_import.php:766
 #, php-format
 msgid "<b>Package</b> %s"
-msgstr "패키지 파일"
+msgstr ""
 
 #: package_import.php:769
 msgid "Press 'Ok' to start Trusting the Signer, or escape to cancel."
@@ -20422,7 +20422,7 @@ msgstr "플러그인 설치"
 #: plugins.php:1760
 #, php-format
 msgid "Plugin '%s' can not be archived before it's been Installed."
-msgstr "플러그인을 설치할 수 없습니다."
+msgstr ""
 
 #: plugins.php:1771
 msgid "Remove Plugin Data Tables and Settings"
@@ -20505,27 +20505,27 @@ msgstr "플러그인 사용"
 #: poller.php:405
 #, php-format
 msgid "WARNING: %s is out of sync with the Poller Interval for Poller[%d]!  The Poller Interval is %d seconds, with a maximum of a %d seconds, but %d seconds have passed since the last poll!"
-msgstr "경고 :  %s이 (가) 폴러 간격과 일치하지 않습니다! 폴러 간격은 &#39;% d&#39;초이며 &#39;% d&#39;초가 최대이지만 마지막 폴링 이후 % d 초가 지났습니다."
+msgstr ""
 
 #: poller.php:579
 #, php-format
 msgid "WARNING: There are %d processes detected as overrunning a polling cycle for Poller[%d], please investigate."
-msgstr "경고 : 폴링주기 초과로 &#39;% d&#39;이 (가) 발견되었습니다. 조사하십시오."
+msgstr ""
 
 #: poller.php:637
 #, php-format
 msgid "WARNING: Poller Output Table not empty for Poller[%d].  Issues: %d, %s."
-msgstr "경고 : 폴러 출력 테이블이 비어 있지 않습니다. 문제 : % d,  %s."
+msgstr ""
 
 #: poller.php:671
 #, php-format
 msgid "ERROR: The spine path: %s is invalid for Poller[%d].  Poller can not continue!"
-msgstr "오류 : 척추 경로 :  %s이 (가) 잘못되었습니다. 폴러는 계속할 수 없습니다!"
+msgstr ""
 
 #: poller.php:819
 #, php-format
 msgid "Maximum runtime of %d seconds exceeded for Poller[%d]. Exiting."
-msgstr "% d 초의 최대 실행 시간을 초과했습니다. 나가기."
+msgstr ""
 
 #: poller.php:944
 msgid "WARNING: Cacti Polling Cycle Exceeded Poller Interval by "
@@ -20543,12 +20543,12 @@ msgstr "하트비트 모드의 폴러"
 #: poller.php:1253
 #, php-format
 msgid "WARNING: 24 hours Poller[%d] avg. run time is %f seconds (more than %d &#37; of time limit)"
-msgstr "경고: 24시간 폴러 [%d] 평균 실행 시간은 %f 초입니다 (시간 제한의 %d % 초과)"
+msgstr ""
 
 #: poller.php:1269
 #, php-format
 msgid "WARNING: In last hour Poller[%d] run time %d times reached more than %d &#37; of time limit"
-msgstr "경고: 지난 시간 동안 폴러 [%d] 실행 시간이 %d 번 시간 제한의 %d % 이상 도달했습니다"
+msgstr ""
 
 #: poller.php:1291
 msgid "Cacti System Notification"
@@ -20561,7 +20561,7 @@ msgstr "참고 : 두 번째 Cacti 데이터 수집기가 추가되었습니다. 
 #: poller_automation.php:54
 #, php-format
 msgid "WARNING: Main Cacti database %s offline or in recovery"
-msgstr "경고: 주요 Cacti 데이터베이스가 오프라인이거나 복구 중입니다."
+msgstr ""
 
 #: poller_automation.php:1037 poller_automation.php:1091
 msgid "Cacti Primary Admin"
@@ -21114,7 +21114,7 @@ msgstr "참고 :이 탭의 경로 설정은 로컬에만 저장됩니다!"
 #: settings.php:138
 #, php-format
 msgid "Cacti Settings (%s)%s"
-msgstr "선인장 설정 ( %s)"
+msgstr ""
 
 #: settings.php:248
 msgid "Changing Permission Model Warning"
@@ -21782,7 +21782,7 @@ msgstr "Cacti와 Spine의 다른 버전!"
 #: support.php:1297
 #, php-format
 msgid "Action[%s]"
-msgstr "행위]"
+msgstr ""
 
 #: support.php:1302
 msgid "No items to poll"
@@ -22016,7 +22016,7 @@ msgstr "데이터 소스, 그래프"
 #: templates_import.php:320
 #, php-format
 msgid "Met: %d"
-msgstr "만남"
+msgstr ""
 
 #: templates_import.php:324
 #, php-format
@@ -23600,7 +23600,7 @@ msgstr "%d 초"
 #: utilities.php:1688
 #, php-format
 msgid "%0.2f percent of update frequency)"
-msgstr "업데이트 빈도의 0.2 %"
+msgstr ""
 
 #: utilities.php:1696
 msgid "RRD Updates:"
@@ -23634,7 +23634,7 @@ msgstr "자세한 런타임 타이머 :"
 #: utilities.php:1779 utilities.php:1781
 #, php-format
 msgid "Process: %d"
-msgstr "1 프로세스"
+msgstr ""
 
 #: utilities.php:1779
 #, php-format

--- a/locales/po/lv-LV.po
+++ b/locales/po/lv-LV.po
@@ -309,12 +309,12 @@ msgstr "Atdalīt ar apkopojumu"
 #: aggregate_graphs.php:970
 #, php-format
 msgid "Click 'Continue' to Place the following Aggregate Graph on Tree %s."
-msgstr "Noklikšķiniet uz \"Turpināt\", lai dzēstu šādu(-as) apkopoto diagrammu veidni(-es)."
+msgstr ""
 
 #: aggregate_graphs.php:971
 #, php-format
 msgid "Click 'Continue' to Duplicate following Aggregate Graphs on Tree %s."
-msgstr "Noklikšķiniet 'Turpināt', lai zem koka zara novietotu šādu(s) apkopoto(-s) grafiku(-us)."
+msgstr ""
 
 #: aggregate_graphs.php:972
 msgid "Place Aggregate Graph on Tree"
@@ -2969,7 +2969,7 @@ msgstr "Noklikšķiniet uz \"Turpināt\", lai dzēstu tālāk norādītos datu v
 #: automation_templates.php:791
 #, php-format
 msgid "Tree Rule Name: '%s'"
-msgstr "Koka kārtulas vienumi"
+msgstr ""
 
 #: automation_templates.php:798
 msgid "Remove Tree Rule"
@@ -3482,7 +3482,7 @@ msgstr "Pilns"
 #: changelog.php:99
 #, php-format
 msgid "Change Log [%s]"
-msgstr "Izmaiņu žurnāls"
+msgstr ""
 
 #: changelog.php:160 support.php:1018
 #, php-format
@@ -5363,7 +5363,7 @@ msgstr "GRAFIKS NEPASTĀV"
 #: graph.php:115 graph.php:409
 #, php-format
 msgid "Graph Utility View for Graph: %s"
-msgstr "Grafika utilīta skats"
+msgstr ""
 
 #: graph.php:160 lib/html.php:585
 msgid "Graph Details, Zooming and Debugging Utilities"
@@ -6078,12 +6078,12 @@ msgstr "Novietot grafikus Pārskatā"
 #: graphs.php:1912
 #, php-format
 msgid "Click 'Continue' to Place the following Graph on Tree %s."
-msgstr "Noklikšķiniet uz \"Turpināt\", lai dzēstu šo koku."
+msgstr ""
 
 #: graphs.php:1913
 #, php-format
 msgid "Click 'Continue' to Duplicate following Graphs on Tree %s."
-msgstr "Noklikšķiniet uz \"Turpināt\", lai dublētu šo vietni."
+msgstr ""
 
 #: graphs.php:1914
 msgid "Place Graph on Tree"
@@ -6325,7 +6325,7 @@ msgstr "Iestatīt noklusējumu"
 #: help.php:44
 #, php-format
 msgid "WARNING: Cacti Page:%s for User:%s Generated a Fatal Error %d!"
-msgstr "BRĪDINĀJUMS: Cacti lapa: %s ģenerēja letālu kļūdu %d!"
+msgstr ""
 
 #: help.php:74
 #, php-format
@@ -6511,12 +6511,12 @@ msgstr "Novietojiet ierīci ziņojumā"
 #: host.php:564
 #, php-format
 msgid "Click 'Continue' to Place the following Device on Tree %s."
-msgstr "Noklikšķiniet uz \"Turpināt\", lai dzēstu šādu(-as) ierīces veidni(-es)."
+msgstr ""
 
 #: host.php:565
 #, php-format
 msgid "Click 'Continue' to Duplicate following Devices on Tree %s."
-msgstr "Noklikšķiniet uz \"Turpināt\", lai dublētu šo vietni."
+msgstr ""
 
 #: host.php:566
 msgid "Place Device on Tree"
@@ -14344,12 +14344,12 @@ msgstr "Atjaunot"
 #: lib/api_automation.php:5309 lib/api_automation.php:5311
 #, php-format
 msgid "Automation Network SNMP Option %s!"
-msgstr "Automatizācijas SNMP opcijas"
+msgstr ""
 
 #: lib/api_automation.php:5315 lib/api_automation.php:5317
 #, php-format
 msgid "Automation Network SNMP Option %s Failed!"
-msgstr "Automatizācijas SNMP opcijas"
+msgstr ""
 
 #: lib/api_automation.php:5351
 msgid "The Automation Network Rule does not include any SNMP Options!"
@@ -14370,7 +14370,7 @@ msgstr "Nezināma veidne"
 #: lib/api_automation.php:5404 lib/api_automation.php:5406
 #, php-format
 msgid "Automation Network Rule '%s' %s!"
-msgstr "Noklusējuma automatizācijas tīkls"
+msgstr ""
 
 #: lib/api_automation.php:5410 lib/api_automation.php:5412
 #, php-format
@@ -14897,7 +14897,7 @@ msgstr "Indeksa saistīšana ar vietējiem datiem ir pabeigta"
 #: lib/data_query.php:392
 #, php-format
 msgid "Update Re-Index Cache complete. There were %s index changes, and %s orphaned indexes."
-msgstr "Atkārtotas indeksēšanas kešatmiņas atjaunināšana ir pabeigta. Tur bija "
+msgstr ""
 
 #: lib/data_query.php:396
 msgid "Update Poller Cache for Query complete"
@@ -17803,7 +17803,7 @@ msgstr "Nav instalējamu ierīču pakotņu"
 #: lib/installer.php:3012
 #, php-format
 msgid "%d Tables to be Upgraded"
-msgstr "Pievienojamā elementa tips."
+msgstr ""
 
 #: lib/installer.php:3012 lib/installer.php:3014 lib/installer.php:3056
 msgid "Table Upgrades"
@@ -18021,7 +18021,7 @@ msgstr "Ierīce %s pievienota Cacti"
 #: lib/installer.php:3680
 #, php-format
 msgid "Output: %s."
-msgstr "Izvades lauki"
+msgstr ""
 
 #: lib/installer.php:3700
 msgid "Creating Graphs for Default Device"
@@ -18409,7 +18409,7 @@ msgstr "%s pakotne veiksmīgi importēta"
 #: lib/plugins.php:1719
 #, php-format
 msgid "The Plugin '%s' archiving process has failed.  Check the Cacti log for errors."
-msgstr "Viens vai vairāki RRDfile labojumi neizdevās. Kļūdas skatiet sadaļā Kaktusu žurnāls."
+msgstr ""
 
 #: lib/plugins.php:1722
 #, php-format
@@ -18445,7 +18445,7 @@ msgstr "GitHub/GitLab atrašanās vietā nav atrasts neviens spraudnis."
 #: lib/plugins.php:1956
 #, php-format
 msgid "The Cacti plugin %s has not releases"
-msgstr "Cacti aptaujātajs vēl nav bijis palaists."
+msgstr ""
 
 #: lib/plugins.php:2011 lib/plugins.php:2149
 msgid "Unable to get archive from GitHub/GitLab location."
@@ -18550,7 +18550,7 @@ msgstr "RRDtool komanda:"
 #: lib/rrd.php:3299
 #, php-format
 msgid "The required RRDfile step size is '%s' but observed step is '%s'"
-msgstr "Nepieciešamais RRD soļa lielums ir “%s”"
+msgstr ""
 
 #: lib/rrd.php:3359
 #, php-format
@@ -18595,7 +18595,7 @@ msgstr "XFF kaktusu RRA ID '%s' ir jābūt '%s'"
 #: lib/rrd.php:3458
 #, php-format
 msgid "The number of rows for Cacti RRA id '%s' is incorrect.  The number of rows are '%s' but should be '%s'"
-msgstr "Rindu skaitam Cacti RRA id '%s' ir jābūt '%s'"
+msgstr ""
 
 #: lib/rrd.php:3476
 #, php-format
@@ -18741,7 +18741,7 @@ msgstr "KĻŪDA: baltā saraksta validācija neizdevās. Pārbaudiet datu ievade
 #: lib/template.php:2267
 #, php-format
 msgid "Graph Not created for %s due to bad data"
-msgstr "Grafiks nav izveidots priekš "
+msgstr ""
 
 #: lib/template.php:2296
 #, php-format
@@ -18827,7 +18827,7 @@ msgstr "Ja jūsu tabulām ir ļoti lieli indeksi, jums ir jādarbojas ar Barracu
 #: lib/utility.php:1254
 #, php-format
 msgid "InnoDB will hold as much tables and indexes in system memory as is possible.  Therefore, you should make the innodb_buffer_pool large enough to hold as much of the tables and index in memory.  Checking the size of the /var/lib/mysql/cacti directory will help in determining this value.  We are recommending 25%% of your systems total memory, but your requirements will vary depending on your systems size.  If you database is very large or remote, you can consider increasing this size.  If remote, it can by as high as 80% of the systems memory.  However, cautions must be taken to reduce the swappiness of the system, or to remove swap to keep the system from swapping."
-msgstr "InnoDB sistēmas atmiņā glabās pēc iespējas vairāk tabulu un indeksu. Tāpēc innodb_buffer_pool ir jāpadara pietiekami liels, lai tajā saglabātu pēc iespējas vairāk tabulu un indeksu. Pārbaudot direktorijas /var/lib/mysql/cacti lielumu, varēsiet noteikt šo vērtību. Mēs iesakām 25%% no jūsu sistēmas kopējās atmiņas, taču jūsu prasības atšķirsies atkarībā no sistēmas lieluma."
+msgstr ""
 
 #: lib/utility.php:1260
 msgid "This settings should remain ON unless your Cacti instances is running on either ZFS or FusionI/O which both have internal journaling to accommodate abrupt system crashes.  However, if you have very good power, and your systems rarely go down and you have backups, turning this setting to OFF can net you almost a 50% increase in database performance."
@@ -19162,7 +19162,7 @@ msgstr "Atteikšanās no kaktusiem"
 #: logout.php:60
 #, php-format
 msgid "You have been logged out of Cacti due to %s."
-msgstr "Jūs esat atteicies no Cacti sesijas noildzes dēļ."
+msgstr ""
 
 #: logout.php:61
 #, php-format
@@ -19360,17 +19360,17 @@ msgstr "Ko jūs vēlētos eksportēt?"
 #: package.php:667
 #, php-format
 msgid "%s Device Package"
-msgstr "Ierīces nosaukums"
+msgstr ""
 
 #: package.php:670
 #, php-format
 msgid "%s Graph Template Package"
-msgstr "Grafika veidnes nosaukums"
+msgstr ""
 
 #: package.php:673
 #, php-format
 msgid "%s Data Query Package"
-msgstr "Datu vaicājuma nosaukums"
+msgstr ""
 
 #: package.php:700 templates_export.php:168
 #, php-format
@@ -19384,7 +19384,7 @@ msgstr "Pieejamās veidnes [%s]"
 #: package.php:709
 #, php-format
 msgid "%s to Export"
-msgstr "Eksportēt"
+msgstr ""
 
 #: package.php:710
 msgid "Choose the exact items to export in the Package."
@@ -19511,7 +19511,7 @@ msgstr "%s pakotni neizdevās importēt"
 #: package_import.php:298
 #, php-format
 msgid "Package %s"
-msgstr "Pakotne"
+msgstr ""
 
 #: package_import.php:305
 msgid "Click 'Continue' to Import the following Package."
@@ -19588,7 +19588,7 @@ msgstr "<b>Autors:</b> <%s> %s.<br>"
 #: package_import.php:766
 #, php-format
 msgid "<b>Package</b> %s"
-msgstr "Pakešu faili"
+msgstr ""
 
 #: package_import.php:769
 msgid "Press 'Ok' to start Trusting the Signer, or escape to cancel."
@@ -20462,7 +20462,7 @@ msgstr "Instalējiet spraudni"
 #: plugins.php:1760
 #, php-format
 msgid "Plugin '%s' can not be archived before it's been Installed."
-msgstr "Spraudni nevar uzstādīt."
+msgstr ""
 
 #: plugins.php:1771
 msgid "Remove Plugin Data Tables and Settings"
@@ -20583,12 +20583,12 @@ msgstr "Aptaujas veicējs sirdspukstu režīmā"
 #: poller.php:1253
 #, php-format
 msgid "WARNING: 24 hours Poller[%d] avg. run time is %f seconds (more than %d &#37; of time limit)"
-msgstr "BRĪDINĀJUMS: 24 stundu aptaujas[%d] vidējais izpildes laiks ir %f sekundes (vairāk nekā %d % no laika ierobežojuma)"
+msgstr ""
 
 #: poller.php:1269
 #, php-format
 msgid "WARNING: In last hour Poller[%d] run time %d times reached more than %d &#37; of time limit"
-msgstr "BRĪDINĀJUMS: pēdējās stundas laikā Poller[%d] izpildes laiks %d reizes sasniedza vairāk nekā %d % no laika ierobežojuma"
+msgstr ""
 
 #: poller.php:1291
 msgid "Cacti System Notification"
@@ -20601,7 +20601,7 @@ msgstr "PIEZĪME. Ir pievienots otrs Cacti datu savācējs. Tāpēc automātiska
 #: poller_automation.php:54
 #, php-format
 msgid "WARNING: Main Cacti database %s offline or in recovery"
-msgstr "BRĪDINĀJUMS: Galvenā kaktusu datubāze bezsaistē vai tiek atkopta"
+msgstr ""
 
 #: poller_automation.php:1037 poller_automation.php:1091
 msgid "Cacti Primary Admin"
@@ -23987,8 +23987,6 @@ msgstr "Nav VDEF"
 #~ msgstr "Noklikšķiniet uz \"Turpināt\", lai sinhronizētu ierīces, kas saistītas ar atlasīto(-ajām) ierīces veidni(-ēm). Ņemiet vērā, ka šī darbība var aizņemt kādu laiku atkarībā no ierīces veidnei piesaistīto ierīču skaita."
 
 #, fuzzy
-#~| msgid "Click 'Continue' to Synchronize all Aggregate Graphs with the selected Color Template."
-#~| msgid_plural "Click 'Continue' to Syncrhonize all Aggregate Graphs with the selected Color Templates."
 #~ msgid "Click 'Continue' to Synchronize all Aggregate Graphs with the selected Color Template."
 #~ msgid_plural "Click 'Continue' to Synchronize all Aggregate Graphs with the selected Color Templates."
 #~ msgstr[0] "Noklikšķiniet uz 'Turpināt', lai sinhronizētu visus apkopotos grafikus ar atlasīto krāsu veidni."
@@ -24014,7 +24012,6 @@ msgstr "Nav VDEF"
 #~ msgstr "Noklikšķiniet uz 'Turpināt', lai kopētu atlasīto lietotāju uz jaunu tālāk norādīto lietotāju."
 
 #, fuzzy
-#~| msgid "Click 'Continue' to delete the folling Automation Template(s)."
 #~ msgid "Click 'Continue' to delete the following Automation Template(s)."
 #~ msgstr "Noklikšķiniet uz 'Turpināt', lai dzēstu sekojošo(-ās) automatizācijas veidni(-es)."
 
@@ -24112,7 +24109,6 @@ msgstr "Nav VDEF"
 #~ msgstr "Konvertēt uz parasto(-iem) grafiku(-iem)"
 
 #, fuzzy
-#~| msgid "DES"
 #~ msgid "DS"
 #~ msgstr "DES"
 

--- a/locales/po/pl-PL.po
+++ b/locales/po/pl-PL.po
@@ -313,7 +313,7 @@ msgstr "Odwiąż z Aggregate"
 #: aggregate_graphs.php:985
 #, php-format
 msgid "Click 'Continue' to Place the following Aggregate Graph on Tree %s."
-msgstr "Kliknij \"Continue\" (Kontynuuj), aby usunąć następujący(-e) szablon(-y) wykresu zagregowanego (Szablon wykresów zagregowanych)."
+msgstr ""
 
 #: aggregate_graphs.php:986
 #, php-format
@@ -336,7 +336,7 @@ msgstr "Oddział docelowy:"
 #: user_admin.php:1876
 #, php-format
 msgid "[edit: %s]"
-msgstr "[edytuj: %s] [edytuj: %s]."
+msgstr ""
 
 #: aggregate_graphs.php:1054 aggregate_graphs.php:1164
 #: aggregate_graphs.php:1166
@@ -1759,7 +1759,7 @@ msgstr "Nie można przeprowadzić wyszukiwania dla sieci wyłączonej \"%s"
 #: automation_networks.php:413
 #, php-format
 msgid "ERROR: Network '%s' is Invalid."
-msgstr "ERROR: \"%\" sieci jest nieważny."
+msgstr ""
 
 #: automation_networks.php:574 host.php:435 lib/html_form.php:1667
 msgid "Update this Field"
@@ -2446,7 +2446,7 @@ msgstr "Kolejność pozycji."
 #: automation_snmp.php:680
 #, php-format
 msgid "SNMP Option Set [edit: %s]"
-msgstr "SNMP Option Set [edit: %s] [edit: %s"
+msgstr ""
 
 #: automation_snmp.php:682
 msgid "SNMP Option Set [new]"
@@ -2725,7 +2725,7 @@ msgstr "Kliknięcie przycisku \"Continue\" (Kontynuuj) powoduje usunięcie nast�
 #: automation_templates.php:915
 #, php-format
 msgid "Tree Rule Name: '%s'"
-msgstr "Punkty Regulaminu Drzewa"
+msgstr ""
 
 #: automation_templates.php:922
 msgid "Remove Tree Rule"
@@ -3277,7 +3277,7 @@ msgstr "Pełny"
 #: changelog.php:99
 #, php-format
 msgid "Change Log [%s]"
-msgstr "ChangeLogLanguage"
+msgstr ""
 
 #: changelog.php:160 support.php:1010
 #, php-format
@@ -4565,7 +4565,7 @@ msgstr "(tylko niektóre elementy do odczytu)"
 #: data_source_profiles.php:999
 #, php-format
 msgid "RRA [edit: %s %s]"
-msgstr "RRA [edit: %s %s] [edit: %s %s]."
+msgstr ""
 
 #: data_source_profiles.php:1089
 #, php-format
@@ -4614,12 +4614,12 @@ msgstr "Usuń pozycję profilu źródła danych"
 #: data_source_profiles.php:1275
 #, php-format
 msgid "%s KBytes per Data Sources and %s Bytes for the Header"
-msgstr "%s KBajty na źródło danych i % Bajtów na nagłówek"
+msgstr ""
 
 #: data_source_profiles.php:1284
 #, php-format
 msgid "%s KBytes per Data Source"
-msgstr "% KBajtów na źródło danych"
+msgstr ""
 
 #: data_source_profiles.php:1286
 msgid "Enter a valid number of Rows to obtain the RRA size."
@@ -6002,12 +6002,12 @@ msgstr "Umieść wykresy na raporcie"
 #: graphs.php:2005
 #, php-format
 msgid "Click 'Continue' to Place the following Graph on Tree %s."
-msgstr "Kliknij 'Kontynuuj', aby usunąć następujące drzewo."
+msgstr ""
 
 #: graphs.php:2006
 #, php-format
 msgid "Click 'Continue' to Duplicate following Graphs on Tree %s."
-msgstr "Kliknij 'Kontynuuj', aby usunąć następujące drzewo."
+msgstr ""
 
 #: graphs.php:2007
 msgid "Place Graph on Tree"
@@ -6059,7 +6059,7 @@ msgstr "Wybrany szablon wykresu"
 #: graphs.php:2402
 #, php-format
 msgid "Choose a Graph Template to apply to this Graph. Please note that you may only change Graph Templates to a 100%% compatible Graph Template, which means that it includes identical Data Sources."
-msgstr "Wybierz szablon wykresu, aby zastosować go do tego wykresu. Należy pamiętać, że szablony wykresów można zmienić tylko na w 100% kompatybilny szablon wykresu, co oznacza, że zawiera on identyczne źródła danych."
+msgstr ""
 
 #: graphs.php:2411
 msgid "Choose the Device that this Graph belongs to."
@@ -6161,7 +6161,7 @@ msgstr "Zarządzanie grupą użytkowników [edytuj: %s]"
 #: graphs.php:3231
 #, php-format
 msgid "Graph Management [ %s ]"
-msgstr "Zarządzanie wykresami"
+msgstr ""
 
 #: graphs_new.php:82
 msgid "Default Settings Saved"
@@ -6230,7 +6230,7 @@ msgstr "Błąd podczas analizowania pliku XML zasobu zapytania o dane dla zapyta
 #: graphs_new.php:698
 #, php-format
 msgid "Error Parsing Data Query Resource XML file for Data Query '%s' with id '%s'.  Field Name '%s' missing a 'direction' attribute"
-msgstr "Błąd podczas analizowania pliku XML zasobu zapytania o dane dla zapytania danych '%s' o identyfikatorze '%s'"
+msgstr ""
 
 #: graphs_new.php:702
 #, php-format
@@ -6353,12 +6353,12 @@ msgstr "ERROR: Urządzenie ["
 #: host.php:215
 #, php-format
 msgid "Device Reindex Completed in %0.2f seconds.  There were %d items updated."
-msgstr "Reindex urządzenia zakończony w% 0,2f sekund. Zaktualizowano% d elementów."
+msgstr ""
 
 #: host.php:359
 #, php-format
 msgid "Unable to add some Devices to Report '%s'"
-msgstr "Nie można połączyć się z serwerem"
+msgstr ""
 
 #: host.php:478
 msgid "Click 'Continue' to Delete the following Device."
@@ -6472,7 +6472,7 @@ msgstr "Umieścić urządzenie(-a) na drzewie"
 #: host.php:580
 #, php-format
 msgid "Click 'Continue' to Place the following Device on Tree %s."
-msgstr "Kliknąć \"Continue\" (Kontynuuj), aby usunąć następujący(-e) szablon(-y) urządzenia."
+msgstr ""
 
 #: host.php:581
 #, fuzzy, php-format
@@ -7834,12 +7834,12 @@ msgstr "Co %d godzin"
 #: include/global_arrays.php:781
 #, php-format
 msgid "Every %d Day"
-msgstr "Każdy %1 Dzień"
+msgstr ""
 
 #: include/global_arrays.php:793
 #, php-format
 msgid "%0.1f Minutes"
-msgstr "%d minut"
+msgstr ""
 
 #: include/global_arrays.php:826 include/global_arrays.php:846
 #: include/global_arrays.php:858 include/global_arrays.php:859
@@ -8558,7 +8558,7 @@ msgstr "w ostatniej godzinie"
 #: include/global_arrays.php:1577 include/global_arrays.php:1578
 #, php-format
 msgid "Last %d Hours"
-msgstr "Ostatnie godziny"
+msgstr ""
 
 #: include/global_arrays.php:1579
 msgid "Last Day"
@@ -8577,7 +8577,7 @@ msgstr "W zeszłym tygodniu"
 #: include/global_arrays.php:1584
 #, php-format
 msgid "Last %d Weeks"
-msgstr "Ostatnie tygodnie"
+msgstr ""
 
 #: include/global_arrays.php:1585
 msgid "Last Month"
@@ -8587,7 +8587,7 @@ msgstr "Ostatni miesiąc"
 #: include/global_arrays.php:1588 include/global_arrays.php:1589
 #, php-format
 msgid "Last %d Months"
-msgstr "Ostatnie miesiące"
+msgstr ""
 
 #: include/global_arrays.php:1590
 msgid "Last Year"
@@ -8596,7 +8596,7 @@ msgstr "W poprzednim roku"
 #: include/global_arrays.php:1591
 #, php-format
 msgid "Last %d Years"
-msgstr "Ostatnie lata"
+msgstr ""
 
 #: include/global_arrays.php:1592
 msgid "Day Shift"
@@ -9042,7 +9042,7 @@ msgstr "Raz na tygodzień"
 #: include/global_arrays.php:2017 include/global_arrays.php:2018
 #, php-format
 msgid "Every %d Weeks"
-msgstr "Co tydzień"
+msgstr ""
 
 #: include/global_arrays.php:2022 include/global_arrays.php:3092
 #: include/global_settings.php:1651
@@ -9764,7 +9764,7 @@ msgstr "Określono liczbę identyfikatorów OID, które można uzyskać w jednym
 #: include/global_form.php:177
 #, php-format
 msgid "%d OID"
-msgstr "Max OID"
+msgstr ""
 
 #: include/global_form.php:178 include/global_form.php:179
 #: include/global_form.php:180 include/global_form.php:181
@@ -9797,7 +9797,7 @@ msgstr "Automatyczne wykrywanie/ustawianie przy pierwszym ponownym indeksowaniu"
 #: include/global_form.php:204
 #, php-format
 msgid "%d Repetition"
-msgstr "Opcje siatki"
+msgstr ""
 
 #: include/global_form.php:205 include/global_form.php:206
 #: include/global_form.php:207 include/global_form.php:208
@@ -9809,7 +9809,7 @@ msgstr "Opcje siatki"
 #: include/global_form.php:219
 #, php-format
 msgid "%d Repetitions"
-msgstr "Opcje siatki"
+msgstr ""
 
 #: include/global_form.php:228
 msgid "The maximum number of attempts to reach a device via an SNMP readstring prior to giving up."
@@ -11964,7 +11964,7 @@ msgstr "Domyślna liczba gwintów urządzenia.  Ma to zastosowanie wyłącznie w
 #: include/global_settings.php:874
 #, php-format
 msgid "%s Thread"
-msgstr "%d Gwint"
+msgstr ""
 
 #: include/global_settings.php:875 include/global_settings.php:876
 #: include/global_settings.php:877 include/global_settings.php:878
@@ -11973,7 +11973,7 @@ msgstr "%d Gwint"
 #: include/global_settings.php:883
 #, php-format
 msgid "%s Threads"
-msgstr "%d Gwinty"
+msgstr ""
 
 #: include/global_settings.php:887
 msgid "Re-index Method for Data Queries"
@@ -14770,12 +14770,12 @@ msgstr "Reguła SNMP sieci automatyzacji '%s' %s nie powiodła się!"
 #: lib/api_automation.php:5525 lib/api_automation.php:5527
 #, php-format
 msgid "Automation Network SNMP Option %s!"
-msgstr "Automatyzacja Opcje SNMP"
+msgstr ""
 
 #: lib/api_automation.php:5531 lib/api_automation.php:5533
 #, php-format
 msgid "Automation Network SNMP Option %s Failed!"
-msgstr "Automatyzacja Opcje SNMP"
+msgstr ""
 
 #: lib/api_automation.php:5573
 msgid "The Automation Network Rule does not include any SNMP Options!"
@@ -14796,7 +14796,7 @@ msgstr "Nieznany szablon"
 #: lib/api_automation.php:5629 lib/api_automation.php:5631
 #, php-format
 msgid "Automation Network Rule '%s' %s!"
-msgstr "Domyślna sieć automatyki"
+msgstr ""
 
 #: lib/api_automation.php:5635 lib/api_automation.php:5637
 #, php-format
@@ -15236,29 +15236,29 @@ msgstr "Urządzenie jest wyłączone"
 #: lib/auth.php:2302 lib/auth.php:2304 lib/auth.php:2310 lib/auth.php:2312
 #, php-format
 msgid "Graph:(%s%s)"
-msgstr "Wykres:"
+msgstr ""
 
 #: lib/auth.php:2325 lib/auth.php:2331 lib/auth.php:2398 lib/auth.php:2400
 #: lib/auth.php:2404 lib/auth.php:2406
 #, php-format
 msgid "Device:(%s%s)"
-msgstr "Urządzenie:"
+msgstr ""
 
 #: lib/auth.php:2339 lib/auth.php:2345 lib/auth.php:2414 lib/auth.php:2416
 #: lib/auth.php:2420 lib/auth.php:2422
 #, php-format
 msgid "Template:(%s%s)"
-msgstr "Szablony"
+msgstr ""
 
 #: lib/auth.php:2352
 #, php-format
 msgid "Graph+Device+Template:(%s%s)"
-msgstr "Szablon urządzenia:"
+msgstr ""
 
 #: lib/auth.php:2389 lib/auth.php:2391
 #, php-format
 msgid "Device+Template:(%s%s)"
-msgstr "Szablon urządzenia:"
+msgstr ""
 
 #: lib/auth.php:2435 lib/auth.php:2442 lib/auth.php:2451
 msgid "Restricted By: "
@@ -15408,7 +15408,7 @@ msgstr "2FA zostało włączone i zweryfikowane"
 #: lib/boost.php:82 utilities.php:1378
 #, php-format
 msgid "%s MBytes"
-msgstr "%d MBajty"
+msgstr ""
 
 #: lib/boost.php:85
 #, php-format
@@ -15645,7 +15645,7 @@ msgstr "Wykryto usunięcie indeksu! Poprzednindex: %s"
 #: lib/data_query.php:403
 #, php-format
 msgid "Verification of %s Local Data ID's Complete"
-msgstr "Indeks Stowarzyszenie z danymi lokalnymi kompletne"
+msgstr ""
 
 #: lib/data_query.php:406
 #, php-format
@@ -15671,7 +15671,7 @@ msgstr "Indeks Stowarzyszenie z danymi lokalnymi kompletne"
 #: lib/data_query.php:435
 #, php-format
 msgid "Update Re-Index Cache complete. There were %s index changes, and %s orphaned indexes."
-msgstr "Aktualizacja Re-Index Cache kompletny. Były to"
+msgstr ""
 
 #: lib/data_query.php:439
 msgid "Update Poller Cache for Query complete"
@@ -15785,7 +15785,7 @@ msgstr "Kliknąć, aby wyświetlić dane wyjściowe dla pola '%s'."
 #: lib/data_query.php:848
 #, php-format
 msgid "Sort field returned no data for field name %s, skipping"
-msgstr "Pole sortowania nie zwróciło żadnych danych.  Nie można kontynuować Re-Index."
+msgstr ""
 
 #: lib/data_query.php:850
 #, php-format
@@ -15915,7 +15915,7 @@ msgstr "Pole \"%s\" %s"
 #: lib/data_query.php:1285
 #, php-format
 msgid "Executing SNMP get for %s oids (%s)"
-msgstr "Wykonanie SNMP uzyskać dla % ofert (%s)"
+msgstr ""
 
 #: lib/data_query.php:1310
 #, fuzzy, php-format
@@ -15955,7 +15955,7 @@ msgstr "Położone pole wejściowe \"%s\" [spacer]."
 #: lib/data_query.php:1403 lib/data_query.php:1412
 #, php-format
 msgid "Sort field returned no data for OID[%s], skipping."
-msgstr "Pole sortowania zwrócone nie dane.  Nie można kontynuować Re-Index dla OID[%]."
+msgstr ""
 
 #: lib/data_query.php:1418
 #, php-format
@@ -16034,7 +16034,7 @@ msgstr "Nie udało się zmienić długości pola hasła, nie może być kontynuo
 #: lib/dsdebug.php:190
 #, php-format
 msgid "Data Source ID %s does not exist"
-msgstr "Źródło danych nie istnieje"
+msgstr ""
 
 #: lib/dsdebug.php:275
 msgid "Debug not completed after 5 pollings"
@@ -16051,12 +16051,12 @@ msgstr "Źródło danych nie jest ustawione jako aktywne"
 #: lib/dsdebug.php:293
 #, php-format
 msgid "RRDfile Folder (rra) is not writable by Poller.  Folder owner: %s.  Poller runs as: %s"
-msgstr "Folder RRD nie może być zapisywany przez Pollera.  Właściciel RRD:"
+msgstr ""
 
 #: lib/dsdebug.php:298
 #, php-format
 msgid "RRDfile is not writable by Poller.  RRDfile owner: %s.  Poller runs as %s"
-msgstr "Plik RRD nie jest zapisywalny przez Pollera.  Właściciel RRD:"
+msgstr ""
 
 #: lib/dsdebug.php:307
 msgid "RRDfile does not match Data Source"
@@ -16301,7 +16301,7 @@ msgstr "- Beta %s"
 #: lib/functions.php:7594
 #, php-format
 msgid "Version %s %s"
-msgstr "Wersja %s"
+msgstr ""
 
 #: lib/functions.php:8151
 #, php-format
@@ -16363,7 +16363,7 @@ msgstr "Zabijaj kolce na wykresach"
 #: lib/html.php:625
 #, php-format
 msgid "%d to %d of %s [ %s ]"
-msgstr "%d do %d %d %s [ %s ]"
+msgstr ""
 
 #: lib/html.php:635
 #, php-format
@@ -16373,7 +16373,7 @@ msgstr "Wszystkie %d %s"
 #: lib/html.php:654
 #, php-format
 msgid "Current Page: %s"
-msgstr "Wartość bieżąca"
+msgstr ""
 
 #: lib/html.php:685
 #, php-format
@@ -16866,7 +16866,7 @@ msgstr "Terminy Zoom sprzed 1 stycznia 1993 r. nie są obsługiwane w Cacti!  Wy
 #: lib/html.php:3517
 #, php-format
 msgid "Version %s | %s"
-msgstr "Wersja %s"
+msgstr ""
 
 #: lib/html_filter.php:347
 msgid "Named Colors"
@@ -16980,7 +16980,7 @@ msgstr "Wprowadź prawidłową ścieżkę katalogową"
 #: lib/html_form.php:1362
 #, php-format
 msgid "Cacti Color (%s)"
-msgstr "Kolor Cacti (%)"
+msgstr ""
 
 #: lib/html_form.php:1430
 msgid "NO FONT VERIFICATION POSSIBLE"
@@ -17147,7 +17147,7 @@ msgstr "WYKRES NIE ISTNIEJE"
 #: lib/html_graph.php:1733 lib/html_graph.php:2065
 #, php-format
 msgid "Graph Utility View for Graph: %s"
-msgstr "Widok narzędzia graficznego"
+msgstr ""
 
 #: lib/html_graph.php:1784
 msgid "CSV Export"
@@ -17530,12 +17530,12 @@ msgstr "nowy] [nowy]."
 #: lib/html_reports.php:1530
 #, php-format
 msgid "Details %s"
-msgstr "Szczegóły"
+msgstr ""
 
 #: lib/html_reports.php:1572
 #, php-format
 msgid "Report Items %s"
-msgstr "Brak pozycji sprawozdania"
+msgstr ""
 
 #: lib/html_reports.php:1666
 msgid "Item Details"
@@ -17544,7 +17544,7 @@ msgstr "Szczegóły produktu"
 #: lib/html_reports.php:1681
 #, php-format
 msgid "Graph: %s"
-msgstr "Kliknij \"Kontynuuj\", aby usunąć następujący(e) zagregowany wykres(y)."
+msgstr ""
 
 #: lib/html_reports.php:1684 lib/html_reports.php:1711
 #: lib/html_reports.php:1724 lib/html_reports.php:1725
@@ -17574,7 +17574,7 @@ msgstr ", Używając RegEx: \"%s\""
 #: lib/html_reports.php:1751
 #, php-format
 msgid "Tree: %s"
-msgstr "Drzewo:"
+msgstr ""
 
 #: lib/html_reports.php:1761
 #, php-format
@@ -17584,7 +17584,7 @@ msgstr "(Z urządzenia: %s)"
 #: lib/html_reports.php:1763
 #, php-format
 msgid ", Branch: %s"
-msgstr "Oddział:"
+msgstr ""
 
 #: lib/html_reports.php:1766
 msgid "(All Branches)"
@@ -17621,7 +17621,7 @@ msgstr "Ograniczający"
 #: lib/html_reports.php:1931
 #, php-format
 msgid "Report Preview %s"
-msgstr "Podgląd raportu"
+msgstr ""
 
 #: lib/html_reports.php:1954 lib/html_reports.php:2248
 #, fuzzy
@@ -17925,7 +17925,7 @@ msgstr "Nie zastosowano określonego odstępu czasu cron"
 #: lib/installer.php:1208
 #, php-format
 msgid "Failed to apply '%s' as Automation Range"
-msgstr "Nie zastosowano określonego zakresu automatyki"
+msgstr ""
 
 #: lib/installer.php:1300
 msgid "No matching snmp option exists"
@@ -18082,7 +18082,7 @@ msgstr "Twoja konfiguracja Cacti ma poprawną ścieżkę (url_path) w config.php
 #: lib/installer.php:2199
 #, php-format
 msgid "PHP - Recommendations (%s)"
-msgstr "PZP - zalecenia"
+msgstr ""
 
 #: lib/installer.php:2203
 msgid "PHP Recommendations ("
@@ -18760,7 +18760,7 @@ msgstr "Aktualizuj"
 #: lib/installer.php:3248
 #, php-format
 msgid "%d Tables to be Upgraded"
-msgstr "Typ elementu do dodania."
+msgstr ""
 
 #: lib/installer.php:3249
 msgid "The following Tables will be Upgraded to InnoDB and Converted to utf8mb4 for performance and internationalization."
@@ -18847,7 +18847,7 @@ msgstr "Import pakietu nr%s '%s' w profilu '%s' nie powiódł się"
 #: lib/installer.php:3653
 #, php-format
 msgid "Mapping Automation Template for Device Template '%s'"
-msgstr "Szablony automatyzacji dla [Usunięty szablon]."
+msgstr ""
 
 #: lib/installer.php:3674
 msgid "No templates were selected for import"
@@ -18860,12 +18860,12 @@ msgstr "Oczekiwanie na konfigurację"
 #: lib/installer.php:3714
 #, php-format
 msgid "Setting default data source profile to %s (%s)"
-msgstr "Domyślny profil źródła danych dla tego szablonu danych."
+msgstr ""
 
 #: lib/installer.php:3739
 #, php-format
 msgid "Failed to find selected profile (%s), no changes were made"
-msgstr "Nie zastosowano określonego profilu %s != %s"
+msgstr ""
 
 #: lib/installer.php:3750
 #, php-format
@@ -18883,12 +18883,12 @@ msgstr "Dodanie dodatkowych ustawień snmp do automatyzacji"
 #: lib/installer.php:3775
 #, php-format
 msgid "Selecting Automation Option Set %s"
-msgstr "Usuń szablon(y) automatyki"
+msgstr ""
 
 #: lib/installer.php:3789
 #, php-format
 msgid "Updating Automation Option Set %s"
-msgstr "Automatyzacja Opcje SNMP"
+msgstr ""
 
 #: lib/installer.php:3793
 #, php-format
@@ -18898,12 +18898,12 @@ msgstr "Pomyślnie zaktualizowano zestaw opcji automatyzacji%s"
 #: lib/installer.php:3795
 #, php-format
 msgid "Resequencing Automation Option Set %s"
-msgstr "Uruchomić automatykę na urządzeniu(-ach)"
+msgstr ""
 
 #: lib/installer.php:3802
 #, php-format
 msgid "Failed to updated Automation Option Set %s"
-msgstr "Nie zastosowano określonego zakresu automatyki"
+msgstr ""
 
 #: lib/installer.php:3805
 msgid "Failed to find any automation option set"
@@ -18930,7 +18930,7 @@ msgstr "Urządzenie %s dodane do Cacti"
 #: lib/installer.php:3862
 #, php-format
 msgid "Output: %s."
-msgstr "Pola wyjściowe"
+msgstr ""
 
 #: lib/installer.php:3882
 msgid "Creating Graphs for Default Device"
@@ -19010,7 +19010,7 @@ msgstr "Tło rozpoczęło się już w%s, ta próba w%s została pominięta"
 #: lib/installer.php:4130
 #, php-format
 msgid "Exception occurred during installation: #%s - %s"
-msgstr "Podczas instalacji miały miejsce wyjątki:  #"
+msgstr ""
 
 #: lib/installer.php:4140
 #, php-format
@@ -19077,17 +19077,17 @@ msgstr "Nie zdefiniowano nazwy użytkownika"
 #: lib/ldap.php:423
 #, php-format
 msgid "Protocol Error, Unable to set version (%s) on Server (%s)"
-msgstr "Błąd protokołu, brak możliwości ustawienia wersji"
+msgstr ""
 
 #: lib/ldap.php:424
 #, php-format
 msgid "Protocol Error, Unable to set referrals option (%s) on Server (%s)"
-msgstr "Protokół Błąd, Nie można ustawić opcji Odsyłanie"
+msgstr ""
 
 #: lib/ldap.php:425
 #, php-format
 msgid "Protocol Error, unable to start TLS communications (%s) on Server (%s)"
-msgstr "Błąd protokołu, brak możliwości uruchomienia komunikacji TLS"
+msgstr ""
 
 #: lib/ldap.php:426
 #, php-format
@@ -19097,27 +19097,27 @@ msgstr "Protokół Błąd, błąd ogólny (%s)"
 #: lib/ldap.php:427
 #, php-format
 msgid "Protocol Error, Unable to bind, LDAP result: (%s) on Server (%s)"
-msgstr "Błąd protokołu, brak możliwości powiązania, wynik LDAP: %s"
+msgstr ""
 
 #: lib/ldap.php:428
 #, php-format
 msgid "Unable to Connect to Server (%s)"
-msgstr "Nie można połączyć się z serwerem"
+msgstr ""
 
 #: lib/ldap.php:429
 #, php-format
 msgid "Connection Timeout to Server (%s)"
-msgstr "Limit czasu połączenia"
+msgstr ""
 
 #: lib/ldap.php:430
 #, php-format
 msgid "Insufficient Access to Server (%s)"
-msgstr "Niewystarczający dostęp"
+msgstr ""
 
 #: lib/ldap.php:431
 #, php-format
 msgid "Group DN could not be found to compare on Server (%s)"
-msgstr "Grupa DN nie mogła być znaleziona do porównania"
+msgstr ""
 
 #: lib/ldap.php:432
 msgid "More than one matching user found"
@@ -19134,7 +19134,7 @@ msgstr "Nie można znaleźć użytkowników DN"
 #: lib/ldap.php:435
 #, php-format
 msgid "Unable to create LDAP connection object to Server (%s)"
-msgstr "Nie można utworzyć obiektu połączenia LDAP"
+msgstr ""
 
 #: lib/ldap.php:436
 msgid "Specific DN and Password required"
@@ -19147,7 +19147,7 @@ msgstr "Podano nieprawidłowe hasło. Logowanie nie powiodło się."
 #: lib/ldap.php:438
 #, php-format
 msgid "Unexpected error %s (Ldap Error: %s) on Server (%s)"
-msgstr "Nieoczekiwany błąd %s (błąd Ldap: %s)"
+msgstr ""
 
 #: lib/package.php:115 package_import.php:82
 msgid "Key Generation Required to Use Tool"
@@ -19380,12 +19380,12 @@ msgstr "Załadowanie nie powiodło się!  Nie można znaleźć dostępnego rekor
 #: lib/plugins.php:1728
 #, php-format
 msgid "The Plugin '%s' has been archived successfully."
-msgstr "Kaktusy pomyślnie oczyszczone z Cacti"
+msgstr ""
 
 #: lib/plugins.php:1730
 #, php-format
 msgid "The Plugin '%s' archiving process has failed.  Check the Cacti log for errors."
-msgstr "Jedna lub więcej napraw plików RRD nie powiodło się.  Informacje o błędach można znaleźć w dzienniku kaktusów."
+msgstr ""
 
 #: lib/plugins.php:1733
 #, php-format
@@ -19555,32 +19555,32 @@ msgstr "Komendy RRDtool:"
 #: lib/rrd.php:3415
 #, php-format
 msgid "The required RRDfile step size is '%s' but observed step is '%s'"
-msgstr "Wymagana wielkość kroku RRD wynosi \"%s"
+msgstr ""
 
 #: lib/rrd.php:3475
 #, php-format
 msgid "Type for Data Source '%s' should be '%s'"
-msgstr "Typ źródła danych \"%\" powinien być \"%\"."
+msgstr ""
 
 #: lib/rrd.php:3481
 #, php-format
 msgid "Heartbeat for Data Source '%s' should be '%s'"
-msgstr "Heartbeat for Data Source \"%\" powinien być \"%\"."
+msgstr ""
 
 #: lib/rrd.php:3493
 #, php-format
 msgid "RRD minimum for Data Source '%s' should be '%s'"
-msgstr "Minimalna wartość RRD dla źródeł danych \"%\" powinna wynosić \"%\"."
+msgstr ""
 
 #: lib/rrd.php:3502
 #, php-format
 msgid "DS '%s' missing in Cacti definition"
-msgstr "DS \"%\" brakujące w definicji Cacti"
+msgstr ""
 
 #: lib/rrd.php:3516 lib/rrd.php:3517
 #, php-format
 msgid "Cacti RRA '%s' has same CF/steps (%s, %s) as '%s'"
-msgstr "RRA Cacti \"%\" ma taki sam CF/etapy (%s, %s) jak \"%s"
+msgstr ""
 
 #: lib/rrd.php:3531 lib/rrd.php:3532
 #, php-format
@@ -19595,22 +19595,22 @@ msgstr "Wartość pdp_per_row dla '%s' jest nieprawidłowa dla RRA '%s' powinna 
 #: lib/rrd.php:3570
 #, php-format
 msgid "The XFF for Cacti RRA id is '%s' but should be '%s'"
-msgstr "XFF dla Cacti RRA id \"%\" powinno być \"%\"."
+msgstr ""
 
 #: lib/rrd.php:3574
 #, php-format
 msgid "The number of rows for Cacti RRA id '%s' is incorrect.  The number of rows are '%s' but should be '%s'"
-msgstr "Liczba wierszy dla Cacti RRA id \"%\" powinna być \"%\"."
+msgstr ""
 
 #: lib/rrd.php:3593
 #, php-format
 msgid "The RRA '%s' missing in the existing Cacti RRDfile"
-msgstr "Brak \"%\" RRA w pliku RRD"
+msgstr ""
 
 #: lib/rrd.php:3600
 #, php-format
 msgid "RRA '%s' missing in Cacti definition"
-msgstr "Brak \"%\" RRA w definicji Cacti"
+msgstr ""
 
 #: lib/rrd.php:3619
 msgid "RRD File Information"
@@ -20000,7 +20000,7 @@ msgstr "ERROR: Walidacja białej listy nie powiodła się. Sprawdź metodę wpro
 #: lib/template.php:2332
 #, php-format
 msgid "Graph Not created for %s due to bad data"
-msgstr "Tworzenie wykresu"
+msgstr ""
 
 #: lib/template.php:2361
 #, php-format
@@ -20056,7 +20056,7 @@ msgstr "Dzięki możliwości zdalnej ankiety duże ilości danych zostaną zsync
 #: lib/utility.php:1185
 #, php-format
 msgid "If using the Cacti Performance Booster and choosing a memory storage engine, you have to be careful to flush your Performance Booster buffer before the system runs out of memory table space.  This is done two ways, first reducing the size of your output column to just the right size.  This column is in the tables poller_output, and poller_output_boost.  The second thing you can do is allocate more memory to memory tables.  We have arbitrarily chosen a recommended value of 10%% of system memory, but if you are using SSD disk drives, or have a smaller system, you may ignore this recommendation or choose a different storage engine.  You may see the expected consumption of the Performance Booster tables under Console -> System Utilities -> View Boost Status."
-msgstr "Jeśli używasz Cacti Performance Booster i wybierasz silnik pamięci masowej, musisz być ostrożny, aby spłukać bufor Performance Booster zanim system zabraknie miejsca na stole pamięci.  Odbywa się to na dwa sposoby, najpierw zmniejszając rozmiar kolumny wyjściowej do właściwego rozmiaru.  Kolumna ta znajduje się w tabelach poller_output i poller_output_boost.  Drugą rzeczą, którą można zrobić, jest przydzielenie większej ilości pamięci do tabel pamięci.  Wybraliśmy arbitralnie zalecaną wartość 10% pamięci systemowej, ale jeśli używasz dysków SSD lub masz mniejszy system, możesz zignorować to zalecenie lub wybrać inny silnik pamięci masowej.  Możesz zobaczyć oczekiwane zużycie tabel Performance Booster w sekcji Konsola -> Narzędzia systemowe -> Zobacz status Boost."
+msgstr ""
 
 #: lib/utility.php:1191
 msgid "When executing subqueries, having a larger temporary table size, keep those temporary tables in memory."
@@ -20086,7 +20086,7 @@ msgstr "Jeśli Twoje tabele mają bardzo duże indeksy, musisz ustawić wartoś�
 #: lib/utility.php:1227
 #, php-format
 msgid "InnoDB will hold as much tables and indexes in system memory as is possible.  Therefore, you should make the innodb_buffer_pool large enough to hold as much of the tables and index in memory.  Checking the size of the /var/lib/mysql/cacti directory will help in determining this value.  We are recommending 25%% of your systems total memory, but your requirements will vary depending on your systems size.  If you database is very large or remote, you can consider increasing this size.  If remote, it can by as high as 80% of the systems memory.  However, cautions must be taken to reduce the swappiness of the system, or to remove swap to keep the system from swapping."
-msgstr "InnoDB będzie trzymać w pamięci systemowej jak najwięcej tabel i indeksów, jak to tylko możliwe.  Dlatego powinieneś sprawić, że innodb_buffer_pool będzie wystarczająco duży, aby pomieścić jak najwięcej tabel i indeksów w pamięci.  Sprawdzenie rozmiaru katalogu /var/lib/mysql/cacti pomoże w określeniu tej wartości.  Zalecamy 25% całkowitej pojemności pamięci systemów, ale Twoje wymagania będą się różnić w zależności od wielkości systemów."
+msgstr ""
 
 #: lib/utility.php:1233
 #, fuzzy
@@ -20198,12 +20198,12 @@ msgstr "PHP %s jest wersją minimalną"
 #: lib/utility.php:1980
 #, php-format
 msgid "A minimum of %s memory limit"
-msgstr "Minimalny limit pamięci MB"
+msgstr ""
 
 #: lib/utility.php:1982
 #, php-format
 msgid "A minimum of %s m execution time"
-msgstr "Minimalny czas realizacji % m"
+msgstr ""
 
 #: lib/utility.php:1984
 msgid "A valid timezone that matches MySQL and the system"
@@ -20414,7 +20414,7 @@ msgstr "Wylogowanie Cacti"
 #: logout.php:70
 #, php-format
 msgid "You have been logged out of Cacti due to %s."
-msgstr "Zostałeś wylogowany z Cacti z powodu limitu czasu sesji."
+msgstr ""
 
 #: logout.php:71
 #, php-format
@@ -20623,17 +20623,17 @@ msgstr "Co chciałbyś eksportować?"
 #: package.php:278
 #, php-format
 msgid "%s Device Package"
-msgstr "Nazwa urządzenia"
+msgstr ""
 
 #: package.php:282
 #, php-format
 msgid "%s Graph Template Package"
-msgstr "Nazwa szablonu wykresu"
+msgstr ""
 
 #: package.php:286
 #, php-format
 msgid "%s Data Query Package"
-msgstr "Nazwa zapytania o dane"
+msgstr ""
 
 #: package.php:314 templates_export.php:168
 #, php-format
@@ -20647,7 +20647,7 @@ msgstr "Dostępne szablony"
 #: package.php:323
 #, php-format
 msgid "%s to Export"
-msgstr "Eksport"
+msgstr ""
 
 #: package.php:324
 msgid "Choose the exact items to export in the Package."
@@ -20722,7 +20722,7 @@ msgstr "Nie można utworzyć katalogu tymczasowego pakietu %s."
 #: package_import.php:208 package_import.php:529
 #, php-format
 msgid "The Package %s Imported Successfully"
-msgstr "Kaktusy pomyślnie oczyszczone z Cacti"
+msgstr ""
 
 #: package_import.php:210 package_import.php:531
 #, php-format
@@ -21683,7 +21683,7 @@ msgstr "Zainstaluj wtyczkę"
 #: plugins.php:1816
 #, php-format
 msgid "Plugin '%s' can not be archived before it's been Installed."
-msgstr "Nie można zainstalować wtyczki."
+msgstr ""
 
 #: plugins.php:1827
 msgid "Remove Plugin Data Tables and Settings"
@@ -21771,27 +21771,27 @@ msgstr "Włącz wtyczkę"
 #: poller.php:405
 #, php-format
 msgid "WARNING: %s is out of sync with the Poller Interval for Poller[%d]!  The Poller Interval is %d seconds, with a maximum of a %d seconds, but %d seconds have passed since the last poll!"
-msgstr "OSTRZEŻENIE: %s nie jest zsynchronizowane z interwałem Pollera!  Interwał Pollera wynosi \"%d\" sekund, z maksimum \"%d\" sekund, ale %d sekund minęło od ostatniej ankiety!"
+msgstr ""
 
 #: poller.php:594
 #, php-format
 msgid "WARNING: There are %d processes detected as overrunning a polling cycle for Poller[%d], please investigate."
-msgstr "OSTRZEŻENIE: Wykryto \"%d\" jako przekroczenie cyklu wyborczego, proszę zbadać."
+msgstr ""
 
 #: poller.php:652
 #, php-format
 msgid "WARNING: Poller Output Table not empty for Poller[%d].  Issues: %d, %s."
-msgstr "OSTRZEŻENIE: Poller Output Table not Empty.  Zagadnienia: %d, %s."
+msgstr ""
 
 #: poller.php:693
 #, php-format
 msgid "ERROR: The spine path: %s is invalid for Poller[%d].  Poller can not continue!"
-msgstr "ERROR: Ścieżka kręgosłupa: %s jest nieważna.  Poller nie może być kontynuowany!"
+msgstr ""
 
 #: poller.php:842
 #, php-format
 msgid "Maximum runtime of %d seconds exceeded for Poller[%d]. Exiting."
-msgstr "Przekroczony maksymalny czas pracy %d sekund. Wyjście."
+msgstr ""
 
 #: poller.php:1022
 #, php-format
@@ -21823,7 +21823,7 @@ msgstr "UWAGA: Dodano drugi moduł gromadzący dane Cacti. Dlatego też automaty
 #: poller_automation.php:57
 #, php-format
 msgid "WARNING: Main Cacti database %s offline or in recovery"
-msgstr "OSTRZEŻENIE: Główna baza danych kaktusów w trybie offline lub w trakcie odzyskiwania"
+msgstr ""
 
 #: poller_automation.php:1071 poller_automation.php:1125
 msgid "Cacti Primary Admin"
@@ -22422,7 +22422,7 @@ msgstr "UWAGA: Ustawienia ścieżki na tej karcie są zapisywane tylko lokalnie!
 #: settings.php:140
 #, php-format
 msgid "Cacti Settings (%s)%s"
-msgstr "Ustawienia Cacti (%s)"
+msgstr ""
 
 #: settings.php:264
 msgid "Changing Permission Model Warning"
@@ -23143,7 +23143,7 @@ msgstr "Różne wersje Cacti i kręgosłupa!"
 #: support.php:1313
 #, php-format
 msgid "Action[%s]"
-msgstr "Działanie[%]"
+msgstr ""
 
 #: support.php:1318
 msgid "No items to poll"
@@ -23373,12 +23373,12 @@ msgstr "Uszkodzona"
 #: templates_import.php:321
 #, php-format
 msgid "Met: %d"
-msgstr "warunków:"
+msgstr ""
 
 #: templates_import.php:325
 #, php-format
 msgid "Unmet: %d"
-msgstr "Niezaspokojone"
+msgstr ""
 
 #: templates_import.php:334
 msgid "Some CDEF Items will not import due to an export error! Contact Template provider for an updated export."
@@ -24069,7 +24069,7 @@ msgstr "Pokaż wyjątki"
 #: user_admin.php:2423
 #, php-format
 msgid "Group Membership %s"
-msgstr "Członkostwo w grupie %"
+msgstr ""
 
 #: user_admin.php:2427
 msgid "Show All"
@@ -24686,7 +24686,7 @@ msgstr "Przejrzysty rejestr Cacti"
 #: utilities.php:192
 #, php-format
 msgid "%s - WEBUI NOTE: Cacti Log Cleared from Web Management Interface."
-msgstr "UWAGA: Cacti Log Cleared from Web Management Interface."
+msgstr ""
 
 #: utilities.php:194
 msgid "Cacti Log Cleared"
@@ -24996,7 +24996,7 @@ msgstr "%d sek."
 #: utilities.php:1358
 #, php-format
 msgid "%0.2f percent of update frequency)"
-msgstr "%0,2f procent częstotliwości aktualizacji)"
+msgstr ""
 
 #: utilities.php:1366
 msgid "RRD Updates:"
@@ -25030,7 +25030,7 @@ msgstr "Szczegółowe Timery Runtime:"
 #: utilities.php:1449 utilities.php:1451
 #, php-format
 msgid "Process: %d"
-msgstr "1 Proces"
+msgstr ""
 
 #: utilities.php:1449
 #, php-format
@@ -25427,10 +25427,6 @@ msgstr "Nr VDEF"
 #~ msgstr[1] ""
 #~ msgstr[2] ""
 
-#, php-format
-#~ msgid "Click 'Continue' to Duplicate following Devices on Tree %s."
-#~ msgstr "Kliknij 'Kontynuuj', aby usunąć następujące drzewo."
-
 #, fuzzy
 #~ msgid "Click 'Continue' to Synchronize Devices associated with the selected Device Template(s).  Note that this action may take some time depending on the number of Devices mapped to the Device Template."
 #~ msgstr "Kliknąć \"Continue\" (Kontynuuj), aby zsynchronizować urządzenia powiązane z wybranym(-i) szablonem(-ami) urządzenia.  Należy pamiętać, że czynność ta może zająć trochę czasu w zależności od liczby urządzeń mapowanych do szablonu urządzenia."
@@ -25602,7 +25598,6 @@ msgstr "Nr VDEF"
 #~ msgstr "Utworzone drzewa"
 
 #, fuzzy
-#~| msgid "DES"
 #~ msgid "DS"
 #~ msgstr "DES"
 
@@ -26240,10 +26235,6 @@ msgstr "Nr VDEF"
 
 #~ msgid "This value represents the number of high and low average samples will be removed from the sample set prior to calculating the Variance Average.  If you choose an outlier value of 5, then both the top and bottom 5 averages are removed."
 #~ msgstr "Wartość ta odpowiada liczbie próbek o wysokiej i niskiej średniej liczbie próbek, które zostaną usunięte z zestawu próbek przed obliczeniem średniej zmienności.  Jeśli wybierzesz wartość odbiegającą od wartości 5, to zarówno górna jak i dolna 5 średnich zostaną usunięte."
-
-#, php-format
-#~ msgid "This value represents the percentage above the adjusted sample average once outliers have been removed from the sample.  For example, a Variance Percentage of 100%% on an adjusted average of 50 would remove any sample above the quantity of 100 from the graph."
-#~ msgstr "Wartość ta stanowi odsetek powyżej skorygowanej średniej próbki po usunięciu wartości odstających z próbki.  Na przykład, Variance Procent 100% przy skorygowanej średniej 50 usunąłby z wykresu każdą próbkę powyżej ilości 100."
 
 #~ msgid "Threads per Process"
 #~ msgstr "Domyślne gwinty na proces"

--- a/locales/po/ru-RU.po
+++ b/locales/po/ru-RU.po
@@ -1,3 +1,4 @@
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Cacti Russian Language File\n"
@@ -16806,7 +16807,7 @@ msgstr "Щелкните, чтобы показать вывод запроса 
 #: lib/data_query.php:741
 #, php-format
 msgid "Sort field returned no data for field name %s, skipping"
-msgstr "Поле сортировки не возвращает никаких данных. Нельзя продолжать ре-индекс."
+msgstr ""
 
 #: lib/data_query.php:743
 #, fuzzy, php-format
@@ -27210,7 +27211,6 @@ msgstr "Нет VDEFs"
 #~ msgstr "Конвертировать в нормальный График(и)"
 
 #, fuzzy
-#~| msgid "DES"
 #~ msgid "DS"
 #~ msgstr "DES"
 

--- a/locales/po/uk-UA.po
+++ b/locales/po/uk-UA.po
@@ -15024,7 +15024,7 @@ msgstr "Графік:(%s%s)"
 #: lib/auth.php:2457 lib/auth.php:2459
 #, php-format
 msgid "Device:(%s%s)"
-msgstr "Пристрій: (%s%)"
+msgstr ""
 
 #: lib/auth.php:2392 lib/auth.php:2398 lib/auth.php:2467 lib/auth.php:2469
 #: lib/auth.php:2473 lib/auth.php:2475
@@ -21331,12 +21331,12 @@ msgstr "Опитувальник у режимі серцебиття"
 #: poller.php:1253
 #, php-format
 msgid "WARNING: 24 hours Poller[%d] avg. run time is %f seconds (more than %d &#37; of time limit)"
-msgstr "ПОПЕРЕДЖЕННЯ: Середній час виконання Poller[%d] за 24 години становить %f секунд (більше ніж %d % від ліміту часу)"
+msgstr ""
 
 #: poller.php:1269
 #, php-format
 msgid "WARNING: In last hour Poller[%d] run time %d times reached more than %d &#37; of time limit"
-msgstr "ПОПЕРЕДЖЕННЯ: За останню годину час виконання Poller[%d] (%d разів) перевищив %d % ліміту часу"
+msgstr ""
 
 #: poller.php:1291
 msgid "Cacti System Notification"


### PR DESCRIPTION
## Summary

Clear msgstr entries where format specifiers (%s, %d) are missing or wrong vs the English msgid. These cause PHP sprintf crashes at runtime.

- 885 entries cleared across 12 languages (0.99% of catalog)
- Affected languages: bg-BG, el-GR, fr-FR, he-IL, hi-IN, it-IT, ja-JP, ko-KR, lv-LV, pl-PL, ru-RU, uk-UA
- Empty msgstr falls back to English at runtime (safe)

Fixes #6846