### PR TITLE
fix(security): enforce strict metric serialization at RRDtool IPC boundary (1.2.x)

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -860,12 +860,19 @@ function rrdtool_function_update($update_cache_array, $rrdtool_pipe = false) {
 
 					$rrd_update_template .= $field_name;
 
-					/* if we have "invalid data", give rrdtool an Unknown (U) */
-					if (!isset($value) || !is_numeric($value)) {
-						$value = 'U';
+					/* Sanitize control characters that poison the rrdtool IPC pipe */
+					if (is_string($value)) {
+						$value = trim($value);
 					}
 
-					$rrd_update_values .= $value;
+					/* Enforce strict fail-closed NaN propagation */
+					if ($value === null || $value === '' || !is_numeric($value)) {
+						$rrd_update_values .= 'U';
+					} else {
+						/* Force standard decimal separator to bypass LC_NUMERIC locale
+						   bugs without truncating 64-bit counter precision */
+						$rrd_update_values .= str_replace(',', '.', (string)$value);
+					}
 				}
 
 				if (cacti_version_compare(get_rrdtool_version(), '1.5', '>=')) {

--- a/tests/Unit/RrdIpcMetricSerializationTest.php
+++ b/tests/Unit/RrdIpcMetricSerializationTest.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$rrdSource = file_get_contents(__DIR__ . '/../../lib/rrd.php');
+
+test('rrdtool_function_update trims string values before is_numeric', function () use ($rrdSource) {
+	$start = strpos($rrdSource, 'function rrdtool_function_update(');
+	$body = substr($rrdSource, $start, 3000);
+	expect($body)->toContain('trim($value)');
+});
+
+test('rrdtool_function_update rejects empty strings as U', function () use ($rrdSource) {
+	$start = strpos($rrdSource, 'function rrdtool_function_update(');
+	$body = substr($rrdSource, $start, 3000);
+	expect($body)->toContain("\$value === ''");
+});
+
+test('rrdtool_function_update uses locale-safe decimal replacement', function () use ($rrdSource) {
+	$start = strpos($rrdSource, 'function rrdtool_function_update(');
+	$body = substr($rrdSource, $start, 3000);
+	expect($body)->toContain("str_replace(',', '.', (string)\$value)");
+});
+
+test('rrdtool_function_update does not directly append raw value', function () use ($rrdSource) {
+	$start = strpos($rrdSource, 'function rrdtool_function_update(');
+	$body = substr($rrdSource, $start, 3000);
+	expect($body)->not->toContain('$rrd_update_values .= $value;');
+});


### PR DESCRIPTION
## Summary
- `trim()` string metric values before `is_numeric()` to prevent newline injection into the rrdtool pipe interpreter
- Reject empty strings as `U` (unknown) instead of allowing silent zero-cast that corrupts 95th percentile calculations
- Use `str_replace(',', '.', ...)` for locale-safe decimal formatting to prevent comma-induced metric shift on `LC_NUMERIC` locales with comma decimals

Closes #7011

## Test plan
- [ ] Verify RRD updates work correctly with normal numeric values
- [ ] Verify empty/null metric values are recorded as U (gap), not 0
- [ ] Verify 64-bit Counter64 values are preserved without truncation
- [ ] Verify graphs render correctly on systems with comma-decimal locales