### PR TITLE
test: add security coverage gap tests for database, auth, import, and PR regressions

### DIFF
--- a/tests/Unit/AuthImportSecurityPatternsTest.php
+++ b/tests/Unit/AuthImportSecurityPatternsTest.php
@@ -1,0 +1,455 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Source-scan tests for auth and import security patterns.
+ *
+ * These tests verify that security-relevant patterns exist in lib/auth.php,
+ * lib/import.php, and lib/package.php by scanning the source text. They do
+ * not execute the functions (which require a DB), but confirm that guards,
+ * allowlists, and validation logic remain in place across refactors.
+ */
+
+$authSource    = file_get_contents(__DIR__ . '/../../lib/auth.php');
+$importSource  = file_get_contents(__DIR__ . '/../../lib/import.php');
+$packageSource = file_get_contents(__DIR__ . '/../../lib/package.php');
+$xmlSource     = file_get_contents(__DIR__ . '/../../lib/xml.php');
+
+// =====================================================================
+// lib/auth.php -- session validation functions exist
+// =====================================================================
+
+test('auth.php defines is_realm_allowed function', function () use ($authSource) {
+	expect($authSource)->toContain('function is_realm_allowed(');
+});
+
+test('auth.php defines is_view_allowed function', function () use ($authSource) {
+	expect($authSource)->toContain('function is_view_allowed(');
+});
+
+test('auth.php defines is_graph_allowed function', function () use ($authSource) {
+	expect($authSource)->toContain('function is_graph_allowed(');
+});
+
+test('auth.php defines is_tree_allowed function', function () use ($authSource) {
+	expect($authSource)->toContain('function is_tree_allowed(');
+});
+
+test('auth.php defines is_device_allowed function', function () use ($authSource) {
+	expect($authSource)->toContain('function is_device_allowed(');
+});
+
+test('auth.php defines auth_valid_user function', function () use ($authSource) {
+	expect($authSource)->toContain('function auth_valid_user(');
+});
+
+test('auth.php defines is_user_perms_valid function', function () use ($authSource) {
+	expect($authSource)->toContain('function is_user_perms_valid(');
+});
+
+// =====================================================================
+// lib/auth.php -- is_view_allowed column allowlist
+// =====================================================================
+
+test('is_view_allowed uses an allowed_views array', function () use ($authSource) {
+	expect($authSource)->toContain('$allowed_views');
+});
+
+test('is_view_allowed checks view against allowed_views with in_array', function () use ($authSource) {
+	expect($authSource)->toContain("in_array(\$view, \$allowed_views, true)");
+});
+
+test('is_view_allowed allowlist contains show_tree', function () use ($authSource) {
+	expect($authSource)->toContain("'show_tree'");
+});
+
+test('is_view_allowed allowlist contains show_list', function () use ($authSource) {
+	expect($authSource)->toContain("'show_list'");
+});
+
+test('is_view_allowed allowlist contains show_preview', function () use ($authSource) {
+	expect($authSource)->toContain("'show_preview'");
+});
+
+test('is_view_allowed allowlist contains graph_settings', function () use ($authSource) {
+	expect($authSource)->toContain("'graph_settings'");
+});
+
+// =====================================================================
+// lib/auth.php -- session constants used instead of raw strings
+// =====================================================================
+
+test('auth.php uses SESS_USER_ID constant for session access', function () use ($authSource) {
+	expect($authSource)->toContain('$_SESSION[SESS_USER_ID]');
+});
+
+test('auth.php uses SESS_USER_REALMS constant for realm caching', function () use ($authSource) {
+	expect($authSource)->toContain('$_SESSION[SESS_USER_REALMS]');
+});
+
+test('auth.php uses SESS_AUTH_NAMES constant', function () use ($authSource) {
+	expect($authSource)->toContain('$_SESSION[SESS_AUTH_NAMES]');
+});
+
+test('auth.php uses kill_session_var for session cleanup', function () use ($authSource) {
+	expect($authSource)->toContain('kill_session_var(SESS_USER_ID)');
+});
+
+// =====================================================================
+// lib/auth.php -- prepared statements for all DB queries
+// =====================================================================
+
+test('auth.php uses db_fetch_cell_prepared for user lookups', function () use ($authSource) {
+	expect($authSource)->toContain('db_fetch_cell_prepared(');
+});
+
+test('auth.php uses db_execute_prepared for user mutations', function () use ($authSource) {
+	expect($authSource)->toContain('db_execute_prepared(');
+});
+
+test('auth.php uses db_fetch_row_prepared for row fetches', function () use ($authSource) {
+	expect($authSource)->toContain('db_fetch_row_prepared(');
+});
+
+// =====================================================================
+// lib/auth.php -- cookie token uses cryptographic randomness
+// =====================================================================
+
+test('set_auth_cookie uses random_bytes for token generation', function () use ($authSource) {
+	expect($authSource)->toContain('random_bytes(');
+});
+
+test('auth cookie tokens are hashed with sha512', function () use ($authSource) {
+	expect($authSource)->toContain("hash('sha512'");
+});
+
+// =====================================================================
+// lib/auth.php -- password security functions
+// =====================================================================
+
+test('auth.php defines secpass_check_pass for password validation', function () use ($authSource) {
+	expect($authSource)->toContain('function secpass_check_pass(');
+});
+
+test('auth.php defines secpass_check_history for password reuse prevention', function () use ($authSource) {
+	expect($authSource)->toContain('function secpass_check_history(');
+});
+
+test('auth.php uses compat_password_verify not raw comparison', function () use ($authSource) {
+	expect($authSource)->toContain('compat_password_verify(');
+});
+
+test('auth.php uses compat_password_hash for hashing', function () use ($authSource) {
+	expect($authSource)->toContain('compat_password_hash(');
+});
+
+// =====================================================================
+// lib/auth.php -- account lockout protection
+// =====================================================================
+
+test('auth.php defines auth_process_lockout function', function () use ($authSource) {
+	expect($authSource)->toContain('function auth_process_lockout(');
+});
+
+test('auth.php defines auth_process_lockout_check function', function () use ($authSource) {
+	expect($authSource)->toContain('function auth_process_lockout_check(');
+});
+
+test('auth.php defines auth_checkclear_lockout function', function () use ($authSource) {
+	expect($authSource)->toContain('function auth_checkclear_lockout(');
+});
+
+// =====================================================================
+// lib/auth.php -- input validation on user management functions
+// =====================================================================
+
+test('user_remove validates user_id with input_validate_input_number', function () use ($authSource) {
+	// user_remove calls input_validate_input_number before any DB ops
+	$start = strpos($authSource, 'function user_remove(');
+	if ($start === false) {
+		$this->fail('function user_remove not found in source');
+	}
+	$fnBody = substr($authSource, $start);
+	$end = strpos($fnBody, "\nfunction ");
+	if ($end === false) {
+		$this->fail('no function follows user_remove in source');
+	}
+	$fnBody = substr($fnBody, 0, $end);
+
+	expect($fnBody)->toContain('input_validate_input_number($user_id');
+});
+
+test('user_disable validates user_id with input_validate_input_number', function () use ($authSource) {
+	$start = strpos($authSource, 'function user_disable(');
+	if ($start === false) {
+		$this->fail('function user_disable not found in source');
+	}
+	$fnBody = substr($authSource, $start);
+	$end = strpos($fnBody, "\nfunction ");
+	if ($end === false) {
+		$this->fail('no function follows user_disable in source');
+	}
+	$fnBody = substr($fnBody, 0, $end);
+
+	expect($fnBody)->toContain('input_validate_input_number($user_id');
+});
+
+test('user_enable validates user_id with input_validate_input_number', function () use ($authSource) {
+	$start = strpos($authSource, 'function user_enable(');
+	if ($start === false) {
+		$this->fail('function user_enable not found in source');
+	}
+	$fnBody = substr($authSource, $start);
+	$end = strpos($fnBody, "\nfunction ");
+	if ($end === false) {
+		$this->fail('no function follows user_enable in source');
+	}
+	$fnBody = substr($fnBody, 0, $end);
+
+	expect($fnBody)->toContain('input_validate_input_number($user_id');
+});
+
+// =====================================================================
+// lib/auth.php -- get_basic_auth_username sanitization
+// =====================================================================
+
+test('auth.php sanitizes basic auth username with sanitize_search_string', function () use ($authSource) {
+	$start = strpos($authSource, 'function auth_get_username(');
+	if ($start === false) {
+		$this->fail('function auth_get_username not found in source');
+	}
+	$fnBody = substr($authSource, $start);
+	$end = strpos($fnBody, "\nfunction ");
+	if ($end === false) {
+		$this->fail('no function follows auth_get_username in source');
+	}
+	$fnBody = substr($fnBody, 0, $end);
+
+	expect($fnBody)->toContain('sanitize_search_string($username)');
+});
+
+test('get_basic_auth_username handles array-typed SERVER vars', function () use ($authSource) {
+	// Protection against header injection via array-typed superglobals
+	expect($authSource)->toContain('is_array($_SERVER[');
+});
+
+// =====================================================================
+// lib/auth.php -- no extract() calls on untrusted data
+// =====================================================================
+
+test('auth.php does not use extract()', function () use ($authSource) {
+	expect($authSource)->not->toMatch('/\bextract\s*\(/');
+});
+
+// =====================================================================
+// lib/import.php -- signature validation exists
+// =====================================================================
+
+test('import.php defines import_validate_signature function', function () use ($importSource) {
+	expect($importSource)->toContain('function import_validate_signature(');
+});
+
+test('import.php uses openssl_verify for package signature verification', function () use ($importSource) {
+	expect($importSource)->toContain('openssl_verify(');
+});
+
+test('import.php supports SHA256 signatures via OPENSSL_ALGO_SHA256', function () use ($importSource) {
+	expect($importSource)->toContain('OPENSSL_ALGO_SHA256');
+});
+
+test('import.php rejects tampered packages with log message', function () use ($importSource) {
+	expect($importSource)->toContain('File has been Tampered with');
+});
+
+// =====================================================================
+// lib/import.php -- per-file signature verification
+// =====================================================================
+
+test('import.php verifies each file signature individually', function () use ($importSource) {
+	expect($importSource)->toContain('Verifying each files signature');
+});
+
+test('import.php decodes file signatures with base64_decode', function () use ($importSource) {
+	expect($importSource)->toContain("base64_decode(\$f['filesignature']");
+});
+
+test('import.php rejects files with invalid signatures', function () use ($importSource) {
+	expect($importSource)->toContain('Could not Verify Signature for file');
+});
+
+// =====================================================================
+// lib/import.php -- file write path restriction
+// =====================================================================
+
+test('import.php restricts file writes to scripts/ and resource/ paths', function () use ($importSource) {
+	// The file write block is gated by checking the name contains scripts/ or resource/
+	expect($importSource)->toContain("str_contains(\$name, 'scripts/')");
+	expect($importSource)->toContain("str_contains(\$name, 'resource/')");
+});
+
+test('import.php constructs write paths relative to CACTI_PATH_BASE', function () use ($importSource) {
+	expect($importSource)->toContain('CACTI_PATH_BASE . "/$name"');
+});
+
+test('import.php checks directory writability before file creation', function () use ($importSource) {
+	expect($importSource)->toContain('is_writable(dirname($filename))');
+});
+
+// =====================================================================
+// lib/import.php -- public key trust validation
+// =====================================================================
+
+test('import.php checks package public key against trusted keys', function () use ($importSource) {
+	expect($importSource)->toContain('package_public_keys');
+});
+
+test('import.php uses strict comparison for key matching', function () use ($importSource) {
+	expect($importSource)->toContain("in_array(\$public_key, \$keys, true)");
+});
+
+test('import.php retrieves Cacti official public keys', function () use ($importSource) {
+	expect($importSource)->toContain('get_public_key_sha1()');
+	expect($importSource)->toContain('get_public_key_sha256()');
+});
+
+// =====================================================================
+// lib/import.php -- no extract() or eval() on untrusted data
+// =====================================================================
+
+test('import.php does not use extract()', function () use ($importSource) {
+	expect($importSource)->not->toMatch('/\bextract\s*\(/');
+});
+
+test('import.php does not use eval()', function () use ($importSource) {
+	expect($importSource)->not->toMatch('/\beval\s*\(/');
+});
+
+// =====================================================================
+// lib/import.php -- XML parsing uses xml_parser_create (not LIBXML_NOENT)
+// =====================================================================
+
+test('xml.php uses xml_parser_create not simplexml with entity loading', function () use ($xmlSource) {
+	// Cacti xml2array uses the expat-based xml_parser_create, which does not
+	// resolve external entities. This is safer than simplexml with LIBXML_NOENT.
+	expect($xmlSource)->toContain('xml_parser_create(');
+});
+
+test('xml.php does not enable external entity loading', function () use ($xmlSource) {
+	expect($xmlSource)->not->toContain('LIBXML_NOENT');
+});
+
+// =====================================================================
+// lib/import.php -- simplexml_load_string usage (for package info only)
+// =====================================================================
+
+test('import.php uses simplexml_load_string without LIBXML_NOENT', function () use ($importSource) {
+	// simplexml_load_string is used only after signature verification
+	expect($importSource)->toContain('simplexml_load_string(');
+	expect($importSource)->not->toContain('LIBXML_NOENT');
+});
+
+// =====================================================================
+// lib/import.php -- no dynamic include/require with user paths
+// =====================================================================
+
+test('import.php only includes via CACTI_PATH_LIBRARY constant', function () use ($importSource) {
+	// Match both parenthesized form: include('path') and bare form: include 'path'
+	// so the scan does not silently miss unparenthesized includes.
+	preg_match_all('/(?:include|require)(?:_once)?\s*(?:\(([^)]+)\)|([\'"][^\'"]+[\'"]))/i', $importSource, $matches);
+
+	// $matches[1] captures parenthesized paths; $matches[2] captures bare paths
+	$paths = array_filter(array_merge($matches[1], $matches[2]));
+
+	foreach ($paths as $path) {
+		expect($path)->toContain('CACTI_PATH_LIBRARY');
+	}
+});
+
+// =====================================================================
+// lib/package.php -- openssl signature signing
+// =====================================================================
+
+test('package.php uses openssl_sign with SHA256 for package signing', function () use ($packageSource) {
+	expect($packageSource)->toContain('openssl_sign(');
+	expect($packageSource)->toContain('OPENSSL_ALGO_SHA256');
+});
+
+test('package.php uses openssl_verify for self-check after signing', function () use ($packageSource) {
+	expect($packageSource)->toContain('openssl_verify(');
+});
+
+// =====================================================================
+// lib/package.php -- file path safety
+// =====================================================================
+
+test('package.php uses basename for resource file display', function () use ($packageSource) {
+	expect($packageSource)->toContain('basename(');
+});
+
+test('package.php uses htmle for output escaping', function () use ($packageSource) {
+	expect($packageSource)->toContain('htmle(');
+});
+
+// =====================================================================
+// lib/package.php -- no eval/extract/dynamic include
+// =====================================================================
+
+test('package.php does not use extract()', function () use ($packageSource) {
+	expect($packageSource)->not->toMatch('/\bextract\s*\(/');
+});
+
+test('package.php does not use eval()', function () use ($packageSource) {
+	expect($packageSource)->not->toMatch('/\beval\s*\(/');
+});
+
+test('package.php does not use dynamic include with request-derived paths', function () use ($packageSource) {
+	// package.php has no include/require at all
+	expect($packageSource)->not->toMatch('/\b(?:include|require)(?:_once)?\s*\(/');
+});
+
+// =====================================================================
+// lib/package.php -- SQLite prepared statements
+// =====================================================================
+
+test('package.php uses SQLite prepared statements with bindValue', function () use ($packageSource) {
+	expect($packageSource)->toContain('->prepare(');
+	expect($packageSource)->toContain('->bindValue(');
+	expect($packageSource)->toContain('SQLITE3_TEXT');
+});
+
+// =====================================================================
+// Findings: patterns that do NOT exist (documented, not failing tests)
+// =====================================================================
+
+/*
+ * FINDING: import.php file write path does not use realpath() or check for
+ * directory traversal sequences (../) in the $name variable from package data.
+ * The write is gated by str_contains checks for 'scripts/' and 'resource/',
+ * and CACTI_PATH_BASE is prepended, but a crafted name like
+ * 'scripts/../../etc/something' would pass the str_contains check.
+ * The package signature verification mitigates this (attacker cannot forge
+ * a signed package), but defense-in-depth path canonicalization is absent.
+ *
+ * FINDING: import.php does not check for ZipArchive/PharData extraction
+ * because it does not use archive extraction. Packages are gzipped XML,
+ * read via compress.zlib:// stream wrapper and parsed line by line.
+ *
+ * FINDING: No CSRF token validation exists in lib/auth.php itself. CSRF
+ * protection is handled at the form/request layer (include/global_session.php),
+ * not in the auth library functions.
+ *
+ * FINDING: package.php has no curl-based remote fetches. The CURLOPT_SSL
+ * patterns are not relevant here; remote package fetching (if any) is
+ * handled elsewhere.
+ */

