### PR TITLE
hardening: move to argument array pattern for shell execution (#6854)

### DIFF
--- a/lib/poller.php
+++ b/lib/poller.php
@@ -114,8 +114,8 @@ function exec_poll_php(string $command, bool $using_proc_function, array $pipes,
  * to execute code in the foreground.
  *
  * @param string $filename      The full pathname to the script to execute
- * @param string $args          Any additional arguments that must be passed onto the executable
- * @param string $redirect_args Any additional arguments for file re-direction.  Otherwise output goes to /dev/null
+ * @param string|array $args          Any additional arguments. Arrays are escaped per-element via cacti_escapeshellarg.
+ * @param string|array $redirect_args Any additional arguments for file re-direction.  Otherwise output goes to /dev/null
  *
  * @return void
  */

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -126,8 +126,11 @@ function exec_background(string $filename, string|array $args = '', string|array
 		$args = implode(' ', array_map('cacti_escapeshellarg', $args));
 	}
 
+	/* redirect_args intentionally bypass escapeshellarg because they contain
+	 * shell operators (>, 2>&1, etc.) that must be passed through literally.
+	 * Only hardcoded redirect strings should be passed here, never user input. */
 	if (is_array($redirect_args)) {
-		$redirect_args = implode(' ', $redirect_args); // redirect args should not be shell escaped generally as they contain > etc
+		$redirect_args = implode(' ', $redirect_args);
 	}
 
 	cacti_log("DEBUG: About to Spawn a Remote Process [CMD: $filename, ARGS: $args]", true, 'POLLER', ($debug ? POLLER_VERBOSITY_NONE : POLLER_VERBOSITY_DEBUG));

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -113,7 +113,7 @@ function exec_poll_php(string $command, bool $using_proc_function, array $pipes,
  * exec_background - executes a program in the background so that php can continue
  * to execute code in the foreground.
  *
- * @param string $filename      The full pathname to the script to execute
+ * @param string       $filename      The full pathname to the script to execute
  * @param string|array $args          Any additional arguments. Arrays are escaped per-element via cacti_escapeshellarg.
  * @param string|array $redirect_args Any additional arguments for file re-direction.  Otherwise output goes to /dev/null
  *

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -119,8 +119,16 @@ function exec_poll_php(string $command, bool $using_proc_function, array $pipes,
  *
  * @return void
  */
-function exec_background(string $filename, string $args = '', string $redirect_args = '') : void {
+function exec_background(string $filename, string|array $args = '', string|array $redirect_args = '') : void {
 	global $debug;
+
+	if (is_array($args)) {
+		$args = implode(' ', array_map('cacti_escapeshellarg', $args));
+	}
+
+	if (is_array($redirect_args)) {
+		$redirect_args = implode(' ', $redirect_args); // redirect args should not be shell escaped generally as they contain > etc
+	}
 
 	cacti_log("DEBUG: About to Spawn a Remote Process [CMD: $filename, ARGS: $args]", true, 'POLLER', ($debug ? POLLER_VERBOSITY_NONE : POLLER_VERBOSITY_DEBUG));
 

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -305,8 +305,12 @@ function rrdtool_execute() : mixed {
 	return call_user_func_array($function, $args);
 }
 
-function __rrd_execute(string $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdtool_pipe = null, string $logopt = 'WEBLOG') : mixed {
+function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdtool_pipe = null, string $logopt = 'WEBLOG') : mixed {
 	static $last_command;
+
+	if (is_array($command_line)) {
+		$command_line = implode(' ', array_map('cacti_escapeshellarg', $command_line));
+	}
 
 	/**
 	 * WIN32: before sending this command off to rrdtool, get rid

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -308,11 +308,11 @@ function rrdtool_execute() : mixed {
 /**
  * Execute an RRDtool command and return the output.
  *
- * @param  string|array $command_line  The RRDtool command to execute
- * @param  bool         $log_to_stdout Whether to echo output to stdout
- * @param  int          $output_flag   Output format constant (RRDTOOL_OUTPUT_*)
- * @param  mixed        $rrdtool_pipe  An open RRDtool pipe resource, or null
- * @param  string       $logopt        Logging context identifier
+ * @param string|array $command_line  The RRDtool command to execute
+ * @param bool         $log_to_stdout Whether to echo output to stdout
+ * @param int          $output_flag   Output format constant (RRDTOOL_OUTPUT_*)
+ * @param mixed        $rrdtool_pipe  An open RRDtool pipe resource, or null
+ * @param string       $logopt        Logging context identifier
  *
  * @return mixed The command output in the requested format
  */

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -305,6 +305,17 @@ function rrdtool_execute() : mixed {
 	return call_user_func_array($function, $args);
 }
 
+/**
+ * Execute an RRDtool command and return the output.
+ *
+ * @param  string|array $command_line  The RRDtool command to execute
+ * @param  bool         $log_to_stdout Whether to echo output to stdout
+ * @param  int          $output_flag   Output format constant (RRDTOOL_OUTPUT_*)
+ * @param  mixed        $rrdtool_pipe  An open RRDtool pipe resource, or null
+ * @param  string       $logopt        Logging context identifier
+ *
+ * @return mixed The command output in the requested format
+ */
 function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdtool_pipe = null, string $logopt = 'WEBLOG') : mixed {
 	static $last_command;
 

--- a/oauth2.php
+++ b/oauth2.php
@@ -92,9 +92,7 @@ switch ($providerName) {
 if (!isrv('code')) { // If we don't have an authorization code then get one
 	$authUrl                 = $provider->getAuthorizationUrl($options);
 	$_SESSION['oauth2state'] = $provider->getState();
-	header('Location: ' . $authUrl);
-
-	exit;
+	cacti_redirect($authUrl, false);
 
 	// Check given state against previously stored one to mitigate CSRF attack
 }

--- a/oauth2.php
+++ b/oauth2.php
@@ -92,7 +92,9 @@ switch ($providerName) {
 if (!isrv('code')) { // If we don't have an authorization code then get one
 	$authUrl                 = $provider->getAuthorizationUrl($options);
 	$_SESSION['oauth2state'] = $provider->getState();
-	cacti_redirect($authUrl, false);
+	header('Location: ' . $authUrl);
+
+	exit;
 
 	// Check given state against previously stored one to mitigate CSRF attack
 }

--- a/tests/Unit/ArgArrayHardeningTest.php
+++ b/tests/Unit/ArgArrayHardeningTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+
+// Mock cacti_escapeshellarg if it doesn't exist in testing env
+if (!function_exists('cacti_escapeshellarg')) {
+	function cacti_escapeshellarg($arg) {
+		return "'" . str_replace("'", "'\\''", $arg) . "'";
+	}
+}
+
+test('__rrd_execute correctly handles array of arguments', function () {
+	$args = ['graph', '-', '--start', '12345; id'];
+	
+	// Simulated logic from __rrd_execute
+	$command_line = implode(' ', array_map('cacti_escapeshellarg', $args));
+	
+	expect($command_line)->toBe("'graph' '-' '--start' '12345; id'");
+});
+
+test('exec_background correctly handles array of arguments', function () {
+	$args = ['--poller=1', '--network=192.168.1.0/24; id'];
+	
+	// Simulated logic from exec_background
+	$args_string = implode(' ', array_map('cacti_escapeshellarg', $args));
+	
+	expect($args_string)->toBe("'--poller=1' '--network=192.168.1.0/24; id'");
+});


### PR DESCRIPTION
This PR introduces a structural hardening change to the shell execution layer by allowing `__rrd_execute()` and `exec_background()` to accept an array of arguments.

When an array is provided, the function automatically applies `cacti_escapeshellarg()` to each element and joins them with spaces. This provides a safe, idiomatic path for executing commands without risky string concatenation.

Fixes #6854
