### PR TITLE
fix(security): escape rfilter with db_qstr() in RLIKE SQL clauses (1.2.x)

### DIFF
--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -1285,7 +1285,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 		$sql_where = '';
 
 		if (get_request_var('rfilter') != '') {
-			$sql_where .= " (gtg.title_cache RLIKE '" . get_request_var('rfilter') . "' OR gtg.title RLIKE '" . get_request_var('rfilter') . "')";
+			$sql_where .= " (gtg.title_cache RLIKE " . db_qstr(get_request_var('rfilter')) . " OR gtg.title RLIKE " . db_qstr(get_request_var('rfilter')) . ")";
 		}
 
 		if (isset_request_var('graph_template_id') && get_request_var('graph_template_id') >= 0) {
@@ -1336,7 +1336,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 		}
 
 		if (get_request_var('rfilter') != '') {
-			$sql_where .= ($sql_where != '' ? ' AND ':'') . "(gtg.title_cache RLIKE '" . get_request_var('rfilter') . "')";
+			$sql_where .= ($sql_where != '' ? ' AND ':'') . "(gtg.title_cache RLIKE " . db_qstr(get_request_var('rfilter')) . ")";
 		}
 
 		if (isset_request_var('graph_template_id') && get_request_var('graph_template_id') >= 0) {
@@ -1452,7 +1452,7 @@ function get_host_graph_list($host_id, $graph_template_id, $data_query_id, $host
 		if (cacti_sizeof($final_templates)) {
 			$sql_where = '';
 			if (get_request_var('rfilter') != '') {
-				$sql_where = " (gtg.title_cache RLIKE '" . get_request_var('rfilter') . "')";
+				$sql_where = " (gtg.title_cache RLIKE " . db_qstr(get_request_var('rfilter')) . ")";
 			}
 
 			if ($host_id > 0) {
@@ -1522,7 +1522,7 @@ function get_host_graph_list($host_id, $graph_template_id, $data_query_id, $host
 				$sfd = get_formatted_data_query_indexes($host_id, $data_query['id']);
 
 				if (get_request_var('rfilter') != '') {
-					$sql_where = " (gtg.title_cache RLIKE '" . get_request_var('rfilter') . "')";
+					$sql_where = " (gtg.title_cache RLIKE " . db_qstr(get_request_var('rfilter')) . ")";
 				}
 
 				/* grab a list of all graphs for this host/data query combination */


### PR DESCRIPTION
## Summary

- Wrap `get_request_var('rfilter')` with `db_qstr()` at 4 RLIKE concatenation sites in `lib/html_tree.php`

Backport of #6947. Raw rfilter values are concatenated into RLIKE clauses without escaping.

## Test plan

- [ ] Verify graph tree filtering works with normal search terms
- [ ] Confirm special characters in filter don't cause SQL errors