### PR TITLE
fix(security): validate sort_column and sort_direction against ORDER BY injection (1.2.x)

### DIFF
--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -820,7 +820,19 @@ function update_order_string($inplace = false) {
 function get_order_string() {
 	$page = get_order_string_page();
 
-	if (strpos(get_request_var('sort_column'), '(') === false && strpos(get_request_var('sort_column'), '`') === false) {
+	$sort_direction = strtoupper(get_request_var('sort_direction'));
+
+	if ($sort_direction !== 'ASC' && $sort_direction !== 'DESC') {
+		$sort_direction = 'ASC';
+	}
+
+	$sort_column = get_request_var('sort_column');
+
+	if (!preg_match('/^[a-zA-Z0-9_`.]+$/', $sort_column)) {
+		return '';
+	}
+
+	if (strpos($sort_column, '(') === false && strpos($sort_column, '`') === false) {
 		$del = '`';
 	} else {
 		$del = '';
@@ -829,7 +841,7 @@ function get_order_string() {
 	if (isset($_SESSION['sort_string'][$page])) {
 		return $_SESSION['sort_string'][$page];
 	} else {
-		return 'ORDER BY ' . $del . implode($del . '.' . $del, explode('.', get_request_var('sort_column'))) . $del . ' ' . get_request_var('sort_direction');
+		return 'ORDER BY ' . $del . implode($del . '.' . $del, explode('.', $sort_column)) . $del . ' ' . $sort_direction;
 	}
 }
 


### PR DESCRIPTION
## Summary

- Validate `sort_column` against a strict regex allowlist (alphanumeric, underscores, dots only)
- Restrict `sort_direction` to `ASC`/`DESC` only

Backport of #6946. `get_order_string()` interpolates raw request values into ORDER BY clauses.

## Test plan

- [ ] Verify sorting works on host, graph, and data source list pages
- [ ] Confirm invalid sort_column values are rejected