### PR TITLE
fix: return text error in graph debug mode when RRD file missing (#6920)

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1647,6 +1647,13 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 						return false;
 					}
 
+					// Both get_error (STDERR output) and print_source (HTML debug view)
+					// are text-output modes; returning PNG bytes in either would produce
+					// garbage in the browser or CLI. Return a human-readable error instead.
+					if (isset($graph_data_array['get_error']) || isset($graph_data_array['print_source'])) {
+						return __('ERROR: RRD file does not exist: %s', $data_source_path);
+					}
+
 					return rrdtool_create_error_image(__('The Cacti Poller has not run yet.'));
 				}
 


### PR DESCRIPTION
## Summary

1 line addition. When graph debug mode is on and the RRD file doesn't exist, return a readable text error instead of raw PNG binary.

The `rrdtool_file_exists` check added in #6909 returns `rrdtool_create_error_image()` (raw PNG) regardless of output mode. When `get_error` (debug mode) is set, the caller expects text, not binary data. This caused raw PNG bytes to render as nonsense in the Graph Debug Mode panel.

Fixes #6920

## Test plan

- [ ] Navigate to Management > Graphs > Any graph
- [ ] Click "Turn on Graph Debug Mode"
- [ ] Verify RRDtool command displays cleanly (not binary nonsense)
- [ ] For a device with no poller data, verify the error image still shows in normal mode