### PR TITLE
security: consolidated defense-in-depth hardening (1.2.x)

### DIFF
--- a/automation_devices.php
+++ b/automation_devices.php
@@ -687,7 +687,7 @@ function export_data($item) {
 	if ($item == '') {
 		return 'N/A';
 	} else {
-		return $item;
+		return cacti_csv_safe($item);
 	}
 }
 

--- a/data_input.php
+++ b/data_input.php
@@ -94,6 +94,17 @@ function form_save() {
 		$save['input_string'] = form_input_validate(get_nfilter_request_var('input_string'), 'input_string', '', true, 3);
 		$save['type_id']      = form_input_validate(get_nfilter_request_var('type_id'), 'type_id', '^[0-9]+$', true, 3);
 
+		// Reject shell metacharacters outside of <placeholder> markers to prevent command injection
+		if (!is_error_message()) {
+			$input_string_bare = preg_replace('/<([_a-zA-Z0-9]+)>/', '', $save['input_string']);
+
+			if (preg_match('/[;&|`$\\\\\n\r]/', $input_string_bare)) {
+				raise_message('validation_error', __('Input string contains dangerous shell characters'), MESSAGE_LEVEL_ERROR);
+				header('Location: data_input.php?action=edit&id=' . (empty($save['id']) ? '' : $save['id']));
+				exit;
+			}
+		}
+
 		if (!is_error_message()) {
 			$data_input_id = sql_save($save, 'data_input');
 
@@ -918,4 +929,3 @@ function data() {
 
 	form_end();
 }
-

--- a/host.php
+++ b/host.php
@@ -604,6 +604,12 @@ function host_export() {
 				}
 			}
 
+			foreach ($h as &$field) {
+				$field = cacti_csv_safe($field);
+			}
+
+			unset($field);
+
 			fputcsv($stdout, $h);
 		}
 	}
@@ -1920,4 +1926,3 @@ function host() {
 
 	api_plugin_hook('device_table_bottom');
 }
-

