### PR TITLE
fix(security): escape html_filter form attributes and JS context (1.2.x)

### DIFF
--- a/lib/html_filter.php
+++ b/lib/html_filter.php
@@ -154,7 +154,7 @@ class CactiTableFilter {
 		html_start_box($this->form_header, $this->form_width, true, '3', 'center', $this->action_url, $this->action_label);
 
 		if (isset($this->filter_array['rows'])) {
-			print "<form id='" . htmlspecialchars($this->form_id, ENT_QUOTES, 'UTF-8') . "' action='" . htmlspecialchars($this->form_action, ENT_QUOTES, 'UTF-8') . "'>\n";
+			print "<form id='" . html_escape($this->form_id) . "' action='" . html_escape($this->form_action) . "'>\n";
 
 			foreach($this->filter_array['rows'] as $index => $row) {
 				print "<div class='filterTable'>\n";
@@ -261,7 +261,7 @@ class CactiTableFilter {
 		}
 
 		$(function() {
-			$('#<?php print htmlspecialchars($this->form_id, ENT_QUOTES, 'UTF-8');?>').submit(function(event) {
+			$('#<?php print html_escape($this->form_id);?>').submit(function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/lib/html_filter.php
+++ b/lib/html_filter.php
@@ -154,7 +154,7 @@ class CactiTableFilter {
 		html_start_box($this->form_header, $this->form_width, true, '3', 'center', $this->action_url, $this->action_label);
 
 		if (isset($this->filter_array['rows'])) {
-			print "<form id='" . $this->form_id . "' action='" . $this->form_action . "'>\n";
+			print "<form id='" . htmlspecialchars($this->form_id, ENT_QUOTES, 'UTF-8') . "' action='" . htmlspecialchars($this->form_action, ENT_QUOTES, 'UTF-8') . "'>\n";
 
 			foreach($this->filter_array['rows'] as $index => $row) {
 				print "<div class='filterTable'>\n";
@@ -261,7 +261,7 @@ class CactiTableFilter {
 		}
 
 		$(function() {
-			$('#<?php print $this->form_id;?>').submit(function(event) {
+			$('#<?php print htmlspecialchars($this->form_id, ENT_QUOTES, 'UTF-8');?>').submit(function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/tests/Unit/HtmlFilterXssTest.php
+++ b/tests/Unit/HtmlFilterXssTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$htmlFilterSource = file_get_contents(dirname(__DIR__, 2) . '/lib/html_filter.php');
+
+test('form_id is escaped with htmlspecialchars in create_filter', function () use ($htmlFilterSource) {
+	expect(str_contains($htmlFilterSource, 'htmlspecialchars($this->form_id'))
+		->toBeTrue();
+});
+
+test('form_action is escaped with htmlspecialchars in create_filter', function () use ($htmlFilterSource) {
+	expect(str_contains($htmlFilterSource, 'htmlspecialchars($this->form_action'))
+		->toBeTrue();
+});
+
+test('form_id escaping uses ENT_QUOTES and UTF-8', function () use ($htmlFilterSource) {
+	expect(str_contains($htmlFilterSource, "htmlspecialchars(\$this->form_id, ENT_QUOTES, 'UTF-8')"))
+		->toBeTrue();
+});
+
+test('form_action escaping uses ENT_QUOTES and UTF-8', function () use ($htmlFilterSource) {
+	expect(str_contains($htmlFilterSource, "htmlspecialchars(\$this->form_action, ENT_QUOTES, 'UTF-8')"))
+		->toBeTrue();
+});
+
+test('form_id is also escaped in create_javascript', function () use ($htmlFilterSource) {
+	// The JS section also prints form_id for the jQuery selector
+	$count = substr_count($htmlFilterSource, 'htmlspecialchars($this->form_id');
+	expect($count)->toBeGreaterThanOrEqual(2);
+});


### PR DESCRIPTION
## Summary
- Escape `form_id` and `form_action` with `htmlspecialchars()` in HTML attribute context
- Escape `form_id` in jQuery selector context
- 2-line change in `lib/html_filter.php`

Closes #6992

## Test plan
- [ ] Verify table filters render and function correctly
- [ ] Verify form submission and AJAX filter apply still work