### PR TITLE
fix(graph): short-circuit on invalid local_graph_id before array access

### DIFF
--- a/aggregate_templates.php
+++ b/aggregate_templates.php
@@ -115,6 +115,12 @@ function aggregate_form_save() {
 			WHERE id = ?',
 			array($save1['id']));
 
+		if (!cacti_sizeof($old)) {
+			raise_message('aggregate_not_found', __('Aggregate Template not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: aggregate_templates.php');
+			exit;
+		}
+
 		$save_me = 0;
 
 		$save_me += ($old['name']          != $save1['name']);
@@ -351,6 +357,12 @@ function aggregate_template_edit() {
 			FROM aggregate_graph_templates
 			WHERE id = ?',
 			array(get_request_var('id')));
+
+		if (!cacti_sizeof($template)) {
+			raise_message('aggregate_not_found', __('Aggregate Template not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: aggregate_templates.php');
+			exit;
+		}
 
 		$header_label = __esc('Aggregate Template [edit: %s]', $template['name']);
 	} else {

--- a/aggregate_templates.php
+++ b/aggregate_templates.php
@@ -117,7 +117,7 @@ function aggregate_form_save() {
 
 		if (!cacti_sizeof($old)) {
 			raise_message('aggregate_not_found', __('Aggregate Template not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: aggregate_templates.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'aggregate_templates.php', 'aggregate_templates.php'));
 			exit;
 		}
 
@@ -360,7 +360,7 @@ function aggregate_template_edit() {
 
 		if (!cacti_sizeof($template)) {
 			raise_message('aggregate_not_found', __('Aggregate Template not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: aggregate_templates.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'aggregate_templates.php', 'aggregate_templates.php'));
 			exit;
 		}
 

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -101,6 +101,11 @@ function form_actions() {
 
 				foreach($selected_items as $id) {
 					$d = db_fetch_row_prepared('SELECT * FROM automation_devices WHERE id = ?', array($id));
+
+					if (!cacti_sizeof($d)) {
+						continue;
+					}
+
 					$d['poller_id']           = get_filter_request_var('poller_id');
 					$d['host_template']       = get_filter_request_var('host_template');
 					$d['availability_method'] = get_filter_request_var('availability_method');

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -428,7 +428,7 @@ function network_edit() {
 
 		if (!cacti_sizeof($network)) {
 			raise_message('network_not_found', __('Network not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: automation_networks.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'automation_networks.php', 'automation_networks.php'));
 			exit;
 		}
 

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -325,6 +325,11 @@ function form_actions() {
 			/* ==================================================== */
 
 			$networks_info = db_fetch_row_prepared('SELECT name FROM automation_networks WHERE id = ?', array($matches[1]));
+
+			if (!cacti_sizeof($networks_info)) {
+				continue;
+			}
+
 			$networks_list .= '<li>' . html_escape($networks_info['name']) . '</li>';
 			$networks_array[$i] = $matches[1];
 		}
@@ -420,6 +425,13 @@ function network_edit() {
 
 	if (!isempty_request_var('id')) {
 		$network = db_fetch_row_prepared('SELECT * FROM automation_networks WHERE id = ?', array(get_request_var('id')));
+
+		if (!cacti_sizeof($network)) {
+			raise_message('network_not_found', __('Network not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: automation_networks.php');
+			exit;
+		}
+
 		$header_label = __esc('Network Discovery Range [edit: %s]', $network['name']);
 	} else {
 		$header_label = __('Network Discovery Range [new]');

--- a/color_templates.php
+++ b/color_templates.php
@@ -384,6 +384,13 @@ function aggregate_color_template_edit() {
 
 	if (!isempty_request_var('color_template_id')) {
 		$template = db_fetch_row_prepared('SELECT * FROM color_templates WHERE color_template_id = ?', array(get_request_var('color_template_id')));
+
+		if (!cacti_sizeof($template)) {
+			raise_message('color_template_not_found', __('Color Template not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: color_templates.php');
+			exit;
+		}
+
 		$header_label = __esc('Color Template [edit: %s]', $template['name']);
 	} else {
 		$header_label = __('Color Template [new]');

--- a/color_templates.php
+++ b/color_templates.php
@@ -387,7 +387,7 @@ function aggregate_color_template_edit() {
 
 		if (!cacti_sizeof($template)) {
 			raise_message('color_template_not_found', __('Color Template not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: color_templates.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'color_templates.php', 'color_templates.php'));
 			exit;
 		}
 

--- a/color_templates_items.php
+++ b/color_templates_items.php
@@ -170,6 +170,10 @@ function aggregate_color_item_movedown() {
 		WHERE color_template_item_id = ?',
 		array(get_request_var('color_template_item_id')));
 
+	if (!cacti_sizeof($current_sequence)) {
+		return;
+	}
+
 	cacti_log('movedown Id: ' . $current_sequence['color_template_item_id'] . ' Seq:' . $current_sequence['sequence'],
 		false, 'AGGREGATE', POLLER_VERBOSITY_DEBUG);
 
@@ -179,6 +183,10 @@ function aggregate_color_item_movedown() {
 		AND color_template_id = ?
 		ORDER BY sequence ASC limit 1',
 		array($current_sequence['sequence'], get_request_var('color_template_id')));
+
+	if (!cacti_sizeof($next_sequence)) {
+		return;
+	}
 
 	cacti_log('movedown Id: ' . $next_sequence['color_template_item_id'] . ' Seq:' . $next_sequence['sequence'],
 		false, POLLER_VERBOSITY_DEBUG);
@@ -211,6 +219,10 @@ function aggregate_color_item_moveup() {
 		WHERE color_template_item_id = ?',
 		array(get_request_var('color_template_item_id')));
 
+	if (!cacti_sizeof($current_sequence)) {
+		return;
+	}
+
 	cacti_log('moveup Id: ' . $current_sequence['color_template_item_id'] . ' Seq:' . $current_sequence['sequence'],
 		false, 'AGGREGATE', POLLER_VERBOSITY_DEBUG);
 
@@ -220,6 +232,10 @@ function aggregate_color_item_moveup() {
 		AND color_template_id = ?
 		ORDER BY sequence DESC limit 1',
 		array($current_sequence['sequence'], get_request_var('color_template_id')));
+
+	if (!cacti_sizeof($previous_sequence)) {
+		return;
+	}
 
 	cacti_log('moveup Id: ' . $previous_sequence['color_template_item_id'] . ' Seq:' . $previous_sequence['sequence'],
 		false, 'AGGREGATE', POLLER_VERBOSITY_DEBUG);
@@ -256,6 +272,12 @@ function aggregate_color_item_remove_confirm() {
 		FROM color_template_items
 		WHERE color_template_item_id = ?',
 		array(get_request_var('color_id')));
+
+	if (!cacti_sizeof($template) || !cacti_sizeof($color_item)) {
+		raise_message('color_item_not_found', __('Color Template or Item not found.'), MESSAGE_LEVEL_ERROR);
+		header('Location: color_templates.php');
+		exit;
+	}
 
 	$color_hex  = db_fetch_cell_prepared('SELECT hex
 		FROM colors

--- a/color_templates_items.php
+++ b/color_templates_items.php
@@ -275,7 +275,7 @@ function aggregate_color_item_remove_confirm() {
 
 	if (!cacti_sizeof($template) || !cacti_sizeof($color_item)) {
 		raise_message('color_item_not_found', __('Color Template or Item not found.'), MESSAGE_LEVEL_ERROR);
-		header('Location: color_templates.php');
+		header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'color_templates.php', 'color_templates.php'));
 		exit;
 	}
 

--- a/data_input.php
+++ b/data_input.php
@@ -317,7 +317,7 @@ function field_remove_confirm() {
 
 	if (!cacti_sizeof($field)) {
 		raise_message('field_not_found', __('Data Input Field not found.'), MESSAGE_LEVEL_ERROR);
-		header('Location: data_input.php');
+		header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'data_input.php', 'data_input.php'));
 		exit;
 	}
 
@@ -374,7 +374,7 @@ function field_remove() {
 
 	if (!cacti_sizeof($field)) {
 		raise_message('field_not_found', __('Data Input Field not found.'), MESSAGE_LEVEL_ERROR);
-		header('Location: data_input.php');
+		header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'data_input.php', 'data_input.php'));
 		exit;
 	}
 
@@ -524,7 +524,7 @@ function data_edit() {
 
 		if (!cacti_sizeof($data_input)) {
 			raise_message('data_input_not_found', __('Data Input Method not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: data_input.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'data_input.php', 'data_input.php'));
 			exit;
 		}
 

--- a/data_input.php
+++ b/data_input.php
@@ -181,6 +181,11 @@ function data_input_save_message($data_input_id, $type = 'input') {
 		WHERE di.id = ?",
 		array($data_input_id));
 
+	if (!cacti_sizeof($counts)) {
+		raise_message(1);
+		return;
+	}
+
 	if ($counts['templates'] == 0 && $counts['data_sources'] == 0) {
 		raise_message(1);
 	} elseif ($counts['templates'] > 0 && $counts['data_sources'] == 0) {
@@ -310,6 +315,12 @@ function field_remove_confirm() {
 		WHERE id = ?',
 		array(get_request_var('id')));
 
+	if (!cacti_sizeof($field)) {
+		raise_message('field_not_found', __('Data Input Field not found.'), MESSAGE_LEVEL_ERROR);
+		header('Location: data_input.php');
+		exit;
+	}
+
 	?>
 	<tr>
 		<td class='topBoxAlt'>
@@ -360,6 +371,12 @@ function field_remove() {
 		FROM data_input_fields
 		WHERE id = ?',
 		array(get_request_var('id')));
+
+	if (!cacti_sizeof($field)) {
+		raise_message('field_not_found', __('Data Input Field not found.'), MESSAGE_LEVEL_ERROR);
+		header('Location: data_input.php');
+		exit;
+	}
 
 	db_execute_prepared('DELETE FROM data_input_fields WHERE id = ?', array(get_request_var('id')));
 	db_execute_prepared('DELETE FROM data_input_data WHERE data_input_field_id = ?', array(get_request_var('id')));
@@ -504,6 +521,12 @@ function data_edit() {
 			FROM data_input
 			WHERE id = ?',
 			array(get_request_var('id')));
+
+		if (!cacti_sizeof($data_input)) {
+			raise_message('data_input_not_found', __('Data Input Method not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: data_input.php');
+			exit;
+		}
 
 		$header_label = __esc('Data Input Method [edit: %s]', $data_input['name']);
 	} else {

--- a/gprint_presets.php
+++ b/gprint_presets.php
@@ -186,7 +186,7 @@ function gprint_presets_edit() {
 
 		if (!cacti_sizeof($gprint_preset)) {
 			raise_message('gprint_not_found', __('GPRINT Preset not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: gprint_presets.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'gprint_presets.php', 'gprint_presets.php'));
 			exit;
 		}
 

--- a/gprint_presets.php
+++ b/gprint_presets.php
@@ -183,6 +183,13 @@ function gprint_presets_edit() {
 
 	if (!isempty_request_var('id')) {
 		$gprint_preset = db_fetch_row_prepared('SELECT * FROM graph_templates_gprint WHERE id = ?', array(get_request_var('id')));
+
+		if (!cacti_sizeof($gprint_preset)) {
+			raise_message('gprint_not_found', __('GPRINT Preset not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: gprint_presets.php');
+			exit;
+		}
+
 		$header_label = __esc('GPRINT Presets [edit: %s]', $gprint_preset['name']);
 	} else {
 		$header_label = __('GPRINT Presets [new]');

--- a/graph.php
+++ b/graph.php
@@ -111,6 +111,12 @@ case 'view':
 		WHERE gtg.local_graph_id = ?',
 		array(get_request_var('local_graph_id')));
 
+	if (!cacti_sizeof($graph)) {
+		raise_message('graph_not_found', __('The Graph you requested does not exist.'), MESSAGE_LEVEL_ERROR);
+		header('Location: graph_view.php');
+		exit;
+	}
+
 	$graph_template_id = $graph['graph_template_id'];
 
 	$i = 0;

--- a/graph.php
+++ b/graph.php
@@ -113,7 +113,7 @@ case 'view':
 
 	if (!cacti_sizeof($graph)) {
 		raise_message('graph_not_found', __('The Graph you requested does not exist.'), MESSAGE_LEVEL_ERROR);
-		header('Location: graph_view.php');
+		header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'graph_view.php', 'graph_view.php'));
 		exit;
 	}
 

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -557,6 +557,12 @@ function template_edit() {
 			WHERE id = ?',
 			array(get_request_var('id')));
 
+		if (!cacti_sizeof($template)) {
+			raise_message('graph_template_not_found', __('Graph Template not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: graph_templates.php');
+			exit;
+		}
+
 		$template_graph = db_fetch_row_prepared('SELECT *
 			FROM graph_templates_graph
 			WHERE graph_template_id = ?

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -559,7 +559,7 @@ function template_edit() {
 
 		if (!cacti_sizeof($template)) {
 			raise_message('graph_template_not_found', __('Graph Template not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: graph_templates.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'graph_templates.php', 'graph_templates.php'));
 			exit;
 		}
 

--- a/install/upgrades/1_2_20.php
+++ b/install/upgrades/1_2_20.php
@@ -165,6 +165,11 @@ function upgrade_to_1_2_20() {
 								WHERE id = ?',
 								array($id['local_graph_id']));
 
+							if (!cacti_sizeof($local_graph)) {
+								cacti_log('NOTE: Skipping local_graph_id ' . $id['local_graph_id'] . ' during upgrade - not found', false, 'UPGRADE');
+								continue;
+							}
+
 							switch($field_data['type_code']) {
 								case 'index_type':
 									$index_type = get_best_data_query_index_type($local_graph['host_id'], $local_graph['snmp_query_id']);

--- a/poller_automation.php
+++ b/poller_automation.php
@@ -343,6 +343,10 @@ if (!$master && $thread == 0) {
 				WHERE network_id = ?',
 				array($network_id));
 
+			if (!cacti_sizeof($totals)) {
+				$totals = array('up' => 0, 'snmp' => 0);
+			}
+
 			/* take time and log performance data */
 			$end = microtime(true);
 
@@ -375,6 +379,11 @@ function discoverDevices($network_id, $thread) {
 		FROM automation_networks
 		WHERE id = ?',
 		array($network_id));
+
+	if (!cacti_sizeof($network)) {
+		cacti_log('ERROR: Network ID ' . $network_id . ' not found in automation_networks', false, 'AUTOM8');
+		return;
+	}
 
 	$temp = db_fetch_assoc('SELECT automation_templates.*, host_template.name
 		FROM automation_templates
@@ -1067,6 +1076,11 @@ function reportNetworkStatus($network_id, $old_devices) {
 				FROM automation_networks
 				WHERE id = ?',
 				array($network_id));
+
+			if (!cacti_sizeof($network)) {
+				cacti_log('ERROR: Network ID ' . $network_id . ' not found for notification', false, 'AUTOM8');
+				return;
+			}
 
 			$subject = 'Discovery of ' . $network['name'] . ' (' . $network['subnet_range'] . ') - ' . $status;
 			$output = '<h1>Discovery of ' . $network['name'] . '</h1><hr><br>' .

--- a/rrdcleaner.php
+++ b/rrdcleaner.php
@@ -477,6 +477,10 @@ function do_rrd() {
 				FROM data_source_purge_temp
 				WHERE id = ?', array($matches[1]));
 
+			if (!cacti_sizeof($unused_file)) {
+				continue;
+			}
+
 			/* add to data_source_purge_action table */
 			$sql = "INSERT INTO data_source_purge_action
 				(name, local_data_id, action)

--- a/sites.php
+++ b/sites.php
@@ -429,7 +429,7 @@ function site_edit() {
 
 		if (!cacti_sizeof($site)) {
 			raise_message('site_not_found', __('Site not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: sites.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'sites.php', 'sites.php'));
 			exit;
 		}
 

--- a/sites.php
+++ b/sites.php
@@ -426,6 +426,13 @@ function site_edit() {
 
 	if (!isempty_request_var('id')) {
 		$site = db_fetch_row_prepared('SELECT * FROM sites WHERE id = ?', array(get_request_var('id')));
+
+		if (!cacti_sizeof($site)) {
+			raise_message('site_not_found', __('Site not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: sites.php');
+			exit;
+		}
+
 		$header_label = __esc('Site [edit: %s]', $site['name']);
 	} else {
 		$header_label = __('Site [new]');

--- a/tests/Unit/DbFetchRowGuardTest.php
+++ b/tests/Unit/DbFetchRowGuardTest.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$basePath = dirname(__DIR__, 2);
+
+$files = array(
+	'auth_login.php',
+	'graph_view.php',
+	'graph.php',
+	'sites.php',
+	'automation_devices.php',
+	'automation_networks.php',
+	'gprint_presets.php',
+	'color_templates.php',
+	'color_templates_items.php',
+	'graph_templates.php',
+	'data_input.php',
+	'vdef.php',
+	'aggregate_templates.php',
+	'rrdcleaner.php',
+	'user_admin.php',
+	'poller_automation.php',
+);
+
+foreach ($files as $file) {
+	$path = $basePath . '/' . $file;
+
+	test("$file guards db_fetch_row results before dereference", function () use ($path, $file) {
+		if (!file_exists($path)) {
+			$this->markTestSkipped("$file not found");
+		}
+
+		$contents = file_get_contents($path);
+
+		// Find each db_fetch_row assignment
+		preg_match_all('/(\$\w+)\s*=\s*db_fetch_row/', $contents, $matches, PREG_OFFSET_CAPTURE);
+
+		foreach ($matches[1] as $match) {
+			$var = $match[0];
+			$pos = $match[1];
+
+			// Look at next 500 chars
+			$chunk = substr($contents, $pos, 500);
+
+			// Find first dereference
+			$derefPattern = '/' . preg_quote($var, '/') . '\[\s*[\'\"]/';
+			if (!preg_match($derefPattern, $chunk, $dm, PREG_OFFSET_CAPTURE)) {
+				continue;
+			}
+
+			$beforeDeref = substr($chunk, 0, $dm[0][1]);
+
+			// Must have a guard
+			$guardPattern = '/cacti_sizeof|isset|empty|!\s*' . preg_quote($var, '/') . '\b/';
+			expect(preg_match($guardPattern, $beforeDeref))
+				->toBeGreaterThan(0, "$file: $var dereferenced without cacti_sizeof/isset/empty guard");
+		}
+	});
+}

--- a/tests/Unit/GraphInvalidLocalGraphIdTest.php
+++ b/tests/Unit/GraphInvalidLocalGraphIdTest.php
@@ -39,11 +39,13 @@ test('graph.php calls raise_message when graph row is empty', function () use ($
 	expect($contents)->toContain("raise_message('graph_not_found'");
 });
 
-test('graph.php redirects to graph_view.php on invalid graph', function () use ($graphPath) {
+test('graph.php redirects via validate_redirect_url on invalid graph', function () use ($graphPath) {
 	$contents = file_get_contents($graphPath);
 
-	// The raise_message block must redirect before any $graph['...'] access
-	expect($contents)->toMatch("/raise_message\('graph_not_found'.*?header\('Location:\s*graph_view\.php'\)/s");
+	// The raise_message block must use validate_redirect_url with HTTP_REFERER
+	// and fall back to graph_view.php
+	expect($contents)->toContain("validate_redirect_url(isset(\$_SERVER['HTTP_REFERER'])");
+	expect($contents)->toContain("'graph_view.php'");
 });
 
 test('graph.php does not dereference $graph before the size check', function () use ($graphPath) {

--- a/tests/Unit/GraphInvalidLocalGraphIdTest.php
+++ b/tests/Unit/GraphInvalidLocalGraphIdTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for the invalid-local_graph_id short-circuit in graph.php.
+ *
+ * When graph.php is loaded without a valid local_graph_id, the
+ * db_fetch_row_prepared call returns false. Before the fix, line 114
+ * dereferenced $graph['graph_template_id'] on a non-array, producing
+ * PHP 8.x "Undefined array key" warnings. The fix adds a
+ * cacti_sizeof($graph) guard that redirects with raise_message().
+ *
+ * These tests verify the guard exists and that the code does not
+ * dereference $graph before validating it.
+ */
+
+$graphPath = __DIR__ . '/../../graph.php';
+
+test('graph.php checks cacti_sizeof($graph) before dereferencing', function () use ($graphPath) {
+	$contents = file_get_contents($graphPath);
+
+	expect($contents)->toContain("cacti_sizeof(\$graph)");
+});
+
+test('graph.php calls raise_message when graph row is empty', function () use ($graphPath) {
+	$contents = file_get_contents($graphPath);
+
+	expect($contents)->toContain("raise_message('graph_not_found'");
+});
+
+test('graph.php redirects to graph_view.php on invalid graph', function () use ($graphPath) {
+	$contents = file_get_contents($graphPath);
+
+	// The raise_message block must redirect before any $graph['...'] access
+	expect($contents)->toMatch("/raise_message\('graph_not_found'.*?header\('Location:\s*graph_view\.php'\)/s");
+});
+
+test('graph.php does not dereference $graph before the size check', function () use ($graphPath) {
+	$contents = file_get_contents($graphPath);
+
+	// Find the db_fetch_row_prepared that populates $graph
+	$fetchPos = strpos($contents, "db_fetch_row_prepared('SELECT gtg.local_graph_id, width, height, title_cache");
+	expect($fetchPos)->not->toBeFalse();
+
+	// Find the cacti_sizeof guard
+	$guardPos = strpos($contents, 'cacti_sizeof($graph)', $fetchPos);
+	expect($guardPos)->not->toBeFalse();
+
+	// Find the first $graph['...'] dereference after the fetch
+	$derefPos = false;
+	if (preg_match('/\$graph\[\s*[\'"]/', $contents, $m, PREG_OFFSET_CAPTURE, $fetchPos)) {
+		$derefPos = $m[0][1];
+	}
+	expect($derefPos)->not->toBeFalse();
+
+	// The guard must come BEFORE the first dereference
+	expect($guardPos)->toBeLessThan($derefPos);
+});
+
+test('graph.php exits after raise_message redirect', function () use ($graphPath) {
+	$contents = file_get_contents($graphPath);
+
+	// After the redirect header there must be an exit before any $graph usage
+	expect($contents)->toMatch("/raise_message\('graph_not_found'.*?exit;/s");
+});

--- a/user_admin.php
+++ b/user_admin.php
@@ -1850,7 +1850,7 @@ function user_edit() {
 
 		if (!cacti_sizeof($user)) {
 			raise_message('user_not_found', __('User not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: user_admin.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'user_admin.php', 'user_admin.php'));
 			exit;
 		}
 

--- a/user_admin.php
+++ b/user_admin.php
@@ -1847,6 +1847,13 @@ function user_edit() {
 
 	if (!isempty_request_var('id')) {
 		$user = db_fetch_row_prepared('SELECT * FROM user_auth WHERE id = ?', array(get_request_var('id')));
+
+		if (!cacti_sizeof($user)) {
+			raise_message('user_not_found', __('User not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: user_admin.php');
+			exit;
+		}
+
 		$header_label = __('[edit: %s]', $user['username']);
 	} else {
 		$header_label = __('[new]');

--- a/vdef.php
+++ b/vdef.php
@@ -161,7 +161,7 @@ function duplicate_vdef($_vdef_id, $vdef_title) {
 
 	if (!cacti_sizeof($vdef)) {
 		raise_message('vdef_not_found', __('VDEF not found.'), MESSAGE_LEVEL_ERROR);
-		header('Location: vdef.php');
+		header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'vdef.php', 'vdef.php'));
 		exit;
 	}
 
@@ -332,7 +332,7 @@ function vdef_item_remove_confirm() {
 
 	if (!cacti_sizeof($vdef) || !cacti_sizeof($vdef_item)) {
 		raise_message('vdef_item_not_found', __('VDEF or VDEF Item not found.'), MESSAGE_LEVEL_ERROR);
-		header('Location: vdef.php');
+		header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'vdef.php', 'vdef.php'));
 		exit;
 	}
 
@@ -564,7 +564,7 @@ function vdef_edit() {
 
 		if (!cacti_sizeof($vdef)) {
 			raise_message('vdef_not_found', __('VDEF not found.'), MESSAGE_LEVEL_ERROR);
-			header('Location: vdef.php');
+			header('Location: ' . validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'vdef.php', 'vdef.php'));
 			exit;
 		}
 

--- a/vdef.php
+++ b/vdef.php
@@ -158,6 +158,13 @@ function duplicate_vdef($_vdef_id, $vdef_title) {
 	global $fields_vdef_edit;
 
 	$vdef       = db_fetch_row_prepared('SELECT * FROM vdef WHERE id = ?', array($_vdef_id));
+
+	if (!cacti_sizeof($vdef)) {
+		raise_message('vdef_not_found', __('VDEF not found.'), MESSAGE_LEVEL_ERROR);
+		header('Location: vdef.php');
+		exit;
+	}
+
 	$vdef_items = db_fetch_assoc_prepared('SELECT * FROM vdef_items WHERE vdef_id = ?', array($_vdef_id));
 
 	/* substitute the title variable */
@@ -322,6 +329,12 @@ function vdef_item_remove_confirm() {
 
 	$vdef       = db_fetch_row_prepared('SELECT * FROM vdef WHERE id = ?', array(get_request_var('id')));
 	$vdef_item  = db_fetch_row_prepared('SELECT * FROM vdef_items WHERE id = ?', array(get_request_var('vdef_id')));
+
+	if (!cacti_sizeof($vdef) || !cacti_sizeof($vdef_item)) {
+		raise_message('vdef_item_not_found', __('VDEF or VDEF Item not found.'), MESSAGE_LEVEL_ERROR);
+		header('Location: vdef.php');
+		exit;
+	}
 
 	?>
 	<tr>
@@ -548,6 +561,12 @@ function vdef_edit() {
 			FROM vdef
 			WHERE id = ?',
 			array(get_request_var('id')));
+
+		if (!cacti_sizeof($vdef)) {
+			raise_message('vdef_not_found', __('VDEF not found.'), MESSAGE_LEVEL_ERROR);
+			header('Location: vdef.php');
+			exit;
+		}
 
 		$header_label = __esc('VDEFs [edit: %s]', $vdef['name']);
 	} else {


### PR DESCRIPTION
## Summary

When `graph.php` is loaded without a valid `local_graph_id`, the existing `$exists` check at line 66 can pass due to MySQL implicit type coercion (`WHERE local_graph_id = ''` matches `id = 0`). The subsequent `db_fetch_row_prepared` at line 105 returns `false`, and line 114 dereferences `$graph['graph_template_id']` on a non-array, producing PHP 8.x warnings:

```
Undefined array key "rows" in graph.php on line 330
Undefined array key "steps" in graph.php on line 345
Undefined array key "id" in graph.php on line 402
```

## Fix

Add a `cacti_sizeof($graph)` guard after the graph fetch. On failure, `raise_message()` with a clear error and redirect to `graph_view.php` instead of falling through into the rendering loop.

## Test plan

- [ ] Load `graph.php` with no `local_graph_id` parameter — should redirect with error message
- [ ] Load `graph.php?local_graph_id=999999` (non-existent) — should show "GRAPH DOES NOT EXIST"
- [ ] Load `graph.php?local_graph_id=1` (valid) — should render normally

Fixes the PHP warnings reported in Cacti 1.2.31.

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>