--- a/include/global.php
+++ b/include/global.php
@@ -430,6 +430,7 @@ if ($config['is_web']) {
 	ini_set('session.cookie_httponly', true);
 	ini_set('session.cookie_path', $config['url_path']);
 	ini_set('session.use_strict_mode', true);
+	ini_set('session.use_only_cookies', true);
 
 	$options = array(
 		'cookie_httponly' => true,
@@ -479,8 +480,10 @@ if ($config['is_web']) {
 
 	/* prevent IE from silently rejects cookies sent from third party sites. */
 	header('P3P: CP="CAO PSA OUR"');
+	header('X-Content-Type-Options: nosniff');
+	header('Referrer-Policy: strict-origin-when-cross-origin');
+	header('Permissions-Policy: camera=(), geolocation=(), interest-cohort=(), microphone=(), payment=(), usb=()');
 	header('Cache-Control: no-store, no-cache, must-revalidate');
-	header('Cache-Control: max-age=31536000');
 
 	cacti_session_start();
 

--- a/index.php
+++ b/index.php
@@ -39,16 +39,27 @@ function render_external_links($style = 'FRONT') {
 		foreach($consoles as $page) {
 			if (is_realm_allowed($page['id']+10000)) {
 				if (preg_match('/^((((ht|f)tp(s?))\:\/\/){1}\S+)/i', $page['contentfile'])) {
-					print '<iframe class="content" src="' . $page['contentfile'] . '" frameborder="0"></iframe>';
+					print '<iframe class="content" src="' . html_escape($page['contentfile']) . '" frameborder="0"></iframe>';
 				} else {
 					print '<div id="content">';
 
-					$file = $config['base_path'] . "/include/content/" . $page['contentfile'];
+					$content_dir = realpath($config['base_path'] . '/include/content');
+					$file = realpath($config['base_path'] . '/include/content/' . $page['contentfile']);
 
-					if (file_exists($file)) {
+					if ($content_dir !== false) {
+						$content_dir = str_replace('\\', '/', $content_dir);
+					}
+					if ($file !== false) {
+						$file = str_replace('\\', '/', $file);
+					}
+
+					/* On Windows, realpath() may return mixed-case drive letters; use
+					 * case-insensitive comparison to avoid false rejections. */
+					$path_cmp = (DIRECTORY_SEPARATOR === '\\') ? 'stripos' : 'strpos';
+					if ($file !== false && $content_dir !== false && $path_cmp($file, $content_dir . '/') === 0) {
 						include_once($file);
 					} else {
-						print '<h1>The file \'' . $page['contentfile'] . '\' does not exist!!</h1>';
+						print '<h1>The file \'' . html_escape($page['contentfile']) . '\' does not exist!!</h1>';
 					}
 
 					print '</div>';

--- a/lib/database.php
+++ b/lib/database.php
@@ -1774,7 +1774,15 @@ function db_replace($table_name, $array_items, $keyCols, $db_conn = false) {
 		$db_conn = $database_sessions["$database_hostname:$database_port:$database_default"];
 	}
 
-	cacti_log("DEVEL: SQL Replace on table '$table_name': '" . serialize($array_items) . "'", false, 'DBCALL', POLLER_VERBOSITY_DEVDBG);
+	$log_items = $array_items;
+	$redact_fields = array('snmp_community', 'snmp_password', 'snmp_priv_passphrase', 'password', 'proxy_password');
+	foreach ($redact_fields as $field) {
+		if (isset($log_items[$field])) {
+			$log_items[$field] = '********';
+		}
+	}
+
+	cacti_log("DEVEL: SQL Replace on table '$table_name': '" . serialize($log_items) . "'", false, 'DBCALL', POLLER_VERBOSITY_DEVDBG);
 
 	_db_replace($db_conn, $table_name, $array_items, $keyCols);
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -7295,6 +7295,25 @@ function cacti_ptoa($title, $addr) {
 	}
 }
 
+/**
+ * cacti_csv_safe - sanitzes a string for inclusion in a CSV file to prevent formula injection
+ *
+ * @param $value - (string) The string to be sanitized
+ *
+ * @returns - (string) The sanitized string
+ */
+function cacti_csv_safe($value) {
+	$value = (string)$value;
+
+	if ($value != '') {
+		if (strpos($value, '=') === 0 || strpos($value, '+') === 0 || strpos($value, '-') === 0 || strpos($value, '@') === 0) {
+			$value = "'" . $value;
+		}
+	}
+
+	return $value;
+}
+
 function cacti_sizeof($array) {
 	return ($array === false || !is_array($array)) ? 0 : sizeof($array);
 }
@@ -7753,4 +7772,3 @@ function cacti_format_ipv6_colon($address) {
 
 	return($address);
 }
-

--- a/lib/rrdcheck.php
+++ b/lib/rrdcheck.php
@@ -159,7 +159,7 @@ function do_rrdcheck($thread_id = 1) {
 			$file = $rrdval['data_source_path'];
 
 			if ($use_proxy) {
-				$file_exists = rrdtool_execute("file_exists $file", true, RRDTOOL_OUTPUT_BOOLEAN, false, 'RRDCHECK');
+				$file_exists = rrdtool_execute('file_exists ' . cacti_escapeshellarg($file), true, RRDTOOL_OUTPUT_BOOLEAN, false, 'RRDCHECK');
 			} else {
 				clearstatcache();
 				$file_exists = file_exists($file);
@@ -210,9 +210,9 @@ function do_rrdcheck($thread_id = 1) {
 				}
 
 				if ($use_proxy) {
-					$output = rrdtool_execute("info $file", false, RRDTOOL_OUTPUT_STDOUT, false, 'RRDCHECK');
+					$output = rrdtool_execute('info ' . cacti_escapeshellarg($file), false, RRDTOOL_OUTPUT_STDOUT, false, 'RRDCHECK');
 				} else {
-					$output = rrdcheck_rrdtool_execute("info $file", $pipes);
+					$output = rrdcheck_rrdtool_execute(['info', $file], $pipes);
 				}
 
 				$matches     = array();
@@ -364,9 +364,9 @@ function do_rrdcheck($thread_id = 1) {
 				$one_hour_limit = ($duration - 3600) / $step;
 
 				if ($use_proxy) {
-					$info_array = rrdtool_execute("fetch $file LAST -s $pstart -e $pend ", false, RRDTOOL_OUTPUT_STDOUT, false, 'RRDCHECK');
+					$info_array = rrdtool_execute(['fetch', $file, 'LAST', '-s', $pstart, '-e', $pend], false, RRDTOOL_OUTPUT_STDOUT, false, 'RRDCHECK');
 				} else {
-					$info_array = rrdcheck_rrdtool_execute("fetch $file LAST -s $pstart -e $pend", $pipes);
+					$info_array = rrdcheck_rrdtool_execute(['fetch', $file, 'LAST', '-s', $pstart, '-e', $pend], $pipes);
 				}
 
 				/* don't do anything if RRDfile did not return data */
@@ -751,9 +751,9 @@ function rrdcheck_poller_bottom () {
 
 		if (read_config_option('path_rrdcheck_log') != '') {
 			if ($config['cacti_server_os'] == 'unix') {
-				$extra_args = '-q ' . $config['base_path'] . '/poller_rrdcheck.php >> ' . read_config_option('path_rrdcheck_log') . ' 2>&1';
+				$extra_args = '-q ' . $config['base_path'] . '/poller_rrdcheck.php >> ' . cacti_escapeshellarg(read_config_option('path_rrdcheck_log')) . ' 2>&1';
 			} else {
-				$extra_args = '-q ' . $config['base_path'] . '/poller_rrdcheck.php >> ' . read_config_option('path_rrdcheck_log');
+				$extra_args = '-q ' . $config['base_path'] . '/poller_rrdcheck.php >> ' . cacti_escapeshellarg(read_config_option('path_rrdcheck_log'));
 			}
 		} else {
 			$extra_args = '-q ' . $config['base_path'] . '/poller_rrdcheck.php';
@@ -818,6 +818,26 @@ function rrdcheck_rrdtool_init() {
  */
 function rrdcheck_rrdtool_execute($command, &$pipes) {
 	static $broken = false;
+
+	if (is_array($command)) {
+		if (cacti_sizeof($command)) {
+			$command_line = array_shift($command);
+
+			if (cacti_sizeof($command)) {
+				$escaped_args = array();
+
+				foreach($command as $arg) {
+					$escaped_args[] = cacti_escapeshellarg($arg);
+				}
+
+				$command_line .= ' ' . implode(' ', $escaped_args);
+			}
+
+			$command = $command_line;
+		} else {
+			$command = '';
+		}
+	}
 
 	$stdout = '';
 
@@ -974,4 +994,3 @@ function rrdcheck_processes_running($type) {
 
 	return $running;
 }
-

--- a/package_import.php
+++ b/package_import.php
@@ -80,6 +80,29 @@ function check_tmp_dir() {
 	}
 }
 
+function package_import_write_session_file() {
+	if (!isset($_SESSION['sess_import_package'])) {
+		return false;
+	}
+
+	$xmlfile = tempnam(sys_get_temp_dir(), 'cacti_pkg_');
+
+	if ($xmlfile === false) {
+		cacti_log('FATAL: Unable to create temporary package import file', true, 'IMPORT');
+
+		return false;
+	}
+
+	if (file_put_contents($xmlfile, $_SESSION['sess_import_package']) === false) {
+		cacti_log('FATAL: Unable to write temporary package import file', true, 'IMPORT');
+		unlink($xmlfile);
+
+		return false;
+	}
+
+	return $xmlfile;
+}
+
 function form_save() {
 	global $config, $preview_only;
 
@@ -94,9 +117,15 @@ function form_save() {
 
 			$_SESSION['sess_import_package'] = file_get_contents($xmlfile);
 		} elseif (isset($_SESSION['sess_import_package'])) {
-			$xmlfile = sys_get_temp_dir() . '/package_import_' . rand();
+			$xmlfile = package_import_write_session_file();
 
-			file_put_contents($xmlfile, $_SESSION['sess_import_package']);
+			if ($xmlfile === false) {
+				/* Session is always active here: auth.php called cacti_session_start()
+				 * before any action dispatch, so raise_message() can safely write. */
+				raise_message('import_fail', __('Unable to create temporary package file.'), MESSAGE_LEVEL_ERROR);
+				header('Location: package_import.php');
+				exit;
+			}
 		} else {
 			header('Location: package_import.php');
 			exit;
@@ -219,9 +248,11 @@ function form_save() {
 
 function package_file_get_contents($filename) {
 	if (isset($_SESSION['sess_import_package'])) {
-		$xmlfile = sys_get_temp_dir() . '/package_import_' . rand();
+		$xmlfile = package_import_write_session_file();
 
-		file_put_contents($xmlfile, $_SESSION['sess_import_package']);
+		if ($xmlfile === false) {
+			return false;
+		}
 
 		$data = import_read_package_data($xmlfile, $binary_signature);
 
@@ -1110,4 +1141,3 @@ function package_prepare_import_array(&$templates, &$files, $package_name, $pack
 		}
 	}
 }
-

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -506,7 +506,7 @@ function boost_launch_children() {
 
 			cacti_log("WARNING: Boost log '$boost_log' is not writable!", true, 'BOOST');
 		} else {
-			$redirect_args = '>> ' . $boost_log;
+			$redirect_args = '>> ' . cacti_escapeshellarg($boost_log);
 		}
 	}
 
@@ -1372,6 +1372,8 @@ function boost_log_child_statistics($rrd_updates, $child) {
 }
 
 function boost_purge_cached_png_files($forcerun) {
+	global $config;
+
 	/* remove stale png's from the cache.  I consider png's stale after 1 hour */
 	if ((read_config_option('boost_png_cache_enable') == 'on') || $forcerun) {
 		$cache_directory = read_config_option('boost_png_cache_directory');
@@ -1380,8 +1382,33 @@ function boost_purge_cached_png_files($forcerun) {
 		$directory_contents = array();
 
 		if (is_dir($cache_directory)) {
-			if ($handle = opendir($cache_directory)) {
-				/* This is the correct way to loop over the directory. */
+			$real_cache_directory = realpath($cache_directory);
+			$real_base_path       = realpath($config['base_path']);
+			$normalized_cache     = ($real_cache_directory === false ? false : str_replace('\\', '/', $real_cache_directory));
+			$normalized_base      = ($real_base_path === false ? false : rtrim(str_replace('\\', '/', $real_base_path), '/'));
+
+			if ($normalized_cache !== false) {
+				$normalized_cache = rtrim($normalized_cache, '/');
+			}
+
+			if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
+				if ($normalized_cache !== false) {
+					$normalized_cache = strtolower($normalized_cache);
+				}
+
+				if ($normalized_base !== false) {
+					$normalized_base = strtolower($normalized_base);
+				}
+			}
+
+			// Verify directory is within CACTI_PATH_BASE to prevent arbitrary file deletion
+			if ($normalized_cache === false || $normalized_base === false
+				|| ($normalized_cache !== $normalized_base && strpos($normalized_cache, $normalized_base . '/') !== 0)) {
+				cacti_log("ERROR: Boost PNG Cache Directory '$cache_directory' is outside of Cacti base path. Purge aborted.", true, 'BOOST');
+				return;
+			}
+
+			if ($handle = opendir($cache_directory)) {				/* This is the correct way to loop over the directory. */
 				while (false !== ($file = readdir($handle))) {
 					$directory_contents[] = $file;
 				}
@@ -1431,4 +1458,3 @@ function display_help () {
 	print "    --force   - Force the execution of a update process\n";
 	print "    --debug   - Display verbose output during execution\n\n";
 }
-

--- a/script_server.php
+++ b/script_server.php
@@ -258,7 +258,30 @@ while (1) {
 
 			/* validate the existence of the function, and include if applicable */
 			if (!function_exists($function)) {
-				if (file_exists($include_file)) {
+				$real_include = realpath($include_file);
+				$base_real    = realpath($config['base_path']);
+
+				if ($real_include !== false) {
+					$real_include = str_replace('\\', '/', $real_include);
+				}
+				if ($base_real !== false) {
+					$base_real = str_replace('\\', '/', $base_real);
+				}
+
+				/* On Windows, realpath() may return mixed-case drive letters; use
+				 * case-insensitive comparison to avoid false rejections. */
+				$path_cmp = (DIRECTORY_SEPARATOR === '\\') ? 'stripos' : 'strpos';
+				if ($real_include !== false && $base_real !== false && $path_cmp($real_include, $base_real . '/') === 0) {
+					$include_file = $real_include;
+				} elseif ($real_include !== false) {
+					cacti_log("WARNING: Script file '$include_file' resolves outside base path. Rejected.", false, 'PHPSVR');
+					$include_file = '';
+				} else {
+					cacti_log("WARNING: Script file '$include_file' could not be resolved. Rejected.", false, 'PHPSVR');
+					$include_file = '';
+				}
+
+				if ($include_file != '' && file_exists($include_file)) {
 					/**
 					 * quirk in php on Windows, believe it or not....
 					 * path must be lower case


### PR DESCRIPTION
## Summary

Consolidated 1.2.x defense-in-depth hardening across command execution, path handling, CSV export safety, session headers, and sensitive-log redaction.

This PR is the kept 1.2.x hardening branch and supersedes #7037. The four-file hardening from `#7037` is already present here, and this branch adds additional validated fixes on top.

## Included hardening

- canonical base-path enforcement for dynamic includes and Boost cache purging
- safer RRDtool command construction in `rrdcheck`
- CSV formula-injection mitigation in exported rows
- stronger input validation for command-like data input strings
- tighter session / response security headers
- path validation and temp-file hardening already covered by the earlier `#7037` slice
- redaction of sensitive fields in DB debug logging

## Follow-up fixes on this branch

After review, this branch also now includes:

- PHP 7.4-compatible prefix checks instead of PHP 8-only `str_starts_with()` usage
- proper `global $config` handling in `boost_purge_cached_png_files()`
- placeholder matching aligned with the existing `<([_a-zA-Z0-9]+)>` format
- RRDtool proxy-safe string execution paths in `lib/rrdcheck.php`
- `unset($field)` after by-reference CSV export loops

## Verification

Syntax-checked all changed PHP files on the branch, including the follow-up fixes in:

- `include/global.php`
- `index.php`
- `script_server.php`
- `package_import.php`
- `poller_boost.php`
- `lib/functions.php`
- `data_input.php`
- `lib/rrdcheck.php`
- `host.php`

## Risk

Moderate. The branch touches multiple security-relevant surfaces, but the follow-up fixes keep it PHP 7.4-compatible and aligned with existing 1.2.x patterns.
