### PR TITLE
fix(security): harden auth lockout, CSPRNG fallback, error escaping, and redirect (1.2.x)

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -3555,8 +3555,15 @@ function auth_process_lockout($username, $realm) {
 				array($username, $realm));
 
 			if (cacti_sizeof($user)) {
+				/* Atomic increment to prevent TOCTOU race in concurrent requests */
+				db_execute_prepared("UPDATE user_auth
+					SET lastfail = ?, failed_attempts = failed_attempts + 1
+					WHERE username = ?
+					AND realm = ?",
+					array(time(), $username, $realm));
+
 				if ($user['enabled'] == '') {
-					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "'. User account Disabled.", false, 'AUTH');
+					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "' from IP Address '" . get_client_addr() . "'.  User account Disabled.", false, 'AUTH');
 
 					$error     = true;
 					$error_msg = __('Access Denied!  Login Disabled.');
@@ -3564,19 +3571,12 @@ function auth_process_lockout($username, $realm) {
 					return;
 				}
 
-				/* Atomic increment to prevent TOCTOU race in concurrent requests */
-				db_execute_prepared("UPDATE user_auth
-					SET lastfail = ?, failed_attempts = failed_attempts + 1
-					WHERE username = ?
-					AND realm = ?
-					AND enabled = 'on'",
-					array(time(), $username, $realm));
-
 				/* Retrieve deterministic state post-increment */
 				$failed = db_fetch_cell_prepared("SELECT failed_attempts
 					FROM user_auth
 					WHERE username = ?
-					AND realm = ?",
+					AND realm = ?
+					AND enabled = 'on'",
 					array($username, $realm));
 
 				cacti_log("LOGIN FAILED: User '$username' failed authentication, incrementing lockout ($failed of $max)", false, 'AUTH', POLLER_VERBOSITY_LOW);
