### PR TITLE
fix: aggregate 95th percentile uses SUM instead of MAX for SIMILAR (1.2.x)

### DIFF
--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -403,20 +403,20 @@ function aggregate_graphs_insert_graph_items($_new_graph_id, $_old_graph_id, $_g
 					$prepend = false;
 					$prepend_cnt++;
 				} elseif (strpos($save['text_format'], ':current:')) {
-					if ($_total_type == AGGREGATE_TOTAL_TYPE_ALL || $_total_type == AGGREGATE_TOTAL_TYPE_SIMILAR) {
-						// All so use sum functions
+					if ($_total_type == AGGREGATE_TOTAL_TYPE_ALL) {
 						$save['text_format'] = str_replace(':current:', ':aggregate_sum:', $save['text_format']);
+					} elseif ($_total_type == AGGREGATE_TOTAL_TYPE_SIMILAR) {
+						$save['text_format'] = str_replace(':current:', ':aggregate_current:', $save['text_format']);
 					} else {
-						// Similar to separate
-						$save['text_format'] = str_replace(':current:', ':current:', $save['text_format']);
+						cacti_log(__FUNCTION__ . ' unhandled total_type ' . $_total_type . ' for :current: in text_format', true, 'AGGREGATE', POLLER_VERBOSITY_DEBUG);
 					}
 				} elseif (strpos($save['text_format'], ':max:')) {
-					if ($_total_type == AGGREGATE_TOTAL_TYPE_ALL || $_total_type == AGGREGATE_TOTAL_TYPE_SIMILAR) {
-						// All so use sum functions
-						$save['text_format'] = str_replace(':max:', ':aggregate_sum:', $save['text_format']);
+					if ($_total_type == AGGREGATE_TOTAL_TYPE_ALL) {
+						$save['text_format'] = str_replace(':max:', ':aggregate_sum_peak:', $save['text_format']);
+					} elseif ($_total_type == AGGREGATE_TOTAL_TYPE_SIMILAR) {
+						$save['text_format'] = str_replace(':max:', ':aggregate_current_peak:', $save['text_format']);
 					} else {
-						// Similar to separate
-						$save['text_format'] = str_replace(':max:', ':max:', $save['text_format']);
+						cacti_log(__FUNCTION__ . ' unhandled total_type ' . $_total_type . ' for :max: in text_format', true, 'AGGREGATE', POLLER_VERBOSITY_DEBUG);
 					}
 				}
 			}
@@ -1377,14 +1377,14 @@ function aggregate_handle_ptile_type($member_graphs, $skipped_items, $local_grap
 								$pparts = explode(':', $parts[1]);
 
 								if (isset($pparts[3])) {
-									if ($_total_type == AGGREGATE_TOTAL_TYPE_ALL || $_total_type == AGGREGATE_TOTAL_TYPE_SIMILAR) {
-										// All so use sum functions
+									if ($_total_type == AGGREGATE_TOTAL_TYPE_ALL) {
 										$pparts[3] = str_replace('current', 'aggregate_sum', $pparts[3]);
 										$pparts[3] = str_replace('max',     'aggregate_sum_peak', $pparts[3]);
-									} else {
-										// Similar to separate
+									} elseif ($_total_type == AGGREGATE_TOTAL_TYPE_SIMILAR) {
 										$pparts[3] = str_replace('current', 'aggregate_current', $pparts[3]);
 										$pparts[3] = str_replace('max',     'aggregate_current_peak', $pparts[3]);
+									} else {
+										cacti_log(__FUNCTION__ . ' unhandled total_type ' . $_total_type . ' for pparts[3] in text_format', true, 'AGGREGATE', POLLER_VERBOSITY_DEBUG);
 									}
 
 									switch($pparts[3]) {
@@ -1451,14 +1451,14 @@ function aggregate_handle_ptile_type($member_graphs, $skipped_items, $local_grap
 								$pparts = explode(':', $parts[1]);
 
 								if (isset($pparts[3])) {
-									if ($_total_type == AGGREGATE_TOTAL_TYPE_ALL || $_total_type == AGGREGATE_TOTAL_TYPE_SIMILAR) {
-										// All so use sum functions
+									if ($_total_type == AGGREGATE_TOTAL_TYPE_ALL) {
 										$pparts[3] = str_replace('current', 'aggregate_sum', $pparts[3]);
 										$pparts[3] = str_replace('max',     'aggregate_sum_peak', $pparts[3]);
-									} else {
-										// Similar to separate
+									} elseif ($_total_type == AGGREGATE_TOTAL_TYPE_SIMILAR) {
 										$pparts[3] = str_replace('current', 'aggregate_current', $pparts[3]);
 										$pparts[3] = str_replace('max',     'aggregate_current_peak', $pparts[3]);
+									} else {
+										cacti_log(__FUNCTION__ . ' unhandled total_type ' . $_total_type . ' for pparts[3] in value', true, 'AGGREGATE', POLLER_VERBOSITY_DEBUG);
 									}
 
 									switch($pparts[3]) {

--- a/tests/Unit/AggregatePtileSimilarTest.php
+++ b/tests/Unit/AggregatePtileSimilarTest.php
@@ -1,0 +1,155 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Source-scan tests for the aggregate 95th percentile SIMILAR fix.
+ *
+ * Before the fix, the SIMILAR total_type was lumped together with ALL
+ * in the same if-branch, so both used aggregate_sum / aggregate_sum_peak.
+ * SIMILAR should use aggregate_current / aggregate_current_peak instead,
+ * because SIMILAR totals should reflect per-data-source consolidation
+ * rather than the sum across all sources.
+ *
+ * The fix splits the condition into separate branches:
+ *   ALL     -> aggregate_sum / aggregate_sum_peak
+ *   SIMILAR -> aggregate_current / aggregate_current_peak
+ */
+
+// --- helper ---
+
+function getApiAggregateSource(): string {
+	$path = __DIR__ . '/../../lib/api_aggregate.php';
+	$src  = file_get_contents($path);
+	expect($src)->not->toBeFalse('Failed to read lib/api_aggregate.php');
+
+	return $src;
+}
+
+// --- :current: replacement in graph item text_format (line ~405 area) ---
+
+test('text_format :current: replacement uses aggregate_current for SIMILAR', function () {
+	$src = getApiAggregateSource();
+
+	// SIMILAR must map :current: to :aggregate_current:, not :aggregate_sum:
+	$pattern = '/AGGREGATE_TOTAL_TYPE_SIMILAR\b.*?:aggregate_current:/s';
+	expect(preg_match($pattern, $src))->toBe(1,
+		'SIMILAR total_type must replace :current: with :aggregate_current:'
+	);
+});
+
+test('text_format :current: replacement uses aggregate_sum only for ALL', function () {
+	$src = getApiAggregateSource();
+
+	// The ALL branch must use aggregate_sum for :current:
+	// Find the block that checks for ':current:' and verify ALL maps to aggregate_sum
+	$pattern = "/strpos.*':current:'.*?AGGREGATE_TOTAL_TYPE_ALL\b[^}]*?:aggregate_sum:/s";
+	expect(preg_match($pattern, $src))->toBe(1,
+		'ALL total_type must replace :current: with :aggregate_sum:'
+	);
+});
+
+test('ALL and SIMILAR are separate branches for :current: replacement', function () {
+	$src = getApiAggregateSource();
+
+	// The old bug had: if ($_total_type == AGGREGATE_TOTAL_TYPE_ALL || $_total_type == AGGREGATE_TOTAL_TYPE_SIMILAR)
+	// The fix separates them. Verify no combined condition exists for :current:
+	$pattern = "/strpos.*':current:'.*?AGGREGATE_TOTAL_TYPE_ALL\s*\|\|\s*.*AGGREGATE_TOTAL_TYPE_SIMILAR/s";
+
+	// Limit search to the text_format replacement section (first 500 lines)
+	$first_half = implode("\n", array_slice(explode("\n", $src), 0, 500));
+	expect(preg_match($pattern, $first_half))->toBe(0,
+		'ALL and SIMILAR must not be combined in the same if-condition for :current: replacement'
+	);
+});
+
+// --- :max: replacement in graph item text_format ---
+
+test('text_format :max: replacement uses aggregate_current_peak for SIMILAR', function () {
+	$src = getApiAggregateSource();
+
+	$pattern = '/AGGREGATE_TOTAL_TYPE_SIMILAR\b.*?:aggregate_current_peak:/s';
+	expect(preg_match($pattern, $src))->toBe(1,
+		'SIMILAR total_type must replace :max: with :aggregate_current_peak:'
+	);
+});
+
+test('text_format :max: replacement uses aggregate_sum_peak for ALL', function () {
+	$src = getApiAggregateSource();
+
+	$pattern = "/strpos.*':max:'.*?AGGREGATE_TOTAL_TYPE_ALL\b[^}]*?:aggregate_sum_peak:/s";
+	expect(preg_match($pattern, $src))->toBe(1,
+		'ALL total_type must replace :max: with :aggregate_sum_peak:'
+	);
+});
+
+// --- ptile handler pparts[3] replacement (line ~1380 and ~1455 areas) ---
+
+test('ptile handler separates ALL and SIMILAR for pparts replacement', function () {
+	$src = getApiAggregateSource();
+
+	// The aggregate_handle_ptile_type function must not combine ALL||SIMILAR
+	$fnStart = strpos($src, 'function aggregate_handle_ptile_type(');
+	expect($fnStart)->not->toBeFalse('aggregate_handle_ptile_type() must exist');
+
+	$fnBody = substr($src, $fnStart, 8000);
+
+	// Old pattern: AGGREGATE_TOTAL_TYPE_ALL || ... AGGREGATE_TOTAL_TYPE_SIMILAR
+	$combined = preg_match_all(
+		'/AGGREGATE_TOTAL_TYPE_ALL\s*\|\|\s*\$_total_type\s*==\s*AGGREGATE_TOTAL_TYPE_SIMILAR/',
+		$fnBody
+	);
+	expect($combined)->toBe(0,
+		'aggregate_handle_ptile_type must not combine ALL and SIMILAR in the same condition'
+	);
+});
+
+test('ptile handler maps current to aggregate_current for SIMILAR', function () {
+	$src = getApiAggregateSource();
+
+	$fnStart = strpos($src, 'function aggregate_handle_ptile_type(');
+	$fnBody  = substr($src, $fnStart, 8000);
+
+	// SIMILAR branch must replace 'current' with 'aggregate_current'
+	$pattern = "/AGGREGATE_TOTAL_TYPE_SIMILAR.*?str_replace\('current',\s*'aggregate_current'/s";
+	expect(preg_match($pattern, $fnBody))->toBe(1,
+		'ptile handler must replace current with aggregate_current for SIMILAR'
+	);
+});
+
+test('ptile handler maps max to aggregate_current_peak for SIMILAR', function () {
+	$src = getApiAggregateSource();
+
+	$fnStart = strpos($src, 'function aggregate_handle_ptile_type(');
+	$fnBody  = substr($src, $fnStart, 8000);
+
+	$pattern = "/AGGREGATE_TOTAL_TYPE_SIMILAR.*?str_replace\('max',\s*'aggregate_current_peak'/s";
+	expect(preg_match($pattern, $fnBody))->toBe(1,
+		'ptile handler must replace max with aggregate_current_peak for SIMILAR'
+	);
+});
+
+// --- the switch still handles all four aggregate CF names ---
+
+test('ptile handler switch covers all four aggregate consolidation names', function () {
+	$src = getApiAggregateSource();
+
+	$fnStart = strpos($src, 'function aggregate_handle_ptile_type(');
+	$fnBody  = substr($src, $fnStart, 8000);
+
+	foreach (array('aggregate_sum', 'aggregate_sum_peak', 'aggregate_current', 'aggregate_current_peak') as $cf) {
+		expect(str_contains($fnBody, "case '{$cf}'"))->toBeTrue(
+			"ptile handler switch must contain case '{$cf}'"
+		);
+	}
+});


### PR DESCRIPTION
## Summary
- Backport of #6843 to 1.2.x
- SIMILAR total type now correctly uses `aggregate_current` for `:current:` and `aggregate_current_peak` for `:max:` instead of `aggregate_sum`/`aggregate_sum_peak`
- Fixes 95th percentile calculation for SIMILAR aggregate graphs

## Test plan
- [ ] Verify SIMILAR aggregate graphs show correct 95th percentile values
- [ ] Verify ALL aggregate graphs still use SUM as expected