### PR TITLE
fix: prevent redirect loop on forced password change

### DIFF
--- a/include/auth.php
+++ b/include/auth.php
@@ -62,7 +62,7 @@ if (is_install_needed() && !defined('IN_CACTI_INSTALL')) {
  * The logout page does not require authentication
  * so, short cut the process.
  */
-if (get_current_page() == 'logout.php') {
+if (get_current_page() == 'logout.php' || get_current_page() == 'auth_changepassword.php' || get_current_page() == 'auth_resetpassword.php') {
 	return true;
 }
 


### PR DESCRIPTION
## Summary

Exclude auth_changepassword.php and auth_resetpassword.php from the
SESS_CHANGE_PASSWORD redirect check in include/auth.php, preventing
an infinite redirect loop during forced password changes.

## Root cause

auth.php line 76 redirects to auth_changepassword.php when
SESS_CHANGE_PASSWORD is set. But auth_changepassword.php includes
auth.php, which sees the session var still set and redirects again.

logout.php was already excluded. This adds the password change pages
to the same exclusion.

## Test plan

- [x] Syntax check passes
- [ ] Fresh install: first login triggers password change without loop
- [ ] Admin-forced password reset works without loop

Fixes #6872