### PR TITLE
fix(security): cast effective_user to int and validate OID format in remote_agent

### DIFF
--- a/remote_agent.php
+++ b/remote_agent.php
@@ -238,9 +238,9 @@ function get_graph_data() : bool {
 		$graph_data_array['graph_theme'] = grv('graph_theme');
 	}
 
-	// set the theme
+	// set the effective user
 	if (isrv('effective_user')) {
-		$user = grv('effective_user');
+		$user = (int) grv('effective_user');
 	} else {
 		$user = 0;
 	}
@@ -257,6 +257,12 @@ function get_graph_data() : bool {
 function get_snmp_data() : void {
 	$host_id = gfrv('host_id');
 	$oid     = gnrv('oid');
+
+	if (!is_string($oid) || !preg_match('/^[0-9.]+$/', $oid)) {
+		print 'U';
+		return;
+	}
+
 	$output  = '';
 
 	if (!empty($host_id)) {
@@ -280,6 +286,12 @@ function get_snmp_data() : void {
 function get_snmp_data_walk() : void {
 	$host_id = gfrv('host_id');
 	$oid     = gnrv('oid');
+
+	if (!is_string($oid) || !preg_match('/^[0-9.]+$/', $oid)) {
+		print 'U';
+		return;
+	}
+
 	$output  = '';
 
 	if (!empty($host_id)) {

--- a/remote_agent.php
+++ b/remote_agent.php
@@ -240,7 +240,7 @@ function get_graph_data() : bool {
 
 	// set the effective user
 	if (isrv('effective_user')) {
-		$user = (int) grv('effective_user');
+		$user = grv('effective_user');
 	} else {
 		$user = 0;
 	}


### PR DESCRIPTION
## Summary

- Cast `effective_user` to `(int)` before use
- Add `is_string()` + OID format validation (`/^[0-9.]+$/`) at both SNMP get and walk sites
- Return 'U' on invalid OID input

`effective_user` accepts non-integer values via `grv()`, and OIDs from `gnrv()` reach SNMP sessions without format validation.

1.2.x backport: #6969

## Test plan

- [ ] Verify SNMP data collection works via remote agent
- [ ] Confirm malformed OIDs return 'U'