### PR TITLE
hardening: improve output layer security with auto-escaping components (#6860)

### DIFF
--- a/lib/html.php
+++ b/lib/html.php
@@ -3511,9 +3511,8 @@ function html_auth_footer(string $section, string $error = '', string $html = ''
 			</form>
 			<hr />
 			<div class='cactiAuthErrors'>
-				<?php print $error; ?>
-			</div>
-			<div class='versionInfo'>
+				<?php print htmle($error); ?>
+			</div>			<div class='versionInfo'>
 				<?php print __('Version %s | %s', CACTI_VERSION_BRIEF, COPYRIGHT_YEARS_SHORT); ?>
 			</div>
 		</div>

--- a/lib/html.php
+++ b/lib/html.php
@@ -3512,7 +3512,8 @@ function html_auth_footer(string $section, string $error = '', string $html = ''
 			<hr />
 			<div class='cactiAuthErrors'>
 				<?php print htmle($error); ?>
-			</div>			<div class='versionInfo'>
+			</div>
+			<div class='versionInfo'>
 				<?php print __('Version %s | %s', CACTI_VERSION_BRIEF, COPYRIGHT_YEARS_SHORT); ?>
 			</div>
 		</div>

--- a/tests/Unit/OutputLayerHardeningTest.php
+++ b/tests/Unit/OutputLayerHardeningTest.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+
+// Mock html_auth_footer logic for testing escaping
+function test_html_auth_footer_logic(string $error) : string {
+	// The Hardened Logic: htmle($error)
+	if (!function_exists('htmle')) {
+		function htmle($string) {
+			return htmlspecialchars($string, ENT_QUOTES | ENT_HTML5, 'UTF-8', false);
+		}
+	}
+	
+	$output = "<div class='cactiAuthErrors'>\n";
+	$output .= "    " . htmle($error) . "\n";
+	$output .= "</div>\n";
+	
+	return $output;
+}
+
+test('html_auth_footer logic escapes error message', function () {
+	$payload = "<script>alert('XSS')</script>";
+	$result = test_html_auth_footer_logic($payload);
+	
+	expect($result)->not->toContain('<script>')
+		->and($result)->toContain('&lt;script&gt;');
+});
+
+test('html_auth_footer logic handles plain text', function () {
+	$message = "Invalid password";
+	$result = test_html_auth_footer_logic($message);
+	
+	expect($result)->toContain($message);
+});


### PR DESCRIPTION
This PR introduces structural hardening to the output layer by refactoring the `html_auth_footer()` component to automatically escape its `$error` parameter using `htmle()`.

This ensures that even if an upstream caller fails to sanitize an error message, the component provides defense-in-depth against reflected XSS.

Fixes #6860
