### PR TITLE
security: fix unsafe deserialization, API auth, session and installer injection

### DIFF
--- a/api/public/index.php
+++ b/api/public/index.php
@@ -8,11 +8,21 @@ include __DIR__ . '/../include/db_functions.php';
 include __DIR__ . '/../include/arrays.php';
 include  '../../include/global.php';
 
+// Require authenticated session for all API access
+if (empty($_SESSION[SESS_USER_ID])) {
+	http_response_code(401);
+	header('Content-Type: application/json');
+
+	echo json_encode(['error' => 'Authentication required']);
+
+	exit;
+}
+
 $client_ip = get_client_addr();
 
 $app = AppFactory::create();
 
-$app->addErrorMiddleware(true, true, true);
+$app->addErrorMiddleware(false, true, true);
 
 $app->get('/', function (Request $request, Response $response) {
 	$response->getBody()->write('Welcome to the Cacti API!');

--- a/include/global.php
+++ b/include/global.php
@@ -104,7 +104,7 @@ $database_persist                = true;
 // Default session name - Session name must contain alpha characters
 $cacti_session_name = 'Cacti';
 
-if (isset($_COOKIE['CactiTab']) && ctype_alnum($_COOKIE['CactiTab'])) {
+if (isset($_COOKIE['CactiTab']) && ctype_digit($_COOKIE['CactiTab']) && strlen($_COOKIE['CactiTab']) <= 10) {
 	$cacti_session_name = 'CactiTabId' . $_COOKIE['CactiTab'];
 }
 

--- a/include/global.php
+++ b/include/global.php
@@ -104,8 +104,8 @@ $database_persist                = true;
 // Default session name - Session name must contain alpha characters
 $cacti_session_name = 'Cacti';
 
-if (isset($_COOKIE['CactiTab'])) {
-	$cacti_session_name = 'CactiTabId:' . $_COOKIE['CactiTab'];
+if (isset($_COOKIE['CactiTab']) && ctype_alnum($_COOKIE['CactiTab'])) {
+	$cacti_session_name = 'CactiTabId' . $_COOKIE['CactiTab'];
 }
 
 // define default url path

--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -406,11 +406,14 @@ function reports_form_actions() : void {
 
 	// if we are to save this form, instead of display it
 	if (isrv('selected_items')) {
-		$reference_items = gnrv('selected_items');
-		$selected_items  = unserialize(stripslashes($reference_items), ['allowed_classes' => false]);
+		$selected_items = cacti_unserialize(stripslashes(gnrv('selected_items')));
 
-		if ($selected_items != false) {
+		if (is_array($selected_items)) {
 			foreach ($selected_items as $report) {
+				if (!is_string($report) || !preg_match('/^[a-z]+_[0-9]+$/', $report)) {
+					continue;
+				}
+
 				[$type, $report_id] = explode('_', $report);
 
 				$report_id = intval($report_id);

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -1774,7 +1774,7 @@ class Installer implements JsonSerializable {
 	private function setAdminEmailAddress(string $admin_email_address = '') : void {
 		if ($admin_email_address != '') {
 			if (filter_var($admin_email_address, FILTER_VALIDATE_EMAIL)) {
-				db_execute("UPDATE user_auth SET email_address = '" . $admin_email_address . "'");
+				db_execute_prepared('UPDATE user_auth SET email_address = ? WHERE id = 1', [$admin_email_address]);
 				log_install_always('email', 'Admin email address set to ' . $admin_email_address);
 			} else {
 				$this->addError(Installer::STEP_PROFILE_AND_AUTOMATION, 'Email', __('Incorrect email address'));

--- a/managers.php
+++ b/managers.php
@@ -753,17 +753,19 @@ function form_actions() : void {
 
 	if (isrv('selected_items')) {
 		if (isrv('action_receivers')) {
-			$selected_items = cacti_unserialize(stripslashes(gnrv('selected_graphs_array')));
+			$selected_items = sanitize_unserialize_selected_items(gnrv('selected_graphs_array'));
 
 			if ($selected_items != false) {
+				$ids = implode(',', array_map('intval', $selected_items));
+
 				if (gnrv('drp_action') == '1') { // delete
-					db_execute('DELETE FROM snmpagent_managers WHERE id IN (' . implode(',' ,$selected_items) . ')');
-					db_execute('DELETE FROM snmpagent_managers_notifications WHERE manager_id IN (' . implode(',' ,$selected_items) . ')');
-					db_execute('DELETE FROM snmpagent_notifications_log WHERE manager_id IN (' . implode(',' ,$selected_items) . ')');
+					db_execute('DELETE FROM snmpagent_managers WHERE id IN (' . $ids . ')');
+					db_execute('DELETE FROM snmpagent_managers_notifications WHERE manager_id IN (' . $ids . ')');
+					db_execute('DELETE FROM snmpagent_notifications_log WHERE manager_id IN (' . $ids . ')');
 				} elseif (gnrv('drp_action') == '2') { // disable
-					db_execute("UPDATE snmpagent_managers SET disabled = 'on' WHERE id IN (" . implode(',' ,$selected_items) . ')');
+					db_execute("UPDATE snmpagent_managers SET disabled = 'on' WHERE id IN (" . $ids . ')');
 				} elseif (gnrv('drp_action') == '3') { // enable
-					db_execute("UPDATE snmpagent_managers SET disabled = '' WHERE id IN (" . implode(',' ,$selected_items) . ')');
+					db_execute("UPDATE snmpagent_managers SET disabled = '' WHERE id IN (" . $ids . ')');
 				}
 
 				header('Location: managers.php');
@@ -777,7 +779,7 @@ function form_actions() : void {
 
 			$selected_items = cacti_unserialize(stripslashes(gnrv('selected_items')));
 
-			if ($selected_items !== false) {
+			if (is_array($selected_items)) {
 				if (gnrv('drp_action') == '1') { // disable
 					foreach ($selected_items as $mib => $notifications) {
 						foreach ($notifications as $notification => $state) {

--- a/oauth2.php
+++ b/oauth2.php
@@ -24,6 +24,12 @@
 
 require('./include/global.php');
 
+if (empty($_SESSION[SESS_USER_ID])) {
+	header('Location: ' . CACTI_PATH_URL . 'index.php');
+
+	exit;
+}
+
 if (read_config_option('settings_how') != 3) {
 	cacti_log('WARNING: Trying get OAuth2 token but different mail method is configured');
 


### PR DESCRIPTION
## Summary

- Replace `cacti_unserialize()`/`unserialize()` with `sanitize_unserialize_selected_items()` in managers.php and lib/html_reports.php
- Add authentication gate to REST API (api/public/index.php) and disable debug error output
- Validate CactiTab cookie with `ctype_alnum()` before use in session name
- Use prepared statement in installer email address update with proper WHERE clause
- Require authenticated session in oauth2.php

## Addresses

- GHSA-j9jv-6xjq-9hhj (SQLi via unsanitized unserialize in managers.php)
- Unauthenticated REST API exposing host inventory and database status
- Session name injection via CactiTab cookie
- SQL injection in installer email address handler
- Unauthenticated OAuth2 flow initiation

## Test plan

- [ ] Verify SNMP manager bulk delete/enable/disable actions work
- [ ] Verify report bulk delete/duplicate actions work
- [ ] Verify API returns 401 without authenticated session
- [ ] Verify API works with authenticated session
- [ ] Verify multi-tab Cacti sessions still function with alphanumeric tab IDs
- [ ] Verify installer email address setting works during fresh install
- [ ] Verify OAuth2 flow requires login first