### PR TITLE
fix: replace undefined cacti_redirect() in oauth2.php

### DIFF
--- a/oauth2.php
+++ b/oauth2.php
@@ -92,7 +92,9 @@ switch ($providerName) {
 if (!isrv('code')) { // If we don't have an authorization code then get one
 	$authUrl                 = $provider->getAuthorizationUrl($options);
 	$_SESSION['oauth2state'] = $provider->getState();
-	cacti_redirect($authUrl, false);
+	header('Location: ' . $authUrl);
+
+	exit;
 
 	// Check given state against previously stored one to mitigate CSRF attack
 }


### PR DESCRIPTION
## Summary
- `cacti_redirect()` was introduced in 61d8e935 but the function does not exist in the codebase
- OAuth2 login flow hits a fatal error when reaching this call
- Reverts to the original `header('Location: ...')` + `exit` pattern

## Test plan
- [ ] Verify OAuth2 login flow completes without fatal error
- [ ] Confirm PHPStan level 6 passes with no errors on oauth2.php