### PR TITLE
fix: guard csrf_get_tokens() in global_session.php

### DIFF
--- a/include/global_session.php
+++ b/include/global_session.php
@@ -133,5 +133,5 @@ if ($graphs) {
 	var sessionLocale='<?php print CACTI_LOCALE; ?>';
 	var sessionNotices=<?php print display_output_messages(); ?>;
     var sessionMessage={};
-	var csrfMagicToken='<?php print csrf_get_tokens(); ?>';
+	var csrfMagicToken='<?php print function_exists('csrf_get_tokens') ? csrf_get_tokens() : ''; ?>';
 </script>


### PR DESCRIPTION
## Summary

- Guard `csrf_get_tokens()` with `function_exists()` in `global_session.php:136`
- Prevents fatal error when a plugin calls `top_header()` from CLI context where `csrf.php` was never loaded

## Root cause

`csrf.php` is only loaded when `$config['is_web']` is true (`global.php:637-638`). When a plugin like syslog calls `syslog_install_advisor()` -> `top_header()` during `cli/plugin_manage.php --install`, the page render path reaches `global_session.php` which unconditionally calls `csrf_get_tokens()`.

## Test plan

- [ ] `php cli/plugin_manage.php --plugin=syslog --install` no longer fatals
- [ ] Web UI CSRF tokens still render correctly