### PR TITLE
fix(security): harden db_qstr fallback and db_dump_data credential handling (1.2.x)

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -1953,7 +1953,9 @@ function db_qstr($s, $db_conn = false) {
 		return $db_conn->quote($s);
 	}
 
-	$s = str_replace(array('\\', "\0", "'"), array('\\\\', "\\\0", "\\'"), $s);
+	cacti_log('WARNING: db_qstr() called without a valid database connection. Escaping may be unsafe.', false, 'SECURITY');
+
+	$s = str_replace(array('\\', "\0", "\n", "\r", "'", '"', "\x1a"), array('\\\\', '\\0', '\\n', '\\r', "\\'", '\\"', '\\Z'), $s);
 
 	return  "'" . $s . "'";
 }
@@ -2248,13 +2250,33 @@ function db_dump_data($database = '', $tables = '', $credentials = array(), $out
 	if (strstr($options, '--defaults-extra-file') !== false) {
 		exec("mysqldump $options $credentials_string $safe_database $tables > " . $safe_output, $output, $retval);
 	} else {
-		exec("mysqldump $options $credentials_string " . $safe_database . ' version >/dev/null 2>&1', $output, $retval);
+		/* Use proc_open with MYSQL_PWD env var to avoid exposing the
+		   password in the process list visible via ps aux or /proc. */
+		$env = null;
 
-		if ($retval) {
-			$pass_arg = ($password != '') ? ' -p' . cacti_escapeshellarg($password) : '';
-			exec("mysqldump $options $credentials_string -u" . cacti_escapeshellarg($username) . $pass_arg . ' ' . $safe_database . " $tables > " . $safe_output, $output, $retval);
+		if ($password != '') {
+			$env = array('MYSQL_PWD' => $password);
+		}
+
+		$cmd = "mysqldump $options $credentials_string -u" . cacti_escapeshellarg($username) . ' ' . $safe_database . " $tables > " . $safe_output . ' 2>&1';
+
+		$descriptors = array(
+			0 => array('pipe', 'r'),
+			1 => array('pipe', 'w'),
+			2 => array('pipe', 'w')
+		);
+
+		$process = proc_open($cmd, $descriptors, $pipes, null, $env);
+
+		if (is_resource($process)) {
+			fclose($pipes[0]);
+			fclose($pipes[1]);
+			fclose($pipes[2]);
+
+			$retval = proc_close($process);
 		} else {
-			exec("mysqldump $options $credentials_string $safe_database $tables > " . $safe_output, $output, $retval);
+			cacti_log('ERROR: Failed to initialize mysqldump process.', false, 'SYSTEM');
+			$retval = 1;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `db_qstr()`: add security warning log when fallback escaping is used without PDO, improve escaping to cover newlines, CR, double quotes, and SUB character
- `db_dump_data()`: use `proc_open()` with `MYSQL_PWD` environment variable instead of passing password via command-line arguments visible in `ps aux`

Closes #6990, closes #6991

## Test plan
- [ ] Verify `db_dump_data` produces valid mysqldump output
- [ ] Verify password is not visible in process list during dump
- [ ] Verify `db_qstr()` logs warning when no PDO connection available