### PR TITLE
security: fix SSRF and SSL verification in help.php (1.2.x backport)

### DIFF
--- a/help.php
+++ b/help.php
@@ -46,15 +46,18 @@ if (isset_request_var('error')) {
 } elseif (isset_request_var('page')) {
 	get_filter_request_var('page', FILTER_CALLBACK, array('options' => 'sanitize_search_string'));
 
-	$page = str_replace('.html', '.md', get_request_var('page'));
+	$page = basename(str_replace('.html', '.md', get_request_var('page')));
 
 	$fgc_contextoption = array(
 		'ssl' => array(
-			'verify_peer'       => false,
-			'verify_peer_name'  => false,
-			'allow_self_signed' => true,
+			'verify_peer'       => true,
+			'verify_peer_name'  => true,
+			'allow_self_signed' => false,
 			'timeout'           => 2,
 			'ignore_errors'     => true
+		),
+		'http' => array(
+			'follow_location' => 0
 		)
 	);
 

--- a/tests/Unit/HelpSsrFTest.php
+++ b/tests/Unit/HelpSsrFTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for SSRF hardening in help.php.
+ *
+ * The fix adds basename() to prevent path traversal in the page parameter,
+ * enables SSL verification (verify_peer, verify_peer_name), and limits
+ * redirects to prevent SSRF via fetch.
+ */
+
+$helpPath = __DIR__ . '/../../help.php';
+
+// --- help.php: path traversal and SSL verification ---
+
+test('help.php uses basename for page parameter', function () use ($helpPath) {
+	$contents = file_get_contents($helpPath);
+
+	expect($contents)->toContain('basename(');
+});
+
+test('help.php enables SSL peer verification', function () use ($helpPath) {
+	$contents = file_get_contents($helpPath);
+
+	expect($contents)->toContain("'verify_peer'       => true");
+	expect($contents)->toContain("'verify_peer_name'  => true");
+});


### PR DESCRIPTION
## Summary

- Disable follow_location in help.php curl requests to prevent SSRF via redirect chains
- Enforce SSL peer verification (CURLOPT_SSL_VERIFYPEER)
- Use basename() to sanitize the page parameter
- Add unit test for SSRF protections

## Security

Addresses GHSA-vq83-4x3q-jv43 (Medium) - SSRF via user-controlled page parameter in help.php

The mitigation disables curl redirect following and enforces SSL verification, preventing an attacker from using the help page proxy to reach internal services.

## Test plan

- [ ] Verify help page loads correctly for valid Cacti doc URLs
- [ ] Verify external/malicious URLs are rejected via disabled redirects
- [ ] Run `vendor/bin/pest tests/Unit/HelpSsrFTest.php`