### PR TITLE
fix(security): validate graph_theme with basename() to prevent LFI (1.2.x)

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -2567,7 +2567,13 @@ function rrdtool_function_theme_font_options(&$graph_data_array) {
 
 
 	if (isset($graph_data_array['graph_theme'])) {
-		$rrdtheme = $config['base_path'] . '/include/themes/' . $graph_data_array['graph_theme'] . '/rrdtheme.php';
+		$theme = basename($graph_data_array['graph_theme']);
+
+		if ($theme === '' || $theme === '.' || $theme === '..') {
+			$theme = get_selected_theme();
+		}
+
+		$rrdtheme = $config['base_path'] . '/include/themes/' . $theme . '/rrdtheme.php';
 	} else {
 		$rrdtheme = $config['base_path'] . '/include/themes/' . get_selected_theme() . '/rrdtheme.php';
 	}


### PR DESCRIPTION
## Summary

- Apply `basename()` to `graph_data_array['graph_theme']` before building the rrdtheme include path

Backport of #6948. The graph_theme parameter passes through `sanitize_search_string()` which does not strip `.` or `/`, allowing path traversal into arbitrary include paths.

## Test plan

- [ ] Verify graph rendering with different themes works
- [ ] Confirm `../` in theme name is stripped