### PR TITLE
hardening: deprecate raw SQL fragment passing in sequence functions (#6857)

### DIFF
--- a/data_queries.php
+++ b/data_queries.php
@@ -416,7 +416,7 @@ function data_query_item_movedown_gsv() : void {
 	gfrv('snmp_query_graph_id');
 	// ====================================================
 
-	move_item_down('snmp_query_graph_sv', grv('id'), 'snmp_query_graph_id=' . grv('snmp_query_graph_id') . ' AND field_name = ' . db_qstr(gnrv('field_name')));
+	move_item_down('snmp_query_graph_sv', grv('id'), ['snmp_query_graph_id' => grv('snmp_query_graph_id'), 'field_name' => gnrv('field_name')]);
 }
 
 function data_query_item_moveup_gsv() : void {
@@ -425,7 +425,7 @@ function data_query_item_moveup_gsv() : void {
 	gfrv('snmp_query_graph_id');
 	// ====================================================
 
-	move_item_up('snmp_query_graph_sv', grv('id'), 'snmp_query_graph_id=' . grv('snmp_query_graph_id') . ' AND field_name = ' . db_qstr(gnrv('field_name')));
+	move_item_up('snmp_query_graph_sv', grv('id'), ['snmp_query_graph_id' => grv('snmp_query_graph_id'), 'field_name' => gnrv('field_name')]);
 }
 
 function data_query_item_remove_gsv() : void {
@@ -445,7 +445,7 @@ function data_query_item_movedown_dssv() : void {
 	gfrv('snmp_query_graph_id');
 	// ====================================================
 
-	move_item_down('snmp_query_graph_rrd_sv', grv('id'), 'data_template_id=' . grv('data_template_id') . ' AND snmp_query_graph_id=' . grv('snmp_query_graph_id') . ' AND field_name = ' . db_qstr(gnrv('field_name')));
+	move_item_down('snmp_query_graph_rrd_sv', grv('id'), ['data_template_id' => grv('data_template_id'), 'snmp_query_graph_id' => grv('snmp_query_graph_id'), 'field_name' => gnrv('field_name')]);
 }
 
 function data_query_item_moveup_dssv() : void {
@@ -455,7 +455,7 @@ function data_query_item_moveup_dssv() : void {
 	gfrv('snmp_query_graph_id');
 	// ====================================================
 
-	move_item_up('snmp_query_graph_rrd_sv', grv('id'), 'data_template_id=' . grv('data_template_id') . ' AND snmp_query_graph_id=' . grv('snmp_query_graph_id') . ' AND field_name = ' . db_qstr(gnrv('field_name')));
+	move_item_up('snmp_query_graph_rrd_sv', grv('id'), ['data_template_id' => grv('data_template_id'), 'snmp_query_graph_id' => grv('snmp_query_graph_id'), 'field_name' => gnrv('field_name')]);
 }
 
 function data_query_sv_check_sequences(string $type, int $snmp_query_graph_id, string $field_name) : bool {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3956,10 +3956,28 @@ function get_graph_parent(int $graph_template_item_id, string $direction) : int 
  *
  * @return int The ID of the next or previous item id
  */
-function get_item(string $tblname, string $field, int $startid, string $lmt_query, string $direction) : int {
+/**
+ * build_where_from_array - builds a SQL WHERE clause fragment from an associative array
+ *
+ * @param array $filters An associative array of field => value
+ * @param array $params  A reference to the params array for prepared statements
+ *
+ * @return string The SQL WHERE fragment
+ */
+function build_where_from_array(array $filters, array &$params) : string {
+	$where = [];
+	foreach ($filters as $field => $value) {
+		$where[] = "`$field` = ?";
+		$params[] = $value;
+	}
+	return implode(' AND ', $where);
+}
+
+function get_item(string $tblname, string $field, int $startid, string|array $lmt_query, string $direction) : int {
 	$sql_operator = '';
 	$sql_order    = '';
 	$new_item_id  = 0;
+	$params       = [];
 
 	if ($direction == 'next') {
 		$sql_operator = '>';
@@ -3975,11 +3993,17 @@ function get_item(string $tblname, string $field, int $startid, string $lmt_quer
 		[$startid]);
 
 	if ($sql_operator != '') {
-		$new_item_id = db_fetch_cell("SELECT id
-			FROM $tblname
-			WHERE $field $sql_operator $current_sequence " . ($lmt_query != '' ? " AND $lmt_query" : '') . "
-			ORDER BY $field $sql_order
-			LIMIT 1");
+		$where_clause = '';
+		if (is_array($lmt_query)) {
+			$where_clause = build_where_from_array($lmt_query, $params);
+		} else {
+			$where_clause = $lmt_query;
+		}
+
+		$sql_query = "SELECT id FROM $tblname WHERE $field $sql_operator ? " . ($where_clause != '' ? " AND $where_clause" : '') . " ORDER BY $field $sql_order LIMIT 1";
+		array_unshift($params, $current_sequence);
+
+		$new_item_id = db_fetch_cell_prepared($sql_query, $params);
 	}
 
 	if (empty($new_item_id)) {
@@ -3999,11 +4023,18 @@ function get_item(string $tblname, string $field, int $startid, string $lmt_quer
  *
  * @return int The next available sequence id
  */
-function get_sequence(mixed $id, string $field, string $table_name, string $group_query) : int {
+function get_sequence(mixed $id, string $field, string $table_name, string|array $group_query) : int {
 	if (empty($id)) {
-		$data = db_fetch_row("SELECT max($field)+1 AS seq
+		$params = [];
+		if (is_array($group_query)) {
+			$where_clause = build_where_from_array($group_query, $params);
+		} else {
+			$where_clause = $group_query;
+		}
+
+		$data = db_fetch_row_prepared("SELECT max($field)+1 AS seq
 			FROM $table_name
-			WHERE $group_query");
+			WHERE $where_clause", $params);
 
 		if (!is_array($data) || $data['seq'] == '') {
 			return 1;
@@ -4029,7 +4060,7 @@ function get_sequence(mixed $id, string $field, string $table_name, string $grou
  *
  * @return void
  */
-function move_item_down(string $table_name, int $current_id, string $group_query = '') : void {
+function move_item_down(string $table_name, int $current_id, string|array $group_query = '') : void {
 	$next_item = get_item($table_name, 'sequence', $current_id, $group_query, 'next');
 
 	$sequence = db_fetch_cell_prepared("SELECT sequence
@@ -4062,7 +4093,7 @@ function move_item_down(string $table_name, int $current_id, string $group_query
  *
  * @return void
  */
-function move_item_up(string $table_name, int $current_id, string $group_query = '') : void {
+function move_item_up(string $table_name, int $current_id, string|array $group_query = '') : void {
 	$last_item = get_item($table_name, 'sequence', $current_id, $group_query, 'previous');
 
 	$sequence = db_fetch_cell_prepared("SELECT sequence

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3974,7 +3974,7 @@ function build_where_from_array(array $filters, array &$params) : string {
 			continue;
 		}
 
-		$where[] = "`$field` = ?";
+		$where[]  = "`$field` = ?";
 		$params[] = $value;
 	}
 
@@ -4002,6 +4002,7 @@ function get_item(string $tblname, string $field, int $startid, string|array $lm
 
 	if ($sql_operator != '') {
 		$where_clause = '';
+
 		if (is_array($lmt_query)) {
 			$where_clause = build_where_from_array($lmt_query, $params);
 		} else {
@@ -4034,6 +4035,7 @@ function get_item(string $tblname, string $field, int $startid, string|array $lm
 function get_sequence(mixed $id, string $field, string $table_name, string|array $group_query) : int {
 	if (empty($id)) {
 		$params = [];
+
 		if (is_array($group_query)) {
 			$where_clause = build_where_from_array($group_query, $params);
 		} else {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3966,10 +3966,18 @@ function get_graph_parent(int $graph_template_item_id, string $direction) : int 
  */
 function build_where_from_array(array $filters, array &$params) : string {
 	$where = [];
+
 	foreach ($filters as $field => $value) {
+		if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $field)) {
+			cacti_log('ERROR: Invalid field name in build_where_from_array: ' . $field, false, 'SECURITY');
+
+			continue;
+		}
+
 		$where[] = "`$field` = ?";
 		$params[] = $value;
 	}
+
 	return implode(' AND ', $where);
 }
 

--- a/tests/Unit/DbLayerHardeningTest.php
+++ b/tests/Unit/DbLayerHardeningTest.php
@@ -19,10 +19,16 @@ require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
 
 function test_build_where_from_array(array $filters, array &$params) : string {
 	$where = [];
+
 	foreach ($filters as $field => $value) {
+		if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $field)) {
+			continue;
+		}
+
 		$where[] = "`$field` = ?";
 		$params[] = $value;
 	}
+
 	return implode(' AND ', $where);
 }
 
@@ -48,7 +54,39 @@ test('build_where_from_array handles empty filters', function () {
 	$params = [];
 	$filters = [];
 	$where = test_build_where_from_array($filters, $params);
-	
+
 	expect($where)->toBe('')
 		->and($params)->toBe([]);
+});
+
+test('build_where_from_array rejects field names with semicolons', function () {
+	$params = [];
+	$where = test_build_where_from_array(['valid' => 1, 'invalid;field' => 2], $params);
+
+	expect($where)->toBe('`valid` = ?')
+		->and($params)->toBe([1]);
+});
+
+test('build_where_from_array rejects field names with backticks', function () {
+	$params = [];
+	$where = test_build_where_from_array(['id` OR 1=1 --' => 1], $params);
+
+	expect($where)->toBe('')
+		->and($params)->toBe([]);
+});
+
+test('build_where_from_array rejects field names with spaces', function () {
+	$params = [];
+	$where = test_build_where_from_array(['field name' => 1], $params);
+
+	expect($where)->toBe('')
+		->and($params)->toBe([]);
+});
+
+test('build_where_from_array accepts underscored field names', function () {
+	$params = [];
+	$where = test_build_where_from_array(['data_template_rrd_id' => 42], $params);
+
+	expect($where)->toBe('`data_template_rrd_id` = ?')
+		->and($params)->toBe([42]);
 });

--- a/tests/Unit/DbLayerHardeningTest.php
+++ b/tests/Unit/DbLayerHardeningTest.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+
+// build_where_from_array is defined in lib/functions.php
+// We'll test it here by mock or by inclusion if dependencies allow.
+
+function test_build_where_from_array(array $filters, array &$params) : string {
+	$where = [];
+	foreach ($filters as $field => $value) {
+		$where[] = "`$field` = ?";
+		$params[] = $value;
+	}
+	return implode(' AND ', $where);
+}
+
+test('build_where_from_array handles single filter', function () {
+	$params = [];
+	$filters = ['id' => 123];
+	$where = test_build_where_from_array($filters, $params);
+	
+	expect($where)->toBe('`id` = ?')
+		->and($params)->toBe([123]);
+});
+
+test('build_where_from_array handles multiple filters', function () {
+	$params = [];
+	$filters = ['host_id' => 1, 'field_name' => "test' OR 1=1"];
+	$where = test_build_where_from_array($filters, $params);
+	
+	expect($where)->toBe('`host_id` = ? AND `field_name` = ?')
+		->and($params)->toBe([1, "test' OR 1=1"]);
+});
+
+test('build_where_from_array handles empty filters', function () {
+	$params = [];
+	$filters = [];
+	$where = test_build_where_from_array($filters, $params);
+	
+	expect($where)->toBe('')
+		->and($params)->toBe([]);
+});


### PR DESCRIPTION
This PR introduces a structural hardening change to the database layer by refactoring `get_item()`, `get_sequence()`, `move_item_up()`, and `move_item_down()` to accept an associative array of filters.

A new helper `build_where_from_array()` is added to `lib/functions.php` to securely construct SQL WHERE clauses using prepared statements for all array-based filters. Critical call sites in `data_queries.php` have been migrated to this new safe pattern.

Fixes #6857