--- a/tests/Unit/DatabaseSecurityPatternsTest.php
+++ b/tests/Unit/DatabaseSecurityPatternsTest.php
@@ -1,0 +1,284 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Source-scan tests for lib/database.php security patterns.
+ *
+ * These tests verify structural security properties of the database layer
+ * by scanning the source code. No database connection is required.
+ *
+ * Verified patterns:
+ * - Prepared statement functions exist and use PDO parameter binding
+ * - No raw superglobals ($_GET, $_POST, $_REQUEST) in database layer
+ * - db_qstr() escaping exists for non-parameterized paths
+ * - SQL input is sanitized via db_strip_control_chars()
+ * - Error logging uses cacti_log() at debug verbosity, not echo/print
+ * - Input helper functions exist in lib/html_utility.php
+ */
+
+$dbSource = file_get_contents(
+	dirname(__DIR__, 2) . '/lib/database.php'
+);
+
+$htmlUtilSource = file_get_contents(
+	dirname(__DIR__, 2) . '/lib/html_utility.php'
+);
+
+// --- Prepared statement functions exist ---
+
+test('db_execute_prepared function is defined', function () use ($dbSource) {
+	expect($dbSource)->toContain('function db_execute_prepared(');
+});
+
+test('db_fetch_cell_prepared function is defined', function () use ($dbSource) {
+	expect($dbSource)->toContain('function db_fetch_cell_prepared(');
+});
+
+test('db_fetch_row_prepared function is defined', function () use ($dbSource) {
+	expect($dbSource)->toContain('function db_fetch_row_prepared(');
+});
+
+test('db_fetch_assoc_prepared function is defined', function () use ($dbSource) {
+	expect($dbSource)->toContain('function db_fetch_assoc_prepared(');
+});
+
+// --- Prepared functions accept a params array ---
+
+test('db_execute_prepared accepts array params parameter', function () use ($dbSource) {
+	expect($dbSource)->toMatch('/function db_execute_prepared\(string \$sql, array \$params/');
+});
+
+test('db_fetch_cell_prepared accepts array params parameter', function () use ($dbSource) {
+	expect($dbSource)->toMatch('/function db_fetch_cell_prepared\(string \$sql, array \$params/');
+});
+
+test('db_fetch_row_prepared accepts array params parameter', function () use ($dbSource) {
+	expect($dbSource)->toMatch('/function db_fetch_row_prepared\(string \$sql, array \$params/');
+});
+
+test('db_fetch_assoc_prepared accepts array params parameter', function () use ($dbSource) {
+	expect($dbSource)->toMatch('/function db_fetch_assoc_prepared\(string \$sql, array \$params/');
+});
+
+// --- PDO parameter binding is used ---
+
+test('db_execute_prepared calls PDO prepare', function () use ($dbSource) {
+	expect($dbSource)->toContain('$db_conn->prepare($sql)');
+});
+
+test('db_execute_prepared passes params to PDO execute', function () use ($dbSource) {
+	expect($dbSource)->toContain('$query->execute($params)');
+});
+
+// --- Non-prepared wrappers delegate to prepared functions ---
+
+test('db_execute delegates to db_execute_prepared', function () use ($dbSource) {
+	expect($dbSource)->toContain('function db_execute(');
+	expect($dbSource)->toContain('return db_execute_prepared($sql, [],');
+});
+
+test('db_fetch_cell delegates to db_fetch_cell_prepared', function () use ($dbSource) {
+	expect($dbSource)->toContain('return db_fetch_cell_prepared($sql, [],');
+});
+
+test('db_fetch_row delegates to db_fetch_row_prepared', function () use ($dbSource) {
+	expect($dbSource)->toContain('return db_fetch_row_prepared($sql, [],');
+});
+
+test('db_fetch_assoc delegates to db_fetch_assoc_prepared', function () use ($dbSource) {
+	expect($dbSource)->toContain('return db_fetch_assoc_prepared($sql, [],');
+});
+
+// --- No raw superglobals in database layer ---
+
+test('database.php does not reference $_GET', function () use ($dbSource) {
+	expect($dbSource)->not->toContain('$_GET');
+});
+
+test('database.php does not reference $_POST', function () use ($dbSource) {
+	expect($dbSource)->not->toContain('$_POST');
+});
+
+test('database.php does not reference $_REQUEST', function () use ($dbSource) {
+	expect($dbSource)->not->toContain('$_REQUEST');
+});
+
+test('database.php does not reference $_COOKIE', function () use ($dbSource) {
+	expect($dbSource)->not->toContain('$_COOKIE');
+});
+
+// --- db_qstr escaping function ---
+
+test('db_qstr function is defined', function () use ($dbSource) {
+	expect($dbSource)->toContain('function db_qstr(');
+});
+
+test('db_qstr uses PDO quote when connection is available', function () use ($dbSource) {
+	expect($dbSource)->toContain('$db_conn->quote($s)');
+});
+
+test('db_qstr has manual escape fallback for backslash and quotes', function () use ($dbSource) {
+	expect($dbSource)->toMatch('/str_replace\(\[.*\\\\\\\\.*\'.*\]/s');
+});
+
+// --- SQL input sanitization ---
+
+test('db_strip_control_chars function is defined', function () use ($dbSource) {
+	expect($dbSource)->toContain('function db_strip_control_chars(');
+});
+
+test('db_execute_prepared calls db_strip_control_chars on SQL', function () use ($dbSource) {
+	expect($dbSource)->toContain('$sql = db_strip_control_chars($sql)');
+});
+
+test('db_strip_control_chars strips trailing semicolons', function () use ($dbSource) {
+	expect(str_contains($dbSource, "trim(clean_up_lines(\$sql), ';')"))->toBeTrue();
+});
+
+// --- Error logging uses cacti_log at debug verbosity, not user-facing output ---
+
+test('error logging uses cacti_log with DBCALL category', function () use ($dbSource) {
+	$matches = [];
+	preg_match_all('/cacti_log\(.+?\'DBCALL\'/', $dbSource, $matches);
+	expect(count($matches[0]))->toBeGreaterThan(0);
+});
+
+test('error logging uses POLLER_VERBOSITY_DEBUG for SQL errors', function () use ($dbSource) {
+	$matches = [];
+	preg_match_all('/cacti_log\(.*SQL.*POLLER_VERBOSITY_DEBUG\)/', $dbSource, $matches);
+	expect(count($matches[0]))->toBeGreaterThan(0);
+});
+
+test('db_execute_prepared does not echo or print SQL errors', function () use ($dbSource) {
+	// Extract db_execute_prepared function body
+	$start = strpos($dbSource, 'function db_execute_prepared(');
+	if ($start === false) {
+		$this->fail('function db_execute_prepared not found in source');
+	}
+	$end = strpos($dbSource, "\nfunction ", $start + 1);
+	if ($end === false) {
+		$this->fail('no function follows db_execute_prepared in source');
+	}
+	$body = substr($dbSource, $start, $end - $start);
+
+	// No direct echo/print of error info to user
+	expect($body)->not->toMatch('/\becho\s+\$errorinfo/');
+	expect($body)->not->toMatch('/\bprint\s+\$errorinfo/');
+});
+
+// --- Error information stored in global, not exposed directly ---
+
+test('database errors are stored in database_last_error global', function () use ($dbSource) {
+	expect($dbSource)->toContain('$database_last_error');
+});
+
+test('db_error function returns the last error from global', function () use ($dbSource) {
+	expect($dbSource)->toContain('function db_error()');
+	expect($dbSource)->toMatch('/function db_error\(\).*\{[^}]*\$database_last_error/s');
+});
+
+// --- PDO exception is caught to prevent credential leakage ---
+
+test('db_connect_real catches PDOException to prevent credential leakage', function () use ($dbSource) {
+	$start = strpos($dbSource, 'function db_connect_real(');
+	if ($start === false) {
+		$this->fail('function db_connect_real not found in source');
+	}
+	$end = strpos($dbSource, "\nfunction ", $start + 1);
+	if ($end === false) {
+		$this->fail('no function follows db_connect_real in source');
+	}
+	$body = substr($dbSource, $start, $end - $start);
+
+	expect($body)->toContain('catch (PDOException $e)');
+	// The original echo/print lines are commented out
+	expect($body)->toContain('// print $e->getMessage()');
+});
+
+// --- sql_save uses db_qstr for string column values ---
+
+test('sql_save escapes string values through db_qstr', function () use ($dbSource) {
+	$start = strpos($dbSource, 'function sql_save(');
+	if ($start === false) {
+		$this->fail('function sql_save not found in source');
+	}
+	$end = strpos($dbSource, "\nfunction ", $start + 1);
+	if ($end === false) {
+		$this->fail('no function follows sql_save in source');
+	}
+	$body = substr($dbSource, $start, $end - $start);
+
+	expect($body)->toContain('db_qstr($value)');
+});
+
+// --- Connection timeout is set to limit DoS from slow DB ---
+
+test('PDO connection timeout is configured', function () use ($dbSource) {
+	expect($dbSource)->toContain('PDO::ATTR_TIMEOUT');
+});
+
+// --- Input helper functions exist in html_utility.php ---
+
+test('get_request_var function is defined', function () use ($htmlUtilSource) {
+	expect($htmlUtilSource)->toContain('function get_request_var(');
+});
+
+test('set_request_var function is defined', function () use ($htmlUtilSource) {
+	expect($htmlUtilSource)->toContain('function set_request_var(');
+});
+
+test('get_filter_request_var function is defined', function () use ($htmlUtilSource) {
+	expect($htmlUtilSource)->toContain('function get_filter_request_var(');
+});
+
+test('get_nfilter_request_var function is defined', function () use ($htmlUtilSource) {
+	expect($htmlUtilSource)->toContain('function get_nfilter_request_var(');
+});
+
+test('get_filter_request_var uses filter_var for validation', function () use ($htmlUtilSource) {
+	$start = strpos($htmlUtilSource, 'function get_filter_request_var(');
+	if ($start === false) {
+		$this->fail('function get_filter_request_var not found in source');
+	}
+	$end = strpos($htmlUtilSource, "\nfunction ", $start + 1);
+	if ($end === false) {
+		$this->fail('no function follows get_filter_request_var in source');
+	}
+	$body = substr($htmlUtilSource, $start, $end - $start);
+
+	expect($body)->toContain('filter_var(');
+});
+
+test('get_filter_request_var defaults to FILTER_VALIDATE_INT', function () use ($htmlUtilSource) {
+	expect($htmlUtilSource)->toMatch(
+		'/function get_filter_request_var\(string \$name, int \$filter = FILTER_VALIDATE_INT/'
+	);
+});
+
+// --- Shorthand aliases exist for input helpers ---
+
+test('grv alias exists for get_request_var', function () use ($htmlUtilSource) {
+	expect($htmlUtilSource)->toContain('function grv(');
+	expect($htmlUtilSource)->toContain('return get_request_var($name');
+});
+
+test('gfrv alias exists for get_filter_request_var', function () use ($htmlUtilSource) {
+	expect($htmlUtilSource)->toContain('function gfrv(');
+	expect($htmlUtilSource)->toContain('return get_filter_request_var($name');
+});
+
+test('gnrv alias exists for get_nfilter_request_var', function () use ($htmlUtilSource) {
+	expect($htmlUtilSource)->toContain('function gnrv(');
+	expect($htmlUtilSource)->toContain('return get_nfilter_request_var($name');
+});

