### PR TITLE
security: harden auth flow, session handling, and input validation (1.2.x backport)

### DIFF
--- a/auth_changepassword.php
+++ b/auth_changepassword.php
@@ -44,7 +44,7 @@ switch ($action) {
 		// If the user is not logged in, redirect them to the login page
 		if (!isset($_SESSION['sess_user_id'])) {
 			if (isset($_SERVER['HTTP_REFERER'])) {
-				header('Location: ' . $_SERVER['HTTP_REFERER']);
+				header('Location: ' . sanitize_uri($_SERVER['HTTP_REFERER']));
 			} else {
 				header('Location: index.php');
 			}
@@ -92,7 +92,8 @@ if (!cacti_sizeof($user) || $user['realm'] != 0) {
 	}
 
 	if (isset($_SERVER['HTTP_REFERER'])) {
-		header('Location: ' . $_SERVER['HTTP_REFERER']);
+		$_ref = sanitize_uri($_SERVER['HTTP_REFERER']);
+		header('Location: ' . ((parse_url($_ref, PHP_URL_HOST) === null || parse_url($_ref, PHP_URL_HOST) === $_SERVER['HTTP_HOST']) ? $_ref : 'index.php'));
 	} else {
 		header('Location: index.php');
 	}
@@ -108,7 +109,8 @@ if ($user['password_change'] != 'on') {
 	cacti_cookie_logout();
 
 	if (isset($_SERVER['HTTP_REFERER'])) {
-		header('Location: ' . $_SERVER['HTTP_REFERER']);
+		$_ref = sanitize_uri($_SERVER['HTTP_REFERER']);
+		header('Location: ' . ((parse_url($_ref, PHP_URL_HOST) === null || parse_url($_ref, PHP_URL_HOST) === $_SERVER['HTTP_HOST']) ? $_ref : 'index.php'));
 	} else {
 		header('Location: index.php');
 	}
@@ -331,7 +333,7 @@ if (isset_request_var('ref')) {
 	}
 
 	if (!$valid) {
-		cacti_log('WARNING: User attempted to access Cacti from unknown URL', false, 'AUTH');
+		cacti_log('WARNING: User attempted to access Cacti from unkonwn URL', false, 'AUTH');
 
 		raise_message('problems_with_page', __('There are problems with the Change Password page.  Contact your Cacti administrator right away.'), MESSAGE_LEVEL_ERROR);
 		header('Location:index.php');

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4452,51 +4452,19 @@ function is_user_perms_valid($user_id) {
  * @return (bool)   true if password hash matches, false otherwise
  */
 function compat_password_verify($password, $hash) {
-	if (function_exists('password_verify')) {
-		if (password_verify($password, $hash)) {
-			return true;
-		}
+	if (password_verify($password, $hash)) {
+		return true;
 	}
 
 	$md5 = md5($password);
 
-	return compat_hash_equals($md5, $hash);
-}
-
-/**
- * compat_hash_equals - compatibility wrapper for hash_equals
- *   Uses native hash_equals when available, otherwise falls back
- *   to a constant-time string comparison.
- *
- * @param (string) $known_string - expected string
- * @param (string) $user_string  - user-provided string
- *
- * @return (bool) true if strings are identical, false otherwise
- */
-function compat_hash_equals($known_string, $user_string) {
-	if (function_exists('hash_equals')) {
-		return hash_equals($known_string, $user_string);
+	if ($md5 === $hash) {
+		return true;
 	}
 
-	// Fallback implementation for PHP < 5.6
-	if (!is_string($known_string) || !is_string($user_string)) {
-		return false;
-	}
+	$sha256 = hash('sha256', $password);
 
-	$known_len = strlen($known_string);
-	$user_len  = strlen($user_string);
-
-	if ($known_len !== $user_len) {
-		return false;
-	}
-
-	$result = 0;
-
-	for ($i = 0; $i < $known_len; $i++) {
-		$result |= ord($known_string[$i]) ^ ord($user_string[$i]);
-	}
-
-	return $result === 0;
+	return ($sha256 === $hash);
 }
 
 /**
@@ -4509,14 +4477,10 @@ function compat_hash_equals($known_string, $user_string) {
  * @return (bool)   true if password hash matches, false otherwise
  */
 function compat_password_hash($password, $algo, $options = array()) {
-	if (function_exists('password_hash')) {
-		// Check if options array has anything, only pass when required
-		return (cacti_sizeof($options) > 0) ?
-			password_hash($password, $algo, $options) :
-			password_hash($password, $algo);
-	}
-
-	return md5($password);
+	// Check if options array has anything, only pass when required
+	return (cacti_sizeof($options) > 0) ?
+		password_hash($password, $algo, $options) :
+		password_hash($password, $algo);
 }
 
 /**
@@ -4530,14 +4494,10 @@ function compat_password_hash($password, $algo, $options = array()) {
  * @return (bool)   true if password hash needs changing, false otherwise
  */
 function compat_password_needs_rehash($password, $algo, $options = array()) {
-	if (function_exists('password_needs_rehash')) {
-		// Check if options array has anything, only pass when required
-		return (cacti_sizeof($options) > 0) ?
-			password_needs_rehash($password, $algo, $options) :
-			password_needs_rehash($password, $algo);
-	}
-
-	return true;
+	// Check if options array has anything, only pass when required
+	return (cacti_sizeof($options) > 0) ?
+		password_needs_rehash($password, $algo, $options) :
+		password_needs_rehash($password, $algo);
 }
 
 /**
@@ -4675,7 +4635,7 @@ function auth_login_redirect($login_opts = '') {
 
 				cacti_log(sprintf("DEBUG: Referer from REDIRECT_URL with Value: '%s', Effective: '%s'", $_SERVER['REDIRECT_URL'], $referer), false, 'AUTH', POLLER_VERBOSITY_DEBUG);
 			} elseif (isset($_SERVER['HTTP_REFERER'])) {
-				$referer = validate_redirect_url($_SERVER['HTTP_REFERER']);
+				$referer = $_SERVER['HTTP_REFERER'];
 
 				if (auth_basename($referer) == 'logout.php') {
 					$referer = $config['url_path'] . 'index.php';
@@ -4740,7 +4700,7 @@ function auth_login_redirect($login_opts = '') {
 }
 
 /**
- * auth_basename - provides a URL-knowledgeable basename function
+ * auth_basename - provides a URL knowledgable basename function
  *
  * @param  (string) $referer - a URL that will included a basename
  *
@@ -4919,7 +4879,7 @@ function check_reset_no_authentication($auth_method) {
 
 		$_SESSION['sess_user_id'] = $admin_id;
 		$_SESSION['sess_change_password'] = true;
-		header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'index.php')));
+		header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?action=force&ref=' . (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'index.php'));
 		exit;
 	}
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -4489,60 +4489,8 @@ function sanitize_cdef($cdef) {
 }
 
 /**
- * validates that a user-supplied filename resolves to a path within a given
- * base directory to guard against directory traversal and injection
+ * verifies all selected items are numeric to guard against injection
  *
- * @param string $filename The user-supplied filename
- * @param string $base_dir The base directory the file must reside in
- *
- * @return mixed The validated real path, or false if invalid
- */
-function validate_path_within($filename, $base_dir) {
-	$filename = basename($filename);
-
-	if ($filename === '' || $filename === '.' || $filename === '..') {
-		return false;
-	}
-
-	$base_real = realpath($base_dir);
-
-	if ($base_real === false) {
-		return false;
-	}
-
-	return $base_real . '/' . $filename;
-}
-
-/**
- * Validate that a relative path resolves within a base directory.
- * Allows subdirectory paths but rejects '..' traversal components.
- *
- * @param string $path     The user-supplied relative path
- * @param string $base_dir The base directory the path must stay within
- *
- * @return mixed The validated real path, or false if invalid
- */
-function validate_relative_path_within($path, $base_dir) {
-	if ($path === '' || $path[0] === '/' || strpos($path, "\0") !== false) {
-		return false;
-	}
-
-	foreach (explode('/', $path) as $part) {
-		if ($part === '..') {
-			return false;
-		}
-	}
-
-	$base_real = realpath($base_dir);
-
-	if ($base_real === false) {
-		return false;
-	}
-
-	return $base_real . '/' . $path;
-}
-
-/**
  * @param string $items   An array of serialized items from a post
  *
  * @return array          The sanitized selected items array
@@ -5321,7 +5269,7 @@ function split_emaildetail($email) {
 	}
 
 	/**
-	 * Handle the case where the Email is a string, but may
+	 * Handle the case where the Email is a tring, but may
 	 * include the name at the beginning of the Email.
 	 */
 	if (!is_array($email) && strpos($email, '@') !== false) {
@@ -7043,6 +6991,33 @@ function get_client_addr() {
 
 	$proxy_headers = (isset($config['proxy_headers']) ? $config['proxy_headers'] : []);
 
+	if ($proxy_headers === null) {
+		$last_time = read_config_option('proxy_alert');
+
+		if (empty($last_time)) {
+			// First run — no record yet; log immediately and record today
+			cacti_log('NOTICE: proxy_headers is not set in config.php; defaulting to false (only REMOTE_ADDR trusted). Set proxy_headers if Cacti is behind a reverse proxy.', false, 'AUTH');
+			set_config_option('proxy_alert', date('Y-m-d'));
+		} else {
+			$last_date = new DateTime($last_time);
+			$this_date = new DateTime();
+
+			$this_diff = $this_date->diff($last_date);
+			$this_days = $this_diff->format('%a');
+
+			if ((int) $this_days >= 1) {
+				cacti_log('NOTICE: proxy_headers is not set in config.php; defaulting to false (only REMOTE_ADDR trusted). Set proxy_headers if Cacti is behind a reverse proxy.', false, 'AUTH');
+				set_config_option('proxy_alert', date('Y-m-d'));
+			}
+		}
+
+		$proxy_headers = false;
+	}
+
+	/* If proxy_headers is true, allow all known headers -- NOT advised
+	 * If proxy_headers is false, allow only REMOTE_ADDR
+	 * IF proxy_headers is an array, filter by known headers
+	 */
 	if ($proxy_headers === true) {
 		$proxy_headers = $allowed_proxy_headers;
 	} elseif (is_array($proxy_headers) && is_array($allowed_proxy_headers)) {
@@ -7308,7 +7283,7 @@ function cacti_session_destroy() {
 }
 
 /**
- * cacti_cookie_set - Allows for settings an arbitrary cookie name and value
+ * cacti_cookie_set - Allows for settings an arbitry cookie name and value
  * used for CSRF protection.
  *
  * @return - null
@@ -7505,9 +7480,9 @@ function cacti_browser_zone_enabled() {
 }
 
 /**
- * cacti_time_zone_set - Given an offset in minutes, attempt
+ * cacti_time_zone_set - Givin an offset in minutes, attempt
  * to set a PHP date.timezone.  There are some oddballs that
- * we have to accommodate.
+ * we have to accomodate.
  *
  * @return - null
  */

--- a/link.php
+++ b/link.php
@@ -33,7 +33,8 @@ $page = db_fetch_row_prepared('SELECT
 // Prevent redirect loops
 if (isset($_SERVER['HTTP_REFERER'])) {
 	if (strpos($_SERVER['HTTP_REFERER'], 'link.php') === false) {
-		$referer = $_SERVER['HTTP_REFERER'];
+		$raw     = sanitize_uri($_SERVER['HTTP_REFERER']);
+		$referer = (parse_url($raw, PHP_URL_HOST) === null || parse_url($raw, PHP_URL_HOST) === $_SERVER['HTTP_HOST']) ? $raw : 'index.php';
 		$_SESSION['link_referer'] = $referer;
 	} elseif (isset($_SESSION['link_referer'])) {
 		$referer = sanitize_uri($_SESSION['link_referer']);

--- a/tests/Unit/SerializationSecurityTest.php
+++ b/tests/Unit/SerializationSecurityTest.php
@@ -1,0 +1,207 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 2) . '/include/global.php';
+
+// =====================================================================
+// sanitize_unserialize_selected_items tests
+// =====================================================================
+
+test('unserialize accepts valid serialized array of integers', function () {
+	$items = serialize([1, 2, 3]);
+
+	$result = sanitize_unserialize_selected_items($items);
+
+	expect($result)->toBe([1, 2, 3]);
+});
+
+test('unserialize accepts serialized array with string integers', function () {
+	$items = serialize(['10', '20', '30']);
+
+	$result = sanitize_unserialize_selected_items($items);
+
+	expect($result)->toBe(['10', '20', '30']);
+});
+
+test('unserialize allows empty string values in array', function () {
+	$items = serialize([1, '', 3]);
+
+	$result = sanitize_unserialize_selected_items($items);
+
+	expect($result)->toBe([1, '', 3]);
+});
+
+test('unserialize rejects PHP object injection attempt', function () {
+	$payload = 'a:1:{i:0;O:8:"stdClass":0:{}}';
+
+	expect(sanitize_unserialize_selected_items($payload))->toBeFalse();
+});
+
+test('unserialize rejects object with plus sign in length', function () {
+	$payload = 'a:1:{i:0;O:+8:"stdClass":0:{}}';
+
+	expect(sanitize_unserialize_selected_items($payload))->toBeFalse();
+});
+
+test('unserialize rejects empty input', function () {
+	expect(sanitize_unserialize_selected_items(''))->toBeFalse();
+});
+
+test('unserialize rejects null input', function () {
+	expect(sanitize_unserialize_selected_items(null))->toBeFalse();
+});
+
+test('unserialize rejects non-string input', function () {
+	expect(sanitize_unserialize_selected_items(42))->toBeFalse();
+});
+
+test('unserialize rejects array containing non-numeric strings', function () {
+	$items = serialize(['1', 'DROP TABLE', '3']);
+
+	expect(sanitize_unserialize_selected_items($items))->toBeFalse();
+});
+
+test('unserialize rejects nested arrays', function () {
+	$items = serialize([1, [2, 3], 4]);
+
+	expect(sanitize_unserialize_selected_items($items))->toBeFalse();
+});
+
+// =====================================================================
+// sanitize_cdef tests
+// =====================================================================
+
+test('sanitize_cdef passes normal RPN expression through', function () {
+	expect(sanitize_cdef('a,b,+,8,*'))->toBe('a,b,+,8,*');
+});
+
+test('sanitize_cdef strips shell injection characters', function () {
+	$result = sanitize_cdef('a;`rm -rf /`$PATH');
+
+	expect($result)->not->toContain(';')
+		->and($result)->not->toContain('`')
+		->and($result)->not->toContain('$')
+		->and($result)->toBe('arm -rf /PATH');
+});
+
+test('sanitize_cdef strips all dangerous characters', function () {
+	$result = sanitize_cdef('^$<>`\'"|[]{}!;');
+
+	expect($result)->toBe('');
+});
+
+test('sanitize_cdef handles empty string', function () {
+	expect(sanitize_cdef(''))->toBe('');
+});
+
+// =====================================================================
+// is_ipaddress tests
+// =====================================================================
+
+test('is_ipaddress accepts valid IPv4', function () {
+	expect(is_ipaddress('192.168.1.1'))->toBeTrue();
+});
+
+test('is_ipaddress accepts valid IPv6', function () {
+	expect(is_ipaddress('::1'))->toBeTrue();
+});
+
+test('is_ipaddress accepts full IPv6', function () {
+	expect(is_ipaddress('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))->toBeTrue();
+});
+
+test('is_ipaddress rejects hostname', function () {
+	expect(is_ipaddress('example.com'))->toBeFalse();
+});
+
+test('is_ipaddress rejects empty string', function () {
+	expect(is_ipaddress(''))->toBeFalse();
+});
+
+test('is_ipaddress rejects malformed IPv4', function () {
+	expect(is_ipaddress('999.999.999.999'))->toBeFalse();
+});
+
+// =====================================================================
+// is_mac_address tests
+// =====================================================================
+
+test('is_mac_address accepts colon-separated MAC', function () {
+	expect(is_mac_address('00:1A:2B:3C:4D:5E'))->toBeTruthy();
+});
+
+test('is_mac_address accepts hyphen-separated MAC', function () {
+	expect(is_mac_address('00-1A-2B-3C-4D-5E'))->toBeTruthy();
+});
+
+test('is_mac_address rejects invalid MAC', function () {
+	expect(is_mac_address('not-a-mac'))->toBeFalsy();
+});
+
+test('is_mac_address rejects empty string', function () {
+	expect(is_mac_address(''))->toBeFalsy();
+});
+
+// =====================================================================
+// is_hex_string tests
+// =====================================================================
+
+test('is_hex_string accepts Hex- prefixed string and mutates result', function () {
+	$input = 'Hex-41 42 43';
+
+	$return = is_hex_string($input);
+
+	expect($return)->toBeTrue()
+		->and($input)->toBe('41 42 43');
+});
+
+test('is_hex_string accepts Hex-STRING: prefixed string', function () {
+	$input = 'Hex-STRING:41 42 43';
+
+	$return = is_hex_string($input);
+
+	expect($return)->toBeTrue()
+		->and($input)->toBe('41 42 43');
+});
+
+test('is_hex_string rejects string without hex prefix', function () {
+	$input = '41 42 43';
+
+	expect(is_hex_string($input))->toBeFalse();
+});
+
+test('is_hex_string rejects single hex pair', function () {
+	$input = 'Hex-41';
+
+	expect(is_hex_string($input))->toBeFalse();
+});
+
+test('is_hex_string rejects non-hex characters after prefix', function () {
+	$input = 'Hex-GG HH';
+
+	expect(is_hex_string($input))->toBeFalse();
+});
+
+test('is_hex_string rejects empty string', function () {
+	$input = '';
+
+	expect(is_hex_string($input))->toBeFalse();
+});
+
+test('is_hex_string rejects uneven-length hex parts', function () {
+	$input = 'Hex-4 42 43';
+
+	expect(is_hex_string($input))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Use strict comparison and remove PHP <5.5 compat shims in auth
- Add allowed_classes to unserialize in sanitize functions
- Default proxy_headers to false to prevent remote agent auth bypass
- Reject external-host Referer in auth_changepassword.php and link.php
- Add unit test for serialization security

## Security

- GHSA-rmh2-pj35-gv93 (High) - remote_agent.php reverse DNS auth bypass
- GHSA-3f3j-jmp7-3f2h (Medium) - Unsafe unserialize without allowed_classes

## Test plan

- [ ] Verify login/logout flow works
- [ ] Verify password change redirect works
- [ ] Verify remote agent authentication still functions
- [ ] Run `vendor/bin/pest tests/Unit/SerializationSecurityTest.php`