### PR TITLE
fix: move sanitize_graph_id_list to top-level scope

### DIFF
--- a/lib/html_graph.php
+++ b/lib/html_graph.php
@@ -2033,31 +2033,6 @@ function html_graph_zoom() : void {
 		$graph_start--;
 	}
 
-/**
- * Parse and sanitize a comma-separated graph list into validated integer IDs.
- *
- * @param string $csv_list  Comma-separated list of graph IDs (from request var)
- * @return array  Array of unique positive integer graph IDs
- */
-function sanitize_graph_id_list(string $csv_list): array {
-	$result = [];
-
-	foreach (explode(',', $csv_list) as $item) {
-		$item = trim($item);
-
-		if ($item !== '' && ctype_digit($item)) {
-			$graph_id = (int) $item;
-
-			if ($graph_id > 0) {
-				$result[] = $graph_id;
-			}
-		}
-	}
-
-	return array_values(array_unique($result));
-}
-
-
 	$graph = db_fetch_row_prepared('SELECT gtg.local_graph_id, width, height, title_cache, gtg.graph_template_id, h.id AS host_id, h.disabled
 		FROM graph_templates_graph AS gtg
 		INNER JOIN graph_local AS gl
@@ -2293,6 +2268,31 @@ function sanitize_graph_id_list(string $csv_list): array {
 	print '</div>';
 
 	bottom_footer();
+}
+
+/**
+ * Parse and sanitize a comma-separated graph list into validated integer IDs.
+ *
+ * @param  string $csv_list Comma-separated list of graph IDs (from request var)
+ *
+ * @return array Array of unique positive integer graph IDs
+ */
+function sanitize_graph_id_list(string $csv_list): array {
+	$result = [];
+
+	foreach (explode(',', $csv_list) as $item) {
+		$item = trim($item);
+
+		if ($item !== '' && ctype_digit($item)) {
+			$graph_id = (int) $item;
+
+			if ($graph_id > 0) {
+				$result[] = $graph_id;
+			}
+		}
+	}
+
+	return array_values(array_unique($result));
 }
 
 function html_graph_properties() : void {


### PR DESCRIPTION
## Summary

- Move `sanitize_graph_id_list()` from inside `html_graph_zoom()` to file scope
- Fixes PHPStan `function.notFound` and `function.inner` errors on develop

## Test plan

- [ ] PHPStan level 6 passes with no new errors
- [ ] Graph list view filtering still works