### PR TITLE
hardening: escape graph_name_regexp into db_qstr() to prevent REGEXP SQLi

### DIFF
--- a/lib/reports.php
+++ b/lib/reports.php
@@ -713,7 +713,7 @@ function reports_tree_has_graphs(int $tree_id,int  $branch_id,int  $effective_us
 	$new_graphs = [];
 
 	if ($search_key != '') {
-		$sql_swhere = " AND gtg.title_cache REGEXP '" . $search_key . "'";
+		$sql_swhere = ' AND gtg.title_cache REGEXP ' . db_qstr($search_key);
 	}
 
 	$device_id = db_fetch_cell_prepared('SELECT host_id
@@ -1233,7 +1233,7 @@ function reports_expand_device(array &$report, array $item, int $device_id, int 
 	if (cacti_sizeof($graph_templates)) {
 		foreach ($graph_templates as $id => $name) {
 			if ($item['graph_name_regexp'] != '') {
-				$sql_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+				$sql_where .= ' AND title_cache REGEXP ' . db_qstr($item['graph_name_regexp']);
 			}
 
 			$graphs = db_fetch_assoc_prepared("SELECT
@@ -1424,7 +1424,7 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 			}
 
 			if ($item['graph_name_regexp'] != '') {
-				$sql_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+				$sql_where .= ' AND title_cache REGEXP ' . db_qstr($item['graph_name_regexp']);
 			}
 
 			if ($leaf_type == 'header' && $nested) {
@@ -1470,7 +1470,7 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 				$gr_where = '';
 
 				if ($item['graph_name_regexp'] != '') {
-					$gr_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+					$gr_where .= ' AND title_cache REGEXP ' . db_qstr($item['graph_name_regexp']);
 				}
 
 				$graph = db_fetch_row('SELECT local_graph_id, title_cache
@@ -1486,7 +1486,7 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 				$gr_where = '';
 
 				if ($item['graph_name_regexp'] != '') {
-					$gr_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+					$gr_where .= ' AND title_cache REGEXP ' . db_qstr($item['graph_name_regexp']);
 				}
 
 				$graph = db_fetch_cell('SELECT count(*)

--- a/tests/Unit/ReportsRegexpSqlEscapingTest.php
+++ b/tests/Unit/ReportsRegexpSqlEscapingTest.php
@@ -1,0 +1,140 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Tests for the graph_name_regexp REGEXP SQL injection hardening in lib/reports.php.
+ *
+ * The fix wraps every graph_name_regexp value with db_qstr() before it enters
+ * a REGEXP clause, replacing raw variable interpolation that allowed an
+ * attacker-controlled report item to inject SQL via the regexp field.
+ *
+ * Two test suites:
+ *   1. Source-scan: verifies the safe pattern is present and the unsafe pattern
+ *      (bare $item['graph_name_regexp'] in a SQL string) is absent.
+ *   2. Behavioral: exercises the db_qstr() quoting contract against SQL-special
+ *      characters without requiring a live DB connection.
+ */
+
+// ---------------------------------------------------------------------------
+// Source file
+// ---------------------------------------------------------------------------
+
+$src = file_get_contents(__DIR__ . '/../../lib/reports.php');
+
+// ---------------------------------------------------------------------------
+// Source-scan suite
+// ---------------------------------------------------------------------------
+
+test('reports: REGEXP clause uses db_qstr() around graph_name_regexp', function () use ($src) {
+	expect($src)->toContain("REGEXP ' . db_qstr(\$item['graph_name_regexp'])");
+});
+
+test('reports: no raw graph_name_regexp concatenated directly into REGEXP string', function () use ($src) {
+	// Patterns that would indicate unescaped interpolation.
+	expect($src)->not->toContain("REGEXP '\$item[")
+		->and($src)->not->toContain("REGEXP '\" . \$item['graph_name_regexp']")
+		->and($src)->not->toContain("REGEXP \" . \$item['graph_name_regexp']");
+});
+
+test('reports: all REGEXP+graph_name_regexp occurrences are wrapped in db_qstr', function () use ($src) {
+	// Every site that builds a REGEXP clause from graph_name_regexp must use db_qstr.
+	$safe_count = substr_count($src, "REGEXP ' . db_qstr(\$item['graph_name_regexp'])");
+
+	// There are multiple call sites; all must be guarded.
+	expect($safe_count)->toBeGreaterThanOrEqual(3);
+});
+
+test('reports: graph_name_regexp non-empty guard still present before REGEXP usage', function () use ($src) {
+	// The fix must not remove the existing non-empty guard; it only adds quoting.
+	expect($src)->toContain("\$item['graph_name_regexp'] != ''");
+});
+
+test('reports: db_qstr is used, not manual addslashes, for REGEXP escaping', function () use ($src) {
+	// Confirms the fix uses the standard Cacti quoting helper rather than ad-hoc
+	// escaping that might miss edge cases.
+	$dbqstr_pos    = strpos($src, "db_qstr(\$item['graph_name_regexp'])");
+	$addslash_pos  = strpos($src, "addslashes(\$item['graph_name_regexp'])");
+
+	expect($dbqstr_pos)->not->toBeFalse();
+	expect($addslash_pos)->toBeFalse();
+});
+
+// ---------------------------------------------------------------------------
+// Behavioral suite — db_qstr() quoting contract
+//
+// db_qstr() wraps a value in single quotes and escapes single quotes and
+// backslashes via addslashes(). The tests confirm this holds for inputs
+// that would otherwise break a REGEXP clause or inject SQL.
+// ---------------------------------------------------------------------------
+
+/*
+ * Mirrors the db_qstr() quoting semantics used in production.
+ */
+function reports_quote(string $value): string {
+	return "'" . addslashes($value) . "'";
+}
+
+test('plain regexp pattern is quoted without modification', function () {
+	$quoted = reports_quote('host.*');
+
+	expect($quoted)->toBe("'host.*'");
+});
+
+test('single quote in regexp is escaped to prevent SQL injection', function () {
+	$quoted = reports_quote("'; DROP TABLE reports; --");
+
+	expect($quoted)->toContain("\\'")
+		->and($quoted)->toStartWith("'")
+		->and($quoted)->toEndWith("'");
+});
+
+test('backslash in regexp is doubled to prevent REGEXP escape confusion', function () {
+	$quoted = reports_quote('path\\to\\graph');
+
+	// addslashes() doubles the backslash; MySQL then interprets \\ as a literal \.
+	expect($quoted)->toContain('\\\\');
+});
+
+test('percent sign is passed through unchanged — REGEXP does not use LIKE wildcards', function () {
+	$quoted = reports_quote('graph%name');
+
+	expect($quoted)->toContain('%');
+});
+
+test('SQL comment sequence is safely enclosed in quotes', function () {
+	$quoted = reports_quote('graph -- DROP TABLE');
+
+	expect($quoted)->toStartWith("'")
+		->and($quoted)->toEndWith("'");
+});
+
+test('empty regexp string produces empty quoted literal', function () {
+	$quoted = reports_quote('');
+
+	expect($quoted)->toBe("''");
+});
+
+test('regexp with UNIX newline is safely quoted', function () {
+	// Newlines are not special to db_qstr() but must not break the SQL string.
+	$quoted = reports_quote("line1\nline2");
+
+	expect($quoted)->toStartWith("'")
+		->and($quoted)->toEndWith("'");
+});
+
+test('regexp with dot-star wildcard passes through correctly', function () {
+	$quoted = reports_quote('.*router.*');
+
+	expect($quoted)->toBe("'.*router.*'");
+});


### PR DESCRIPTION
## Summary

Fixes GHSA-xrh3-6pfg-ff35: five locations in `lib/reports.php` interpolated `$item['graph_name_regexp']` and `$search_key` directly into SQL `REGEXP '...'` string literals without escaping. A crafted regexp value could break out of the string literal and alter query structure.

- `reports_tree_has_graphs()` line 716: `$search_key` used in `REGEXP '...'`
- `report_graph_collector()` lines 1236, 1427: `$item['graph_name_regexp']` in `$sql_where`
- Lines 1473, 1489: `$item['graph_name_regexp']` in `$gr_where`

**Fix:** replace all five raw interpolations with `db_qstr()`, which wraps and escapes the value returning a fully-quoted SQL string literal.

```php
// Before
$sql_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
// After
$sql_where .= ' AND title_cache REGEXP ' . db_qstr($item['graph_name_regexp']);
```

## Test plan

- [ ] Confirm `reports_tree_has_graphs()` with a `graph_name_regexp` value containing single quotes returns correct results without SQL error
- [ ] Confirm `report_graph_collector()` filters graphs correctly for regexp patterns with special characters
- [ ] PHPStan level 6 passes
- [ ] PHP CS Fixer passes

Fixes: GHSA-xrh3-6pfg-ff35