--- a/tests/Unit/SecurityPrRegressionTest.php
+++ b/tests/Unit/SecurityPrRegressionTest.php
@@ -1,0 +1,142 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression tests for merged security PRs.
+ * Source-scan tests verify that security fixes remain in place.
+ *
+ * PR #6971: rrdtool tune shell escaping in lib/rrd.php
+ * PR #6973: graph_theme LFI prevention in lib/rrd.php
+ * PR #6974: remote_agent effective_user and OID validation
+ */
+
+$rrdPath         = __DIR__ . '/../../lib/rrd.php';
+$remoteAgentPath = __DIR__ . '/../../remote_agent.php';
+
+// --- PR #6971: rrdtool_function_tune shell escaping ---
+
+test('rrdtool_function_tune uses cacti_escapeshellcmd for rrdtool binary path', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	expect($contents)->toContain("cacti_escapeshellcmd(read_config_option('path_rrdtool'))");
+});
+
+test('rrdtool_function_tune uses cacti_escapeshellarg for data_source_path', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	// The tune command line must escape the data source path
+	expect($contents)->toMatch('/cacti_escapeshellcmd\(.*path_rrdtool.*\)\s*\.\s*\'\s*tune\s*\'\s*\.\s*cacti_escapeshellarg\(\$data_source_path\)/');
+});
+
+test('rrdtool_function_tune uses cacti_escapeshellarg for --heartbeat flag', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	expect($contents)->toMatch('/--heartbeat.*cacti_escapeshellarg\(\$data_source_name\s*\.\s*\':\'/');
+});
+
+test('rrdtool_function_tune uses cacti_escapeshellarg for --minimum flag', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	expect($contents)->toMatch('/--minimum.*cacti_escapeshellarg\(\$data_source_name\s*\.\s*\':\'/');
+});
+
+test('rrdtool_function_tune uses cacti_escapeshellarg for --maximum flag', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	expect($contents)->toMatch('/--maximum.*cacti_escapeshellarg\(\$data_source_name\s*\.\s*\':\'/');
+});
+
+test('rrdtool_function_tune uses cacti_escapeshellarg for --data-source-type flag', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	expect($contents)->toMatch('/--data-source-type.*cacti_escapeshellarg\(\$data_source_name\s*\.\s*\':\'/');
+});
+
+test('rrdtool_function_tune uses cacti_escapeshellarg for --data-source-rename flag', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	expect($contents)->toMatch('/--data-source-rename.*cacti_escapeshellarg\(\$data_source_name\s*\.\s*\':\'/');
+});
+
+test('rrdtool_function_tune does not pass raw data_source_path to popen', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	// Extract just the rrdtool_function_tune function body
+	$start = strpos($contents, 'function rrdtool_function_tune(');
+	if ($start === false) {
+		$this->fail('function rrdtool_function_tune not found in source');
+	}
+	$nextFunc = strpos($contents, "\nfunction ", $start + 1);
+	if ($nextFunc === false) {
+		$this->fail('no function follows rrdtool_function_tune in source');
+	}
+	$tuneBody = substr($contents, $start, $nextFunc - $start);
+
+	// popen should receive $rrd_cmd (pre-escaped), not raw $data_source_path
+	expect($tuneBody)->toContain('popen($rrd_cmd,');
+	expect($tuneBody)->not->toMatch('/popen\s*\([^)]*\$data_source_path/');
+});
+
+// --- PR #6973: graph_theme LFI prevention via basename() ---
+
+test('rrd graph theme applies basename to prevent path traversal', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	expect($contents)->toContain("basename(\$graph_data_array['graph_theme'])");
+});
+
+test('rrd graph theme rejects dot-only basename values', function () use ($rrdPath) {
+	$contents = file_get_contents($rrdPath);
+
+	// After basename(), the code must reject '.' and '..' to prevent traversal
+	expect($contents)->toContain("\$theme === '.'");
+	expect($contents)->toContain("\$theme === '..'");
+});
+
+// --- PR #6974: remote_agent effective_user and OID validation ---
+
+test('remote_agent registers effective_user with gfrv for int validation', function () use ($remoteAgentPath) {
+	$contents = file_get_contents($remoteAgentPath);
+
+	// gfrv() defaults to FILTER_VALIDATE_INT, ensuring effective_user is validated
+	expect($contents)->toContain("gfrv('effective_user')");
+});
+
+test('remote_agent OID validation regex in get_snmp_data', function () use ($remoteAgentPath) {
+	$contents = file_get_contents($remoteAgentPath);
+
+	// OID must match digits-and-dots only pattern: /^[0-9.]+$/
+	expect(str_contains($contents, "preg_match('/^[0-9.]+$/', \$oid)"))->toBeTrue();
+});
+
+test('remote_agent validates OID as string before regex check', function () use ($remoteAgentPath) {
+	$contents = file_get_contents($remoteAgentPath);
+
+	// Type check must precede regex to prevent type juggling
+	expect($contents)->toContain('!is_string($oid)');
+});
+
+test('remote_agent OID validation exists in get_snmp_data_walk', function () use ($remoteAgentPath) {
+	$contents = file_get_contents($remoteAgentPath);
+
+	// Both get_snmp_data and get_snmp_data_walk must validate OIDs
+	$walkStart = strpos($contents, 'function get_snmp_data_walk()');
+	if ($walkStart === false) {
+		$this->fail('function get_snmp_data_walk not found in source');
+	}
+	$walkBody = substr($contents, $walkStart, 600);
+
+	expect($walkBody)->toContain('!is_string($oid)');
+	expect(str_contains($walkBody, "preg_match('/^[0-9.]+$/', \$oid)"))->toBeTrue();
+});


### PR DESCRIPTION
Source-scan coverage backstop for recently-fixed security surfaces. These tests assert that mitigation patterns exist in the source; they are not a replacement for behavioral tests.

**Scope:**
- \`DatabaseSecurityPatternsTest\`: prepared-statement signatures and no-superglobal invariants in \`lib/database.php\`
- \`AuthImportSecurityPatternsTest\`: basename() guards, include/require path scan, session constant usage in \`lib/auth.php\` and \`lib/import.php\`
- \`SecurityPrRegressionTest\`: invariants locked in by #6971, #6973, #6974

**What these tests do not cover:** runtime behavior, actual query execution, or auth flows. A follow-up issue should add behavioral coverage once a DB-backed test harness is available.

**Copilot feedback addressed:**
- All \`strpos()\`/\`substr()\` offset uses now have explicit \`fail()\` early-outs so a renamed or missing function produces a clear failure rather than a vacuous pass.
- The \`include\`/\`require\` scan regex now matches both parenthesized (\`include('path')\`) and bare (\`include 'path'\`) forms.