### PR TITLE
hardening: standardize input handling with request variable wrappers (#6865)

### DIFF
--- a/include/global.php
+++ b/include/global.php
@@ -397,7 +397,7 @@ if ($config['poller_id'] > 1 || isset($rdatabase_hostname)) {
 			print $li . 'the credentials in config.php are valid.' . $il;
 			print $lu . $sp;
 
-			if (isset($_REQUEST['display_db_errors']) && !empty($config['DATABASE_ERROR'])) { // @phpstan-ignore-line
+			if (isrv('display_db_errors') && !empty($config['DATABASE_ERROR'])) { // @phpstan-ignore-line
 				print $ps . 'The following database errors occurred: ' . $ul;
 
 				foreach ($config['DATABASE_ERROR'] as $e) { // @phpstan-ignore-line
@@ -419,7 +419,7 @@ if ($config['poller_id'] > 1 || isset($rdatabase_hostname)) {
 			print $li . 'the credentials in config.php are valid and correct.' . $il;
 			print $lu . $sp;
 
-			if (isset($_REQUEST['display_db_errors']) && !empty($config['DATABASE_ERROR'])) { // @phpstan-ignore-line
+			if (isrv('display_db_errors') && !empty($config['DATABASE_ERROR'])) { // @phpstan-ignore-line
 				print $ps . 'The following database errors occurred: ' . $ul;
 
 				foreach ($config['DATABASE_ERROR'] as $e) { // @phpstan-ignore-line

--- a/include/global_languages.php
+++ b/include/global_languages.php
@@ -44,19 +44,19 @@ if (!read_config_option('i18n_language_support') && read_config_option('i18n_lan
 
 // Repair legacy language support
 if (!empty($config['i18n_force_language'])) {
-	$_REQUEST['language'] = $config['i18n_force_language'];
+	set_request_var('language', $config['i18n_force_language']);
 }
 
-if (!empty($_REQUEST['language'])) {
-	$_REQUEST['language'] = repair_locale($_REQUEST['language']);
+if (isrv('language')) {
+	set_request_var('language', repair_locale(grv('language')));
 }
 
 // determine whether or not we can support the language
 $user_locale = '';
 
-if (!empty($_REQUEST['language']) && !empty($lang2locale[$_REQUEST['language']])) {
+if (isrv('language') && !empty($lang2locale[grv('language')])) {
 	// user requests another language
-	$user_locale = apply_locale($_REQUEST['language']);
+	$user_locale = apply_locale(grv('language'));
 	unset($_SESSION['sess_current_date1']);
 	unset($_SESSION['sess_current_date2']);
 

--- a/include/global_languages.php
+++ b/include/global_languages.php
@@ -47,14 +47,14 @@ if (!empty($config['i18n_force_language'])) {
 	set_request_var('language', $config['i18n_force_language']);
 }
 
-if (isrv('language')) {
+if (!isempty_request_var('language')) {
 	set_request_var('language', repair_locale(grv('language')));
 }
 
 // determine whether or not we can support the language
 $user_locale = '';
 
-if (isrv('language') && !empty($lang2locale[grv('language')])) {
+if (!isempty_request_var('language') && !empty($lang2locale[grv('language')])) {
 	// user requests another language
 	$user_locale = apply_locale(grv('language'));
 	unset($_SESSION['sess_current_date1']);

--- a/oauth2.php
+++ b/oauth2.php
@@ -89,17 +89,15 @@ switch ($providerName) {
 		die('Provider missing');
 }
 
-if (!isset($_GET['code'])) { // If we don't have an authorization code then get one
+if (!isrv('code')) { // If we don't have an authorization code then get one
 	$authUrl                 = $provider->getAuthorizationUrl($options);
 	$_SESSION['oauth2state'] = $provider->getState();
-	header('Location: ' . $authUrl);
-
-	exit;
+	cacti_redirect($authUrl, false);
 
 	// Check given state against previously stored one to mitigate CSRF attack
 }
 
-if (empty($_GET['state']) || (isset($_SESSION['oauth2state']) && ($_GET['state'] !== $_SESSION['oauth2state']))) {
+if (isempty_request_var('state') || (isset($_SESSION['oauth2state']) && (grv('state') !== $_SESSION['oauth2state']))) {
 	unset($_SESSION['oauth2state']);
 
 	exit('Invalid state');
@@ -107,7 +105,7 @@ if (empty($_GET['state']) || (isset($_SESSION['oauth2state']) && ($_GET['state']
 	$token = $provider->getAccessToken(
 		'authorization_code',
 		[
-			'code' => $_GET['code']
+			'code' => grv('code')
 		]
 	);
 


### PR DESCRIPTION
This PR audits and refactors the codebase to ensure that direct access to `$_GET`, `$_POST`, and `$_REQUEST` is replaced with Cacti's `isrv()`, `grv()`, and `set_request_var()` wrappers.

Standardizing on these wrappers ensures that input handling remains consistent and follows established validation patterns, providing a more robust defense against injection attacks.

Fixes #6865
