### PR TITLE
security: harden shell command execution against injection (1.2.x backport)

### DIFF
--- a/graph_realtime.php
+++ b/graph_realtime.php
@@ -210,11 +210,11 @@ case 'countdown':
 	$graph_data_array['image_format'] = $gtype;
 
 	/* call poller */
-	$local_graph_id = (int) get_request_var('local_graph_id');
+	$local_graph_id = get_filter_request_var('local_graph_id');
 	$graph_rrd      = read_config_option('realtime_cache_path') . '/user_' . $hash . '_lgi_' . $local_graph_id . '.png';
 	$php_binary     = cacti_escapeshellcmd(read_config_option('path_php_binary'));
 	$script_path    = cacti_escapeshellarg($config['base_path'] . '/poller_realtime.php');
-	$args           = '--graph=' . $local_graph_id . ' --interval=' . (int) $graph_data_array['ds_step'] . ' --poller_id=' . $hash;
+	$args           = '--graph=' . $local_graph_id . ' --interval=' . $graph_data_array['ds_step'] . ' --poller_id=' . $hash;
 
 	shell_exec($php_binary . ' -q ' . $script_path . ' ' . $args);
 

--- a/graph_realtime.php
+++ b/graph_realtime.php
@@ -296,7 +296,7 @@ case 'countdown':
 	exit;
 	break;
 case 'view':
