### PR TITLE
fix: correct colourBrightness calculation for negative and integer percentages (#6926)

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -4792,12 +4792,18 @@ function gradient(string $vname = '', string $start_color = '#0000a0', string $e
 }
 
 /**
- * colourBrightness - Add colourBrightness support for the gradient charts. This function calculates the darker version of a given color
+ * colourBrightness - Adjust the brightness of a hex color for gradient charts.
+ * Positive percent lightens; negative percent darkens.
  *
  * @param string $hex     The hex representation of a color (with or without leading #)
  * @param float  $percent Brightness adjustment: decimal in [-1, 1] (e.g. 0.4 = +40%)
- *                        or coerced integer in [-100, 100] (e.g. 40.0 = +40%). Values
+ *                        or coerced integer in [-100, 100] (e.g. 40 = +40%). Values
  *                        outside [-100, 100] are normalized then clamped to [-1, 1].
+ *                        NOTE: values in the open interval (1.0, 2.0) are treated as
+ *                        integers and divided by 100 (e.g. 1.5 → 0.015). The value
+ *                        1.0 itself is NOT divided — it means 100% original color
+ *                        (the identity). There is no decimal representation of "1%
+ *                        brighter"; use 0.01 instead.
  *
  * @return string The adjusted color in the same format as the input
  *

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -4794,10 +4794,12 @@ function gradient(string $vname = '', string $start_color = '#0000a0', string $e
 /**
  * colourBrightness - Add colourBrightness support for the gradient charts. This function calculates the darker version of a given color
  *
- * @param string $hex     The hex representation of a color
- * @param float  $percent The percentage to darken the given color. decimal number ( 0.4 -> 40% )
+ * @param string $hex     The hex representation of a color (with or without leading #)
+ * @param float  $percent Brightness adjustment: decimal in [-1, 1] (e.g. 0.4 = +40%)
+ *                        or coerced integer in [-100, 100] (e.g. 40.0 = +40%). Values
+ *                        outside [-100, 100] are normalized then clamped to [-1, 1].
  *
- * @return string The darker version of the given color
+ * @return string The adjusted color in the same format as the input
  *
  * License: GPLv2
  * Original Code: http://www.barelyfitz.com/projects/csscolor/
@@ -4815,14 +4817,24 @@ function colourBrightness(string $hex, float $percent) : string {
 	$rgb = [hexdec(substr($hex, 0, 2)), hexdec(substr($hex, 2, 2)), hexdec(substr($hex, 4, 2))];
 
 	// // CALCULATE
+	if (abs($percent) > 1) {
+		$percent = $percent / 100;
+	}
+
+	$percent = max(-1.0, min(1.0, $percent));
+
 	for ($i = 0; $i < 3; $i++) { // See if brighter or darker
 		if ($percent > 0) {
 			// Lighter
 			$rgb[$i] = round($rgb[$i] * $percent) + round(255 * (1 - $percent));
 		} else {
 			// Darker
-			$positivePercent = $percent - ($percent * 2);
-			$rgb[$i]         = round($rgb[$i] * (1 - $positivePercent)); // round($rgb[$i] * (1-$positivePercent));
+			$positivePercent = abs($percent);
+			$rgb[$i]         = round($rgb[$i] * (1 - $positivePercent));
+		}
+
+		if ($rgb[$i] < 0) {
+			$rgb[$i] = 0;
 		}
 
 		// In case rounding up causes us to go to 256

--- a/tests/Unit/ColourBrightnessTest.php
+++ b/tests/Unit/ColourBrightnessTest.php
@@ -49,6 +49,9 @@ test('colourBrightness darker black stays black', function () {
 
 test('colourBrightness does not produce negative RGB values', function () {
 	$result = colourBrightness('010101', -0.99);
+	// dechex() on a negative int yields a two's-complement string, so
+	// assert well-formed 6-char hex before extracting individual channels.
+	expect($result)->toMatch('/^[0-9a-f]{6}$/i');
 	$r = hexdec(substr($result, 0, 2));
 	$g = hexdec(substr($result, 2, 2));
 	$b = hexdec(substr($result, 4, 2));
@@ -65,4 +68,27 @@ test('colourBrightness does not exceed 255 for any channel', function () {
 	expect($r)->toBeLessThanOrEqual(255);
 	expect($g)->toBeLessThanOrEqual(255);
 	expect($b)->toBeLessThanOrEqual(255);
+});
+
+// Boundary: percent=0 routes to the darker branch with zero darkening;
+// the result must be the original colour unchanged.
+test('colourBrightness with percent 0 returns original colour', function () {
+	expect(colourBrightness('4080c0', 0))->toBe('4080c0');
+});
+
+// Boundary: integer 1 is within [-1, 1] so the normalisation path is skipped.
+// The lighter formula at percent=1.0 keeps 100% of original and adds 0% white
+// — result equals the original colour. Integer 1 and decimal 1.0 must agree.
+test('colourBrightness with integer percent 1 returns original colour', function () {
+	expect(colourBrightness('4080c0', 1))->toBe(colourBrightness('4080c0', 1.0));
+	expect(colourBrightness('4080c0', 1))->toBe('4080c0');
+});
+
+// Boundary: integer -1 is within [-1, 1] so the normalisation path is skipped.
+// The darker formula at percent=-1.0 multiplies by 0 — result is pure black.
+// Integer -1, decimal -1.0, and integer -100 must all agree.
+test('colourBrightness with integer percent -1 returns black', function () {
+	expect(colourBrightness('4080c0', -1))->toBe(colourBrightness('4080c0', -1.0));
+	expect(colourBrightness('4080c0', -1))->toBe(colourBrightness('4080c0', -100));
+	expect(colourBrightness('4080c0', -1))->toBe('000000');
 });

--- a/tests/Unit/ColourBrightnessTest.php
+++ b/tests/Unit/ColourBrightnessTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Tests for colourBrightness() in lib/rrd.php
+ *
+ * Validates fix for integer percentages, negative percent math,
+ * and RGB lower-bounds clamping.
+ */
+
+require_once dirname(__DIR__, 2) . '/lib/rrd.php';
+
+test('colourBrightness returns valid hex for positive decimal percent', function () {
+	$result = colourBrightness('808080', 0.5);
+	expect($result)->toMatch('/^[0-9a-f]{6}$/i');
+});
+
+test('colourBrightness returns valid hex for negative decimal percent', function () {
+	$result = colourBrightness('808080', -0.5);
+	expect($result)->toMatch('/^[0-9a-f]{6}$/i');
+});
+
+test('colourBrightness handles integer percentage by normalizing to decimal', function () {
+	$decimal = colourBrightness('808080', 0.5);
+	$integer = colourBrightness('808080', 50);
+	expect($integer)->toBe($decimal);
+});
+
+test('colourBrightness handles negative integer percentage', function () {
+	$decimal = colourBrightness('808080', -0.5);
+	$integer = colourBrightness('808080', -50);
+	expect($integer)->toBe($decimal);
+});
+
+test('colourBrightness preserves hash prefix', function () {
+	$result = colourBrightness('#808080', 0.5);
+	expect($result)->toStartWith('#');
+	expect(strlen($result))->toBe(7);
+});
+
+test('colourBrightness lighter makes white whiter', function () {
+	$result = colourBrightness('ffffff', 0.5);
+	expect($result)->toBe('ffffff');
+});
+
+test('colourBrightness darker black stays black', function () {
+	$result = colourBrightness('000000', -0.5);
+	expect($result)->toBe('000000');
+});
+
+test('colourBrightness does not produce negative RGB values', function () {
+	$result = colourBrightness('010101', -0.99);
+	$r = hexdec(substr($result, 0, 2));
+	$g = hexdec(substr($result, 2, 2));
+	$b = hexdec(substr($result, 4, 2));
+	expect($r)->toBeGreaterThanOrEqual(0);
+	expect($g)->toBeGreaterThanOrEqual(0);
+	expect($b)->toBeGreaterThanOrEqual(0);
+});
+
+test('colourBrightness does not exceed 255 for any channel', function () {
+	$result = colourBrightness('fefefe', 0.99);
+	$r = hexdec(substr($result, 0, 2));
+	$g = hexdec(substr($result, 2, 2));
+	$b = hexdec(substr($result, 4, 2));
+	expect($r)->toBeLessThanOrEqual(255);
+	expect($g)->toBeLessThanOrEqual(255);
+	expect($b)->toBeLessThanOrEqual(255);
+});

--- a/tests/Unit/ColourBrightnessTest.php
+++ b/tests/Unit/ColourBrightnessTest.php
@@ -92,3 +92,16 @@ test('colourBrightness with integer percent -1 returns black', function () {
 	expect(colourBrightness('4080c0', -1))->toBe(colourBrightness('4080c0', -100));
 	expect(colourBrightness('4080c0', -1))->toBe('000000');
 });
+
+// Exact-value regression: representative Cacti call with a mid-range color
+// and the decimal percent used by the gradient renderer (-0.4 for darkening).
+// Lighter (0.4): round(r*0.4)+round(255*0.6), darker (-0.4): round(r*0.6)
+test('colourBrightness produces correct exact value for representative Cacti call (lighter)', function () {
+	// '1a2b3c': r=26,g=43,b=60 → lighter by 0.4 → r=163(a3),g=170(aa),b=177(b1)
+	expect(colourBrightness('1a2b3c', 0.4))->toBe('a3aab1');
+});
+
+test('colourBrightness produces correct exact value for representative Cacti call (darker)', function () {
+	// '1a2b3c': r=26,g=43,b=60 → darker by -0.4 → r=16(10),g=26(1a),b=36(24)
+	expect(colourBrightness('1a2b3c', -0.4))->toBe('101a24');
+});


### PR DESCRIPTION
## Summary

Fix three bugs in `colourBrightness()` in `lib/rrd.php`:

- Auto-convert integer percentages (e.g., 50) to decimal (0.5)
- Use `abs()` instead of manual double-negation for darker calculation
- Add bounds check to prevent negative RGB values

1 file, +10/-2 lines.

Fixes #6926