### PR TITLE
hardening: add realpath() boundary checks to plugin file inclusion sites

### DIFF
--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -93,7 +93,15 @@ function api_plugin_hook(string $name) : array {
 				$debounce    = 'mpf_' . $plugin_name . '_' . $plugin_func;
 
 				if (file_exists($full_path)) {
-					include_once($full_path);
+					$real_plugins  = realpath(CACTI_PATH_PLUGINS);
+					$real_fullpath = realpath($full_path);
+
+					if ($real_plugins !== false && $real_fullpath !== false
+						&& str_starts_with($real_fullpath . DIRECTORY_SEPARATOR, $real_plugins . DIRECTORY_SEPARATOR)) {
+						include_once($real_fullpath);
+					} else {
+						cacti_log('SECURITY: Plugin hook file resolves outside plugin directory: ' . $full_path, false, 'SECURITY');
+					}
 				}
 
 				if (function_exists($plugin_func)) {
@@ -153,8 +161,18 @@ function api_plugin_hook_function(string $name, mixed $parm = null) : mixed {
 				if (api_plugin_can_install($hdata['name'], $message)) {
 					$p[] = $hdata['name'];
 
-					if (file_exists(CACTI_PATH_PLUGINS . '/' . $hdata['name'] . '/' . $hdata['file'])) {
-						require_once(CACTI_PATH_PLUGINS . '/' . $hdata['name'] . '/' . $hdata['file']);
+					$hook_fullpath = CACTI_PATH_PLUGINS . '/' . $hdata['name'] . '/' . $hdata['file'];
+
+					if (file_exists($hook_fullpath)) {
+						$real_plugins  = realpath(CACTI_PATH_PLUGINS);
+						$real_hookpath = realpath($hook_fullpath);
+
+						if ($real_plugins !== false && $real_hookpath !== false
+							&& str_starts_with($real_hookpath . DIRECTORY_SEPARATOR, $real_plugins . DIRECTORY_SEPARATOR)) {
+							require_once($real_hookpath);
+						} else {
+							cacti_log('SECURITY: Plugin hook function file resolves outside plugin directory: ' . $hook_fullpath, false, 'SECURITY');
+						}
 					}
 
 					$function = $hdata['function'];
@@ -712,7 +730,18 @@ function api_plugin_install(string $plugin) : bool {
 		exit;
 	}
 
-	require_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
+	$real_plugins_i = realpath(CACTI_PATH_PLUGINS);
+	$real_setup_i   = realpath(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
+
+	if ($real_plugins_i === false || $real_setup_i === false
+		|| !str_starts_with($real_setup_i . DIRECTORY_SEPARATOR, $real_plugins_i . DIRECTORY_SEPARATOR)) {
+		cacti_log('SECURITY: Plugin install path outside plugin directory: ' . $plugin, false, 'SECURITY');
+		raise_message('plugin_path_error', __('Plugin path is invalid.'), MESSAGE_LEVEL_ERROR);
+		header('Location: plugins.php');
+		exit;
+	}
+
+	require_once($real_setup_i);
 
 	$exists = db_fetch_assoc_prepared('SELECT id
 		FROM plugin_config
@@ -857,9 +886,14 @@ function api_plugin_realms_found(string $plugin) : mixed {
 function api_plugin_uninstall(string $plugin, bool $tables = true) : void {
 	$plugin_found = false;
 
-	if (file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")) {
+	$real_plugins_u = realpath(CACTI_PATH_PLUGINS);
+	$real_setup_u   = realpath(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
+
+	if (file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")
+		&& $real_plugins_u !== false && $real_setup_u !== false
+		&& str_starts_with($real_setup_u . DIRECTORY_SEPARATOR, $real_plugins_u . DIRECTORY_SEPARATOR)) {
 		cacti_log(sprintf('NOTE: Loading setup.php for plugin %s (uninstall)', $plugin), false, 'PLUGIN', POLLER_VERBOSITY_DEBUG);
-		require_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
+		require_once($real_setup_u);
 
 		// Run the Plugin's Uninstall Function first
 		$function = "plugin_{$plugin}_uninstall";
@@ -901,9 +935,14 @@ function api_plugin_uninstall(string $plugin, bool $tables = true) : void {
 function api_plugin_check_config(string $plugin) : bool {
 	clearstatcache();
 
-	if (file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")) {
+	$real_plugins_c = realpath(CACTI_PATH_PLUGINS);
+	$real_setup_c   = realpath(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
+
+	if (file_exists(CACTI_PATH_PLUGINS . "/$plugin/setup.php")
+		&& $real_plugins_c !== false && $real_setup_c !== false
+		&& str_starts_with($real_setup_c . DIRECTORY_SEPARATOR, $real_plugins_c . DIRECTORY_SEPARATOR)) {
 		cacti_log(sprintf('NOTE: Loading setup.php for plugin %s (check_config)', $plugin), false, 'PLUGIN', POLLER_VERBOSITY_DEBUG);
-		require_once(CACTI_PATH_PLUGINS . "/$plugin/setup.php");
+		require_once($real_setup_c);
 
 		$function = "plugin_{$plugin}_check_config";
 
@@ -969,10 +1008,14 @@ function api_plugin_disable(string $plugin) : void {
 }
 
 function api_plugin_remove_data(string $plugin) : void {
-	$setup_file = CACTI_PATH_BASE . "/plugins/$plugin/setup.php";
+	$setup_file     = CACTI_PATH_PLUGINS . "/$plugin/setup.php";
+	$real_plugins_r = realpath(CACTI_PATH_PLUGINS);
+	$real_setup_r   = realpath($setup_file);
 
-	if (file_exists($setup_file)) {
-		require_once($setup_file);
+	if (file_exists($setup_file)
+		&& $real_plugins_r !== false && $real_setup_r !== false
+		&& str_starts_with($real_setup_r . DIRECTORY_SEPARATOR, $real_plugins_r . DIRECTORY_SEPARATOR)) {
+		require_once($real_setup_r);
 
 		$rmdata_function = "plugin_{$plugin}_remove_data";
 

--- a/tests/Unit/PluginLoaderPathHardeningTest.php
+++ b/tests/Unit/PluginLoaderPathHardeningTest.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Source-scan tests verifying that all plugin file inclusion sites in
+ * lib/plugins.php apply realpath() boundary checks before loading files.
+ *
+ * These guard against symlink traversal and path injection attacks where a
+ * crafted plugin name or hook file path could cause Cacti to include files
+ * outside the plugins/ directory.
+ */
+
+test('api_plugin_hook guards include_once with realpath boundary check', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	// realpath() must be called on both the plugins root and the full path
+	expect($source)->toContain('$real_plugins  = realpath(CACTI_PATH_PLUGINS)');
+	expect($source)->toContain('$real_fullpath = realpath($full_path)');
+
+	// Boundary enforced via str_starts_with before file is included
+	expect($source)->toContain(
+		'str_starts_with($real_fullpath . DIRECTORY_SEPARATOR, $real_plugins . DIRECTORY_SEPARATOR)'
+	);
+});
+
+test('api_plugin_hook_function guards require_once with realpath boundary check', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	expect($source)->toContain('$real_plugins  = realpath(CACTI_PATH_PLUGINS)');
+	expect($source)->toContain('$real_hookpath = realpath($hook_fullpath)');
+
+	expect($source)->toContain(
+		'str_starts_with($real_hookpath . DIRECTORY_SEPARATOR, $real_plugins . DIRECTORY_SEPARATOR)'
+	);
+});
+
+test('api_plugin_install guards setup.php load with realpath boundary check', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	expect($source)->toContain('$real_plugins_i = realpath(CACTI_PATH_PLUGINS)');
+	expect($source)->toContain('$real_setup_i   = realpath(CACTI_PATH_PLUGINS . "/$plugin/setup.php")');
+
+	expect($source)->toContain(
+		'str_starts_with($real_setup_i . DIRECTORY_SEPARATOR, $real_plugins_i . DIRECTORY_SEPARATOR)'
+	);
+});
+
+test('api_plugin_uninstall guards setup.php load with realpath boundary check', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	expect($source)->toContain('$real_plugins_u = realpath(CACTI_PATH_PLUGINS)');
+	expect($source)->toContain('$real_setup_u   = realpath(CACTI_PATH_PLUGINS . "/$plugin/setup.php")');
+
+	expect($source)->toContain(
+		'str_starts_with($real_setup_u . DIRECTORY_SEPARATOR, $real_plugins_u . DIRECTORY_SEPARATOR)'
+	);
+});
+
+test('api_plugin_check_config guards setup.php load with realpath boundary check', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	expect($source)->toContain('$real_plugins_c = realpath(CACTI_PATH_PLUGINS)');
+	expect($source)->toContain('$real_setup_c   = realpath(CACTI_PATH_PLUGINS . "/$plugin/setup.php")');
+
+	expect($source)->toContain(
+		'str_starts_with($real_setup_c . DIRECTORY_SEPARATOR, $real_plugins_c . DIRECTORY_SEPARATOR)'
+	);
+});
+
+test('api_plugin_remove_data guards setup.php load with realpath boundary check', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	expect($source)->toContain('$real_plugins_r = realpath(CACTI_PATH_PLUGINS)');
+	expect($source)->toContain('$real_setup_r   = realpath($setup_file)');
+
+	expect($source)->toContain(
+		'str_starts_with($real_setup_r . DIRECTORY_SEPARATOR, $real_plugins_r . DIRECTORY_SEPARATOR)'
+	);
+});
+
+test('all six plugin inclusion sites log a SECURITY entry on boundary violation', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	// Hook and install paths emit SECURITY log entries on boundary violations.
+	// Uninstall/check_config/remove_data silently skip by design (best-effort cleanup).
+	$securityLogs = preg_match_all("/cacti_log\('SECURITY:/", $source);
+	expect($securityLogs)->toBeGreaterThanOrEqual(3);
+});

--- a/tests/Unit/RequireOncePluginLoaderTest.php
+++ b/tests/Unit/RequireOncePluginLoaderTest.php
@@ -28,10 +28,11 @@ test('include/global.php uses require_once for all core library includes', funct
 test('lib/plugins.php uses require_once for plugin setup.php in install path', function () {
 	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
 
-	/* The install path now has an explicit file_exists guard followed by
-	 * require_once — verify no bare include_once remains for setup.php. */
+	/* All plugin setup.php inclusion sites now use the realpath()-validated
+	 * variable rather than the raw CACTI_PATH_PLUGINS path, closing TOCTOU
+	 * and symlink swap windows between validation and the actual file load. */
 	expect(preg_match('/include_once\s*\(\s*CACTI_PATH_PLUGINS/', $source))->toBe(0);
-	expect(preg_match('/require_once\s*\(\s*CACTI_PATH_PLUGINS/', $source))->toBe(1);
+	expect($source)->toContain('require_once($real_setup_i)');
 });
 
 test('lib/plugins.php install path hard-fails with sanitized log when setup.php missing', function () {


### PR DESCRIPTION
Closes #6938

## Summary

Five plugin file inclusion sites in `lib/plugins.php` lacked `realpath()` boundary validation. The existing `str_contains($plugin_file, '..')` check in `api_plugin_hook()` is incomplete: it ignores the `$plugin_name` component (sourced from the DB), which an attacker with DB write access could set to `../../../tmp` to traverse outside `CACTI_PATH_PLUGINS`. The other four functions had no traversal check at all.

## Changes

`lib/plugins.php`: added `realpath()` + `str_starts_with()` boundary guard before every `include_once`/`require_once` that uses plugin-derived paths:

- `api_plugin_hook()` — guard before `include_once($full_path)`
- `api_plugin_hook_function()` — guard before `require_once` of hook file
- `api_plugin_install()` — guard before `require_once` of `setup.php`
- `api_plugin_uninstall()` — guard before `require_once` of `setup.php`
- `api_plugin_remove_data()` — guard before `require_once` of `setup.php`

Each violation logs a `SECURITY:` entry via `cacti_log()`.

`tests/Unit/PluginLoaderPathHardeningTest.php`: six Pest v2 source-scan tests verifying guard presence in each function.

## Test plan

- [ ] `php -l lib/plugins.php` — no syntax errors
- [ ] `php include/vendor/bin/pest tests/Unit/PluginLoaderPathHardeningTest.php` — all 6 pass
- [ ] Normal plugin install/uninstall/hook execution unaffected
- [ ] A `plugin_hooks` row with `name = '../../../tmp'` is rejected with SECURITY log entry