### PR TITLE
fix(security): validate graph_theme with basename() to prevent LFI

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -3007,7 +3007,13 @@ function rrdtool_function_theme_font_options(array &$graph_data_array) : string 
 	$themeborder = 'rrdborder';
 
 	if (isset($graph_data_array['graph_theme'])) {
-		$rrdtheme = CACTI_PATH_INCLUDE . '/themes/' . $graph_data_array['graph_theme'] . '/rrdtheme.php';
+		$theme = basename($graph_data_array['graph_theme']);
+
+		if ($theme === '' || $theme === '.' || $theme === '..') {
+			$theme = get_selected_theme();
+		}
+
+		$rrdtheme = CACTI_PATH_INCLUDE . '/themes/' . $theme . '/rrdtheme.php';
 	} else {
 		$rrdtheme = CACTI_PATH_INCLUDE . '/themes/' . get_selected_theme() . '/rrdtheme.php';
 	}


### PR DESCRIPTION
## Summary

- Apply `basename()` to `graph_data_array['graph_theme']` before building the rrdtheme include path
- Reject edge cases (empty, `.`, `..`) by falling back to selected theme

`sanitize_search_string()` does not strip `.` or `/`, allowing path traversal to arbitrary include paths via the graph_theme parameter.

1.2.x backport: #6966

## Test plan

- [ ] Verify graph rendering with different themes works
- [ ] Confirm `../` in theme name is stripped