### PR TITLE
security: harden SQL query construction against injection (1.2.x backport)

### DIFF
--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -1238,7 +1238,7 @@ function aggregate_items() {
 						<?php print __('Search');?>
 					</td>
 					<td>
-						<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='45' onChange='applyFilter()' value='<?php print get_request_var('rfilter');?>'>
+						<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='45' onChange='applyFilter()' value='<?php print html_escape_request_var('rfilter');?>'>
 					</td>
 					<td>
 						<?php print __('Graphs');?>

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -1122,7 +1122,7 @@ function aggregate_items() {
 	if (get_request_var('rfilter') == '') {
 		$sql_where = '';
 	} elseif (validate_is_regex(get_request_var('rfilter'))) {
-		$sql_where = "WHERE gtg.title_cache RLIKE '" . get_request_var('rfilter') . "'";
+		$sql_where = 'WHERE gtg.title_cache ' . db_qstr_rlike(get_request_var('rfilter'));
 	} else {
 		$filters = explode(' ', get_request_var('rfilter'));
 		$sql_where = '';

--- a/lib/database.php
+++ b/lib/database.php
@@ -1959,6 +1959,18 @@ function db_qstr($s, $db_conn = false) {
 }
 
 /**
+ * db_qstr_rlike - Safely quote a value for use in a RLIKE/REGEXP clause.
+ *
+ * @param string $s       The regex pattern value to quote
+ * @param mixed  $db_conn An optional database connection object
+ *
+ * @return string The safe 'RLIKE <quoted>' SQL fragment
+ */
+function db_qstr_rlike($s, $db_conn = false) {
+	return 'RLIKE ' . db_qstr($s, $db_conn);
+}
+
+/**
  * db_strip_control_chars - Strip control characters from SQL command
  *
  * @param  (string) The SQL command to loose it's control chars

--- a/lib/html_filter.php
+++ b/lib/html_filter.php
@@ -313,12 +313,20 @@ class CactiTableFilter {
 		}
 
 		if (isset($this->filter_array['sort'])) {
+			$sort_default = $this->filter_array['sort']['sort_column'];
+
 			$filters['sort_column']['filter']     = FILTER_CALLBACK;
-			$filters['sort_column']['options']    = array('options' => 'sanitize_search_string');
-			$filters['sort_column']['default']    = $this->filter_array['sort']['sort_column'];
+			$filters['sort_column']['options']    = array('options' => function ($v) use ($sort_default) {
+				return preg_match('/^[a-zA-Z_][a-zA-Z0-9_.]*$/', $v) ? $v : $sort_default;
+			});
+			$filters['sort_column']['default']    = $sort_default;
 
 			$filters['sort_direction']['filter']  = FILTER_CALLBACK;
-			$filters['sort_direction']['options'] = array('options' => 'sanitize_search_string');
+			$filters['sort_direction']['options'] = array('options' => function ($v) {
+				$v = strtoupper(trim($v));
+
+				return in_array($v, array('ASC', 'DESC'), true) ? $v : 'ASC';
+			});
 			$filters['sort_direction']['default'] = $this->filter_array['sort']['sort_direction'];
 		}
 

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -1285,7 +1285,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 		$sql_where = '';
 
 		if (get_request_var('rfilter') != '') {
-			$sql_where .= " (gtg.title_cache RLIKE '" . get_request_var('rfilter') . "' OR gtg.title RLIKE '" . get_request_var('rfilter') . "')";
+			$sql_where .= ' (gtg.title_cache ' . db_qstr_rlike(get_request_var('rfilter')) . ' OR gtg.title ' . db_qstr_rlike(get_request_var('rfilter')) . ')';
 		}
 
 		if (isset_request_var('graph_template_id') && get_request_var('graph_template_id') >= 0) {
@@ -1336,7 +1336,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 		}
 
 		if (get_request_var('rfilter') != '') {
-			$sql_where .= ($sql_where != '' ? ' AND ':'') . "(gtg.title_cache RLIKE '" . get_request_var('rfilter') . "')";
+			$sql_where .= ($sql_where != '' ? ' AND ' : '') . '(gtg.title_cache ' . db_qstr_rlike(get_request_var('rfilter')) . ')';
 		}
 
 		if (isset_request_var('graph_template_id') && get_request_var('graph_template_id') >= 0) {
@@ -1452,7 +1452,7 @@ function get_host_graph_list($host_id, $graph_template_id, $data_query_id, $host
 		if (cacti_sizeof($final_templates)) {
 			$sql_where = '';
 			if (get_request_var('rfilter') != '') {
-				$sql_where = " (gtg.title_cache RLIKE '" . get_request_var('rfilter') . "')";
+				$sql_where = ' (gtg.title_cache ' . db_qstr_rlike(get_request_var('rfilter')) . ')';
 			}
 
 			if ($host_id > 0) {
@@ -1522,7 +1522,7 @@ function get_host_graph_list($host_id, $graph_template_id, $data_query_id, $host
 				$sfd = get_formatted_data_query_indexes($host_id, $data_query['id']);
 
 				if (get_request_var('rfilter') != '') {
-					$sql_where = " (gtg.title_cache RLIKE '" . get_request_var('rfilter') . "')";
+					$sql_where = ' (gtg.title_cache ' . db_qstr_rlike(get_request_var('rfilter')) . ')';
 				}
 
 				/* grab a list of all graphs for this host/data query combination */


### PR DESCRIPTION
## Summary

Backport of #6894 to 1.2.x.

- Add `db_qstr_rlike()` helper for safe RLIKE/REGEXP quoting
- Replace 5 unsafe RLIKE sites in lib/html_tree.php (4) and aggregate_graphs.php (1)
- Harden CactiTableFilter sort_column/sort_direction validation

## Addresses

- GHSA-9jqv-4cpm-vm2c, GHSA-cfhh-pwvx-gp5g, GHSA-fwh3-8c8r-378r, GHSA-84q3-92xc-c3pf

## Test plan

- [x] Verify graph tree view filtering with regex patterns
- [x] Verify table sorting across CactiTableFilter pages