### PR TITLE
fix(security): harden exec_background, log path redirection, and CLI args (1.2.x)

### DIFF
--- a/lib/boost.php
+++ b/lib/boost.php
@@ -1541,16 +1541,19 @@ function boost_poller_bottom() {
 		}
 
 		$command_string = read_config_option('path_php_binary');
+		$safe_poller    = cacti_escapeshellarg($config['base_path'] . '/poller_boost.php');
+		$safe_log       = cacti_escapeshellarg($boost_log);
+
 		if ($boost_log != '') {
 			if ($config['cacti_server_os'] == 'unix') {
-				$extra_args    = '-q '  . $config['base_path'] . '/poller_boost.php --debug';
-				$redirect_args =  '>> ' . $boost_log . ' 2>&1';
+				$extra_args    = "-q $safe_poller --debug";
+				$redirect_args = ">> $safe_log 2>&1";
 			} else {
-				$extra_args    = '-q ' . $config['base_path'] . '/poller_boost.php --debug';
-				$redirect_args = '>> ' . $boost_log;
+				$extra_args    = "-q $safe_poller --debug";
+				$redirect_args = ">> $safe_log";
 			}
 		} else {
-			$extra_args = '-q ' . $config['base_path'] . '/poller_boost.php';
+			$extra_args = "-q $safe_poller";
 		}
 
 		exec_background($command_string, $extra_args, $redirect_args);

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -134,6 +134,10 @@ function exec_background($filename, $args = '', $redirect_args = '') {
 
 	if (is_array($args)) {
 		$args = implode(' ', array_map('cacti_escapeshellarg', $args));
+	} else {
+		/* SECURITY: If args are passed as a string, strip shell operators to
+		 * prevent background command chaining if a caller forgot to escape */
+		$args = preg_replace('/[&;|]+/', '', $args);
 	}
 
 	if (is_array($redirect_args)) {

--- a/poller.php
+++ b/poller.php
@@ -108,7 +108,9 @@ if (cacti_sizeof($parms)) {
 		switch ($arg) {
 			case '-p':
 			case '--poller':
-				$poller_id = $value;
+				/* SECURITY: Force integer casting to prevent CLI-based SQLi
+				 * and command injection via crafted --poller argument */
+				$poller_id = (int)$value;
 
 				break;
 			case '-d':
@@ -673,7 +675,7 @@ while ($poller_runs_completed < $poller_runs) {
 		}
 
 		if (read_config_option('path_stderrlog') != '' && $config['cacti_server_os'] != 'win32') {
-			$extra_parms = '>> ' . read_config_option('path_stderrlog') . ' 2>&1';
+			$extra_parms = '>> ' . cacti_escapeshellarg(read_config_option('path_stderrlog')) . ' 2>&1';
 		} else {
 			$extra_parms = '';
 		}

--- a/tests/Unit/ExecBackgroundHardeningTest.php
+++ b/tests/Unit/ExecBackgroundHardeningTest.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$boostSource  = file_get_contents(__DIR__ . '/../../lib/boost.php');
+$pollerSource = file_get_contents(__DIR__ . '/../../poller.php');
+$pollerLib    = file_get_contents(__DIR__ . '/../../lib/poller.php');
+
+test('boost.php escapes poller path with cacti_escapeshellarg', function () use ($boostSource) {
+	expect($boostSource)->toContain("cacti_escapeshellarg(\$config['base_path'] . '/poller_boost.php')");
+});
+
+test('boost.php escapes log path with cacti_escapeshellarg', function () use ($boostSource) {
+	expect($boostSource)->toContain('cacti_escapeshellarg($boost_log)');
+});
+
+test('poller.php casts poller_id to int', function () use ($pollerSource) {
+	expect($pollerSource)->toContain('$poller_id = (int)$value');
+});
+
+test('poller.php escapes stderrlog path', function () use ($pollerSource) {
+	expect($pollerSource)->toContain("cacti_escapeshellarg(read_config_option('path_stderrlog'))");
+});
+
+test('exec_background strips shell operators from string args', function () use ($pollerLib) {
+	$start = strpos($pollerLib, 'function exec_background(');
+	$body = substr($pollerLib, $start, 800);
+	expect($body)->toContain("preg_replace('/[&;|]+/', '', \$args)");
+});


### PR DESCRIPTION
## Summary
Three targeted fixes in the background daemon execution path:

1. **boost.php**: escape log path and poller path with `cacti_escapeshellarg()` before shell redirection to prevent second-order RCE via database settings
2. **poller.php**: cast `--poller` CLI argument to `(int)` immediately; escape `path_stderrlog` before shell redirection
3. **lib/poller.php**: strip shell operators (`&`, `;`, `|`) from string args in `exec_background()` as a fail-safe

Closes #7015

## Test plan
- [ ] Verify boost poller launches correctly with debug logging
- [ ] Verify poller.php accepts valid integer --poller values
- [ ] Verify background processes spawn correctly
- [ ] Verify stderr log redirection works with valid paths