@@ -3598,18 +3598,18 @@ function auth_process_lockout($username, $realm) {
 					array($username, isset($user['id']) ? $user['id']:0, get_client_addr()));
 
 				if ($user['locked'] == 'on') {
-					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "'. Account is locked out.", false, 'AUTH');
+					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "' from IP Address '" . get_client_addr() . "'.  Account is locked out.", false, 'AUTH');
 
 					$error     = true;
 					$error_msg = __('Your account has been locked.  Please contact your Administrator.');
 				} else {
-					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "'.", false, 'AUTH');
+					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "' from IP Address '" . get_client_addr() . "'.", false, 'AUTH');
 
 					$error     = true;
 					$error_msg = __('Access Denied!  Login Failed.');
 				}
 			} else {
-				cacti_log("LOGIN FAILED: Local Login Failed to find user '" . $username . "'.", false, 'AUTH');
+				cacti_log("LOGIN FAILED: Local Login Failed to find user '" . $username . "' from IP Address '" . get_client_addr() . "'.", false, 'AUTH');
 
 				$error     = true;
 				$error_msg = __('Access Denied!  Login Failed.');
@@ -4636,7 +4636,7 @@ function auth_display_custom_error_message($message) {
 
 	print '</head>';
 	print '<body><center>';
-	print '<div class="ui-state-error ui-corner-all" style="width:50%;margin-left:auto;margin-right:auto;margin-top:200px;padding:20px"><p>' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '</p><p>' . htmlspecialchars($custom_message, ENT_QUOTES, 'UTF-8') . '</p></div>';
+	print '<div class="ui-state-error ui-corner-all" style="width:50%;margin-left:auto;margin-right:auto;margin-top:200px;padding:20px"><p>' . html_escape($message) . '</p><p>' . html_escape($custom_message) . '</p></div>';
 
 	if ($auth_method != 2) {
 		print '<div class="ui-corner-all" style="width:50%;margin:auto;padding:20px"><a href="index.php">' . __('Login Again') . '</a></div><script type="text/javascript">$(function() { $("a").button(); });</script>';
@@ -4676,17 +4676,13 @@ function auth_login_redirect($login_opts = '') {
 			 * have console access
 			 */
 			if (isset($_SERVER['REDIRECT_URL'])) {
-				$referer = sanitize_uri($_SERVER['REDIRECT_URL']);
-
-				/* Enforce relative path to prevent open redirect via
-				   protocol-relative URLs (//evil.com) or external schemes */
-				if ($referer !== '' && ($referer[0] !== '/' || (isset($referer[1]) && $referer[1] === '/'))) {
-					$referer = $config['url_path'] . 'index.php';
-				}
+				$redirect_url = $_SERVER['REDIRECT_URL'];
 
 				if (isset($_SERVER['REDIRECT_QUERY_STRING'])) {
-					$referer .= '?' . $_SERVER['REDIRECT_QUERY_STRING'];
+					$redirect_url .= '?' . $_SERVER['REDIRECT_QUERY_STRING'];
 				}
+
+				$referer = validate_redirect_url($redirect_url);
 
 				cacti_log(sprintf("DEBUG: Referer from REDIRECT_URL with Value: '%s', Effective: '%s'", $_SERVER['REDIRECT_URL'], $referer), false, 'AUTH', POLLER_VERBOSITY_DEBUG);
 			} elseif (isset($_SERVER['HTTP_REFERER'])) {

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -82,7 +82,9 @@ function set_auth_cookie($user) {
 		try {
 			$nssecret = bin2hex(random_bytes(32));
 		} catch (Exception $e) {
-			$nssecret = md5($_SERVER['REQUEST_TIME'] . mt_rand(10000, 10000000)) . md5(get_client_addr());
+			cacti_log('FATAL: CSPRNG failed. Cannot generate secure authentication token.', false, 'AUTH');
+
+			return false;
 		}
 
 		$secret = hash('sha512', $nssecret, false);
@@ -3542,12 +3544,11 @@ function auth_process_lockout_check($username, $realm) {
 function auth_process_lockout($username, $realm) {
 	global $error, $error_msg;
 
-	// Mark failed login attempts
 	$secPassLockFailed = read_config_option('secpass_lockfailed');
 	if ($secPassLockFailed > 0) {
 		$max = intval($secPassLockFailed);
 		if ($max > 0) {
-			$user = db_fetch_row_prepared("SELECT id, username, enabled, lastfail, failed_attempts, `locked`, password
+			$user = db_fetch_row_prepared("SELECT id, enabled, `locked`
 				FROM user_auth
 				WHERE username = ?
 				AND realm = ?",
@@ -3555,17 +3556,32 @@ function auth_process_lockout($username, $realm) {
 
 			if (cacti_sizeof($user)) {
 				if ($user['enabled'] == '') {
-					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "' from IP Address '" . get_client_addr() . "'.  User account Disabled.", false, 'AUTH');
+					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "'. User account Disabled.", false, 'AUTH');
 
 					$error     = true;
 					$error_msg = __('Access Denied!  Login Disabled.');
+
+					return;
 				}
 
-				$failed = intval($user['failed_attempts']) + 1;
+				/* Atomic increment to prevent TOCTOU race in concurrent requests */
+				db_execute_prepared("UPDATE user_auth
+					SET lastfail = ?, failed_attempts = failed_attempts + 1
+					WHERE username = ?
+					AND realm = ?
+					AND enabled = 'on'",
+					array(time(), $username, $realm));
 
-				cacti_log('LOGIN FAILED: User \'' . $username . '\' failed authentication, incrementing lockout (' . $failed . ' of ' . $max . ')', false, 'AUTH', POLLER_VERBOSITY_LOW);
+				/* Retrieve deterministic state post-increment */
+				$failed = db_fetch_cell_prepared("SELECT failed_attempts
+					FROM user_auth
+					WHERE username = ?
+					AND realm = ?",
+					array($username, $realm));
 
-				if ($failed >= $max) {
+				cacti_log("LOGIN FAILED: User '$username' failed authentication, incrementing lockout ($failed of $max)", false, 'AUTH', POLLER_VERBOSITY_LOW);
+
+				if ($failed >= $max && $user['locked'] != 'on') {
 					db_execute_prepared("UPDATE user_auth
 						SET `locked` = 'on'
 						WHERE username = ?
@@ -3576,35 +3592,24 @@ function auth_process_lockout($username, $realm) {
 					$user['locked'] = 'on';
 				}
 
-				$user['lastfail'] = time();
-
-				db_execute_prepared("UPDATE user_auth
-					SET lastfail = ?, failed_attempts = ?
-					WHERE username = ?
-					AND realm = ?
-					AND enabled = 'on'",
-					array($user['lastfail'], $failed, $username, $realm));
-
-				// Log the invalid password attempt
 				db_execute_prepared('INSERT IGNORE INTO user_log
 					(username, user_id, result, ip, time)
 					VALUES (?, ?, 0, ?, NOW())',
 					array($username, isset($user['id']) ? $user['id']:0, get_client_addr()));
 
 				if ($user['locked'] == 'on') {
-					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "' from IP Address '" . get_client_addr() . "'.  Account is locked out.", false, 'AUTH');
+					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "'. Account is locked out.", false, 'AUTH');
 
 					$error     = true;
 					$error_msg = __('Your account has been locked.  Please contact your Administrator.');
 				} else {
-					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "' from IP Address '" . get_client_addr() . "'.", false, 'AUTH');
+					cacti_log("LOGIN FAILED: Local Login Failed for user '" . $username . "'.", false, 'AUTH');
 
-					/* error */
 					$error     = true;
 					$error_msg = __('Access Denied!  Login Failed.');
 				}
 			} else {
-				cacti_log("LOGIN FAILED: Local Login Failed to find user '" . $username . "' from IP Address '" . get_client_addr() . "'.", false, 'AUTH');
+				cacti_log("LOGIN FAILED: Local Login Failed to find user '" . $username . "'.", false, 'AUTH');
 
 				$error     = true;
 				$error_msg = __('Access Denied!  Login Failed.');
@@ -4631,7 +4636,7 @@ function auth_display_custom_error_message($message) {
 
 	print '</head>';
 	print '<body><center>';
-	print '<div class="ui-state-error ui-corner-all" style="width:50%;margin-left:auto;margin-right:auto;margin-top:200px;padding:20px"><p>' . $message . '</p><p>' . $custom_message . '</p></div>';
+	print '<div class="ui-state-error ui-corner-all" style="width:50%;margin-left:auto;margin-right:auto;margin-top:200px;padding:20px"><p>' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '</p><p>' . htmlspecialchars($custom_message, ENT_QUOTES, 'UTF-8') . '</p></div>';
 
 	if ($auth_method != 2) {
 		print '<div class="ui-corner-all" style="width:50%;margin:auto;padding:20px"><a href="index.php">' . __('Login Again') . '</a></div><script type="text/javascript">$(function() { $("a").button(); });</script>';
@@ -4672,6 +4677,12 @@ function auth_login_redirect($login_opts = '') {
 			 */
 			if (isset($_SERVER['REDIRECT_URL'])) {
 				$referer = sanitize_uri($_SERVER['REDIRECT_URL']);
+
+				/* Enforce relative path to prevent open redirect via
+				   protocol-relative URLs (//evil.com) or external schemes */
+				if ($referer !== '' && ($referer[0] !== '/' || (isset($referer[1]) && $referer[1] === '/'))) {
+					$referer = $config['url_path'] . 'index.php';
+				}
 
 				if (isset($_SERVER['REDIRECT_QUERY_STRING'])) {
 					$referer .= '?' . $_SERVER['REDIRECT_QUERY_STRING'];

--- a/tests/Unit/AuthLoginHardeningTest.php
+++ b/tests/Unit/AuthLoginHardeningTest.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$authSource = file_get_contents(dirname(__DIR__, 2) . '/lib/auth.php');
+
+test('auth_process_lockout uses atomic SQL increment for failed_attempts', function () use ($authSource) {
+	// The fix replaces SELECT-then-UPDATE with a single atomic UPDATE
+	expect(str_contains($authSource, 'failed_attempts = failed_attempts + 1'))
+		->toBeTrue();
+});
+
+test('auth_process_lockout atomic increment is inside auth_process_lockout function', function () use ($authSource) {
+	// Extract the function body and verify the pattern is there
+	$start = strpos($authSource, 'function auth_process_lockout(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 2000);
+	expect(str_contains($body, 'failed_attempts = failed_attempts + 1'))
+		->toBeTrue();
+});
+
+test('set_auth_cookie does not use mt_rand', function () use ($authSource) {
+	// Extract set_auth_cookie function body
+	$start = strpos($authSource, 'function set_auth_cookie(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 1000);
+	expect(str_contains($body, 'mt_rand'))
+		->toBeFalse();
+});
+
+test('set_auth_cookie does not use md5 with REQUEST_TIME', function () use ($authSource) {
+	$start = strpos($authSource, 'function set_auth_cookie(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 1000);
+	expect(str_contains($body, "md5(\$_SERVER['REQUEST_TIME']"))
+		->toBeFalse();
+});
+
+test('set_auth_cookie uses random_bytes for CSPRNG', function () use ($authSource) {
+	$start = strpos($authSource, 'function set_auth_cookie(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 1000);
+	expect(str_contains($body, 'random_bytes('))
+		->toBeTrue();
+});
+
+test('set_auth_cookie fails closed on CSPRNG failure', function () use ($authSource) {
+	$start = strpos($authSource, 'function set_auth_cookie(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 1000);
+	// Must catch Exception from random_bytes and return false
+	expect(str_contains($body, 'catch (Exception'))
+		->toBeTrue();
+	expect(str_contains($body, 'return false'))
+		->toBeTrue();
+});
+
+test('auth_display_custom_error_message escapes message with htmlspecialchars', function () use ($authSource) {
+	$start = strpos($authSource, 'function auth_display_custom_error_message(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 1500);
+	expect(str_contains($body, 'htmlspecialchars($message'))
+		->toBeTrue();
+});
+
+test('auth_display_custom_error_message escapes custom_message with htmlspecialchars', function () use ($authSource) {
+	$start = strpos($authSource, 'function auth_display_custom_error_message(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 1500);
+	expect(str_contains($body, 'htmlspecialchars($custom_message'))
+		->toBeTrue();
+});
+
+test('auth_login_redirect blocks protocol-relative open redirect', function () use ($authSource) {
+	$start = strpos($authSource, 'function auth_login_redirect(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 3000);
+	// The fix checks that $referer[1] === '/' to block //evil.com
+	expect(str_contains($body, "\$referer[1] === '/'"))
+		->toBeTrue();
+});
+
+test('auth_login_redirect validates referer starts with slash', function () use ($authSource) {
+	$start = strpos($authSource, 'function auth_login_redirect(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 3000);
+	// Must check $referer[0] to ensure path is relative
+	expect(str_contains($body, "\$referer[0] !== '/'"))
+		->toBeTrue();
+});


### PR DESCRIPTION
## Summary
Four targeted security fixes in `lib/auth.php`:

1. **TOCTOU lockout bypass** (#6996): atomic `failed_attempts = failed_attempts + 1` prevents concurrent brute-force requests from bypassing the lockout threshold
2. **CSPRNG fallback** (#6997): remove predictable `mt_rand()` fallback in `set_auth_cookie()`; fail closed if `random_bytes()` is unavailable
3. **XSS in error display** (#6998): escape `$message` and `$custom_message` with `htmlspecialchars()` in `auth_display_custom_error_message()`
4. **Open redirect** (#6999): enforce relative path validation on `REDIRECT_URL` (reject protocol-relative `//` URLs)

Closes #6996, closes #6997, closes #6998, closes #6999

## Test plan
- [ ] Verify login lockout triggers correctly after N failed attempts
- [ ] Verify remember-me cookie is not set if CSPRNG fails
- [ ] Verify LDAP error messages render as text, not HTML
- [ ] Verify post-login redirect works for valid relative paths
- [ ] Verify `//evil.com` in REDIRECT_URL redirects to index.php instead