### PR TITLE
fix: IPv6 support for SNMP sessions, ping validation, and binary transport (1.2.x)

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -6645,14 +6645,22 @@ if (isset($config['cacti_server_os']) && $config['cacti_server_os'] == 'win32' &
 }
 
 function is_ipaddress($ip_address = '') {
+	/* Strip IPv6 Scope ID (Zone Index) for validation, as
+	   filter_var rejects valid link-local addresses like fe80::1%eth0 */
+	$clean_ip = $ip_address;
+	if (strpos($clean_ip, '%') !== false) {
+		$parts = explode('%', $clean_ip, 2);
+		$clean_ip = $parts[0];
+	}
+
 	/* check for ipv4/v6 */
 	if (function_exists('filter_var')) {
-		if (filter_var($ip_address, FILTER_VALIDATE_IP) !== false) {
+		if (filter_var($clean_ip, FILTER_VALIDATE_IP) !== false) {
 			return true;
 		} else {
 			return false;
 		}
-	} elseif (inet_pton($ip_address) !== false) {
+	} elseif (@inet_pton($clean_ip) !== false) {
 		return true;
 	} else {
 		return false;

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -722,14 +722,22 @@ class Net_Ping
 	} /* end_ping */
 
 	function is_ipaddress($ip_address = '') {
+		/* Strip IPv6 Scope ID (Zone Index) for validation, as
+		   filter_var rejects valid link-local addresses like fe80::1%eth0 */
+		$clean_ip = $ip_address;
+		if (strpos($clean_ip, '%') !== false) {
+			$parts = explode('%', $clean_ip, 2);
+			$clean_ip = $parts[0];
+		}
+
 		/* check for ipv4/v6 */
 		if (function_exists('filter_var')) {
-			if (filter_var($ip_address, FILTER_VALIDATE_IP) !== false) {
+			if (filter_var($clean_ip, FILTER_VALIDATE_IP) !== false) {
 				return true;
 			} else {
 				return false;
 			}
-		} elseif (inet_pton($ip_address) !== false) {
+		} elseif (@inet_pton($clean_ip) !== false) {
 			return true;
 		} else {
 			return false;

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -71,8 +71,15 @@ function cacti_snmp_session($hostname, $community, $version, $auth_user = '', $a
 
 	$timeout_us = (int) ($timeout_ms * 1000);
 
+	/* Encapsulate IPv6 addresses in brackets to prevent the SNMP library
+	   from interpreting the port as an IPv6 hextet */
+	$snmp_hostname = $hostname;
+	if (strpos($snmp_hostname, ':') !== false && strpos($snmp_hostname, '[') === false) {
+		$snmp_hostname = '[' . $snmp_hostname . ']';
+	}
+
 	try {
-		$session = @new SNMP($version, $hostname . ':' . $port, ($version == 3 ? $auth_user : $community), $timeout_us, $retries);
+		$session = @new SNMP($version, $snmp_hostname . ':' . $port, ($version == 3 ? $auth_user : $community), $timeout_us, $retries);
 	} catch (Exception $e) {
 		return false;
 	}
@@ -197,7 +204,7 @@ function cacti_snmp_get($hostname, $community, $oid, $version, $auth_user = '', 
 			' -v ' . $version .
 			' -t ' . $timeout_s .
 			' -r ' . $retries .
-			' '    . cacti_escapeshellarg($hostname) . ':' . $port .
+			' '    . snmp_format_target($hostname, $port) .
 			' '    . cacti_escapeshellarg($oid);
 
 		if (isset($_SESSION)) {
@@ -297,7 +304,7 @@ function cacti_snmp_get_raw($hostname, $community, $oid, $version, $auth_user = 
 			' -v ' . $version .
 			' -t ' . $timeout_s .
 			' -r ' . $retries .
-			' '    . cacti_escapeshellarg($hostname) . ':' . $port .
+			' '    . snmp_format_target($hostname, $port) .
 			' '    . cacti_escapeshellarg($oid);
 
 		if (isset($_SESSION)) {
@@ -392,7 +399,7 @@ function cacti_snmp_getnext($hostname, $community, $oid, $version, $auth_user = 
 			' -v ' . $version .
 			' -t ' . $timeout_s .
 			' -r ' . $retries .
-			' '    . cacti_escapeshellarg($hostname) . ':' . $port .
+			' '    . snmp_format_target($hostname, $port) .
 			' '    . cacti_escapeshellarg($oid);
 
 		if (isset($_SESSION)) {
@@ -724,7 +731,7 @@ function cacti_snmp_walk($hostname, $community, $oid, $version, $auth_user = '',
 				' -r '     . $retries .
 				' -Cr'     . $bulk_walk_size .
 				' '        . $oidCheck . ' ' .
-				cacti_escapeshellarg($hostname) . ':' . $port . ' ' .
+				snmp_format_target($hostname, $port) . ' ' .
 				cacti_escapeshellarg($oid);
 
 			if (isset($_SESSION)) {
@@ -739,7 +746,7 @@ function cacti_snmp_walk($hostname, $community, $oid, $version, $auth_user = '',
 				' -t '     . $timeout_s .
 				' -r '     . $retries .
 				' '        . $oidCheck . ' ' .
-				' '        . cacti_escapeshellarg($hostname) . ':' . $port .
+				' '        . snmp_format_target($hostname, $port) .
 				' '        . cacti_escapeshellarg($oid);
 
 			if (isset($_SESSION)) {
@@ -999,6 +1006,26 @@ function format_snmp_string($string, $snmp_oid_included, $value_output_format = 
 	}
 
 	return $string;
+}
+
+/**
+ * snmp_format_target - format hostname:port for binary SNMP commands,
+ * forcing udp6: transport for IPv6 to prevent DNS ambiguity.
+ *
+ * @param string $hostname - The target hostname or IP
+ * @param int    $port     - The SNMP port
+ *
+ * @return string The formatted target string
+ */
+function snmp_format_target($hostname, $port) {
+	if (strpos($hostname, ':') !== false) {
+		/* IPv6: force udp6: transport and bracket-encapsulate */
+		$clean = str_replace(array('[', ']'), '', $hostname);
+
+		return cacti_escapeshellarg('udp6:[' . $clean . ']:' . $port);
+	}
+
+	return cacti_escapeshellarg($hostname) . ':' . $port;
 }
 
 function snmp_escape_string($string) {

--- a/tests/Unit/Ipv6SupportHardeningTest.php
+++ b/tests/Unit/Ipv6SupportHardeningTest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$snmpSource = file_get_contents(__DIR__ . '/../../lib/snmp.php');
+$pingSource = file_get_contents(__DIR__ . '/../../lib/ping.php');
+$funcSource = file_get_contents(__DIR__ . '/../../lib/functions.php');
+
+test('cacti_snmp_session brackets IPv6 before port append', function () use ($snmpSource) {
+	$start = strpos($snmpSource, 'function cacti_snmp_session(');
+	$body = substr($snmpSource, $start, 1500);
+	expect($body)->toContain("snmp_hostname = '[' . \$snmp_hostname . ']'");
+});
+
+test('snmp_format_target function exists', function () use ($snmpSource) {
+	expect($snmpSource)->toContain('function snmp_format_target($hostname, $port)');
+});
+
+test('snmp_format_target forces udp6 for IPv6', function () use ($snmpSource) {
+	$start = strpos($snmpSource, 'function snmp_format_target(');
+	$body = substr($snmpSource, $start, 500);
+	expect($body)->toContain("'udp6:[' . \$clean . ']:'");
+});
+
+test('binary SNMP commands use snmp_format_target', function () use ($snmpSource) {
+	$count = substr_count($snmpSource, 'snmp_format_target($hostname, $port)');
+	expect($count)->toBeGreaterThanOrEqual(5);
+});
+
+test('ping.php is_ipaddress strips zone index', function () use ($pingSource) {
+	$start = strpos($pingSource, 'function is_ipaddress(');
+	$body = substr($pingSource, $start, 500);
+	expect($body)->toContain("explode('%', \$clean_ip, 2)");
+});
+
+test('functions.php is_ipaddress strips zone index', function () use ($funcSource) {
+	$start = strpos($funcSource, 'function is_ipaddress(');
+	$body = substr($funcSource, $start, 500);
+	expect($body)->toContain("explode('%', \$clean_ip, 2)");
+});


### PR DESCRIPTION
## Summary
Three IPv6 handling fixes:

1. **SNMP session port corruption**: bracket-encapsulate IPv6 addresses in `cacti_snmp_session()` before appending port to prevent `2001:db8::1:161` ambiguity
2. **Zone Index rejection**: strip `%scope_id` from IPv6 addresses before `FILTER_VALIDATE_IP` in both `lib/ping.php` and `lib/functions.php` `is_ipaddress()`
3. **Binary SNMP transport**: add `snmp_format_target()` helper that forces `udp6:` transport prefix for IPv6 targets in all 5 shell-out SNMP command sites

Closes #7013

## Test plan
- [ ] Verify SNMP polling works with IPv6 addresses on custom ports
- [ ] Verify link-local IPv6 addresses with Zone IDs pass validation
- [ ] Verify binary SNMP commands work correctly for IPv6 targets
- [ ] Verify IPv4 behavior is unchanged