### PR TITLE
security: fix unsafe deserialization in managers.php (1.2.x backport)

### DIFF
--- a/managers.php
+++ b/managers.php
@@ -915,22 +915,19 @@ function form_actions() {
 
 	if (isset_request_var('selected_items')) {
 		if (isset_request_var('action_receivers')) {
-			$selected_items = cacti_unserialize(stripslashes(get_nfilter_request_var('selected_graphs_array')));
+			$selected_items = sanitize_unserialize_selected_items(get_nfilter_request_var('selected_graphs_array'));
 
 			if ($selected_items !== false) {
-				/* validate the selected items are ids */
-				foreach($selected_items as $index => $id) {
-					input_validate_input_number($id);
-				}
+				$ids = implode(',', array_map('intval', $selected_items));
 
 				if (get_nfilter_request_var('drp_action') == '1') { // delete
-					db_execute('DELETE FROM snmpagent_managers WHERE id IN (' . implode(',' ,$selected_items) . ')');
-					db_execute('DELETE FROM snmpagent_managers_notifications WHERE manager_id IN (' . implode(',' ,$selected_items) . ')');
-					db_execute('DELETE FROM snmpagent_notifications_log WHERE manager_id IN (' . implode(',' ,$selected_items) . ')');
+					db_execute('DELETE FROM snmpagent_managers WHERE id IN (' . $ids . ')');
+					db_execute('DELETE FROM snmpagent_managers_notifications WHERE manager_id IN (' . $ids . ')');
+					db_execute('DELETE FROM snmpagent_notifications_log WHERE manager_id IN (' . $ids . ')');
 				} elseif (get_nfilter_request_var('drp_action') == '2') { // enable
-					db_execute("UPDATE snmpagent_managers SET disabled = '' WHERE id IN (" . implode(',' ,$selected_items) . ')');
+					db_execute("UPDATE snmpagent_managers SET disabled = '' WHERE id IN (" . $ids . ')');
 				} elseif (get_nfilter_request_var('drp_action') == '3') { // disable
-					db_execute("UPDATE snmpagent_managers SET disabled = 'on' WHERE id IN (" . implode(',' ,$selected_items) . ')');
+					db_execute("UPDATE snmpagent_managers SET disabled = 'on' WHERE id IN (" . $ids . ')');
 				}
 
 				header('Location: managers.php?header=false');
@@ -943,7 +940,7 @@ function form_actions() {
 
 			$selected_items = cacti_unserialize(stripslashes(get_nfilter_request_var('selected_items')));
 
-			if ($selected_items !== false) {
+			if (is_array($selected_items)) {
 				if (get_nfilter_request_var('drp_action') == '1') { // disable
 					foreach($selected_items as $mib => $notifications) {
 						foreach($notifications as $notification => $state) {


### PR DESCRIPTION
## Summary

Backport of #6895 (managers.php portion) to 1.2.x.

- Replace `cacti_unserialize()` with `sanitize_unserialize_selected_items()` at both call sites
- Add `intval()` cast on imploded IDs

## Addresses

- GHSA-j9jv-6xjq-9hhj

## Test plan

- [ ] Verify SNMP manager bulk delete/enable/disable actions