-	$graph_rrd = read_config_option('realtime_cache_path') . '/user_' . $hash . '_lgi_' . (int) get_request_var('local_graph_id') . '.png';
+	$graph_rrd = read_config_option('realtime_cache_path') . '/user_' . $hash . '_lgi_' . get_filter_request_var('local_graph_id') . '.png';
 
 	if (file_exists($graph_rrd)) {
 		print base64_encode(file_get_contents($graph_rrd));

--- a/graph_realtime.php
+++ b/graph_realtime.php
@@ -210,18 +210,20 @@ case 'countdown':
 	$graph_data_array['image_format'] = $gtype;
 
 	/* call poller */
-	$graph_rrd = read_config_option('realtime_cache_path') . '/user_' . $hash . '_lgi_' . get_request_var('local_graph_id') . '.png';
-	$command   = read_config_option('path_php_binary');
-	$args      = sprintf('poller_realtime.php --graph=%s --interval=%d --poller_id=' . $hash, get_request_var('local_graph_id'), $graph_data_array['ds_step']);
+	$local_graph_id = (int) get_request_var('local_graph_id');
+	$graph_rrd      = read_config_option('realtime_cache_path') . '/user_' . $hash . '_lgi_' . $local_graph_id . '.png';
+	$php_binary     = cacti_escapeshellcmd(read_config_option('path_php_binary'));
+	$script_path    = cacti_escapeshellarg($config['base_path'] . '/poller_realtime.php');
+	$args           = '--graph=' . $local_graph_id . ' --interval=' . (int) $graph_data_array['ds_step'] . ' --poller_id=' . $hash;
 
-	shell_exec("$command $args");
+	shell_exec($php_binary . ' -q ' . $script_path . ' ' . $args);
 
 	/* construct the image name  */
 	$graph_data_array['export_realtime'] = $graph_rrd;
 	$graph_data_array['output_flag']     = RRDTOOL_OUTPUT_GRAPH_DATA;
 	$null_param = array();
 
-	$output = rrdtool_function_graph(get_request_var('local_graph_id'), '', $graph_data_array, '', $null_param, $_SESSION['sess_user_id']);
+	$output = rrdtool_function_graph($local_graph_id, '', $graph_data_array, '', $null_param, $_SESSION['sess_user_id']);
 
 	$error = '';
 	if (file_exists($graph_rrd)) {
@@ -235,7 +237,7 @@ case 'countdown':
 	if (empty($output) && empty($error)) {
 		$graph_data_array['get_error'] = true;
 		$null_param = array();
-		rrdtool_function_graph(get_request_var('local_graph_id'), '', $graph_data_array, '', $null_param, $_SESSION['sess_user_id']);
+		rrdtool_function_graph($local_graph_id, '', $graph_data_array, '', $null_param, $_SESSION['sess_user_id']);
 
 		$error = ob_get_contents();
 
@@ -278,7 +280,7 @@ case 'countdown':
 
 	/* send text information back to browser as well as image information */
 	$return_array = array(
-		'local_graph_id' => get_request_var('local_graph_id'),
+		'local_graph_id' => $local_graph_id,
 		'top'            => get_request_var('top'),
 		'left'           => get_request_var('left'),
 		'ds_step'        => html_escape(isset($_SESSION['sess_realtime_ds_step']) ? $_SESSION['sess_realtime_ds_step']:$graph_data_array['ds_step']),
@@ -294,7 +296,7 @@ case 'countdown':
 	exit;
 	break;
 case 'view':
-	$graph_rrd = read_config_option('realtime_cache_path') . '/user_' . $hash . '_lgi_' . get_request_var('local_graph_id') . '.png';
+	$graph_rrd = read_config_option('realtime_cache_path') . '/user_' . $hash . '_lgi_' . (int) get_request_var('local_graph_id') . '.png';
 
 	if (file_exists($graph_rrd)) {
 		print base64_encode(file_get_contents($graph_rrd));

--- a/host.php
+++ b/host.php
@@ -191,7 +191,8 @@ function host_reindex() {
 
 	$start = microtime(true);
 
-	shell_exec(read_config_option('path_php_binary') . ' -q ' . $config['base_path'] . '/cli/poller_reindex_hosts.php --qid=all --id=' . get_filter_request_var('host_id'));
+	$host_id = (int) get_filter_request_var('host_id');
+	shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/poller_reindex_hosts.php') . ' --qid=all --id=' . $host_id);
 
 	$end = microtime(true);
 
@@ -200,7 +201,7 @@ function host_reindex() {
 	$items = db_fetch_cell_prepared('SELECT COUNT(*)
 		FROM host_snmp_cache
 		WHERE host_id = ?',
-		array(get_filter_request_var('host_id')));
+		array($host_id));
 
 	raise_message('host_reindex', __('Device Reindex Completed in %0.2f seconds.  There were %d items updated.', $total_time, $items), MESSAGE_LEVEL_INFO);
 }

--- a/host.php
+++ b/host.php
@@ -191,7 +191,7 @@ function host_reindex() {
 
 	$start = microtime(true);
 
-	$host_id = (int) get_filter_request_var('host_id');
+	$host_id = get_filter_request_var('host_id');
 	shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/poller_reindex_hosts.php') . ' --qid=all --id=' . $host_id);
 
 	$end = microtime(true);

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -1430,7 +1430,13 @@ function boost_rrdtool_function_create($local_data_id, $show_source, &$rrdtool_p
 		$success = rrdtool_execute("create $data_source_path $create_ds$create_rra", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'BOOST');
 
 		if ($config['cacti_server_os'] != 'win32' && posix_getuid() == 0) {
-			shell_exec("chown $owner_id:$group_id $data_source_path");
+			if (!chown($data_source_path, (int) $owner_id)) {
+				cacti_log("WARNING: Unable to set owner for '" . $data_source_path . "'", false, 'BOOST');
+			}
+
+			if (!chgrp($data_source_path, (int) $group_id)) {
+				cacti_log("WARNING: Unable to set group for '" . $data_source_path . "'", false, 'BOOST');
+			}
 		}
 
 		return $success;

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -164,34 +164,34 @@ class Net_Ping
 			 * The other fields are numerical fields only and thus
 			 * not vulnerable for command injection */
 			if (substr_count(strtolower(PHP_OS), 'sun')) {
-				$result = shell_exec('ping ' . $this->host['hostname']);
+				$result = shell_exec('ping ' . cacti_escapeshellarg($this->host['hostname']));
 			} elseif (substr_count(strtolower(PHP_OS), 'hpux')) {
-				$result = shell_exec('ping -m ' . ceil($this->timeout/1000) . ' -n ' . $this->retries . ' ' . $this->host['hostname']);
+				$result = shell_exec('ping -m ' . ceil($this->timeout/1000) . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 			} elseif (substr_count(strtolower(PHP_OS), 'mac')) {
-				$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+				$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 			} elseif (substr_count(strtolower(PHP_OS), 'freebsd')) {
 				if (strpos($host_ip, ':') !== false) {
-					$result = shell_exec('ping6 -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+					$result = shell_exec('ping6 -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 				} else {
-					$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+					$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 				}
 			} elseif (substr_count(strtolower(PHP_OS), 'darwin')) {
-				$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+				$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 			} elseif (substr_count(strtolower(PHP_OS), 'bsd')) {
-				$result = shell_exec('ping -w ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+				$result = shell_exec('ping -w ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 			} elseif (substr_count(strtolower(PHP_OS), 'aix')) {
-				$result = shell_exec('ping -i ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . $this->host['hostname']);
+				$result = shell_exec('ping -i ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 			} elseif (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-				$result = shell_exec('chcp 437 && ping -w ' . $this->timeout . ' -n ' . $this->retries . ' ' . $this->host['hostname']);
+				$result = shell_exec('chcp 437 && ping -w ' . $this->timeout . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 			} else {
 				/* please know, that when running SELinux, httpd will throw
 				 * ping: cap_set_proc: Permission denied
 				 * as it now tries to open an ICMP socket and fails
 				 * $result will be empty, then. */
 				if (strpos($host_ip, ':') !== false) {
-					$result = shell_exec('ping -6 -W ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . $this->host['hostname']);
+					$result = shell_exec('ping -6 -W ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . cacti_escapeshellarg($this->host['hostname']));
 				} else {
-					$result = shell_exec('ping -W ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . $this->host['hostname'] . ' 2>&1');
+					$result = shell_exec('ping -W ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . cacti_escapeshellarg($this->host['hostname']) . ' 2>&1');
 
 					if (strpos($result, 'unknown host') !== false || strpos($result, 'Address family') !== false) {
 						if (file_exists('/usr/bin/ping6')) {
@@ -202,7 +202,7 @@ class Net_Ping
 							$ping_path = '/bin/ping6';
 						}
 
-						$result = shell_exec($ping_path . ' -W ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . $this->host['hostname']);
+						$result = shell_exec($ping_path . ' -W ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . cacti_escapeshellarg($this->host['hostname']));
 					}
 				}
 			}

--- a/scripts/sql.php
+++ b/scripts/sql.php
@@ -4,11 +4,22 @@ error_reporting(0);
 
 include(dirname(__FILE__) . '/../include/cli_check.php');
 
-if ($database_password == '') {
-	$sql = `mysqladmin -h $database_hostname -u $database_username status | awk '{print $6 }'`;
-} else {
-	$sql = `mysqladmin -h $database_hostname -u $database_username -p$database_password status | awk '{print $6 }'`;
+global $database_hostname, $database_username, $database_password;
+
+$cmd = 'mysqladmin -h ' . cacti_escapeshellarg($database_hostname) . ' -u ' . cacti_escapeshellarg($database_username);
+
+if ($database_password != '') {
+	$cmd .= ' -p' . cacti_escapeshellarg($database_password);
 }
 
-print trim($sql);
+$cmd .= ' status';
 
+$output = shell_exec($cmd);
+
+if ($output === null || $output === '') {
+	print 'U';
+} else {
+	// Extract the 6th field (Queries per second avg), matching original awk '{print $6}'
+	$parts = preg_split('/\s+/', trim($output));
+	print isset($parts[5]) ? $parts[5] : 'U';
+}

--- a/scripts/ss_sql.php
+++ b/scripts/ss_sql.php
@@ -36,10 +36,10 @@ function ss_sql() {
 	global $database_password;
 	global $database_hostname;
 
+	$cmd = 'mysqladmin --host=' . cacti_escapeshellarg($database_hostname) . ' --user=' . cacti_escapeshellarg($database_username);
+
 	if ($database_password != '') {
-		$result = `mysqladmin --host=$database_hostname --user=$database_username --password=$database_password status`;
-	} else {
-		$result = `mysqladmin --host=$database_hostname --user=$database_username status`;
+		$cmd .= ' --password=' . cacti_escapeshellarg($database_password);
 	}
 
 	$result = preg_replace('/: /', ':', $result);
@@ -49,6 +49,6 @@ function ss_sql() {
 	$result = preg_replace('/Queries per second avg/', 'QPS', $result);
 	$result = preg_replace('/Flush tables/', 'FlushTables', $result);
 
-	return trim($result);
+	return trim($result) ?: 'U';
 }
 

--- a/scripts/ss_sql.php
+++ b/scripts/ss_sql.php
@@ -42,6 +42,8 @@ function ss_sql() {
 		$cmd .= ' --password=' . cacti_escapeshellarg($database_password);
 	}
 
+	$result = shell_exec($cmd);
+	
 	$result = preg_replace('/: /', ':', $result);
 	$result = preg_replace('/  /', ' ', $result);
 	$result = preg_replace('/Slow queries/', 'SlowQueries', $result);

--- a/tests/Unit/GraphRealtimeShellTest.php
+++ b/tests/Unit/GraphRealtimeShellTest.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for command injection hardening in graph_realtime.php.
+ *
+ * grv('local_graph_id') was interpolated into shell_exec via sprintf without
+ * escaping. The fix casts to (int), uses cacti_escapeshellcmd for the PHP
+ * binary, and cacti_escapeshellarg for the script path.
+ */
+
+$graphRealtimePath = __DIR__ . '/../../graph_realtime.php';
+
+// --- graph_realtime.php: shell escaping for poller invocation ---
+
+test('graph_realtime.php uses cacti_escapeshellcmd for PHP binary', function () use ($graphRealtimePath) {
+	$contents = file_get_contents($graphRealtimePath);
+
+	expect($contents)->toContain("cacti_escapeshellcmd(read_config_option('path_php_binary')");
+});
+
+test('graph_realtime.php uses cacti_escapeshellarg for poller_realtime script path', function () use ($graphRealtimePath) {
+	$contents = file_get_contents($graphRealtimePath);
+
+	expect($contents)->toContain('cacti_escapeshellarg(CACTI_PATH_BASE');
+	expect($contents)->toContain('poller_realtime.php');
+});
+
+test('graph_realtime.php casts local_graph_id to int before shell_exec', function () use ($graphRealtimePath) {
+	$contents = file_get_contents($graphRealtimePath);
+
+	expect($contents)->toMatch('/\(int\)\s+gfrv\s*\(\s*[\'"]local_graph_id[\'"]\s*\)/');
+});
+
+test('graph_realtime.php does not pass raw grv local_graph_id to sprintf for shell', function () use ($graphRealtimePath) {
+	$contents = file_get_contents($graphRealtimePath);
+
+	expect($contents)->not->toMatch('/sprintf\s*\([^)]*grv\s*\(\s*[\'"]local_graph_id[\'"]\s*\)/');
+});

--- a/tests/Unit/SqlScriptsTest.php
+++ b/tests/Unit/SqlScriptsTest.php
@@ -1,0 +1,172 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for scripts/sql.php and scripts/ss_sql.php.
+ *
+ * Covers two hardening steps:
+ * 1. Backtick-to-shell_exec migration (PHP 8.4 deprecates the backtick
+ *    operator; the fix replaces backticks with shell_exec()).
+ * 2. cacti_escapeshellarg() wrapper (Cacti's internal contract; bare
+ *    escapeshellarg() bypasses any future Cacti-level escaping hooks).
+ */
+
+$sqlPhpPath   = __DIR__ . '/../../scripts/sql.php';
+$ssSqlPhpPath = __DIR__ . '/../../scripts/ss_sql.php';
+
+// --- scripts/sql.php: no backtick operators remain ---
+
+test('sql.php contains no backtick operators', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->not->toMatch('/`[^`]*mysqladmin[^`]*`/');
+});
+
+test('sql.php uses shell_exec for command execution', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain('shell_exec(');
+});
+
+test('sql.php escapes database_hostname with cacti_escapeshellarg', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain('cacti_escapeshellarg($database_hostname)');
+});
+
+test('sql.php escapes database_username with cacti_escapeshellarg', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain('cacti_escapeshellarg($database_username)');
+});
+
+test('sql.php escapes database_password with cacti_escapeshellarg', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain('cacti_escapeshellarg($database_password)');
+});
+
+test('sql.php uses no bare escapeshellarg calls', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	// Negative lookbehind: match escapeshellarg( NOT preceded by cacti_
+	expect(preg_match('/(?<!cacti_)escapeshellarg\(/', $contents))->toBe(0);
+});
+
+test('sql.php handles null return from shell_exec', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->toContain("?? ''");
+});
+
+test('sql.php returns U on empty/null shell_exec output', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	/* Cacti data source scripts must return 'U' on error, never empty string. */
+	expect($contents)->toContain(": 'U'");
+});
+
+// --- scripts/ss_sql.php: no backtick operators remain ---
+
+test('ss_sql.php contains no backtick operators', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->not->toMatch('/`[^`]*mysqladmin[^`]*`/');
+});
+
+test('ss_sql.php uses shell_exec for command execution', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain('shell_exec(');
+});
+
+test('ss_sql.php escapes database_hostname with cacti_escapeshellarg', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain('cacti_escapeshellarg($database_hostname)');
+});
+
+test('ss_sql.php escapes database_username with cacti_escapeshellarg', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain('cacti_escapeshellarg($database_username)');
+});
+
+test('ss_sql.php escapes database_password with cacti_escapeshellarg', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain('cacti_escapeshellarg($database_password)');
+});
+
+test('ss_sql.php uses no bare escapeshellarg calls', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	// Negative lookbehind: match escapeshellarg( NOT preceded by cacti_
+	expect(preg_match('/(?<!cacti_)escapeshellarg\(/', $contents))->toBe(0);
+});
+
+test('ss_sql.php handles null return from shell_exec', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->toContain("?? ''");
+});
+
+test('ss_sql.php returns U on empty/null shell_exec output', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	/* Cacti data source scripts must return 'U' on error, never empty string. */
+	expect($contents)->toContain(": 'U'");
+});
+
+// --- runtime: cacti_escapeshellarg is callable and ss_sql() falls back to 'U' ---
+
+test('ss_sql() returns U when shell_exec produces no output', function () use ($ssSqlPhpPath) {
+	/* Bootstrap cacti_escapeshellarg if global.php has not yet been loaded. */
+	if (!function_exists('cacti_escapeshellarg')) {
+		/* Minimal stub: delegate to the native call so arg-quoting still works. */
+		function cacti_escapeshellarg(string $arg, bool $quote = true): string {
+			return escapeshellarg($arg);
+		}
+	}
+
+	/* Provide dummy globals so the function can build its command string. */
+	$GLOBALS['database_hostname'] = '127.0.0.1';
+	$GLOBALS['database_username'] = 'cacti_test_no_such_user';
+	$GLOBALS['database_password'] = '';
+
+	/* Include the script in "called by script server" mode so only the
+	 * function definition is loaded, not the top-level print statement. */
+	$called_by_script_server = true;
+	if (!function_exists('ss_sql')) {
+		require $ssSqlPhpPath;
+	}
+
+	/* mysqladmin will fail (bad credentials / no server), shell_exec returns
+	 * null or empty.  ss_sql() must map that to 'U'. */
+	expect(ss_sql())->toBe('U');
+});
+
+// --- no raw variable interpolation in shell commands ---
+
+test('sql.php does not interpolate variables directly in shell strings', function () use ($sqlPhpPath) {
+	$contents = file_get_contents($sqlPhpPath);
+
+	expect($contents)->not->toMatch('/`[^`]*\$database_/');
+});
+
+test('ss_sql.php does not interpolate variables directly in shell strings', function () use ($ssSqlPhpPath) {
+	$contents = file_get_contents($ssSqlPhpPath);
+
+	expect($contents)->not->toMatch('/`[^`]*\$database_/');
+});


### PR DESCRIPTION
## Summary

- Apply `cacti_escapeshellarg()` to hostname in `lib/ping.php`
- Escape PHP binary and script path in `graph_realtime.php` `shell_exec`
- Escape host_id in host_reindex shell command
- Replace `shell_exec` chown with PHP `chown()`/`chgrp()` in `rrd.php` and `boost.php`
- Escape `db_dump_data` exec arguments in `lib/rrd.php`
- Use `cacti_escapeshellarg()` in `scripts/sql.php` and `scripts/ss_sql.php`
- Add unit tests for graph_realtime shell and SQL script hardening

## Security

Addresses GHSA-xq98-376r-hv9j (Critical) - Command Injection in RRDtool execution

## Test plan

- [ ] Verify ping functionality with special characters in hostname
- [ ] Verify realtime graph rendering still works
- [ ] Verify host reindex operates correctly
- [ ] Verify RRD file ownership changes work via PHP native functions
- [ ] Run `vendor/bin/pest tests/Unit/GraphRealtimeShellTest.php tests/Unit/SqlScriptsTest.php`