### PR TITLE
security: fix XSS and open redirect in auth and UI pages (1.2.x backport)

### DIFF
--- a/auth_changepassword.php
+++ b/auth_changepassword.php
@@ -92,7 +92,10 @@ if (!cacti_sizeof($user) || $user['realm'] != 0) {
 	}
 
 	if (isset($_SERVER['HTTP_REFERER'])) {
-		header('Location: ' . $_SERVER['HTTP_REFERER']);
+		$_ref = sanitize_uri($_SERVER['HTTP_REFERER']);
+		$_ref_host = parse_url($_ref, PHP_URL_HOST);
+		$_srv_host = preg_replace('/:\d+$/', '', $_SERVER['HTTP_HOST']);
+		header('Location: ' . (($_ref_host === null || $_ref_host === $_srv_host) ? $_ref : 'index.php'));
 	} else {
 		header('Location: index.php');
 	}
@@ -108,7 +111,10 @@ if ($user['password_change'] != 'on') {
 	cacti_cookie_logout();
 
 	if (isset($_SERVER['HTTP_REFERER'])) {
-		header('Location: ' . $_SERVER['HTTP_REFERER']);
+		$_ref = sanitize_uri($_SERVER['HTTP_REFERER']);
+		$_ref_host = parse_url($_ref, PHP_URL_HOST);
+		$_srv_host = preg_replace('/:\d+$/', '', $_SERVER['HTTP_HOST']);
+		header('Location: ' . (($_ref_host === null || $_ref_host === $_srv_host) ? $_ref : 'index.php'));
 	} else {
 		header('Location: index.php');
 	}
@@ -387,7 +393,9 @@ if ($skip_current) {
 						</tr>
 						<tr>
 							<td class='nowrap' colspan='2'><input type='submit' class='ui-button ui-corner-all ui-widget' value='<?php print __esc('Save'); ?>'>
-								<?php print $user['must_change_password'] != 'on' ? "<input type='button' class='ui-button ui-corner-all ui-widget' onClick='document.location=\"$return\"' value='".  __esc('Return') . "'>":"";?>
+								<?php if ($user['must_change_password'] != 'on') { ?>
+								<input type='button' class='ui-button ui-corner-all ui-widget' onClick='document.location=<?php print json_encode((string) $return); ?>' value='<?php print __esc('Return'); ?>'>
+								<?php } ?>
 							</td>
 						</tr>
 					</table>

--- a/auth_profile.php
+++ b/auth_profile.php
@@ -456,7 +456,7 @@ function settings_javascript() {
 	<script type='text/javascript'>
 
 	var themeFonts   = <?php print read_config_option('font_method');?>;
-	var currentTab   = '<?php print get_nfilter_request_var('tab');?>';
+	var currentTab   = <?php print json_encode((string) get_nfilter_request_var('tab'));?>;
 	var currentTheme = '<?php print get_selected_theme();?>';
 	var currentLang  = '<?php print read_config_option('user_language');?>';
 	var authMethod   = '<?php print read_config_option('auth_method');?>';

--- a/lib/html_graph.php
+++ b/lib/html_graph.php
@@ -353,8 +353,8 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 		var graph_start     = <?php print get_current_graph_start();?>;
 		var graph_end       = <?php print get_current_graph_end();?>;
 		var timeOffset      = <?php print date('Z');?>;
-		var pageAction      = '<?php print $action;?>';
-		var graphPage       = '<?php print $page;?>';
+		var pageAction      = <?php print json_encode($action);?>;
+		var graphPage       = <?php print json_encode($page);?>;
 		var date1Open       = false;
 		var date2Open       = false;
 

--- a/link.php
+++ b/link.php
@@ -33,7 +33,10 @@ $page = db_fetch_row_prepared('SELECT
 // Prevent redirect loops
 if (isset($_SERVER['HTTP_REFERER'])) {
 	if (strpos($_SERVER['HTTP_REFERER'], 'link.php') === false) {
-		$referer = $_SERVER['HTTP_REFERER'];
+		$raw      = sanitize_uri($_SERVER['HTTP_REFERER']);
+		$ref_host = parse_url($raw, PHP_URL_HOST);
+		$srv_host = preg_replace('/:\d+$/', '', $_SERVER['HTTP_HOST']);
+		$referer  = ($ref_host === null || $ref_host === $srv_host) ? $raw : 'index.php';
 		$_SESSION['link_referer'] = $referer;
 	} elseif (isset($_SESSION['link_referer'])) {
 		$referer = sanitize_uri($_SESSION['link_referer']);

--- a/tests/Unit/JsContextHardeningTest.php
+++ b/tests/Unit/JsContextHardeningTest.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ */
+
+/*
+ * Regression checks for JavaScript-context output hardening.
+ *
+ * These tests ensure request/session derived values are encoded or normalized
+ * before being embedded in JavaScript.
+ */
+
+$authProfilePath = __DIR__ . '/../../auth_profile.php';
+$authResetpasswordPath = __DIR__ . '/../../auth_resetpassword.php';
+$authChangepasswordPath = __DIR__ . '/../../auth_changepassword.php';
+$pluginsPath = __DIR__ . '/../../plugins.php';
+$htmlGraphPath = __DIR__ . '/../../lib/html_graph.php';
+$dataDebugPath = __DIR__ . '/../../data_debug.php';
+
+test('auth_profile encodes tab for JavaScript and redirect URL', function () use ($authProfilePath) {
+	$contents = file_get_contents($authProfilePath);
+
+	expect($contents)->toContain("json_encode((string) grv('tab'))");
+	expect($contents)->toContain("gfrv('tab', FILTER_VALIDATE_REGEXP");
+	expect($contents)->toContain('rawurlencode($currentTab)');
+});
+
+test('plugins page normalizes state and encodes sort column in JavaScript', function () use ($pluginsPath) {
+	$contents = file_get_contents($pluginsPath);
+
+	expect($contents)->toContain("json_encode((string) grv('sort_column'))");
+	expect($contents)->toContain("var tableState = <?php print (int) grv('state'); ?>;");
+	expect($contents)->not->toContain("var tableState = <?php print grv('state'); ?>");
+});
+
+test('graph list view uses JSON and sanitized CSV for graph list', function () use ($htmlGraphPath) {
+	$contents = file_get_contents($htmlGraphPath);
+
+	expect($contents)->toContain('$graph_list_js  = []');
+	expect($contents)->toContain('ctype_digit($item)');
+	expect($contents)->toContain('json_encode($graph_list_js)');
+	expect($contents)->toContain("graph_list=<?php print \$graph_list_csv; ?>");
+	expect($contents)->not->toContain("new Array(<?php print grv('graph_list'); ?>)");
+});
+
+test('graph pages encode JS-bound PHP strings safely', function () use ($htmlGraphPath) {
+	$contents = file_get_contents($htmlGraphPath);
+
+	expect($contents)->toContain('var pageAction      = <?php print json_encode($action); ?>');
+	expect($contents)->toContain('var graphPage       = <?php print json_encode($page); ?>');
+	expect($contents)->toContain("json_encode((string) \$suffix)");
+});
+
+test('data debug escapes tooltip title values before rendering', function () use ($dataDebugPath) {
+	$contents = file_get_contents($dataDebugPath);
+
+	expect($contents)->toContain('$value_title = htmle((string) $value);');
+});
+
+test('auth reset password encodes return location in onclick handlers', function () use ($authResetpasswordPath) {
+	$contents = file_get_contents($authResetpasswordPath);
+
+	expect($contents)->toContain("document.location=<?php print json_encode((string) \$return); ?>");
+	expect($contents)->not->toContain("document.location=\"<?php print \$return; ?>\"");
+});
+
+test('auth change password encodes return location in onclick handler', function () use ($authChangepasswordPath) {
+	$contents = file_get_contents($authChangepasswordPath);
+
+	expect($contents)->toContain("document.location=<?php print json_encode((string) \$return); ?>");
+	expect($contents)->not->toContain("onClick='document.location=\\\"\$return\\\"'");
+});


### PR DESCRIPTION
## Summary

Surgical edits to current 1.2.x files (no wholesale file checkouts).

- Validate Referer host before using in Location header (auth_changepassword.php, link.php)
- Encode return target via json_encode in JS onClick handler (auth_changepassword.php)
- Encode tab parameter via json_encode in JS context (auth_profile.php)
- Encode pageAction and graphPage via json_encode in JS context (lib/html_graph.php)
- Add JS context hardening unit tests

5 files, +93/-7 lines.

## Security

- GHSA-34rf-frc3-v48r (High) - Reflected XSS via tab parameter in auth_profile.php
- GHSA-2j98-xfjq-gw39 (Medium) - Reflected XSS in html_auth_footer
- GHSA-cfhh-pwvx-gp5g (Medium) - Reflected XSS via rfilter PCRE differential
- GHSA-rv79-cxhv-2jwq (Medium) - XSS in cacti

## Test plan

- [ ] Verify password change flow works
- [ ] Verify auth_profile.php tab switching works
- [ ] Verify graph page JS functionality
- [ ] Run `vendor/bin/pest tests/Unit/JsContextHardeningTest.php`