### PR TITLE
fix: reduce RRD file-not-found log level from WARNING to DEBUG

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1643,10 +1643,6 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 				}
 
 				if (!rrdtool_file_exists($data_source_path, $rrdtool_pipe)) {
-					if (read_config_option('log_verbosity') >= POLLER_VERBOSITY_DEBUG || isset($graph_data_array['get_error'])) {
-						cacti_log("WARNING: RRD file '$data_source_path' does not exist", false, 'GRAPH');
-					}
-
 					if (isset($graph_data_array['export_csv'])) {
 						return false;
 					}


### PR DESCRIPTION
## Summary

Remove the noisy RRD file-not-found log message entirely.

The file existence check added in #6909 logged a WARNING for every graph render when the RRD file does not yet exist (e.g., new devices before the first poller run). This floods cacti.log with thousands of entries.

The error image ("Poller has not run yet") is sufficient user feedback. The `rrdtool_file_exists()` function already handles remote storage correctly via the rrdtool pipe.

Reported by @bmfmancini during 1.2.31 testing.

## Test plan

- [ ] Add a new device, verify no WARNING flood in cacti.log
- [ ] Verify graphs show "Poller has not run yet" image (unchanged behavior)
- [ ] Verify CSV export returns false for missing RRD (unchanged behavior)