### PR TITLE
fix(security): cast effective_user to int and validate OID format in remote_agent (1.2.x)

### DIFF
--- a/remote_agent.php
+++ b/remote_agent.php
@@ -224,7 +224,7 @@ function get_graph_data() {
 
 	/* set the theme */
 	if (isset_request_var('effective_user')) {
-		$user = get_request_var('effective_user');
+		$user = (int) get_request_var('effective_user');
 	} else {
 		$user = 0;
 	}
@@ -241,6 +241,11 @@ function get_graph_data() {
 function get_snmp_data() {
 	$host_id = get_filter_request_var('host_id');
 	$oid     = get_nfilter_request_var('oid');
+
+	if (!is_string($oid) || !preg_match('/^[0-9.]+$/', $oid)) {
+		print 'U';
+		return;
+	}
 
 	if (!empty($host_id)) {
 		$host = db_fetch_row_prepared('SELECT * FROM host WHERE id = ?', array($host_id));
@@ -263,6 +268,11 @@ function get_snmp_data() {
 function get_snmp_data_walk() {
 	$host_id = get_filter_request_var('host_id');
 	$oid     = get_nfilter_request_var('oid');
+
+	if (!is_string($oid) || !preg_match('/^[0-9.]+$/', $oid)) {
+		print 'U';
+		return;
+	}
 
 	if (!empty($host_id)) {
 		$host = db_fetch_row_prepared('SELECT * FROM host WHERE id = ?', array($host_id));

--- a/remote_agent.php
+++ b/remote_agent.php
@@ -248,7 +248,7 @@ function get_graph_data() {
 
 	/* set the theme */
 	if (isset_request_var('effective_user')) {
-		$user = (int) get_request_var('effective_user');
+		$user = get_request_var('effective_user');
 	} else {
 		$user = 0;
 	}


### PR DESCRIPTION
## Summary

- Cast `effective_user` to `(int)` before use
- Add OID format validation (`/^[0-9.]+$/`) before SNMP get and walk operations

Backport of #6943. `effective_user` accepts non-integer values, and OIDs from `get_nfilter_request_var()` reach SNMP sessions without format validation.

## Test plan

- [ ] Verify SNMP data collection works via remote agent
- [ ] Confirm non-numeric effective_user values are safely cast
- [ ] Confirm malformed OIDs return 'U' instead of reaching SNMP