### PR TITLE
hardening: harden utility.php binary validation, output escaping, and PRNG (1.2.x)

### DIFF
--- a/lib/utility.php
+++ b/lib/utility.php
@@ -27,11 +27,17 @@
    @arg $poller_id - the id of the poller impacted by hash update
    @arg $variable  - the variable name to store in the settings table */
 function update_replication_crc($poller_id, $variable) {
-	$hash = hash('ripemd160', date('Y-m-d H:i:s') . rand() . $poller_id);
+	try {
+		$entropy = bin2hex(random_bytes(16));
+	} catch (Exception $e) {
+		$entropy = md5(uniqid('', true) . mt_rand());
+	}
 
-	db_execute_prepared("REPLACE INTO settings
-		SET value = ?, name='$variable" . ($poller_id > 0 ? "_" . "$poller_id'":"'"),
-		array($hash));
+	$hash         = hash('ripemd160', date('Y-m-d H:i:s') . $entropy . $poller_id);
+	$setting_name = $variable . ($poller_id > 0 ? '_' . $poller_id : '');
+
+	db_execute_prepared('REPLACE INTO settings (name, value) VALUES (?, ?)',
+		array($setting_name, $hash));
 }
 
 function repopulate_poller_cache() {
@@ -121,11 +127,14 @@ function update_poller_cache_from_query($host_id, $data_query_id, $local_data_id
 
 	include_once($config['library_path'] . '/api_data_source.php');
 
+	/* SECURITY: Cast all elements to integers to prevent SQL Injection */
+	$safe_ids = array_map('intval', $local_data_ids);
+
 	$poller_data = db_fetch_assoc_prepared('SELECT ' . SQL_NO_CACHE . ' *
 		FROM data_local
 		WHERE host_id = ?
 		AND snmp_query_id = ?
-		AND id IN(' . implode(', ', $local_data_ids) . ')
+		AND id IN(' . implode(', ', $safe_ids) . ')
 		AND snmp_index != ""',
 		array($host_id, $data_query_id));
 
@@ -614,7 +623,9 @@ function poller_update_poller_cache_from_buffer($local_data_ids, &$poller_items,
 
 	/* set all fields present value to 0, to mark the outliers when we are all done */
 	if (cacti_sizeof($local_data_ids)) {
-		$ids = implode(', ', $local_data_ids);
+		/* SECURITY: Cast all elements to integers to prevent SQL Injection */
+		$safe_ids = array_map('intval', $local_data_ids);
+		$ids      = implode(', ', $safe_ids);
 
 		if ($ids != '') {
 			db_execute_prepared("UPDATE poller_item
@@ -1641,11 +1652,11 @@ function utilities_get_mysql_recommendations() {
 
 				form_alternate_row();
 
-				print "<td>" . $name . "</td>";
-				print "<td class='right $class'>$value_display</td>";
-				print "<td class='center'>$compare</td>";
-				print "<td>$value_recommend</td>";
-				print "<td class='$class'>" . $r['comment'] . "</td>";
+				print '<td>' . html_escape($name) . '</td>';
+				print "<td class='right $class'>" . html_escape($value_display) . '</td>';
+				print "<td class='center'>" . html_escape($compare) . '</td>';
+				print '<td>' . html_escape($value_recommend) . '</td>';
+				print "<td class='$class'>" . html_escape($r['comment']) . '</td>';
 
 				form_end_row();
 			}
@@ -1798,9 +1809,18 @@ function utility_php_sort_extensions($a, $b) {
 function utility_php_extensions() {
 	global $config;
 
-	$php = cacti_escapeshellcmd(read_config_option('path_php_binary', true));
+	$php_binary = read_config_option('path_php_binary', true);
+
+	/* SECURITY: Validate the binary path prevents RCE if the database is compromised */
+	if (empty($php_binary) || !is_executable($php_binary) || !preg_match('/^php[0-9.]*(?:-cgi|-fpm)?(?:\.exe)?$/i', basename($php_binary))) {
+		cacti_log('ERROR: Invalid or non-executable PHP binary path configured: ' . $php_binary, false, 'SYSTEM');
+
+		return array();
+	}
+
+	$php      = cacti_escapeshellcmd($php_binary);
 	$php_file = cacti_escapeshellarg($config['base_path'] . '/install/cli_check.php') . ' extensions';
-	$json = shell_exec($php . ' -q ' . $php_file);
+	$json     = shell_exec($php . ' -q ' . $php_file);
 	$ext = @json_decode($json, true);
 
 	utility_php_verify_extensions($ext, 'web');
@@ -1857,9 +1877,18 @@ function utility_php_verify_extensions(&$extensions, $source) {
 function utility_php_recommends() {
 	global $config;
 
-	$php = cacti_escapeshellcmd(read_config_option('path_php_binary', true));
+	$php_binary = read_config_option('path_php_binary', true);
+
+	/* SECURITY: Validate the binary path prevents RCE if the database is compromised */
+	if (empty($php_binary) || !is_executable($php_binary) || !preg_match('/^php[0-9.]*(?:-cgi|-fpm)?(?:\.exe)?$/i', basename($php_binary))) {
+		cacti_log('ERROR: Invalid or non-executable PHP binary path configured: ' . $php_binary, false, 'SYSTEM');
+
+		return array();
+	}
+
+	$php      = cacti_escapeshellcmd($php_binary);
 	$php_file = cacti_escapeshellarg($config['base_path'] . '/install/cli_check.php') . ' recommends';
-	$json = shell_exec($php . ' -q ' . $php_file);
+	$json     = shell_exec($php . ' -q ' . $php_file);
 	$ext = array('web' => '', 'cli' => '');
 	$ext['cli'] = @json_decode($json, true);
 
@@ -1980,9 +2009,18 @@ function utility_php_set_recommends_text(&$recs) {
 function utility_php_optionals() {
 	global $config;
 
-	$php = cacti_escapeshellcmd(read_config_option('path_php_binary', true));
+	$php_binary = read_config_option('path_php_binary', true);
+
+	/* SECURITY: Validate the binary path prevents RCE if the database is compromised */
+	if (empty($php_binary) || !is_executable($php_binary) || !preg_match('/^php[0-9.]*(?:-cgi|-fpm)?(?:\.exe)?$/i', basename($php_binary))) {
+		cacti_log('ERROR: Invalid or non-executable PHP binary path configured: ' . $php_binary, false, 'SYSTEM');
+
+		return array();
+	}
+
+	$php      = cacti_escapeshellcmd($php_binary);
 	$php_file = cacti_escapeshellarg($config['base_path'] . '/install/cli_check.php') . ' optionals';
-	$json = shell_exec($php . ' -q ' . $php_file);
+	$json     = shell_exec($php . ' -q ' . $php_file);
 	$opt = @json_decode($json, true);
 
 	utility_php_verify_optionals($opt, 'web');

--- a/tests/Unit/UtilitySecurityHardeningTest.php
+++ b/tests/Unit/UtilitySecurityHardeningTest.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$utilSource = file_get_contents(__DIR__ . '/../../lib/utility.php');
+
+test('utility_php_extensions validates binary path before shell_exec', function () use ($utilSource) {
+	expect($utilSource)->toContain("!preg_match('/^php");
+	expect($utilSource)->toContain('is_executable($php_binary)');
+});
+
+test('utility_php_recommends validates binary path', function () use ($utilSource) {
+	$count = substr_count($utilSource, 'is_executable($php_binary)');
+	expect($count)->toBeGreaterThanOrEqual(3);
+});
+
+test('poller_update_poller_cache_from_buffer casts ids to intval', function () use ($utilSource) {
+	expect($utilSource)->toContain("array_map('intval', \$local_data_ids)");
+});
+
+test('update_poller_cache_from_query casts ids to intval', function () use ($utilSource) {
+	expect($utilSource)->toContain("array_map('intval', \$local_data_ids)");
+});
+
+test('update_replication_crc uses random_bytes', function () use ($utilSource) {
+	expect($utilSource)->toContain('random_bytes(16)');
+});
+
+test('update_replication_crc uses parameterized query', function () use ($utilSource) {
+	$start = strpos($utilSource, 'function update_replication_crc(');
+	$body = substr($utilSource, $start, 500);
+	expect($body)->toContain('REPLACE INTO settings (name, value) VALUES (?, ?)');
+});
+
+test('mysql recommendations output uses html_escape', function () use ($utilSource) {
+	expect($utilSource)->toContain("html_escape(\$name)");
+	expect($utilSource)->toContain("html_escape(\$value_display)");
+	expect($utilSource)->toContain("html_escape(\$value_recommend)");
+});


### PR DESCRIPTION
## Summary
Four targeted fixes in `lib/utility.php`:

1. **RCE prevention** (#7003): validate `path_php_binary` is executable and matches PHP binary filename pattern before `shell_exec` in `utility_php_extensions()`, `utility_php_recommends()`, `utility_php_optionals()`
2. **SQL injection** (#7004): cast array elements to `intval` in `poller_update_poller_cache_from_buffer()` and `update_poller_cache_from_query()` before `IN()` clause implosion
3. **Weak PRNG** (#7005): use `random_bytes()` instead of `rand()` in `update_replication_crc()`; parameterize the REPLACE INTO query
4. **XSS** (#7005): escape MySQL recommendation output with `html_escape()` in `utilities_get_mysql_recommendations()`

Closes #7003, closes #7004, closes #7005

## Test plan
- [ ] Verify System Utilities page renders correctly
- [ ] Verify poller cache updates work with valid data
- [ ] Verify replication CRC updates propagate to remote pollers