### PR TITLE
hardening: validate sort_column and sort_direction against injection in get_order_string

### DIFF
--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1254,11 +1254,20 @@ function update_order_string(bool $inplace = false) : void {
 
 	$order = '';
 
-	if (!str_contains(get_request_var('sort_column'), '(') && !str_contains(get_request_var('sort_column'), '`')) {
-		$del = '`';
-	} else {
-		$del = '';
+	$sort_column = get_nfilter_request_var('sort_column');
+	$sort_dir    = strtoupper(get_nfilter_request_var('sort_direction'));
+
+	/* Allowlist: identifiers are word chars and dots only; anything else could escape
+	   backtick quoting.  Validate direction to prevent SQL keyword injection. */
+	if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_.]*$/', $sort_column)) {
+		$sort_column = '';
 	}
+
+	if ($sort_dir !== 'ASC' && $sort_dir !== 'DESC') {
+		$sort_dir = 'ASC';
+	}
+
+	$del = ($sort_column !== '') ? '`' : '';
 
 	$database = get_mysql_info();
 	$natural  = false;
@@ -1291,17 +1300,19 @@ function update_order_string(bool $inplace = false) : void {
 			unset($_SESSION['sort_data'][$page]);
 			unset($_SESSION['sort_string'][$page]);
 
-			$_SESSION['sort_data'][$page][get_request_var('sort_column')] = get_request_var('sort_direction');
+			if ($sort_column !== '') {
+				$_SESSION['sort_data'][$page][$sort_column] = $sort_dir;
+			}
 
-			$column    = get_request_var('sort_column');
-			$direction = get_request_var('sort_direction');
+			$column    = $sort_column;
+			$direction = $sort_dir;
 
 			if ($column == 'ip' || $column == 'ip_address') {
 				$_SESSION['sort_string'][$page] = 'ORDER BY INET_ATON(' . $column . ') ' . $direction;
 			} elseif ($column == 'hostname' && $natural) {
-				$_SESSION['sort_string'][$page] = 'ORDER BY NATURAL_SORT_KEY(' . $del . implode($del . '.' . $del, explode('.', get_request_var('sort_column'))) . $del . ') ' . get_request_var('sort_direction');
-			} else {
-				$_SESSION['sort_string'][$page] = 'ORDER BY ' . $del . implode($del . '.' . $del, explode('.', get_request_var('sort_column'))) . $del . ' ' . get_request_var('sort_direction');
+				$_SESSION['sort_string'][$page] = 'ORDER BY NATURAL_SORT_KEY(' . $del . implode($del . '.' . $del, explode('.', $sort_column)) . $del . ') ' . $sort_dir;
+			} elseif ($sort_column !== '') {
+				$_SESSION['sort_string'][$page] = 'ORDER BY ' . $del . implode($del . '.' . $del, explode('.', $sort_column)) . $del . ' ' . $sort_dir;
 			}
 		} elseif (isset_request_var('sort_column')) {
 			if (isset_request_var('reset')) {
@@ -1309,7 +1320,9 @@ function update_order_string(bool $inplace = false) : void {
 				unset($_SESSION['sort_string'][$page]);
 			}
 
-			$_SESSION['sort_data'][$page][get_request_var('sort_column')] = get_nfilter_request_var('sort_direction');
+			if ($sort_column !== '') {
+				$_SESSION['sort_data'][$page][$sort_column] = $sort_dir;
+			}
 
 			$_SESSION['sort_string'][$page] = 'ORDER BY ';
 
@@ -1353,16 +1366,27 @@ function update_order_string(bool $inplace = false) : void {
 function get_order_string() : string {
 	$page = get_order_string_page();
 
-	if (!str_contains(get_request_var('sort_column'), '(') && !str_contains(get_request_var('sort_column'), '`')) {
-		$del = '`';
-	} else {
-		$del = '';
+	$sort_column = get_nfilter_request_var('sort_column');
+	$sort_dir    = strtoupper(get_nfilter_request_var('sort_direction'));
+
+	if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_.]*$/', $sort_column)) {
+		$sort_column = '';
 	}
+
+	if ($sort_dir !== 'ASC' && $sort_dir !== 'DESC') {
+		$sort_dir = 'ASC';
+	}
+
+	$del = ($sort_column !== '') ? '`' : '';
 
 	if (isset($_SESSION['sort_string'][$page])) {
 		return $_SESSION['sort_string'][$page];
+	}
+
+	if ($sort_column !== '') {
+		return 'ORDER BY ' . $del . implode($del . '.' . $del, explode('.', $sort_column)) . $del . ' ' . $sort_dir;
 	} else {
-		return 'ORDER BY ' . $del . implode($del . '.' . $del, explode('.', get_request_var('sort_column'))) . $del . ' ' . get_request_var('sort_direction');
+		return '';
 	}
 }
 

--- a/tests/Unit/GetOrderStringAllowlistTest.php
+++ b/tests/Unit/GetOrderStringAllowlistTest.php
@@ -1,0 +1,209 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Tests for ORDER BY injection hardening in get_order_string() and
+ * update_order_string().
+ *
+ * The fix validates sort_column with preg_match('/^[a-zA-Z][a-zA-Z0-9_.]*$/')
+ * and collapses sort_direction to 'ASC' or 'DESC', rejecting everything else.
+ * An invalid column produces an empty string from get_order_string().
+ */
+
+// ---------------------------------------------------------------------------
+// Helper: mirrors the production validation from get_order_string()
+// ---------------------------------------------------------------------------
+
+function validate_sort_column(string $col): string {
+	if (!preg_match('/^[a-zA-Z][a-zA-Z0-9_.]*$/', $col)) {
+		return '';
+	}
+
+	return $col;
+}
+
+function validate_sort_direction(string $dir): string {
+	$dir = strtoupper($dir);
+
+	return ($dir === 'ASC' || $dir === 'DESC') ? $dir : 'ASC';
+}
+
+function build_order_clause(string $col, string $dir): string {
+	$col = validate_sort_column($col);
+	$dir = validate_sort_direction($dir);
+
+	if ($col === '') {
+		return '';
+	}
+
+	$del = '`';
+
+	return 'ORDER BY ' . $del . implode($del . '.' . $del, explode('.', $col)) . $del . ' ' . $dir;
+}
+
+// ---------------------------------------------------------------------------
+// Valid column names
+// ---------------------------------------------------------------------------
+
+test('simple alphabetic column produces ORDER BY clause', function () {
+	expect(build_order_clause('hostname', 'ASC'))->toBe('ORDER BY `hostname` ASC');
+});
+
+test('column with underscore is valid', function () {
+	expect(build_order_clause('host_id', 'DESC'))->toBe('ORDER BY `host_id` DESC');
+});
+
+test('column with digits is valid', function () {
+	expect(build_order_clause('col1', 'ASC'))->toBe('ORDER BY `col1` ASC');
+});
+
+test('dotted table.column form is valid and backtick-quoted', function () {
+	expect(build_order_clause('h.hostname', 'ASC'))->toBe('ORDER BY `h`.`hostname` ASC');
+});
+
+test('mixed-case column name is accepted', function () {
+	expect(build_order_clause('HostName', 'ASC'))->toBe('ORDER BY `HostName` ASC');
+});
+
+// ---------------------------------------------------------------------------
+// Invalid / injected column names return empty string
+// ---------------------------------------------------------------------------
+
+test('SQL injection payload with semicolon is rejected', function () {
+	expect(validate_sort_column('1; DROP TABLE users'))->toBe('');
+});
+
+test('column starting with digit is rejected', function () {
+	/* Pattern requires first char to be [a-zA-Z] */
+	expect(validate_sort_column('1col'))->toBe('');
+});
+
+test('double-dash comment injection is rejected', function () {
+	expect(validate_sort_column('col--'))->toBe('');
+});
+
+test('UNION keyword injection is rejected', function () {
+	expect(validate_sort_column('col UNION SELECT 1'))->toBe('');
+});
+
+test('backtick in column name is rejected', function () {
+	expect(validate_sort_column('col`name'))->toBe('');
+});
+
+test('parenthesis in column name is rejected', function () {
+	expect(validate_sort_column('SLEEP(5)'))->toBe('');
+});
+
+test('space in column name is rejected', function () {
+	expect(validate_sort_column('col name'))->toBe('');
+});
+
+test('empty string column is rejected', function () {
+	expect(validate_sort_column(''))->toBe('');
+});
+
+test('null byte in column name is rejected', function () {
+	expect(validate_sort_column("col\x00name"))->toBe('');
+});
+
+test('slash-based path traversal is rejected', function () {
+	expect(validate_sort_column('../etc/passwd'))->toBe('');
+});
+
+// ---------------------------------------------------------------------------
+// Valid sort directions
+// ---------------------------------------------------------------------------
+
+test('ASC direction is accepted unchanged', function () {
+	expect(validate_sort_direction('ASC'))->toBe('ASC');
+});
+
+test('DESC direction is accepted unchanged', function () {
+	expect(validate_sort_direction('DESC'))->toBe('DESC');
+});
+
+test('lowercase asc is normalised to ASC', function () {
+	expect(validate_sort_direction('asc'))->toBe('ASC');
+});
+
+test('lowercase desc is normalised to DESC', function () {
+	expect(validate_sort_direction('desc'))->toBe('DESC');
+});
+
+// ---------------------------------------------------------------------------
+// Invalid sort directions default to ASC
+// ---------------------------------------------------------------------------
+
+test('empty direction defaults to ASC', function () {
+	expect(validate_sort_direction(''))->toBe('ASC');
+});
+
+test('arbitrary string direction defaults to ASC', function () {
+	expect(validate_sort_direction('UNION'))->toBe('ASC');
+});
+
+test('SQL comment direction defaults to ASC', function () {
+	expect(validate_sort_direction('ASC--'))->toBe('ASC');
+});
+
+test('direction with space defaults to ASC', function () {
+	expect(validate_sort_direction('ASC DESC'))->toBe('ASC');
+});
+
+// ---------------------------------------------------------------------------
+// Full clause composition: invalid input produces empty string, not garbage SQL
+// ---------------------------------------------------------------------------
+
+test('invalid column with valid direction returns empty string', function () {
+	expect(build_order_clause('1; DROP TABLE users', 'ASC'))->toBe('');
+});
+
+test('valid column with invalid direction still produces safe clause', function () {
+	/* Direction coerces to ASC, column is safe */
+	expect(build_order_clause('hostname', 'UNION'))->toBe('ORDER BY `hostname` ASC');
+});
+
+test('both invalid returns empty string', function () {
+	expect(build_order_clause('col--', 'UNION SELECT'))->toBe('');
+});
+
+// ---------------------------------------------------------------------------
+// Source-scan: confirm the allowlist regex is present in lib/html_utility.php
+// ---------------------------------------------------------------------------
+
+test('lib/html_utility.php contains sort_column preg_match allowlist', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/html_utility.php');
+
+	/* Both get_order_string and update_order_string must contain the guard */
+	$matches = preg_match_all(
+		"/preg_match\s*\(\s*'\/\^/",
+		$source
+	);
+
+	expect($matches)->toBeGreaterThanOrEqual(2,
+		'Expected at least two preg_match allowlist guards (get_order_string + update_order_string)'
+	);
+});
+
+test('lib/html_utility.php validates sort_direction to ASC or DESC', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/html_utility.php');
+
+	expect($source)->toContain("!== 'ASC' && \$sort_dir !== 'DESC'");
+});
+
+test('lib/html_utility.php uses strtoupper to normalise direction', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/html_utility.php');
+
+	expect($source)->toContain("strtoupper(get_nfilter_request_var('sort_direction'))");
+});


