### PR TITLE
fix(security): defense-in-depth hardening (1.2.x)

### DIFF
--- a/include/global.php
+++ b/include/global.php
@@ -430,6 +430,7 @@ if ($config['is_web']) {
 	ini_set('session.cookie_httponly', true);
 	ini_set('session.cookie_path', $config['url_path']);
 	ini_set('session.use_strict_mode', true);
+	ini_set('session.use_only_cookies', true);
 
 	$options = array(
 		'cookie_httponly' => true,
@@ -479,8 +480,10 @@ if ($config['is_web']) {
 
 	/* prevent IE from silently rejects cookies sent from third party sites. */
 	header('P3P: CP="CAO PSA OUR"');
+	header('X-Content-Type-Options: nosniff');
+	header('Referrer-Policy: strict-origin-when-cross-origin');
+	header('Permissions-Policy: camera=(), geolocation=(), interest-cohort=(), microphone=(), payment=(), usb=()');
 	header('Cache-Control: no-store, no-cache, must-revalidate');
-	header('Cache-Control: max-age=31536000');
 
 	cacti_session_start();
 

--- a/index.php
+++ b/index.php
@@ -39,16 +39,27 @@ function render_external_links($style = 'FRONT') {
 		foreach($consoles as $page) {
 			if (is_realm_allowed($page['id']+10000)) {
 				if (preg_match('/^((((ht|f)tp(s?))\:\/\/){1}\S+)/i', $page['contentfile'])) {
-					print '<iframe class="content" src="' . $page['contentfile'] . '" frameborder="0"></iframe>';
+					print '<iframe class="content" src="' . html_escape($page['contentfile']) . '" frameborder="0"></iframe>';
 				} else {
 					print '<div id="content">';
 
-					$file = $config['base_path'] . "/include/content/" . $page['contentfile'];
+					$content_dir = realpath($config['base_path'] . '/include/content');
+					$file = realpath($config['base_path'] . '/include/content/' . $page['contentfile']);
 
-					if (file_exists($file)) {
+					if ($content_dir !== false) {
+						$content_dir = str_replace('\\', '/', $content_dir);
+					}
+					if ($file !== false) {
+						$file = str_replace('\\', '/', $file);
+					}
+
+					/* On Windows, realpath() may return mixed-case drive letters; use
+					 * case-insensitive comparison to avoid false rejections. */
+					$path_cmp = (DIRECTORY_SEPARATOR === '\\') ? 'stripos' : 'strpos';
+					if ($file !== false && $content_dir !== false && $path_cmp($file, $content_dir . '/') === 0) {
 						include_once($file);
 					} else {
-						print '<h1>The file \'' . $page['contentfile'] . '\' does not exist!!</h1>';
+						print '<h1>The file \'' . html_escape($page['contentfile']) . '\' does not exist!!</h1>';
 					}
 
 					print '</div>';

--- a/package_import.php
+++ b/package_import.php
@@ -80,6 +80,29 @@ function check_tmp_dir() {
 	}
 }
 
+function package_import_write_session_file() {
+	if (!isset($_SESSION['sess_import_package'])) {
+		return false;
+	}
+
+	$xmlfile = tempnam(sys_get_temp_dir(), 'cacti_pkg_');
+
+	if ($xmlfile === false) {
+		cacti_log('FATAL: Unable to create temporary package import file', true, 'IMPORT');
+
+		return false;
+	}
+
+	if (file_put_contents($xmlfile, $_SESSION['sess_import_package']) === false) {
+		cacti_log('FATAL: Unable to write temporary package import file', true, 'IMPORT');
+		unlink($xmlfile);
+
+		return false;
+	}
+
+	return $xmlfile;
+}
+
 function form_save() {
 	global $config, $preview_only;
 
@@ -94,9 +117,15 @@ function form_save() {
 
 			$_SESSION['sess_import_package'] = file_get_contents($xmlfile);
 		} elseif (isset($_SESSION['sess_import_package'])) {
-			$xmlfile = sys_get_temp_dir() . '/package_import_' . rand();
+			$xmlfile = package_import_write_session_file();
 
-			file_put_contents($xmlfile, $_SESSION['sess_import_package']);
+			if ($xmlfile === false) {
+				/* Session is always active here: auth.php called cacti_session_start()
+				 * before any action dispatch, so raise_message() can safely write. */
+				raise_message('import_fail', __('Unable to create temporary package file.'), MESSAGE_LEVEL_ERROR);
+				header('Location: package_import.php');
+				exit;
+			}
 		} else {
 			header('Location: package_import.php');
 			exit;
@@ -219,9 +248,11 @@ function form_save() {
 
 function package_file_get_contents($filename) {
 	if (isset($_SESSION['sess_import_package'])) {
-		$xmlfile = sys_get_temp_dir() . '/package_import_' . rand();
+		$xmlfile = package_import_write_session_file();
 
-		file_put_contents($xmlfile, $_SESSION['sess_import_package']);
+		if ($xmlfile === false) {
+			return false;
+		}
 
 		$data = import_read_package_data($xmlfile, $binary_signature);
 
@@ -1110,4 +1141,3 @@ function package_prepare_import_array(&$templates, &$files, $package_name, $pack
 		}
 	}
 }
-

--- a/script_server.php
+++ b/script_server.php
@@ -258,7 +258,30 @@ while (1) {
 
 			/* validate the existence of the function, and include if applicable */
 			if (!function_exists($function)) {
-				if (file_exists($include_file)) {
+				$real_include = realpath($include_file);
+				$base_real    = realpath($config['base_path']);
+
+				if ($real_include !== false) {
+					$real_include = str_replace('\\', '/', $real_include);
+				}
+				if ($base_real !== false) {
+					$base_real = str_replace('\\', '/', $base_real);
+				}
+
+				/* On Windows, realpath() may return mixed-case drive letters; use
+				 * case-insensitive comparison to avoid false rejections. */
+				$path_cmp = (DIRECTORY_SEPARATOR === '\\') ? 'stripos' : 'strpos';
+				if ($real_include !== false && $base_real !== false && $path_cmp($real_include, $base_real . '/') === 0) {
+					$include_file = $real_include;
+				} elseif ($real_include !== false) {
+					cacti_log("WARNING: Script file '$include_file' resolves outside base path. Rejected.", false, 'PHPSVR');
+					$include_file = '';
+				} else {
+					cacti_log("WARNING: Script file '$include_file' could not be resolved. Rejected.", false, 'PHPSVR');
+					$include_file = '';
+				}
+
+				if ($include_file != '' && file_exists($include_file)) {
 					/**
 					 * quirk in php on Windows, believe it or not....
 					 * path must be lower case


### PR DESCRIPTION
## Status

This PR is now superseded by #7039.

I compared the current branch heads directly and there is no unique code left in `#7037` that is not already present in `#7039`. The four files changed here are identical on the `#7039` branch, and `#7039` then adds additional 1.2.x hardening on top.

## Original scope

Defense-in-depth hardening for the 1.2.x stable branch:

- `include/global.php` session and HTTP header hardening
- `index.php` content-panel include path validation
- `script_server.php` script include path validation
- `package_import.php` temp file hardening via `tempnam()`

## Recommendation

Merge #7039 and close this PR as superseded to avoid duplicate hardening history on `1.2.x`.
