### PR TITLE
fix(security): enable SSL peer verification for remote package fetches

### DIFF
--- a/package_import.php
+++ b/package_import.php
@@ -1926,8 +1926,8 @@ function get_repo_file(string $repo_id, string $filename = 'package.manifest', b
 
 			$context = [
 				'ssl' => [
-					'verify_peer'      => false,
-					'verify_peer_name' => false,
+					'verify_peer'      => true,
+					'verify_peer_name' => true,
 				],
 			];
 


### PR DESCRIPTION
## Summary

- Change `verify_peer` and `verify_peer_name` from `false` to `true` in the SSL stream context used by `file_get_contents()` for remote package fetches

Without SSL verification, MITM attacks can inject malicious packages during remote fetch operations.

## Test plan

- [ ] Verify remote package fetch works with valid SSL certificates
- [ ] Confirm self-signed or invalid certificates are rejected