### PR TITLE
security: harden SQL query construction against injection

### DIFF
--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -1576,7 +1576,7 @@ function aggregate_items() : void {
 	if (grv('rfilter') == '') {
 		$sql_where = '';
 	} elseif (validate_is_regex(grv('rfilter'))) {
-		$sql_where = "WHERE gtg.title_cache RLIKE '" . grv('rfilter') . "'";
+		$sql_where = 'WHERE gtg.title_cache ' . db_qstr_rlike(grv('rfilter'));
 	} else {
 		$filters   = explode(' ', grv('rfilter'));
 		$sql_where = '';
@@ -1698,7 +1698,7 @@ function aggregate_items() : void {
 							<?php print __('Search'); ?>
 						</td>
 						<td>
-							<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='45' onChange='applyFilter()' value='<?php print grv('rfilter'); ?>'>
+							<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='45' onChange='applyFilter()' value='<?php print htmlerv('rfilter'); ?>'>
 						</td>
 						<td>
 							<?php print __('Graphs'); ?>

--- a/cli/rrdresize.php
+++ b/cli/rrdresize.php
@@ -838,7 +838,7 @@ if ($scanned_directory['folders']) {
 
 					// return the last identified value
 					if ($selected_archive_index !== false) {
-						$last_values = (!isset($calculated_index)) ? 'NaN' : $rrd_data['rra'][$selected_archive_index]['database']['row'][$calculated_index]['v'];
+						$last_values = ($calculated_index === null) ? 'NaN' : $rrd_data['rra'][$selected_archive_index]['database']['row'][$calculated_index]['v'];
 					}
 
 					if (is_array($last_values)) {

--- a/lib/database.php
+++ b/lib/database.php
@@ -2224,6 +2224,21 @@ function db_qstr(mixed $s, mixed $db_conn = false) : string {
 }
 
 /**
+ * db_qstr_rlike - Safely quote a value for use in a RLIKE/REGEXP clause.
+ *
+ * Returns the string 'RLIKE <quoted_value>' where the value is properly
+ * escaped via db_qstr(), preventing SQL injection through regex patterns.
+ *
+ * @param string $s       The regex pattern value to quote
+ * @param mixed  $db_conn An optional database connection object
+ *
+ * @return string The safe 'RLIKE <quoted>' SQL fragment
+ */
+function db_qstr_rlike(string $s, mixed $db_conn = false) : string {
+	return 'RLIKE ' . db_qstr($s, $db_conn);
+}
+
+/**
  * db_strip_control_chars - Strip control characters from SQL command
  *
  * @param string $sql The SQL command to loose it's control chars

--- a/lib/html_filter.php
+++ b/lib/html_filter.php
@@ -958,12 +958,20 @@ class CactiTableFilter {
 		}
 
 		if (isset($this->filter_array['sort'])) {
+			$sort_default = $this->filter_array['sort']['sort_column'];
+
 			$filters['sort_column']['filter']     = FILTER_CALLBACK;
-			$filters['sort_column']['options']    = ['options' => 'sanitize_search_string'];
-			$filters['sort_column']['default']    = $this->filter_array['sort']['sort_column'];
+			$filters['sort_column']['options']    = ['options' => function ($v) use ($sort_default) {
+				return preg_match('/^[a-zA-Z_][a-zA-Z0-9_.]*$/', $v) ? $v : $sort_default;
+			}];
+			$filters['sort_column']['default']    = $sort_default;
 
 			$filters['sort_direction']['filter']  = FILTER_CALLBACK;
-			$filters['sort_direction']['options'] = ['options' => 'sanitize_search_string'];
+			$filters['sort_direction']['options'] = ['options' => function ($v) {
+				$v = strtoupper(trim($v));
+
+				return in_array($v, ['ASC', 'DESC'], true) ? $v : 'ASC';
+			}];
 			$filters['sort_direction']['default'] = $this->filter_array['sort']['sort_direction'];
 		}
 

--- a/lib/html_graph.php
+++ b/lib/html_graph.php
@@ -855,7 +855,7 @@ function html_graph_preview_view() : void {
 	$sql_where  = '';
 
 	if (!ierv('rfilter')) {
-		$sql_where .= " gtg.title_cache RLIKE '" . grv('rfilter') . "'";
+		$sql_where .= ' gtg.title_cache ' . db_qstr_rlike(grv('rfilter'));
 	}
 
 	$sql_where .= ($sql_or != '' && $sql_where != '' ? ' AND ' : '') . $sql_or;
@@ -1231,7 +1231,7 @@ function html_graph_list_view() : void {
 	$sql_where  = '';
 
 	if (!ierv('rfilter')) {
-		$sql_where .= " gtg.title_cache RLIKE '" . grv('rfilter') . "'";
+		$sql_where .= ' gtg.title_cache ' . db_qstr_rlike(grv('rfilter'));
 	}
 
 	if (!ierv('site_id') && grv('site_id') > 0) {

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -1429,7 +1429,7 @@ function grow_right_pane_tree(int $tree_id, int $leaf_id, string $host_group_dat
 		$sql_where = '';
 
 		if (grv('rfilter') != '') {
-			$sql_where .= " (gtg.title_cache RLIKE '" . grv('rfilter') . "' OR gtg.title RLIKE '" . grv('rfilter') . "')";
+			$sql_where .= ' (gtg.title_cache ' . db_qstr_rlike(grv('rfilter')) . ' OR gtg.title ' . db_qstr_rlike(grv('rfilter')) . ')';
 		}
 
 		if (isrv('graph_template_id') && grv('graph_template_id') != '' && grv('graph_template_id') != -1) {
@@ -1486,7 +1486,7 @@ function grow_right_pane_tree(int $tree_id, int $leaf_id, string $host_group_dat
 		}
 
 		if (grv('rfilter') != '') {
-			$sql_where .= ($sql_where != '' ? ' AND ' : '') . "(gtg.title_cache RLIKE '" . grv('rfilter') . "')";
+			$sql_where .= ($sql_where != '' ? ' AND ' : '') . '(gtg.title_cache ' . db_qstr_rlike(grv('rfilter')) . ')';
 		}
 
 		if (isrv('graph_template_id') && grv('graph_template_id') != '') {
@@ -1637,7 +1637,7 @@ function get_host_graph_list(int $host_id, int $graph_template_id, int $data_que
 			$sql_where = '';
 
 			if (grv('rfilter') != '') {
-				$sql_where .= " (gtg.title_cache RLIKE '" . grv('rfilter') . "')";
+				$sql_where .= ' (gtg.title_cache ' . db_qstr_rlike(grv('rfilter')) . ')';
 			}
 
 			if ($host_id > 0) {
@@ -1721,7 +1721,7 @@ function get_host_graph_list(int $host_id, int $graph_template_id, int $data_que
 				$sfd = get_formatted_data_query_indexes($host_id, $data_query['id']);
 
 				if (grv('rfilter') != '') {
-					$sql_where = " (gtg.title_cache RLIKE '" . grv('rfilter') . "')";
+					$sql_where = ' (gtg.title_cache ' . db_qstr_rlike(grv('rfilter')) . ')';
 				}
 
 				// grab a list of all graphs for this host/data query combination


### PR DESCRIPTION
## Summary

- Add `db_qstr_rlike()` helper to safely quote RLIKE/REGEXP values via `db_qstr()`
- Replace 7 unsafe RLIKE string concatenation sites with the new helper
- Harden CactiTableFilter `sort_column` validation to strict identifier regex `^[a-zA-Z_][a-zA-Z0-9_.]*$`
- Harden CactiTableFilter `sort_direction` to `['ASC','DESC']` allowlist
- Fix reflected XSS in aggregate_graphs.php rfilter output via `htmlerv()`

## Addresses

- GHSA-9jqv-4cpm-vm2c (pre-auth SQLi via rfilter RLIKE)
- GHSA-cfhh-pwvx-gp5g (SQLi/XSS via rfilter parser differential)
- GHSA-fwh3-8c8r-378r (reflected XSS via rfilter in aggregate_graphs)
- GHSA-84q3-92xc-c3pf (ORDER BY SQLi via sort_column)

## Test plan

- [ ] Verify graph tree view filtering still works with regex patterns
- [ ] Verify aggregate graph search filtering works
- [ ] Verify table sorting works across pages using CactiTableFilter
- [ ] Verify sort_column values with `table.column` format (e.g., `dtd.name_cache`) work
- [ ] Confirm `db_qstr_rlike()` produces identical SQL for benign inputs