### PR TITLE
hardening: modernize string comparisons with PHP 8 functions (#6863)

### DIFF
--- a/lib/time.php
+++ b/lib/time.php
@@ -193,7 +193,7 @@ function get_timespan(array &$span, int $curr_time, int $timespan_given, int $fi
  */
 function month_shift(string $shift_size) : bool {
 	// is monthly shifting required?
-	return (strpos(cacti_strtolower($shift_size), 'month') !== false);
+	return (str_contains(cacti_strtolower($shift_size), 'month'));
 }
 
 /**

--- a/user_admin.php
+++ b/user_admin.php
@@ -1683,7 +1683,7 @@ function user_realms_edit(string $header_label) : void {
 
 			$local_user_auth_realms = __($user_auth_realms[$realm], $r['directory']);
 
-			$pos = (strpos($local_user_auth_realms, '->') !== false ? strpos($local_user_auth_realms, '->') + 2 : 0);
+			$pos = (str_contains($local_user_auth_realms, '->') ? strpos($local_user_auth_realms, '->') + 2 : 0);
 
 			if ($i == 0) {
 				print "<tr class='tableHeader'><th class='left' colspan='2'>" . __('Plugin Permissions') . '</th></tr>';
@@ -1718,7 +1718,7 @@ function user_realms_edit(string $header_label) : void {
 				$old_value = '';
 			}
 
-			$pos = (strpos($user_auth_realms[$realm], '->') !== false ? strpos($user_auth_realms[$realm], '->') + 2 : 0);
+			$pos = (str_contains($user_auth_realms[$realm], '->') ? strpos($user_auth_realms[$realm], '->') + 2 : 0);
 
 			print '<div class="flexChild">';
 			form_checkbox('section' . $realm, $old_value, substr($user_auth_realms[$realm], $pos), '', '', '', '', $name, true);

--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -1546,7 +1546,7 @@ function user_group_realms_edit(string $header_label) : void {
 
 			unset($all_realms[$realm]);
 
-			$pos = (strpos($user_auth_realms[$realm], '->') !== false ? strpos($user_auth_realms[$realm], '->') + 2 : 0);
+			$pos = (str_contains($user_auth_realms[$realm], '->') ? strpos($user_auth_realms[$realm], '->') + 2 : 0);
 
 			if ($i == 0) {
 				print "<tr class='tableHeader'><th colspan='2'>" . __('Plugin Permissions') . '</th></tr>';
@@ -1582,7 +1582,7 @@ function user_group_realms_edit(string $header_label) : void {
 				$old_value = '';
 			}
 
-			$pos = (strpos($user_auth_realms[$realm], '->') !== false ? strpos($user_auth_realms[$realm], '->') + 2 : 0);
+			$pos = (str_contains($user_auth_realms[$realm], '->') ? strpos($user_auth_realms[$realm], '->') + 2 : 0);
 
 			print '<div class="flexChild">';
 			form_checkbox('section' . $realm, $old_value, substr($user_auth_realms[$realm], $pos), '', '', '', '', $name, true);


### PR DESCRIPTION
This PR modernizes string comparisons by replacing legacy `strpos()` and `substr()` patterns with PHP 8's `str_contains()`, `str_starts_with()`, and `str_ends_with()`.

These changes improve readability and reduce the likelihood of logic errors associated with legacy string functions.

Fixes #6863
