### PR TITLE
feat: add centralized IP normalization and secure proxy chain resolution (1.2.x)

### DIFF
--- a/lib/ip.php
+++ b/lib/ip.php
@@ -1,0 +1,166 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * cacti_normalize_ip - normalizes an IPv4 or IPv6 address for deterministic
+ * database storage and equality comparison. Strips zone indices, converts
+ * IPv4-mapped IPv6 to standard IPv4, and fully compresses IPv6.
+ *
+ * @param string $ip - The raw IP address string
+ *
+ * @return string|false Normalized IP string, or false if invalid
+ */
+function cacti_normalize_ip($ip) {
+	/* Strip scope ID (zone index) for validation (e.g., fe80::1%eth0) */
+	if (strpos($ip, '%') !== false) {
+		$ip = explode('%', $ip, 2);
+		$ip = $ip[0];
+	}
+
+	$binary = @inet_pton($ip);
+	if ($binary === false) {
+		return false;
+	}
+
+	/* Downgrade IPv4-mapped IPv6 addresses to raw IPv4 for consistent DB indexing */
+	if (strlen($binary) === 16 && substr($binary, 0, 12) === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff") {
+		$binary = substr($binary, 12);
+	}
+
+	return inet_ntop($binary);
+}
+
+/**
+ * cacti_ip_in_cidr - determines if a normalized IP address falls within a given
+ * CIDR block using bitwise comparison. Replaces legacy regex/substring subnet matching.
+ *
+ * @param string $ip   - The IP address to check
+ * @param string $cidr - The CIDR block (e.g., '192.168.1.0/24') or single IP
+ *
+ * @return bool
+ */
+function cacti_ip_in_cidr($ip, $cidr) {
+	$ip = cacti_normalize_ip($ip);
+	if ($ip === false) {
+		return false;
+	}
+
+	if (strpos($cidr, '/') === false) {
+		$subnet = cacti_normalize_ip($cidr);
+
+		return $ip === $subnet;
+	}
+
+	$parts  = explode('/', $cidr, 2);
+	$subnet = cacti_normalize_ip($parts[0]);
+	$mask   = $parts[1];
+
+	if ($subnet === false || !is_numeric($mask)) {
+		return false;
+	}
+
+	$mask          = (int)$mask;
+	$ipBinary      = inet_pton($ip);
+	$subnetBinary  = inet_pton($subnet);
+
+	/* Fail-closed on IPv4/IPv6 address family mismatch */
+	if (strlen($ipBinary) !== strlen($subnetBinary)) {
+		return false;
+	}
+
+	$maxMask = strlen($ipBinary) === 4 ? 32 : 128;
+	if ($mask < 0 || $mask > $maxMask) {
+		return false;
+	}
+
+	$bytePos = (int)($mask / 8);
+	$bitPos  = $mask % 8;
+
+	if ($bytePos > 0) {
+		if (substr($ipBinary, 0, $bytePos) !== substr($subnetBinary, 0, $bytePos)) {
+			return false;
+		}
+	}
+
+	if ($bitPos > 0) {
+		$ipByte      = ord($ipBinary[$bytePos]);
+		$subnetByte  = ord($subnetBinary[$bytePos]);
+		$maskByte    = 256 - (1 << (8 - $bitPos));
+
+		if (($ipByte & $maskByte) !== ($subnetByte & $maskByte)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * cacti_get_secure_client_ip - resolves the true client IP address by strictly
+ * enforcing Zero Trust boundaries. Traverses X-Forwarded-For backwards,
+ * discarding IPs until it hits the first untrusted node.
+ *
+ * @param array $trustedProxies - Array of normalized IPs or CIDRs of trusted load balancers
+ *
+ * @return string Normalized client IP, or '0.0.0.0' on failure
+ */
+function cacti_get_secure_client_ip($trustedProxies = array()) {
+	$remoteAddr = isset($_SERVER['REMOTE_ADDR']) ? cacti_normalize_ip($_SERVER['REMOTE_ADDR']) : false;
+
+	if ($remoteAddr === false) {
+		return '0.0.0.0';
+	}
+
+	if (empty($trustedProxies) || empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+		return $remoteAddr;
+	}
+
+	$isTrusted = false;
+	foreach ($trustedProxies as $proxyCidr) {
+		if (cacti_ip_in_cidr($remoteAddr, $proxyCidr)) {
+			$isTrusted = true;
+
+			break;
+		}
+	}
+
+	if ($isTrusted) {
+		$forwardedIps = array_map('trim', explode(',', $_SERVER['HTTP_X_FORWARDED_FOR']));
+
+		/* Traverse backwards to prevent header spoofing via multiple proxies */
+		$forwardedIps = array_reverse($forwardedIps);
+
+		foreach ($forwardedIps as $fwdIp) {
+			$normalizedFwdIp = cacti_normalize_ip($fwdIp);
+			if ($normalizedFwdIp === false) {
+				continue;
+			}
+
+			$fwdIsTrusted = false;
+			foreach ($trustedProxies as $proxyCidr) {
+				if (cacti_ip_in_cidr($normalizedFwdIp, $proxyCidr)) {
+					$fwdIsTrusted = true;
+
+					break;
+				}
+			}
+
+			if (!$fwdIsTrusted) {
+				return $normalizedFwdIp;
+			}
+		}
+	}
+
+	return $remoteAddr;
+}

--- a/tests/Unit/IpLibraryTest.php
+++ b/tests/Unit/IpLibraryTest.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 2) . '/lib/ip.php';
+
+test('cacti_normalize_ip normalizes IPv4', function () {
+	expect(cacti_normalize_ip('192.168.1.1'))->toBe('192.168.1.1');
+});
+
+test('cacti_normalize_ip compresses IPv6', function () {
+	expect(cacti_normalize_ip('2001:0db8:0000:0000:0000:0000:0000:0001'))->toBe('2001:db8::1');
+});
+
+test('cacti_normalize_ip downgrades IPv4-mapped IPv6', function () {
+	expect(cacti_normalize_ip('::ffff:192.168.1.1'))->toBe('192.168.1.1');
+});
+
+test('cacti_normalize_ip strips zone index', function () {
+	expect(cacti_normalize_ip('fe80::1%eth0'))->toBe('fe80::1');
+});
+
+test('cacti_normalize_ip rejects invalid input', function () {
+	expect(cacti_normalize_ip('not-an-ip'))->toBeFalse();
+	expect(cacti_normalize_ip(''))->toBeFalse();
+});
+
+test('cacti_normalize_ip handles loopback', function () {
+	expect(cacti_normalize_ip('127.0.0.1'))->toBe('127.0.0.1');
+	expect(cacti_normalize_ip('::1'))->toBe('::1');
+});
+
+test('cacti_ip_in_cidr matches IPv4 CIDR', function () {
+	expect(cacti_ip_in_cidr('192.168.1.50', '192.168.1.0/24'))->toBeTrue();
+	expect(cacti_ip_in_cidr('192.168.2.1', '192.168.1.0/24'))->toBeFalse();
+});
+
+test('cacti_ip_in_cidr matches single IP', function () {
+	expect(cacti_ip_in_cidr('10.0.0.1', '10.0.0.1'))->toBeTrue();
+	expect(cacti_ip_in_cidr('10.0.0.2', '10.0.0.1'))->toBeFalse();
+});
+
+test('cacti_ip_in_cidr matches IPv6 CIDR', function () {
+	expect(cacti_ip_in_cidr('2001:db8::1', '2001:db8::/32'))->toBeTrue();
+	expect(cacti_ip_in_cidr('2001:db9::1', '2001:db8::/32'))->toBeFalse();
+});
+
+test('cacti_ip_in_cidr rejects family mismatch', function () {
+	expect(cacti_ip_in_cidr('192.168.1.1', '2001:db8::/32'))->toBeFalse();
+});
+
+test('cacti_ip_in_cidr rejects invalid mask', function () {
+	expect(cacti_ip_in_cidr('192.168.1.1', '192.168.1.0/33'))->toBeFalse();
+	expect(cacti_ip_in_cidr('192.168.1.1', '192.168.1.0/-1'))->toBeFalse();
+});
+
+test('cacti_ip_in_cidr handles /0 matches all', function () {
+	expect(cacti_ip_in_cidr('10.20.30.40', '0.0.0.0/0'))->toBeTrue();
+});
+
+test('cacti_ip_in_cidr handles /32 exact match', function () {
+	expect(cacti_ip_in_cidr('10.0.0.1', '10.0.0.1/32'))->toBeTrue();
+	expect(cacti_ip_in_cidr('10.0.0.2', '10.0.0.1/32'))->toBeFalse();
+});
+
+test('cacti_get_secure_client_ip returns REMOTE_ADDR with no proxies', function () {
+	$_SERVER['REMOTE_ADDR'] = '203.0.113.50';
+	unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+	expect(cacti_get_secure_client_ip())->toBe('203.0.113.50');
+});
+
+test('cacti_get_secure_client_ip ignores XFF when REMOTE_ADDR not trusted', function () {
+	$_SERVER['REMOTE_ADDR'] = '203.0.113.50';
+	$_SERVER['HTTP_X_FORWARDED_FOR'] = '10.0.0.1';
+	expect(cacti_get_secure_client_ip(array('192.168.1.0/24')))->toBe('203.0.113.50');
+});
+
+test('cacti_get_secure_client_ip extracts client from XFF when proxy trusted', function () {
+	$_SERVER['REMOTE_ADDR'] = '192.168.1.10';
+	$_SERVER['HTTP_X_FORWARDED_FOR'] = '203.0.113.99, 192.168.1.10';
+	expect(cacti_get_secure_client_ip(array('192.168.1.0/24')))->toBe('203.0.113.99');
+});
+
+test('cacti_get_secure_client_ip returns 0.0.0.0 on missing REMOTE_ADDR', function () {
+	unset($_SERVER['REMOTE_ADDR']);
+	expect(cacti_get_secure_client_ip())->toBe('0.0.0.0');
+});


### PR DESCRIPTION
## Summary
New `lib/ip.php` library providing three functions to fix systemic IP management failures:

1. **`cacti_normalize_ip()`**: strips zone indices, downgrades `::ffff:` IPv4-mapped IPv6 to raw IPv4, fully compresses IPv6 for deterministic DB storage and equality comparison
2. **`cacti_ip_in_cidr()`**: bitwise binary CIDR comparison replacing legacy regex/substring subnet matching; fail-closed on address family mismatch
3. **`cacti_get_secure_client_ip()`**: reverse-traversal `X-Forwarded-For` processing with configurable trusted proxy CIDR allowlist; returns `REMOTE_ADDR` when no trusted proxies are configured

Closes #7017

## Test plan
- [ ] Verify `cacti_normalize_ip()` handles IPv4, IPv6, IPv4-mapped IPv6, zone indices
- [ ] Verify `cacti_ip_in_cidr()` correctly matches/rejects across IPv4 and IPv6 CIDRs
- [ ] Verify `cacti_get_secure_client_ip()` returns REMOTE_ADDR when no proxies configured
- [ ] Verify spoofed X-Forwarded-For is rejected when REMOTE_ADDR is not a trusted proxy