### PR TITLE
security: fix XSS, path traversal, open redirect, and IDOR (1.2.x backport)

### DIFF
--- a/graph_xport.php
+++ b/graph_xport.php
@@ -234,7 +234,7 @@ if (is_array($xport_array) && isset($xport_array['meta']['start'])) {
 			<th class='tableSubHeaderColumn left ui-resizable'>" . __('Date') . "</th>\n";
 
 		for ($i = 1; $i <= $xport_array['meta']['columns']; $i++) {
-			print "<th class='{sorter: \"numberFormat\"} tableSubHeaderColumn right ui-resizable'>" . $xport_array['meta']['legend']['col' . $i] . "</th>\n";
+			print "<th class='{sorter: \"numberFormat\"} tableSubHeaderColumn right ui-resizable'>" . html_escape($xport_array['meta']['legend']['col' . $i]) . "</th>\n";
 		}
 
 		print "</tr></thead>\n";

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4460,7 +4460,43 @@ function compat_password_verify($password, $hash) {
 
 	$md5 = md5($password);
 
-	return hash_equals($md5, $hash);
+	return compat_hash_equals($md5, $hash);
+}
+
+/**
+ * compat_hash_equals - compatibility wrapper for hash_equals
+ *   Uses native hash_equals when available, otherwise falls back
+ *   to a constant-time string comparison.
+ *
+ * @param (string) $known_string - expected string
+ * @param (string) $user_string  - user-provided string
+ *
+ * @return (bool) true if strings are identical, false otherwise
+ */
+function compat_hash_equals($known_string, $user_string) {
+	if (function_exists('hash_equals')) {
+		return hash_equals($known_string, $user_string);
+	}
+
+	// Fallback implementation for PHP < 5.6
+	if (!is_string($known_string) || !is_string($user_string)) {
+		return false;
+	}
+
+	$known_len = strlen($known_string);
+	$user_len  = strlen($user_string);
+
+	if ($known_len !== $user_len) {
+		return false;
+	}
+
+	$result = 0;
+
+	for ($i = 0; $i < $known_len; $i++) {
+		$result |= ord($known_string[$i]) ^ ord($user_string[$i]);
+	}
+
+	return $result === 0;
 }
 
 /**

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4460,7 +4460,7 @@ function compat_password_verify($password, $hash) {
 
 	$md5 = md5($password);
 
-	return ($md5 === $hash);
+	return hash_equals($md5, $hash);
 }
 
 /**
@@ -4639,7 +4639,7 @@ function auth_login_redirect($login_opts = '') {
 
 				cacti_log(sprintf("DEBUG: Referer from REDIRECT_URL with Value: '%s', Effective: '%s'", $_SERVER['REDIRECT_URL'], $referer), false, 'AUTH', POLLER_VERBOSITY_DEBUG);
 			} elseif (isset($_SERVER['HTTP_REFERER'])) {
-				$referer = $_SERVER['HTTP_REFERER'];
+				$referer = validate_redirect_url($_SERVER['HTTP_REFERER']);
 
 				if (auth_basename($referer) == 'logout.php') {
 					$referer = $config['url_path'] . 'index.php';
@@ -4883,7 +4883,7 @@ function check_reset_no_authentication($auth_method) {
 
 		$_SESSION['sess_user_id'] = $admin_id;
 		$_SESSION['sess_change_password'] = true;
-		header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?action=force&ref=' . (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'index.php'));
+		header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'index.php')));
 		exit;
 	}
 }

--- a/lib/database.php
+++ b/lib/database.php
@@ -1959,6 +1959,18 @@ function db_qstr($s, $db_conn = false) {
 }
 
 /**
+ * db_qstr_rlike - Safely quote a value for use in a RLIKE/REGEXP clause.
+ *
+ * @param string $s       The regex pattern value to quote
+ * @param mixed  $db_conn An optional database connection object
+ *
+ * @return string The safe 'RLIKE <quoted>' SQL fragment
+ */
+function db_qstr_rlike($s, $db_conn = false) {
+	return 'RLIKE ' . db_qstr($s, $db_conn);
+}
+
+/**
  * db_strip_control_chars - Strip control characters from SQL command
  *
  * @param  (string) The SQL command to loose it's control chars

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -4491,6 +4491,57 @@ function sanitize_cdef($cdef) {
 /**
  * verifies all selected items are numeric to guard against injection
  *
+ * @param string $filename The user-supplied filename
+ * @param string $base_dir The base directory the file must reside in
+ *
+ * @return mixed The validated real path, or false if invalid
+ */
+function validate_path_within($filename, $base_dir) {
+	$filename = basename($filename);
+
+	if ($filename === '' || $filename === '.' || $filename === '..') {
+		return false;
+	}
+
+	$base_real = realpath($base_dir);
+
+	if ($base_real === false) {
+		return false;
+	}
+
+	return $base_real . '/' . $filename;
+}
+
+/**
+ * Validate that a relative path resolves within a base directory.
+ * Allows subdirectory paths but rejects '..' traversal components.
+ *
+ * @param string $path     The user-supplied relative path
+ * @param string $base_dir The base directory the path must stay within
+ *
+ * @return mixed The validated real path, or false if invalid
+ */
+function validate_relative_path_within($path, $base_dir) {
+	if ($path === '' || $path[0] === '/' || strpos($path, "\0") !== false) {
+		return false;
+	}
+
+	foreach (explode('/', $path) as $part) {
+		if ($part === '..') {
+			return false;
+		}
+	}
+
+	$base_real = realpath($base_dir);
+
+	if ($base_real === false) {
+		return false;
+	}
+
+	return $base_real . '/' . $path;
+}
+
+/**
  * @param string $items   An array of serialized items from a post
  *
  * @return array          The sanitized selected items array

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -4489,7 +4489,8 @@ function sanitize_cdef($cdef) {
 }
 
 /**
- * verifies all selected items are numeric to guard against injection
+ * validates that a user-supplied filename resolves to a path within a given
+ * base directory to guard against directory traversal and injection
  *
  * @param string $filename The user-supplied filename
  * @param string $base_dir The base directory the file must reside in

--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -265,7 +265,16 @@ function reports_form_save() {
 		if (isempty_request_var('id')) {
 			$save['user_id'] = $_SESSION['sess_user_id'];
 		} else {
-			$save['user_id'] = db_fetch_cell_prepared('SELECT user_id FROM reports WHERE id = ?', array(get_nfilter_request_var('id')));
+			$owner_id = db_fetch_cell_prepared('SELECT user_id FROM reports WHERE id = ?', array(get_nfilter_request_var('id')));
+
+			if ($owner_id != $_SESSION['sess_user_id'] && !is_realm_allowed(21)) {
+				raise_message('permission_denied');
+				header('Location: reports.php');
+
+				exit;
+			}
+
+			$save['user_id'] = $owner_id;
 		}
 
 		$save['id']            = get_nfilter_request_var('id');
@@ -274,7 +283,7 @@ function reports_form_save() {
 		$save['enabled']       = (isset_request_var('enabled') ? 'on' : '');
 
 		$save['cformat']       = (isset_request_var('cformat') ? 'on' : '');
-		$save['format_file']   = get_nfilter_request_var('format_file');
+		$save['format_file']   = basename(get_nfilter_request_var('format_file'));
 		$save['font_size']     = form_input_validate(get_nfilter_request_var('font_size'), 'font_size', '^[0-9]+$', false, 3);
 		$save['alignment']     = form_input_validate(get_nfilter_request_var('alignment'), 'alignment', '^[0-9]+$', false, 3);
 		$save['graph_linked']  = (isset_request_var('graph_linked') ? 'on' : '');
@@ -1458,6 +1467,13 @@ function reports_edit() {
 	$report = array();
 	if (get_filter_request_var('id') > 0) {
 		$report = db_fetch_row_prepared('SELECT * FROM reports WHERE id = ?', array(get_request_var('id')));
+
+		if (!empty($report) && $report['user_id'] != $_SESSION['sess_user_id'] && !is_realm_allowed(21)) {
+			raise_message('permission_denied');
+			header('Location: reports.php');
+
+			exit;
+		}
 	}
 
 	reports_tabs(get_request_var('id'));

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -860,6 +860,52 @@ function get_order_string_page() {
 	return $page;
 }
 
+/**
+ * Validate that a redirect URL points to an internal Cacti page.
+ * Prevents open redirect attacks by rejecting external URLs.
+ *
+ * @param string $url The URL to validate
+ *
+ * @return string The validated URL, or 'index.php' if invalid
+ */
+function validate_redirect_url($url) {
+	if ($url === '') {
+		return 'index.php';
+	}
+
+	$url = trim($url);
+
+	// reject URLs with protocol schemes (external redirects, javascript:, data:)
+	if (preg_match('#^[a-z][a-z0-9+.\-]*:#i', $url)) {
+		$base = read_config_option('base_url');
+
+		$base = rtrim($base, '/') . '/';
+
+		if ($base !== '/' && strpos($url, $base) === 0) {
+			return $url;
+		}
+
+		return 'index.php';
+	}
+
+	// reject protocol-relative URLs
+	if (strpos($url, '//') === 0) {
+		return 'index.php';
+	}
+
+	// reject URLs with newlines (header injection)
+	if (preg_match('/[\r\n]/', $url)) {
+		return 'index.php';
+	}
+
+	// reject path traversal sequences
+	if (strpos($url, '..') !== false) {
+		return 'index.php';
+	}
+
+	return $url;
+}
+
 function validate_is_regex($regex) {
 	if ($regex == '') {
 		return true;

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -637,7 +637,15 @@ function reports_load_format_file($format_file, &$output, &$report_tag_included,
 		$format_file = 'cacti_group.format';
 	}
 
-	$format_file = $config['base_path'] . '/formats/' . $format_file;
+	$validated = validate_path_within($format_file, $config['base_path'] . '/formats');
+
+	if ($validated === false) {
+		cacti_log('ERROR: Invalid format file path rejected: ' . $format_file, false, 'REPORTS');
+
+		return false;
+	}
+
+	$format_file = $validated;
 
 	if (file_exists($format_file) && is_readable($format_file)) {
 		$contents = file($format_file);
@@ -685,7 +693,7 @@ function reports_tree_has_graphs($tree_id, $branch_id, $effective_user, $search_
 	$new_graphs = array();
 
 	if ($search_key != '') {
-		$sql_swhere = " AND gtg.title_cache REGEXP '" . $search_key . "'";
+		$sql_swhere = ' AND gtg.title_cache ' . db_qstr_rlike($search_key);
 	}
 
 	$device_id = db_fetch_cell_prepared('SELECT host_id
@@ -1095,7 +1103,7 @@ function reports_expand_device(&$report, $item, $device_id, $output, $format_ok,
 	if (cacti_sizeof($graph_templates)) {
 		foreach ($graph_templates as $id => $name) {
 			if ($item['graph_name_regexp'] != '') {
-				$sql_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+				$sql_where .= ' AND title_cache ' . db_qstr_rlike($item['graph_name_regexp']);
 			}
 
 			$graphs = db_fetch_assoc_prepared("SELECT
@@ -1266,27 +1274,27 @@ function reports_expand_tree(&$report, $item, $parent, $output, $format_ok, $the
 			}
 
 			if (!empty($tree_name) && empty($leaf_name) && empty($host_name)) {
-				$title = $title_delimiter . __('Tree:') . " $tree_name";
+				$title = $title_delimiter . __('Tree:') . ' ' . html_escape($tree_name);
 				$title_delimiter = ' > ';
 			}
 
 			if (!empty($leaf_name)) {
-				$title .= $title_delimiter . " $leaf_name";
+				$title .= $title_delimiter . ' ' . html_escape($leaf_name);
 				$title_delimiter = ' > ';
 			}
 
 			if (!empty($host_name)) {
-				$title .= $title_delimiter . " $host_name";
+				$title .= $title_delimiter . ' ' . html_escape($host_name);
 				$title_delimiter = ' > ';
 			}
 
 			if (!empty($graph_name) && !$nested) {
-				$title .= $title_delimiter . " $graph_name";
+				$title .= $title_delimiter . ' ' . html_escape($graph_name);
 				$title_delimiter = ' > ';
 			}
 
 			if ($item['graph_name_regexp'] != '') {
-				$sql_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+				$sql_where .= ' AND title_cache ' . db_qstr_rlike($item['graph_name_regexp']);
 			}
 
 			if ($leaf_type == 'header' && $nested) {
@@ -1330,7 +1338,7 @@ function reports_expand_tree(&$report, $item, $parent, $output, $format_ok, $the
 			} elseif ($leaf_type == 'graph' && $nested) {
 				$gr_where = '';
 				if ($item['graph_name_regexp'] != '') {
-					$gr_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+					$gr_where .= ' AND title_cache ' . db_qstr_rlike($item['graph_name_regexp']);
 				}
 
 				$graph = db_fetch_row("SELECT local_graph_id, title_cache
@@ -1345,7 +1353,7 @@ function reports_expand_tree(&$report, $item, $parent, $output, $format_ok, $the
 			} elseif ($leaf_type == 'graph') {
 				$gr_where = '';
 				if ($item['graph_name_regexp'] != '') {
-					$gr_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+					$gr_where .= ' AND title_cache ' . db_qstr_rlike($item['graph_name_regexp']);
 				}
 
 				$graph = db_fetch_cell("SELECT count(*)

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -640,7 +640,7 @@ function reports_load_format_file($format_file, &$output, &$report_tag_included,
 	$validated = validate_path_within($format_file, $config['base_path'] . '/formats');
 
 	if ($validated === false) {
-		cacti_log('ERROR: Invalid format file path rejected: ' . $format_file, false, 'REPORTS');
+		cacti_log('ERROR: Invalid format file path rejected: ' . json_encode($format_file), false, 'REPORTS');
 
 		return false;
 	}

--- a/package_import.php
+++ b/package_import.php
@@ -280,7 +280,15 @@ function package_diff_file() {
 		$newfile = explode("\n", $newfile);
 	}
 
-	$oldfile = file_get_contents($config['base_path'] . '/' . $filename);
+	$validated_path = validate_relative_path_within($filename, $config['base_path']);
+
+	if ($validated_path === false) {
+		print '<h3>' . __('Error: Invalid file path.') . '</h3>';
+
+		return;
+	}
+
+	$oldfile = file_get_contents($validated_path);
 
 	if ($oldfile !== false) {
 		$oldfile = str_replace("\n\r", "\n", $oldfile);


### PR DESCRIPTION
## Summary

Backport of #6896 to 1.2.x.

- Apply `html_escape()` to SNMP legend headers and report tree titles
- Add `validate_path_within()` and `validate_relative_path_within()` helpers
- Guard report format_file and package_import filename against traversal
- Add `validate_redirect_url()` and wire to HTTP_REFERER
- Add ownership checks to report edit/save
- Use `hash_equals()` in `compat_password_verify()`

Uses 1.2.x function names: `html_escape()` instead of `htmle()`,
`get_request_var()` instead of `grv()`, `strpos()` instead of
`str_starts_with()`, `array()` instead of `[]`.

## Addresses

- GHSA-977w-79m7-xjc4, GHSA-6233-v5hc-6gvf, GHSA-mjvw-mhj5-9jcj
- GHSA-pr9x-34w8-4mf7, GHSA-6gr7-53g8-vchq, GHSA-86cv-28wq-mc65, GHSA-8p2f-6jvx-j75j

## Test plan

- [ ] Verify graph export table view renders legends correctly
- [ ] Verify report generation with tree items
- [ ] Verify report format file dropdown
- [ ] Verify package import diff for scripts/resource files
- [ ] Verify post-login redirect for internal/external URLs
- [ ] Verify report ownership enforcement