### PR TITLE
fix(csrf): broaden GET deny-list, harden csrf-magic cookie and token compare

### DIFF
--- a/include/global.php
+++ b/include/global.php
@@ -617,7 +617,12 @@ if ($config['is_web']) {
 	if (isset_request_var('action')) {
 		$action = get_nfilter_request_var('action');
 
-		$bad_actions = array('save', 'update_data', 'changepassword');
+		$bad_actions = array(
+			'save', 'update_data', 'changepassword',
+			'delete', 'remove', 'purge', 'disable', 'enable',
+			'install', 'uninstall', 'moveup', 'movedown',
+			'clear', 'kill', 'apply', 'ajax_save', 'update_fields'
+		);
 
 		foreach($bad_actions as $bad) {
 			if ($action == $bad && !isset($_POST['__csrf_magic'])) {

--- a/include/vendor/csrf/csrf-magic.php
+++ b/include/vendor/csrf/csrf-magic.php
@@ -140,7 +140,13 @@ function csrf_get_tokens() {
 		$token = 'sid:' . csrf_hash(session_id()) . $ip;
 	} elseif ($GLOBALS['csrf']['cookie']) {
 		$val = csrf_generate_secret();
-		setcookie($GLOBALS['csrf']['cookie'], $val, time() + 3600, $GLOBALS['csrf']['url_path']);
+		setcookie($GLOBALS['csrf']['cookie'], $val, array(
+            'expires'  => time() + 3600,
+            'path'     => $GLOBALS['csrf']['url_path'],
+            'secure'   => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+            'httponly'  => true,
+            'samesite' => 'Strict',
+        ));
 		$token = 'cookie:' . csrf_hash($val) . $ip;
 	} elseif ($GLOBALS['csrf']['key']) {
 		$token = 'key:' . csrf_hash($GLOBALS['csrf']['key']) . $ip;
@@ -260,17 +266,17 @@ function csrf_check_token($token) {
 			if ($check_token) {
 				switch ($type) {
 					case 'sid':
-						$valid_token = ($value === csrf_hash(session_id(), $time));
+						$valid_token = hash_equals(csrf_hash(session_id(), $time), $value);
 						break;
 					case 'cookie':
 						$n = $GLOBALS['csrf']['cookie'];
 						if ($n && isset($_COOKIE[$n])) {
-							$valid_token = ($value === csrf_hash($_COOKIE[$n], $time));
+							$valid_token = hash_equals(csrf_hash($_COOKIE[$n], $time), $value);
 						}
 						break;
 					case 'key':
 						if ($GLOBALS['csrf']['key']) {
-							$valid_token = ($value === csrf_hash($GLOBALS['csrf']['key'], $time));
+							$valid_token = hash_equals(csrf_hash($GLOBALS['csrf']['key'], $time), $value);
 						}
 						break;
 
@@ -279,7 +285,7 @@ function csrf_check_token($token) {
 						// implementation.
 					case 'user':
 						if (csrf_get_secret() && $GLOBALS['csrf']['user'] !== false) {
-							$valid_token = ($value === csrf_hash($GLOBALS['csrf']['user'], $time));
+							$valid_token = hash_equals(csrf_hash($GLOBALS['csrf']['user'], $time), $value);
 						}
 						break;
 					case 'ip':
@@ -292,7 +298,7 @@ function csrf_check_token($token) {
 
 							$client_ip = csrf_get_client_addr();
 							if (!empty($client_ip)) {
-								$valid_token = ($value === csrf_hash($client_ip, $time));
+								$valid_token = hash_equals(csrf_hash($client_ip, $time), $value);
 							}
 						}
 						break;

--- a/logout.php
+++ b/logout.php
@@ -31,6 +31,12 @@ set_default_action();
 
 api_plugin_hook('logout_pre_session_destroy');
 
+/* Note: logout is reachable via GET without CSRF token. Impact is limited
+ * to forced-logout (annoyance, no privilege escalation). SameSite=Strict
+ * on the session cookie prevents cross-site exploitation on modern browsers.
+ * Tracked in issue #7051 (csrf-magic evaluation). */
+
+
 /* Clear session */
 cacti_cookie_logout();
 cacti_session_destroy();

--- a/tests/Unit/CsrfHardeningTest.php
+++ b/tests/Unit/CsrfHardeningTest.php
@@ -1,0 +1,28 @@
+<?php
+
+$globalPath = __DIR__ . '/../../include/global.php';
+$csrfPath = __DIR__ . '/../../include/vendor/csrf/csrf-magic.php';
+
+test('global.php GET deny-list covers state-mutating actions', function () use ($globalPath) {
+    $source = file_get_contents($globalPath);
+    $actions = array('save', 'delete', 'remove', 'purge', 'disable', 'enable',
+        'install', 'uninstall', 'moveup', 'movedown', 'kill', 'clear');
+    foreach ($actions as $action) {
+        expect($source)->toContain("'" . $action . "'");
+    }
+});
+
+test('csrf-magic fallback cookie sets httponly flag', function () use ($csrfPath) {
+    $source = file_get_contents($csrfPath);
+    expect($source)->toContain("'httponly'");
+});
+
+test('csrf-magic fallback cookie sets samesite flag', function () use ($csrfPath) {
+    $source = file_get_contents($csrfPath);
+    expect($source)->toContain("'samesite'");
+});
+
+test('csrf-magic uses hash_equals for token comparison', function () use ($csrfPath) {
+    $source = file_get_contents($csrfPath);
+    expect($source)->toContain('hash_equals');
+});


### PR DESCRIPTION
Defense-in-depth CSRF hardening. SameSite=Strict is the primary defense; these tighten the fallback layers.

## Fixes

1. **GET deny-list** (include/global.php) — expanded from 3 actions to 16, covering plugin install/uninstall, automation remove/purge, moveup/movedown, kill, clear, apply, ajax_save
2. **csrf-magic fallback cookie** (include/vendor/csrf/csrf-magic.php) — added Secure, HttpOnly, SameSite=Strict flags via PHP 7.3+ options-array setcookie form
3. **csrf-magic token compare** (include/vendor/csrf/csrf-magic.php) — replaced 5 raw === comparisons with hash_equals() for timing-safe validation
4. **Logout CSRF** (logout.php) — documented risk acceptance: annoyance-only impact, SameSite=Strict mitigates cross-site exploitation

## Test plan

- [ ] Login and browse normally — verify no CSRF token errors on normal navigation
- [ ] POST forms (device edit, graph template save) — verify __csrf_magic accepted
- [ ] GET request with state-mutating action (e.g. plugins.php?action=install) — verify rejection
- [ ] Force-logout via direct URL — verify it still works (intentional)

## Related

- #7051 — csrf-magic vendor evaluation tracking issue

PHP 7.4 compatible.

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>