### PR TITLE
hardening: harden data_query execution boundaries and XML processing (1.2.x)

### DIFF
--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -934,13 +934,28 @@ function query_snmp_host($host_id, $snmp_query_id) {
 
 	/* Filtered index by value */
 	if (isset($snmp_queries['value_index_parse'])) {
-		$value_parse_regexp = '/' . str_replace('VALUE/REGEXP:', '', $snmp_queries['value_index_parse']) . '/';
+		$raw_pattern = str_replace('VALUE/REGEXP:', '', $snmp_queries['value_index_parse']);
+		$value_parse_regexp = '/' . str_replace('/', '\/', $raw_pattern) . '/';
+
+		/* SECURITY: Prevent Regex Denial of Service (ReDoS) on imported patterns */
+		$old_backtrack = ini_get('pcre.backtrack_limit');
+		$old_recursion = ini_get('pcre.recursion_limit');
+		ini_set('pcre.backtrack_limit', '10000');
+		ini_set('pcre.recursion_limit', '10000');
 
 		foreach ($snmp_indexes as $oid => $value) {
-			if (!preg_match($value_parse_regexp, $value)) {
+			$matched = @preg_match($value_parse_regexp, $value);
+
+			if ($matched === false) {
+				cacti_log('ERROR: Malformed or complex regex in Data Query (ReDoS prevented): ' . $value_parse_regexp, true, 'REINDEX');
+				unset($snmp_indexes[$oid]);
+			} elseif (!$matched) {
 				unset($snmp_indexes[$oid]);
 			}
 		}
+
+		ini_set('pcre.backtrack_limit', $old_backtrack);
+		ini_set('pcre.recursion_limit', $old_recursion);
 		query_debug_timer_offset('data_query', __esc('List of indexes filtered by value @ \'%s\' Index Count: %s', $snmp_queries['oid_index'] , cacti_sizeof($snmp_indexes)));
 
 		/* show list of indices found */
@@ -2358,8 +2373,19 @@ function get_script_query_path($args, $script_path, $host_id) {
 		$extra_arguments = '';
 	}
 
-	/* get a complete path for out target script */
-	return substitute_script_query_path($script_path) . ' ' . $extra_arguments;
+	/* SECURITY: The base script path MUST be sanitized to prevent RCE from malicious templates */
+	$parsed_script_path = substitute_script_query_path($script_path);
+
+	if (strpos($parsed_script_path, '..') !== false) {
+		cacti_log('FATAL: Malicious path traversal detected in Data Query script path: ' . $parsed_script_path, true, 'REINDEX');
+
+		return false;
+	}
+
+	$safe_script_path = cacti_escapeshellcmd($parsed_script_path);
+
+	/* get a complete path for our target script */
+	return $safe_script_path . ' ' . $extra_arguments;
 }
 
 
@@ -2517,6 +2543,9 @@ function data_query_duplicate($_data_query_id, $data_query_name) {
 	}
 
 	$data_query_name = str_replace('<dataquery_name>', $data_query['name'], $data_query_name);
+
+	/* SECURITY: Strip HTML tags to prevent Stored XSS while preserving legitimate characters */
+	$data_query_name = strip_tags($data_query_name);
 
 	$save         = $data_query;
 	$save['id']   = 0;

--- a/lib/import.php
+++ b/lib/import.php
@@ -354,8 +354,28 @@ function import_package_get_details($xmlfile) {
 	$filename = "compress.zlib://$xmlfile";
 
 	$return = array();
-	$data   = file_get_contents($filename, 'r');
+	$data = file_get_contents($filename, 'r');
+
+	/* SECURITY: Disable external entity loading to prevent XXE on PHP < 8.0 */
+	$disable_entities = false;
+	if (LIBXML_VERSION < 20900) {
+		$disable_entities = libxml_disable_entity_loader(true);
+	}
+
+	libxml_use_internal_errors(true);
 	$xmlget = simplexml_load_string($data);
+	libxml_use_internal_errors(false);
+
+	if (LIBXML_VERSION < 20900) {
+		libxml_disable_entity_loader($disable_entities);
+	}
+
+	if ($xmlget === false) {
+		cacti_log('FATAL: Unable to parse package XML structure.', true, 'IMPORT', POLLER_VERBOSITY_LOW);
+
+		return array();
+	}
+
 	$pkgarr = xml_to_array($xmlget);
 	$return = $pkgarr['info'];
 
@@ -448,8 +468,27 @@ function import_read_package_data($xmlfile, &$public_key) {
 
 	cacti_log('Loading Plugin Information from package', false, 'IMPORT', POLLER_VERBOSITY_MEDIUM);
 
+	/* SECURITY: Disable external entity loading to prevent XXE on PHP < 8.0 */
+	$disable_entities = false;
+	if (LIBXML_VERSION < 20900) {
+		$disable_entities = libxml_disable_entity_loader(true);
+	}
+
+	libxml_use_internal_errors(true);
 	$xmlget = simplexml_load_string($xml);
-	$data   = xml_to_array($xmlget);
+	libxml_use_internal_errors(false);
+
+	if (LIBXML_VERSION < 20900) {
+		libxml_disable_entity_loader($disable_entities);
+	}
+
+	if ($xmlget === false) {
+		cacti_log('FATAL: Unable to parse XML structure.', true, 'IMPORT', POLLER_VERBOSITY_LOW);
+
+		return false;
+	}
+
+	$data = xml_to_array($xmlget);
 
 	if (cacti_sizeof($data)) {
 		return $data;

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -648,6 +648,11 @@ class Net_Ping
 			cacti_log('WARNING: sockets support not enabled in PHP, falling back to SNMP ping');
 		}
 
+		/* SECURITY: Enforce strict integer casting to prevent string-to-int
+		 * loose comparison bypasses leading to OS command injection */
+		$retries = (int)$retries;
+		$timeout = (int)$timeout;
+
 		if (($retries <= 0) || ($retries > 5)) {
 			$this->retries = 2;
 		} else {

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -1009,10 +1009,11 @@ function snmp_escape_string($string) {
 	}
 
 	if ($config['cacti_server_os'] == 'win32') {
-		if (substr_count($string, SNMP_ESCAPE_CHARACTER)) {
-			$string = str_replace(SNMP_ESCAPE_CHARACTER, "\\" . SNMP_ESCAPE_CHARACTER, $string);
-			return SNMP_ESCAPE_CHARACTER . $string . SNMP_ESCAPE_CHARACTER;
-		}
+		/* SECURITY: Always wrap the string in quotes on Windows,
+		 * preventing command chaining via &, |, or ^ operators. */
+		$string = str_replace(SNMP_ESCAPE_CHARACTER, "\\" . SNMP_ESCAPE_CHARACTER, $string);
+
+		return SNMP_ESCAPE_CHARACTER . $string . SNMP_ESCAPE_CHARACTER;
 	}
 
 	return cacti_escapeshellarg($string);

--- a/tests/Unit/CoreSecurityHardeningTest.php
+++ b/tests/Unit/CoreSecurityHardeningTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$pingSource = file_get_contents(__DIR__ . '/../../lib/ping.php');
+$snmpSource = file_get_contents(__DIR__ . '/../../lib/snmp.php');
+$dqSource   = file_get_contents(__DIR__ . '/../../lib/data_query.php');
+$impSource  = file_get_contents(__DIR__ . '/../../lib/import.php');
+
+test('ping constructor casts retries to int', function () use ($pingSource) {
+	expect($pingSource)->toContain('$retries = (int)$retries');
+});
+
+test('ping constructor casts timeout to int', function () use ($pingSource) {
+	expect($pingSource)->toContain('$timeout = (int)$timeout');
+});
+
+test('snmp_escape_string always wraps Windows strings', function () use ($snmpSource) {
+	$start = strpos($snmpSource, 'function snmp_escape_string(');
+	$body = substr($snmpSource, $start, 500);
+	expect($body)->not->toContain('if (substr_count($string, SNMP_ESCAPE_CHARACTER))');
+});
+
+test('get_script_query_path uses cacti_escapeshellcmd on script path', function () use ($dqSource) {
+	$start = strpos($dqSource, 'function get_script_query_path(');
+	$body = substr($dqSource, $start, 800);
+	expect($body)->toContain('cacti_escapeshellcmd($parsed_script_path)');
+});
+
+test('get_script_query_path rejects path traversal', function () use ($dqSource) {
+	$start = strpos($dqSource, 'function get_script_query_path(');
+	$body = substr($dqSource, $start, 800);
+	expect(str_contains($body, "strpos(\$parsed_script_path, '..')"))->toBeTrue();
+});
+
+test('data_query value_index_parse constrains PCRE backtrack limit', function () use ($dqSource) {
+	expect($dqSource)->toContain("ini_set('pcre.backtrack_limit', '10000')");
+	expect($dqSource)->toContain("ini_set('pcre.recursion_limit', '10000')");
+});
+
+test('data_query value_index_parse restores PCRE limits', function () use ($dqSource) {
+	expect($dqSource)->toContain("ini_set('pcre.backtrack_limit', \$old_backtrack)");
+	expect($dqSource)->toContain("ini_set('pcre.recursion_limit', \$old_recursion)");
+});
+
+test('data_query_duplicate uses strip_tags on name', function () use ($dqSource) {
+	$start = strpos($dqSource, 'function data_query_duplicate(');
+	$body = substr($dqSource, $start, 500);
+	expect($body)->toContain('strip_tags($data_query_name)');
+});
+
+test('import.php disables entity loader for XXE prevention', function () use ($impSource) {
+	expect($impSource)->toContain('libxml_disable_entity_loader(true)');
+});
+
+test('import.php suppresses libxml warnings', function () use ($impSource) {
+	expect($impSource)->toContain('libxml_use_internal_errors(true)');
+});


### PR DESCRIPTION
## Summary
Six targeted security fixes across core library files:

1. **ping.php**: cast `$retries`/`$timeout` to `(int)` to prevent loose type juggling RCE (#7009)
2. **snmp.php**: always quote Windows SNMP strings to prevent `&`/`|` command chaining (#7009)
3. **data_query.php**: `cacti_escapeshellcmd()` on script_path from XML templates to prevent RCE (#7007)
4. **data_query.php**: constrain PCRE limits during template regex evaluation to prevent ReDoS (#7007)
5. **data_query.php**: sanitize `data_query_name` to prevent stored XSS (#7008)
6. **import.php**: disable XML external entity loading on PHP < 8.0 to prevent XXE (#7008)

Closes #7007, closes #7008, closes #7009

## Test plan
- [ ] Verify ping works correctly with valid integer retries/timeout
- [ ] Verify SNMP polling works on Windows with special chars in community strings
- [ ] Verify Data Query script execution works with valid templates
- [ ] Verify package import parses XML correctly
- [ ] Verify Data Query duplication sanitizes names