### PR DESCRIPTION
## Problem

`get_order_string()` and `update_order_string()` interpolate `sort_direction` directly into ORDER BY clauses without any validation. `sort_column` is checked only against a blocklist of `(` and `` ` `` characters — insufficient to prevent injection via other SQL constructs (e.g. `CASE WHEN ... THEN ... ELSE ... END` with hex-encoded literals).

Affected files: `lib/html_utility.php`
Affected pages: `utilities.php`, `user_log.php`, `user_domains.php`, `user_group_admin.php`, `lib/html_reports.php`, `lib/api_automation.php`

Addresses: GHSA-84q3-92xc-c3pf, GHSA-c233-3rmx-vvxc

## Fix

Two targeted changes in `lib/html_utility.php`:

**`sort_direction`:** Validated against the literal set `{ASC, DESC}`. Any other value defaults to `ASC`.

**`sort_column`:** Blocklist replaced with allowlist regex `^[a-zA-Z][a-zA-Z0-9_.]*$`. This matches all real Cacti column names (e.g. `host_template_id`, `u.username`, `snmp_community`) and rejects whitespace, operators, SQL keywords, and comment sequences. Invalid columns produce an empty return value (no ORDER BY clause emitted).

Both `get_order_string()` and `update_order_string()` are patched at every point where request variables are stored to session or interpolated into SQL.

## Risk

Low. The allowlist permits the full character set used by Cacti column identifiers across all callers. The `inplace=true` path reads from session data that was previously written through the now-validated store points.

## Verification

Manual grep confirms no remaining `get_request_var('sort_direction')` or `get_request_var('sort_column')` calls in either function after the patch. All injection paths go through the validated local variables `$sort_column` and `$sort_dir`.