### PR TITLE
security: fix XSS, path traversal, open redirect, and IDOR in reports and auth

### DIFF
--- a/graph_xport.php
+++ b/graph_xport.php
@@ -288,7 +288,7 @@ if (isset($xport_array['meta']['start'])) {
 			<th class='tableSubHeaderColumn left ui-resizable'>" . __('Date') . '</th>';
 
 		for ($i = 1; $i <= $xport_array['meta']['columns']; $i++) {
-			print "<th class='{sorter: \"numberFormat\"} tableSubHeaderColumn right ui-resizable'>" . $xport_array['meta']['legend']['col' . $i] . '</th>';
+			print "<th class='{sorter: \"numberFormat\"} tableSubHeaderColumn right ui-resizable'>" . htmle($xport_array['meta']['legend']['col' . $i]) . '</th>';
 		}
 
 		print '</tr></thead>';

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4392,14 +4392,14 @@ function compat_password_verify(string $password, string $hash) : bool {
 	if (function_exists('md5')) {
 		$md5 = md5($password);
 
-		if ($md5 === $hash) {
+		if (hash_equals($md5, $hash)) {
 			return true;
 		}
 	}
 
 	$sha256 = hash('sha256', $password);
 
-	return ($sha256 === $hash);
+	return hash_equals($sha256, $hash);
 }
 
 /**
@@ -4565,7 +4565,7 @@ function auth_login_redirect(string $login_opts = '') : void {
 
 				cacti_log(sprintf("DEBUG: Referer from REDIRECT_URL with Value: '%s', Effective: '%s'", $_SERVER['REDIRECT_URL'], $referer), false, 'AUTH', POLLER_VERBOSITY_DEBUG);
 			} elseif (isset($_SERVER['HTTP_REFERER'])) {
-				$referer = $_SERVER['HTTP_REFERER'];
+				$referer = validate_redirect_url($_SERVER['HTTP_REFERER']);
 
 				if (auth_basename($referer) == 'logout.php') {
 					$referer = CACTI_PATH_URL . 'index.php';
@@ -4810,7 +4810,7 @@ function check_reset_no_authentication(int $auth_method) : bool {
 
 		$_SESSION[SESS_USER_ID]         = $admin_id;
 		$_SESSION[SESS_CHANGE_PASSWORD] = true;
-		header('Location: ' . CACTI_PATH_URL . 'auth_changepassword.php?action=force&ref=' . ($_SERVER['HTTP_REFERER'] ?? 'index.php'));
+		header('Location: ' . CACTI_PATH_URL . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url($_SERVER['HTTP_REFERER'] ?? 'index.php')));
 
 		exit;
 	}

--- a/lib/database.php
+++ b/lib/database.php
@@ -2224,6 +2224,18 @@ function db_qstr(mixed $s, mixed $db_conn = false) : string {
 }
 
 /**
+ * db_qstr_rlike - Safely quote a value for use in a RLIKE/REGEXP clause.
+ *
+ * @param string $s       The regex pattern value to quote
+ * @param mixed  $db_conn An optional database connection object
+ *
+ * @return string The safe 'RLIKE <quoted>' SQL fragment
+ */
+function db_qstr_rlike(string $s, mixed $db_conn = false) : string {
+	return 'RLIKE ' . db_qstr($s, $db_conn);
+}
+
+/**
  * db_strip_control_chars - Strip control characters from SQL command
  *
  * @param string $sql The SQL command to loose it's control chars

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5103,6 +5103,60 @@ function sanitize_cdef(string $cdef) : string {
 }
 
 /**
+ * Validate that a filename resolves to a path within a flat directory.
+ * Uses basename() to strip traversal, then verifies via realpath().
+ *
+ * @param string $filename The user-supplied filename
+ * @param string $base_dir The base directory the file must reside in
+ *
+ * @return string|false The validated real path, or false if invalid
+ */
+function validate_path_within(string $filename, string $base_dir) : string|false {
+	$filename = basename($filename);
+
+	if ($filename === '' || $filename === '.' || $filename === '..') {
+		return false;
+	}
+
+	$base_real = realpath($base_dir);
+
+	if ($base_real === false) {
+		return false;
+	}
+
+	return $base_real . '/' . $filename;
+}
+
+/**
+ * Validate that a relative path resolves within a base directory.
+ * Allows subdirectory paths but rejects '..' traversal components.
+ *
+ * @param string $path     The user-supplied relative path
+ * @param string $base_dir The base directory the path must stay within
+ *
+ * @return string|false The validated real path, or false if invalid
+ */
+function validate_relative_path_within(string $path, string $base_dir) : string|false {
+	if ($path === '' || $path[0] === '/' || str_contains($path, "\0")) {
+		return false;
+	}
+
+	foreach (explode('/', $path) as $part) {
+		if ($part === '..') {
+			return false;
+		}
+	}
+
+	$base_real = realpath($base_dir);
+
+	if ($base_real === false) {
+		return false;
+	}
+
+	return $base_real . '/' . $path;
+}
+
+/**
  * verifies all selected items are numeric to guard against injection
  *
  * @param mixed $items An array of serialized items from a post

--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -271,7 +271,16 @@ function reports_form_save() : void {
 		if (ierv('id')) {
 			$save['user_id'] = $_SESSION[SESS_USER_ID];
 		} else {
-			$save['user_id'] = db_fetch_cell_prepared('SELECT user_id FROM reports WHERE id = ?', [$post['id']]);
+			$owner_id = db_fetch_cell_prepared('SELECT user_id FROM reports WHERE id = ?', [$post['id']]);
+
+			if ($owner_id != $_SESSION[SESS_USER_ID] && !is_realm_allowed(21)) {
+				raise_message('permission_denied');
+				header('Location: reports.php');
+
+				exit;
+			}
+
+			$save['user_id'] = $owner_id;
 		}
 
 		$save['id']            = $post['id'];
@@ -280,7 +289,7 @@ function reports_form_save() : void {
 		$save['enabled']       = (isset($post['enabled']) ? 'on' : '');
 
 		$save['cformat']       = (isset($post['cformat']) ? 'on' : '');
-		$save['format_file']   = $post['format_file'];
+		$save['format_file']   = basename($post['format_file']);
 		$save['font_size']     = form_input_validate($post['font_size'], 'font_size', '^[0-9]+$', false, 3);
 		$save['alignment']     = form_input_validate($post['alignment'], 'alignment', '^[0-9]+$', false, 3);
 		$save['graph_linked']  = (isset($post['graph_linked']) ? 'on' : '');
@@ -1513,6 +1522,13 @@ function reports_edit() : void {
 
 	if (gfrv('id') > 0) {
 		$report = db_fetch_row_prepared('SELECT * FROM reports WHERE id = ?', [grv('id')]);
+
+		if (!empty($report) && $report['user_id'] != $_SESSION[SESS_USER_ID] && !is_realm_allowed(21)) {
+			raise_message('permission_denied');
+			header('Location: reports.php');
+
+			exit;
+		}
 	}
 
 	reports_tabs(grv('id'));

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1415,6 +1415,52 @@ function get_order_string_page() : string {
 }
 
 /**
+ * Validate that a redirect URL points to an internal Cacti page.
+ * Prevents open redirect attacks by rejecting external URLs.
+ *
+ * @param string $url The URL to validate
+ *
+ * @return string The validated URL, or 'index.php' if invalid
+ */
+function validate_redirect_url(string $url) : string {
+	if ($url === '') {
+		return 'index.php';
+	}
+
+	$url = trim($url);
+
+	// reject URLs with protocol schemes (external redirects, javascript:, data:)
+	if (preg_match('#^[a-z][a-z0-9+.\-]*:#i', $url)) {
+		$base = read_config_option('base_url');
+
+		$base = rtrim($base, '/') . '/';
+
+		if ($base !== '/' && str_starts_with($url, $base)) {
+			return $url;
+		}
+
+		return 'index.php';
+	}
+
+	// reject protocol-relative URLs
+	if (str_starts_with($url, '//')) {
+		return 'index.php';
+	}
+
+	// reject URLs with newlines (header injection)
+	if (preg_match('/[\r\n]/', $url)) {
+		return 'index.php';
+	}
+
+	// reject path traversal sequences
+	if (str_contains($url, '..')) {
+		return 'index.php';
+	}
+
+	return $url;
+}
+
+/**
  * Validates if the given string is a valid regular expression.
  *
  * This function checks if the provided regular expression is valid and safe to use.

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -664,7 +664,15 @@ function reports_load_format_file(string $format_file, mixed &$output, bool &$re
 		$format_file = 'cacti_group.format';
 	}
 
-	$format_file = CACTI_PATH_FORMATS . '/' . $format_file;
+	$validated = validate_path_within($format_file, CACTI_PATH_FORMATS);
+
+	if ($validated === false) {
+		cacti_log('ERROR: Invalid format file path rejected: ' . $format_file, false, 'REPORTS');
+
+		return false;
+	}
+
+	$format_file = $validated;
 
 	if (file_exists($format_file) && is_readable($format_file)) {
 		$contents = file($format_file);
@@ -713,7 +721,7 @@ function reports_tree_has_graphs(int $tree_id,int  $branch_id,int  $effective_us
 	$new_graphs = [];
 
 	if ($search_key != '') {
-		$sql_swhere = " AND gtg.title_cache REGEXP '" . $search_key . "'";
+		$sql_swhere = ' AND gtg.title_cache ' . db_qstr_rlike($search_key);
 	}
 
 	$device_id = db_fetch_cell_prepared('SELECT host_id
@@ -1233,7 +1241,7 @@ function reports_expand_device(array &$report, array $item, int $device_id, int 
 	if (cacti_sizeof($graph_templates)) {
 		foreach ($graph_templates as $id => $name) {
 			if ($item['graph_name_regexp'] != '') {
-				$sql_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+				$sql_where .= ' AND title_cache ' . db_qstr_rlike($item['graph_name_regexp']);
 			}
 
 			$graphs = db_fetch_assoc_prepared("SELECT
@@ -1404,27 +1412,27 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 			}
 
 			if (!empty($tree_name) && empty($leaf_name) && empty($host_name)) {
-				$title           = $title_delimiter . __('Tree:') . " $tree_name";
+				$title           = $title_delimiter . __('Tree:') . ' ' . htmle($tree_name);
 				$title_delimiter = ' > ';
 			}
 
 			if (!empty($leaf_name)) {
-				$title .= $title_delimiter . " $leaf_name";
+				$title .= $title_delimiter . ' ' . htmle($leaf_name);
 				$title_delimiter = ' > ';
 			}
 
 			if (!empty($host_name)) {
-				$title .= $title_delimiter . " $host_name";
+				$title .= $title_delimiter . ' ' . htmle($host_name);
 				$title_delimiter = ' > ';
 			}
 
 			if (!empty($graph_name) && !$nested) {
-				$title .= $title_delimiter . " $graph_name";
+				$title .= $title_delimiter . ' ' . htmle($graph_name);
 				$title_delimiter = ' > ';
 			}
 
 			if ($item['graph_name_regexp'] != '') {
-				$sql_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+				$sql_where .= ' AND title_cache ' . db_qstr_rlike($item['graph_name_regexp']);
 			}
 
 			if ($leaf_type == 'header' && $nested) {
@@ -1470,7 +1478,7 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 				$gr_where = '';
 
 				if ($item['graph_name_regexp'] != '') {
-					$gr_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+					$gr_where .= ' AND title_cache ' . db_qstr_rlike($item['graph_name_regexp']);
 				}
 
 				$graph = db_fetch_row('SELECT local_graph_id, title_cache
@@ -1486,7 +1494,7 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 				$gr_where = '';
 
 				if ($item['graph_name_regexp'] != '') {
-					$gr_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+					$gr_where .= ' AND title_cache ' . db_qstr_rlike($item['graph_name_regexp']);
 				}
 
 				$graph = db_fetch_cell('SELECT count(*)

--- a/package_import.php
+++ b/package_import.php
@@ -671,7 +671,15 @@ function package_diff_file() : void {
 		$newfile = explode("\n", $newfile);
 	}
 
-	$oldfile = file_get_contents(CACTI_PATH_BASE . '/' . $filename);
+	$validated_path = validate_relative_path_within($filename, CACTI_PATH_BASE);
+
+	if ($validated_path === false) {
+		print '<h3>' . __('Error: Invalid file path.') . '</h3>';
+
+		return;
+	}
+
+	$oldfile = file_get_contents($validated_path);
 
 	if ($oldfile !== false) {
 		$oldfile = str_replace("\n\r", "\n", $oldfile);


### PR DESCRIPTION
## Summary

- Apply `htmle()` to SNMP-derived legend headers in graph_xport.php (stored XSS)
- Escape tree/leaf/host/graph names in report title construction (stored XSS via email)
- Add `validate_path_within()` and `validate_relative_path_within()` path validation helpers
- Guard report format_file and package_import filename against path traversal
- Add `validate_redirect_url()` and wire to HTTP_REFERER in auth_login_redirect()
- Add ownership checks to report edit/save endpoints (IDOR)
- Use `hash_equals()` for legacy password hash comparisons (timing side-channel)

## Addresses

- GHSA-977w-79m7-xjc4 (stored XSS via SNMP data in graph export)
- GHSA-6233-v5hc-6gvf (stored XSS in report tree titles)
- GHSA-mjvw-mhj5-9jcj (path traversal in report format_file)
- GHSA-pr9x-34w8-4mf7 (path traversal in package_import.php)
- GHSA-6gr7-53g8-vchq (open redirect via HTTP_REFERER)
- GHSA-86cv-28wq-mc65 (open redirect in auth_changepassword.php)
- GHSA-8p2f-6jvx-j75j (reports IDOR, no ownership check)

## Test plan

- [ ] Verify graph export table view displays legends correctly
- [ ] Verify report generation with tree items renders titles properly
- [ ] Verify report format file dropdown still loads valid format files
- [ ] Verify package import diff works for scripts/ and resource/ files
- [ ] Verify post-login redirect works for internal pages
- [ ] Verify post-login redirect blocks external URLs in HTTP_REFERER
- [ ] Verify non-admin users cannot edit other users' reports
- [ ] Verify admin users (realm 21) can still manage all reports