### PR TITLE
hardening: block server-executable files in plugin archive extraction

### DIFF
--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -1530,9 +1530,28 @@ function api_plugin_archive_restore(string $plugin, string $id, string $type = '
 						continue;
 					}
 
+					// block server-executable file types; writing them to the
+					// web-accessible plugin directory would enable webshell execution
+					$ext = strtolower(pathinfo($tfile, PATHINFO_EXTENSION));
+					if (in_array($ext, ['php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar'], true)) {
+						continue;
+					}
+
 					$archive_files[$tfile] = $pfile;
 				} else {
 					$tfile = str_replace("phar://{$tmpfile}", '', $file->getPathname());
+
+					// type='archive' had no content filter; apply hidden-file and
+					// executable-extension guards here as well
+					$basename_tfile = basename($tfile);
+					if (str_starts_with($basename_tfile, '.') && $basename_tfile != '.htaccess') {
+						continue;
+					}
+
+					$ext = strtolower(pathinfo($tfile, PATHINFO_EXTENSION));
+					if (in_array($ext, ['php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar'], true)) {
+						continue;
+					}
 
 					$archive_files[$tfile] = $tfile;
 				}
@@ -1590,6 +1609,11 @@ function api_plugin_archive_restore(string $plugin, string $id, string $type = '
 			chdir($restore_path);
 
 			foreach ($archive_files as $basefile => $pharpath) {
+				// reject paths with traversal sequences that slipped through normalisation
+				if (str_contains($basefile, '..')) {
+					continue;
+				}
+
 				$output = file_get_contents("phar://my.tgz{$pharpath}");
 
 				if (strlen($output)) {

--- a/tests/Unit/PluginArchiveFileBlockTest.php
+++ b/tests/Unit/PluginArchiveFileBlockTest.php
@@ -1,0 +1,168 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Tests for GHSA-j696-m433-87qq: server-executable file types must be
+ * rejected during plugin archive extraction so a crafted archive cannot
+ * plant a webshell in the web-accessible plugin directory.
+ *
+ * The guard uses pathinfo(PATHINFO_EXTENSION) on the lowercased path, so
+ * only the final extension segment is evaluated.
+ */
+
+// ---------------------------------------------------------------------------
+// Helper: mirrors the production check in api_plugin_archive_restore()
+// ---------------------------------------------------------------------------
+
+function is_plugin_file_blocked(string $filename): bool {
+	$ext = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+	return in_array($ext, ['php', 'php3', 'php4', 'php5', 'php7', 'php8', 'phtml', 'phar'], true);
+}
+
+// ---------------------------------------------------------------------------
+// Blocked extensions
+// ---------------------------------------------------------------------------
+
+test('plain .php file is blocked', function () {
+	expect(is_plugin_file_blocked('shell.php'))->toBeTrue();
+});
+
+test('.phtml file is blocked', function () {
+	expect(is_plugin_file_blocked('template.phtml'))->toBeTrue();
+});
+
+test('.phar file is blocked', function () {
+	expect(is_plugin_file_blocked('package.phar'))->toBeTrue();
+});
+
+test('.php7 file is blocked', function () {
+	expect(is_plugin_file_blocked('legacy.php7'))->toBeTrue();
+});
+
+test('.php3 file is blocked', function () {
+	expect(is_plugin_file_blocked('old.php3'))->toBeTrue();
+});
+
+test('.php4 file is blocked', function () {
+	expect(is_plugin_file_blocked('older.php4'))->toBeTrue();
+});
+
+test('.php5 file is blocked', function () {
+	expect(is_plugin_file_blocked('compat.php5'))->toBeTrue();
+});
+
+test('.php8 file is blocked', function () {
+	expect(is_plugin_file_blocked('modern.php8'))->toBeTrue();
+});
+
+test('uppercase .PHP extension is blocked (case-insensitive)', function () {
+	/* strtolower() normalises before the in_array check */
+	expect(is_plugin_file_blocked('SHELL.PHP'))->toBeTrue();
+});
+
+test('mixed-case .Php extension is blocked', function () {
+	expect(is_plugin_file_blocked('shell.Php'))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// Allowed extensions
+// ---------------------------------------------------------------------------
+
+test('.xml file is allowed', function () {
+	expect(is_plugin_file_blocked('data_query.xml'))->toBeFalse();
+});
+
+test('.json file is allowed', function () {
+	expect(is_plugin_file_blocked('config.json'))->toBeFalse();
+});
+
+test('.js file is allowed', function () {
+	expect(is_plugin_file_blocked('app.js'))->toBeFalse();
+});
+
+test('.css file is allowed', function () {
+	expect(is_plugin_file_blocked('style.css'))->toBeFalse();
+});
+
+test('.html file is allowed', function () {
+	expect(is_plugin_file_blocked('index.html'))->toBeFalse();
+});
+
+test('.png file is allowed', function () {
+	expect(is_plugin_file_blocked('logo.png'))->toBeFalse();
+});
+
+test('.sql file is allowed', function () {
+	expect(is_plugin_file_blocked('install.sql'))->toBeFalse();
+});
+
+test('.txt file is allowed', function () {
+	expect(is_plugin_file_blocked('README.txt'))->toBeFalse();
+});
+
+// ---------------------------------------------------------------------------
+// Double-extension behaviour
+// pathinfo() returns only the final segment, so .php.bak → 'bak' (allowed)
+// while .jpg.php → 'php' (blocked).
+// ---------------------------------------------------------------------------
+
+test('.php.bak double extension is allowed (final ext is bak)', function () {
+	/* Backup file: extension is 'bak', not 'php' */
+	expect(is_plugin_file_blocked('shell.php.bak'))->toBeFalse();
+});
+
+test('.jpg.php double extension is blocked (final ext is php)', function () {
+	/* Classic disguise: extension is 'php' */
+	expect(is_plugin_file_blocked('image.jpg.php'))->toBeTrue();
+});
+
+test('.phtml.bak double extension is allowed (final ext is bak)', function () {
+	expect(is_plugin_file_blocked('template.phtml.bak'))->toBeFalse();
+});
+
+test('.tar.php double extension is blocked (final ext is php)', function () {
+	expect(is_plugin_file_blocked('archive.tar.php'))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// Source-scan: confirm the blocking logic lives in lib/plugins.php
+// ---------------------------------------------------------------------------
+
+test('lib/plugins.php contains the executable-extension in_array guard', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	/* Both the type != archive and type == archive branches must contain the guard */
+	$matches = preg_match_all(
+		"/in_array\s*\(\s*\\\$ext\s*,\s*\['php'/",
+		$source
+	);
+
+	expect($matches)->toBeGreaterThanOrEqual(2,
+		'Expected at least two in_array extension guards (one per extraction branch)'
+	);
+});
+
+test('lib/plugins.php guard covers phtml and phar', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	expect($source)->toContain("'phtml'");
+	expect($source)->toContain("'phar'");
+});
+
+test('lib/plugins.php uses pathinfo PATHINFO_EXTENSION for extension extraction', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/plugins.php');
+
+	expect($source)->toContain('pathinfo($tfile, PATHINFO_EXTENSION)');
+});


### PR DESCRIPTION
## Summary

- `api_plugin_archive_restore()` in `lib/plugins.php` extracted all archive entries into the web-accessible `plugins/<name>/` directory without filtering `.php` or other server-executable extensions.
- For `type='available'` (action=load): only hidden files (`.`-prefixed) were skipped; `.php` files passed through unchecked and were written to disk.
- For `type='archive'` (action=restore): no content filtering existed at all.
- An administrator who controls the `github_repository` setting, or has direct database write access, could serve a malicious archive and achieve webshell execution.

Reported privately as GHSA-j696-m433-87qq (CVSS 6.8, PR:H).

## Changes

`lib/plugins.php` — `api_plugin_archive_restore()`:

1. Added server-executable extension blocklist (`php`, `php3`–`php8`, `phtml`, `phar`) for the `type='available'` branch after the existing hidden-file check.
2. Applied the same hidden-file and extension blocklist guards to the `type='archive'` branch, which had no filtering previously.
3. Added a path-traversal guard (`str_contains($basefile, '..')`) in the write loop as defense-in-depth.

## Test plan

- [ ] Load a plugin archive containing a `.php` file via action=load; confirm the file is not written to `plugins/<name>/`
- [ ] Restore an archive via action=restore with a `.php` entry; confirm it is excluded
- [ ] Confirm `.htaccess` is still written (existing behavior preserved)
- [ ] Confirm normal plugin files (`.js`, `.css`, `.html`, `INFO`) are still written
- [ ] Confirm path traversal entry (e.g. `../../evil.php`) is skipped in the write loop

🤖 Generated with [Claude Code](https://claude.ai/claude-code)