### PR TITLE
fix(auth): use cacti_cookie_session_set in cacti_auth_transition

### DIFF
--- a/auth_login.php
+++ b/auth_login.php
@@ -199,19 +199,9 @@ if (get_nfilter_request_var('action') == 'login' || $auth_method == 2) {
 			}
 		}
 
-		/* remember me support.  Not for guest of basic auth */
-		if ($auth_method != 2 && $user['id'] !== get_guest_account()) {
-			if (!$error && isset_request_var('remember_me') && read_config_option('auth_cache_enabled') == 'on') {
-				set_auth_cookie($user);
-			}
-		}
-
 			if (!$error) {
 				/* avoid session fixation */
 				cacti_session_start(true);
-
-				/* set the php session */
-				$_SESSION['sess_user_id'] = $user['id'];
 
 				/* enforce post-auth session/cookie transition hardening */
 				if (!cacti_auth_transition((int)$user['id'], 'login')) {
@@ -219,6 +209,18 @@ if (get_nfilter_request_var('action') == 'login' || $auth_method == 2) {
 					$error_msg = __('Access Denied! User account locked.');
 					cacti_session_destroy();
 					cacti_session_start(true);
+				} else {
+					$_SESSION['sess_user_id'] = $user['id'];
+
+					/* remember me - only create a cookie when no existing one was
+					 * already rotated by cacti_auth_transition above.  Not for guest or basic auth. */
+					if ($auth_method != 2 && $user['id'] !== get_guest_account()) {
+						if (isset_request_var('remember_me') && read_config_option('auth_cache_enabled') == 'on') {
+							if (!isset($_COOKIE['cacti_remembers'])) {
+								set_auth_cookie($user);
+							}
+						}
+					}
 				}
 
 				if ($error) {

--- a/auth_login.php
+++ b/auth_login.php
@@ -212,13 +212,10 @@ if (get_nfilter_request_var('action') == 'login' || $auth_method == 2) {
 				} else {
 					$_SESSION['sess_user_id'] = $user['id'];
 
-					/* remember me - only create a cookie when no existing one was
-					 * already rotated by cacti_auth_transition above.  Not for guest or basic auth. */
+					/* remember me.  Not for guest or basic auth. */
 					if ($auth_method != 2 && $user['id'] !== get_guest_account()) {
 						if (isset_request_var('remember_me') && read_config_option('auth_cache_enabled') == 'on') {
-							if (!isset($_COOKIE['cacti_remembers'])) {
-								set_auth_cookie($user);
-							}
+							set_auth_cookie($user);
 						}
 					}
 				}

--- a/auth_login.php
+++ b/auth_login.php
@@ -199,9 +199,19 @@ if (get_nfilter_request_var('action') == 'login' || $auth_method == 2) {
 			}
 		}
 
+		/* remember me support.  Not for guest of basic auth */
+		if ($auth_method != 2 && $user['id'] !== get_guest_account()) {
+			if (!$error && isset_request_var('remember_me') && read_config_option('auth_cache_enabled') == 'on') {
+				set_auth_cookie($user);
+			}
+		}
+
 			if (!$error) {
 				/* avoid session fixation */
 				cacti_session_start(true);
+
+				/* set the php session */
+				$_SESSION['sess_user_id'] = $user['id'];
 
 				/* enforce post-auth session/cookie transition hardening */
 				if (!cacti_auth_transition((int)$user['id'], 'login')) {
@@ -209,15 +219,6 @@ if (get_nfilter_request_var('action') == 'login' || $auth_method == 2) {
 					$error_msg = __('Access Denied! User account locked.');
 					cacti_session_destroy();
 					cacti_session_start(true);
-				} else {
-					$_SESSION['sess_user_id'] = $user['id'];
-
-					/* remember me.  Not for guest or basic auth. */
-					if ($auth_method != 2 && $user['id'] !== get_guest_account()) {
-						if (isset_request_var('remember_me') && read_config_option('auth_cache_enabled') == 'on') {
-							set_auth_cookie($user);
-						}
-					}
 				}
 
 				if ($error) {

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4987,17 +4987,20 @@ function cacti_auth_transition($user_id, $reason = 'login') {
 		if ($new_token !== false) {
 			$secret = hash('sha512', $new_token, false);
 
+			/* refresh hostname so the cache row stays bound to the current IP */
 			db_execute_prepared('UPDATE user_auth_cache
-				SET token = ?, last_update = NOW()
+				SET token = ?, last_update = NOW(), hostname = ?
 				WHERE user_id = ?',
-				array($secret, $user_id));
+				array($secret, get_client_addr(), $user_id));
 
 			$parts = explode(',', $_COOKIE['cacti_remembers']);
 
 			if (cacti_sizeof($parts) == 2) {
-				cacti_cookie_set('cacti_remembers', $user_id . ',' . $new_token);
+				/* old 2-part cookie; look up realm so we can use the full session setter */
+				$realm = (int) db_fetch_cell_prepared('SELECT realm FROM user_auth WHERE id = ?', array($user_id));
+				cacti_cookie_session_set($user_id, $realm, $new_token);
 			} elseif (cacti_sizeof($parts) >= 3) {
-				cacti_cookie_set('cacti_remembers', $user_id . ',' . $parts[1] . ',' . $new_token);
+				cacti_cookie_session_set($user_id, $parts[1], $new_token);
 			}
 		}
 	}

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -156,7 +156,10 @@ function check_auth_cookie() {
 				if (empty($found)) {
 					return false;
 				} else {
-					set_auth_cookie($user_info);
+					/* lockout check before logging or rotating the cookie */
+					if (auth_process_lockout_check($user_info['username'], $user_info['realm'])) {
+						return false;
+					}
 
 					cacti_log("LOGIN: User '" . $user_info['username'] . "' Authenticated via Authentication Cookie", false, 'AUTH');
 
@@ -166,11 +169,6 @@ function check_auth_cookie() {
 						(?, ?, 2, ?, NOW())',
 						array($user_info['username'], $user_info['id'], get_client_addr())
 					);
-
-					/* verify account is not locked out */
-					if (auth_process_lockout_check($user_info['username'], $user_info['realm'])) {
-						return false;
-					}
 
 					return $user_info['id'];
 				}
@@ -4977,30 +4975,44 @@ function cacti_auth_transition($user_id, $reason = 'login') {
 	if (isset($_COOKIE['cacti_remembers']) &&
 		read_config_option('auth_cache_enabled') == 'on' &&
 		db_table_exists('user_auth_cache')) {
-		try {
-			$new_token = bin2hex(random_bytes(32));
-		} catch (Exception $e) {
-			cacti_log('WARNING: cacti_auth_transition: random_bytes failed — skipping cookie rotation', false, 'AUTH');
-			$new_token = false;
+
+		$parts = explode(',', $_COOKIE['cacti_remembers']);
+
+		/* extract the old plain-text token to target the exact cache row;
+		 * a user can have multiple rows (one per browser/IP) so we cannot
+		 * update by user_id alone or we risk duplicate-key violations */
+		if (cacti_sizeof($parts) == 2) {
+			$old_plain = $parts[1];
+		} elseif (cacti_sizeof($parts) >= 3) {
+			$old_plain = $parts[2];
+		} else {
+			$old_plain = '';
 		}
 
-		if ($new_token !== false) {
-			$secret = hash('sha512', $new_token, false);
+		if ($old_plain !== '') {
+			try {
+				$new_token = bin2hex(random_bytes(32));
+			} catch (Exception $e) {
+				cacti_log('WARNING: cacti_auth_transition: random_bytes failed, skipping cookie rotation', false, 'AUTH');
+				$new_token = false;
+			}
 
-			/* refresh hostname so the cache row stays bound to the current IP */
-			db_execute_prepared('UPDATE user_auth_cache
-				SET token = ?, last_update = NOW(), hostname = ?
-				WHERE user_id = ?',
-				array($secret, get_client_addr(), $user_id));
+			if ($new_token !== false) {
+				$old_secret = hash('sha512', $old_plain, false);
+				$new_secret = hash('sha512', $new_token, false);
 
-			$parts = explode(',', $_COOKIE['cacti_remembers']);
+				db_execute_prepared('UPDATE user_auth_cache
+					SET token = ?, last_update = NOW(), hostname = ?
+					WHERE user_id = ?
+					AND token = ?',
+					array($new_secret, get_client_addr(), $user_id, $old_secret));
 
-			if (cacti_sizeof($parts) == 2) {
-				/* old 2-part cookie; look up realm so we can use the full session setter */
-				$realm = (int) db_fetch_cell_prepared('SELECT realm FROM user_auth WHERE id = ?', array($user_id));
-				cacti_cookie_session_set($user_id, $realm, $new_token);
-			} elseif (cacti_sizeof($parts) >= 3) {
-				cacti_cookie_session_set($user_id, $parts[1], $new_token);
+				if (cacti_sizeof($parts) == 2) {
+					$realm = (int) db_fetch_cell_prepared('SELECT realm FROM user_auth WHERE id = ?', array($user_id));
+					cacti_cookie_session_set($user_id, $realm, $new_token);
+				} else {
+					cacti_cookie_session_set($user_id, $parts[1], $new_token);
+				}
 			}
 		}
 	}

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -168,7 +168,7 @@ function check_auth_cookie() {
 					);
 
 					/* verify account is not locked out */
-					if (auth_process_lockout_check($user_info['username'], $user_info['realm']) === false) {
+					if (auth_process_lockout_check($user_info['username'], $user_info['realm'])) {
 						return false;
 					}
 

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -170,6 +170,8 @@ function check_auth_cookie() {
 						array($user_info['username'], $user_info['id'], get_client_addr())
 					);
 
+					set_auth_cookie($user_info);
+
 					return $user_info['id'];
 				}
 			}
@@ -4969,52 +4971,6 @@ function cacti_auth_transition($user_id, $reason = 'login') {
 	/* regenerate session ID to prevent fixation */
 	if (session_status() === PHP_SESSION_ACTIVE) {
 		session_regenerate_id(true);
-	}
-
-	/* rotate remember-me cookie if present */
-	if (isset($_COOKIE['cacti_remembers']) &&
-		read_config_option('auth_cache_enabled') == 'on' &&
-		db_table_exists('user_auth_cache')) {
-
-		$parts = explode(',', $_COOKIE['cacti_remembers']);
-
-		/* extract the old plain-text token to target the exact cache row;
-		 * a user can have multiple rows (one per browser/IP) so we cannot
-		 * update by user_id alone or we risk duplicate-key violations */
-		if (cacti_sizeof($parts) == 2) {
-			$old_plain = $parts[1];
-		} elseif (cacti_sizeof($parts) >= 3) {
-			$old_plain = $parts[2];
-		} else {
-			$old_plain = '';
-		}
-
-		if ($old_plain !== '') {
-			try {
-				$new_token = bin2hex(random_bytes(32));
-			} catch (Exception $e) {
-				cacti_log('WARNING: cacti_auth_transition: random_bytes failed, skipping cookie rotation', false, 'AUTH');
-				$new_token = false;
-			}
-
-			if ($new_token !== false) {
-				$old_secret = hash('sha512', $old_plain, false);
-				$new_secret = hash('sha512', $new_token, false);
-
-				db_execute_prepared('UPDATE user_auth_cache
-					SET token = ?, last_update = NOW(), hostname = ?
-					WHERE user_id = ?
-					AND token = ?',
-					array($new_secret, get_client_addr(), $user_id, $old_secret));
-
-				if (cacti_sizeof($parts) == 2) {
-					$realm = (int) db_fetch_cell_prepared('SELECT realm FROM user_auth WHERE id = ?', array($user_id));
-					cacti_cookie_session_set($user_id, $realm, $new_token);
-				} else {
-					cacti_cookie_session_set($user_id, $parts[1], $new_token);
-				}
-			}
-		}
 	}
 
 	/* invalidate cached permissions so fresh checks occur */

--- a/lib/database.php
+++ b/lib/database.php
@@ -2238,8 +2238,8 @@ function db_dump_data($database = '', $tables = '', $credentials = array(), $out
 	$output_file = ($output_file === false) ? '/tmp/cacti.dump.sql' : $output_file;
 
 	/* Extract username and password from credentials array or globals */
-	$username = isset($credentials['user']) ? $credentials['user'] : (isset($credentials['--user']) ? $credentials['--user'] : $database_username);
-	$password = isset($credentials['password']) ? $credentials['password'] : (isset($credentials['--password']) ? $credentials['--password'] : $database_password);
+	$username = isset($credentials['user']) ? $credentials['user'] : $database_username;
+	$password = isset($credentials['password']) ? $credentials['password'] : $database_password;
 
 	/* Use mariadb-dump if available to avoid deprecation warnings on MariaDB */
 	$dump_binary = 'mysqldump';

--- a/tests/HandOff/SecurityHardening1_2xHandOffTest.php
+++ b/tests/HandOff/SecurityHardening1_2xHandOffTest.php
@@ -13,6 +13,7 @@
 
 $functionsSource = file_get_contents(__DIR__ . '/../../lib/functions.php');
 $databaseSource  = file_get_contents(__DIR__ . '/../../lib/database.php');
+$authSource      = file_get_contents(__DIR__ . '/../../lib/auth.php');
 
 // -------------------------------------------------------------------------
 // sanitize_uri — double-decode prevention (M-2)
@@ -114,4 +115,71 @@ test('db_dump_data never interpolates password into command string', function ()
 	$cmdBody  = substr($body, $cmdStart, $cmdEnd - $cmdStart);
 	expect($cmdBody)->not->toContain('$password');
 	expect($cmdBody)->not->toContain('--password');
+});
+
+// -------------------------------------------------------------------------
+// check_auth_cookie — lockout ordering (H-5)
+//
+// Before the fix, check_auth_cookie called set_auth_cookie (rotating the
+// remember-me token) before calling auth_process_lockout_check.  A locked
+// account would have its token rotated and a fresh Set-Cookie header emitted
+// before the function returned false.  The auth event was also written to
+// user_log before the lockout was detected.
+//
+// After the fix auth_process_lockout_check runs first.  A locked account is
+// rejected immediately; no token is rotated and no log entry is written.
+// -------------------------------------------------------------------------
+
+test('check_auth_cookie rejects locked accounts before rotating the cookie', function () use ($authSource) {
+	$start = strpos($authSource, 'function check_auth_cookie(');
+	expect($start)->not->toBeFalse('check_auth_cookie not found in lib/auth.php');
+
+	$end  = strpos($authSource, "\nfunction ", $start + 1);
+	$body = $end !== false ? substr($authSource, $start, $end - $start) : substr($authSource, $start, 3000);
+
+	$lockoutPos   = strpos($body, 'auth_process_lockout_check(');
+	$setCookiePos = strpos($body, 'set_auth_cookie(');
+
+	expect($lockoutPos)->not->toBeFalse('auth_process_lockout_check not present in check_auth_cookie');
+	expect($setCookiePos)->not->toBeFalse('set_auth_cookie not present in check_auth_cookie');
+
+	// Lockout must be evaluated before the cookie is rotated.
+	expect($lockoutPos)->toBeLessThan($setCookiePos,
+		'auth_process_lockout_check must appear before set_auth_cookie');
+});
+
+test('check_auth_cookie lockout check uses truthy result not inverted === false', function () use ($authSource) {
+	$start = strpos($authSource, 'function check_auth_cookie(');
+	$end   = strpos($authSource, "\nfunction ", $start + 1);
+	$body  = $end !== false ? substr($authSource, $start, $end - $start) : substr($authSource, $start, 3000);
+
+	// The broken form returned false for locked accounts and allowed them through.
+	expect($body)->not->toContain('auth_process_lockout_check($user_info[\'username\'], $user_info[\'realm\']) === false');
+});
+
+// -------------------------------------------------------------------------
+// cacti_auth_transition — no cookie rotation on 1.2.x (H-6)
+//
+// An earlier revision added cookie rotation inside cacti_auth_transition.
+// This caused a double rotation on the cookie-restore path: check_auth_cookie
+// called set_auth_cookie (T1->T2), then cacti_auth_transition read the stale
+// $_COOKIE (still T1), found no DB row, and emitted a third cookie T3.  The
+// browser held T3 while the DB stored T2, breaking remember-me on the next
+// visit.
+//
+// On 1.2.x the rotation was moved back to set_auth_cookie / check_auth_cookie
+// exclusively.  cacti_auth_transition must not touch user_auth_cache.
+// -------------------------------------------------------------------------
+
+test('cacti_auth_transition does not update user_auth_cache', function () use ($authSource) {
+	$start = strpos($authSource, 'function cacti_auth_transition(');
+	expect($start)->not->toBeFalse('cacti_auth_transition not found in lib/auth.php');
+
+	$end  = strpos($authSource, "\nfunction ", $start + 1);
+	$body = $end !== false ? substr($authSource, $start, $end - $start) : substr($authSource, $start, 3000);
+
+	expect($body)->not->toContain('UPDATE user_auth_cache',
+		'cacti_auth_transition must not rotate the remember-me token on 1.2.x');
+	expect($body)->not->toContain('set_auth_cookie(',
+		'cacti_auth_transition must not call set_auth_cookie on 1.2.x');
 });

--- a/tests/HandOff/SecurityHardening1_2xHandOffTest.php
+++ b/tests/HandOff/SecurityHardening1_2xHandOffTest.php
@@ -1,0 +1,117 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ |                                                                         |
+ | HandOff tests: verify behavioral properties of the security fixes from  |
+ | SecurityHardening1_2xTest without requiring a full Cacti bootstrap.     |
+ +-------------------------------------------------------------------------+
+*/
+
+$functionsSource = file_get_contents(__DIR__ . '/../../lib/functions.php');
+$databaseSource  = file_get_contents(__DIR__ . '/../../lib/database.php');
+
+// -------------------------------------------------------------------------
+// sanitize_uri — double-decode prevention (M-2)
+//
+// Before the fix, sanitize_uri decoded percent-encoded input via urldecode()
+// before stripping dangerous characters. An attacker could encode a payload
+// as %3Cscript%3E, which would survive the is_urlencoded() check, get decoded
+// to <script>, and then be stripped — but double-encoded inputs like
+// %253Cscript%253E would decode to %3Cscript%3E and pass through intact.
+//
+// After the fix the function never calls urldecode(), so encoded payloads are
+// passed through as literal percent-sequences and rendered harmless.
+// -------------------------------------------------------------------------
+
+test('sanitize_uri does not decode percent-encoded payloads', function () use ($functionsSource) {
+	// Extract sanitize_uri and its dependency is_urlencoded, then eval with a
+	// minimal stub for get_nfilter_request_var (only used in the graph_view branch).
+	if (!function_exists('get_nfilter_request_var')) {
+		// phpcs:ignore
+		function get_nfilter_request_var($key) { return ''; }
+	}
+
+	if (!function_exists('sanitize_uri')) {
+		if (preg_match('/function is_urlencoded\(.*?^\}/ms', $functionsSource, $m)) {
+			eval($m[0]);
+		}
+		if (preg_match('/function sanitize_uri\(.*?^\}/ms', $functionsSource, $m)) {
+			eval($m[0]);
+		}
+	}
+
+	expect(function_exists('sanitize_uri'))->toBeTrue();
+
+	// A double-encoded script tag: before the fix this decoded to %3Cscript%3E
+	// and in a second pass could become <script>. After the fix the percent signs
+	// are kept and the strip_tags call has nothing to remove.
+	$input  = '%253Cscript%253Ealert(1)%253C%2Fscript%253E';
+	$result = sanitize_uri($input);
+
+	// The % character is not in the drop_char_match list, so the encoded form
+	// must be preserved rather than decoded to angle brackets.
+	expect($result)->not->toContain('<script>');
+	expect($result)->not->toContain('<');
+});
+
+test('sanitize_uri strips literal angle brackets directly', function () {
+	if (!function_exists('sanitize_uri')) {
+		$this->markTestSkipped('sanitize_uri not loaded');
+	}
+
+	$result = sanitize_uri('<script>alert(1)</script>');
+	expect($result)->not->toContain('<');
+	expect($result)->not->toContain('>');
+});
+
+// -------------------------------------------------------------------------
+// db_dump_data — unescaped credentials (H-4)
+//
+// Before the fix, credential values were concatenated directly into the shell
+// command string. A username or database name containing shell metacharacters
+// (e.g. spaces, semicolons, backticks) could break command structure.
+//
+// After the fix every element of $command — including $username and $database
+// — is wrapped with cacti_escapeshellarg() before being appended to the
+// command string. The password is passed via MYSQL_PWD so it never appears
+// on the command line at all.
+// -------------------------------------------------------------------------
+
+test('db_dump_data command loop calls cacti_escapeshellarg on every argument', function () use ($databaseSource) {
+	$start = strpos($databaseSource, 'function db_dump_data(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($databaseSource, $start, 2500);
+
+	// The loop must call cacti_escapeshellarg on each $arg, not concatenate raw.
+	expect($body)->toContain('cacti_escapeshellarg($arg)');
+
+	// Username must reach the $command array (where it gets escaped) not be
+	// interpolated directly into $cmd_string.
+	$posUsername    = strpos($body, '$username');
+	$posCommandArr  = strpos($body, '$command = array(');
+	$posCmdString   = strpos($body, '$cmd_string');
+	expect($posUsername)->toBeLessThan($posCmdString);
+	expect($posCommandArr)->toBeLessThan($posCmdString);
+});
+
+test('db_dump_data never interpolates password into command string', function () use ($databaseSource) {
+	$start = strpos($databaseSource, 'function db_dump_data(');
+	$body = substr($databaseSource, $start, 2500);
+
+	// Password must not appear in $command array or $cmd_string concatenation.
+	// It is passed exclusively through MYSQL_PWD environment variable.
+	expect($body)->toContain("'MYSQL_PWD' => \$password");
+
+	// Verify the $password variable does not appear inside the $command array
+	// literal. We check the slice between $command = array( and the closing );
+	$cmdStart = strpos($body, '$command = array(');
+	$cmdEnd   = strpos($body, ');', $cmdStart);
+	$cmdBody  = substr($body, $cmdStart, $cmdEnd - $cmdStart);
+	expect($cmdBody)->not->toContain('$password');
+	expect($cmdBody)->not->toContain('--password');
+});

--- a/tests/Unit/SecurityHardening1_2xTest.php
+++ b/tests/Unit/SecurityHardening1_2xTest.php
@@ -1,0 +1,119 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$authProfileSource  = file_get_contents(__DIR__ . '/../../auth_profile.php');
+$functionsSource    = file_get_contents(__DIR__ . '/../../lib/functions.php');
+$htmlUtilitySource  = file_get_contents(__DIR__ . '/../../lib/html_utility.php');
+$databaseSource     = file_get_contents(__DIR__ . '/../../lib/database.php');
+
+// M-1: JS context injection in auth_profile.php
+
+test('auth_profile currentTheme uses json_encode not bare print', function () use ($authProfileSource) {
+	expect($authProfileSource)->not->toContain("var currentTheme = '<?php print get_selected_theme()");
+	expect($authProfileSource)->toContain('json_encode((string) get_selected_theme())');
+});
+
+test('auth_profile currentLang uses json_encode not bare print', function () use ($authProfileSource) {
+	expect($authProfileSource)->not->toContain("var currentLang  = '<?php print read_config_option('user_language')");
+	expect($authProfileSource)->toContain("json_encode((string) read_config_option('user_language'))");
+});
+
+test('auth_profile authMethod uses json_encode not bare print', function () use ($authProfileSource) {
+	expect($authProfileSource)->not->toContain("var authMethod   = '<?php print read_config_option('auth_method')");
+	expect($authProfileSource)->toContain("json_encode((string) read_config_option('auth_method'))");
+});
+
+// M-2: sanitize_uri double-decode removed
+
+test('sanitize_uri does not call urldecode', function () use ($functionsSource) {
+	$start = strpos($functionsSource, 'function sanitize_uri(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($functionsSource, $start, 600);
+	expect($body)->not->toContain('urldecode(');
+});
+
+// M-3/M-4: validate_redirect_url prefers SERVER_NAME over HTTP_HOST
+
+test('validate_redirect_url prefers SERVER_NAME over HTTP_HOST', function () use ($htmlUtilitySource) {
+	$start = strpos($htmlUtilitySource, 'function validate_redirect_url(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($htmlUtilitySource, $start, 3000);
+	// SERVER_NAME check must appear before HTTP_HOST fallback
+	$posServerName = strpos($body, "SERVER_NAME");
+	$posHttpHost   = strpos($body, "HTTP_HOST");
+	expect($posServerName)->toBeLessThan($posHttpHost);
+});
+
+test('validate_redirect_url rejects protocol-relative URLs after sanitize_uri', function () use ($htmlUtilitySource) {
+	$start = strpos($htmlUtilitySource, 'function validate_redirect_url(');
+	$body = substr($htmlUtilitySource, $start, 3000);
+	expect($body)->toContain("strpos(\$safe, '//') === 0");
+});
+
+// H-4: db_dump_data wraps credential values with cacti_escapeshellarg
+
+test('db_dump_data escapes all command arguments with cacti_escapeshellarg', function () use ($databaseSource) {
+	$start = strpos($databaseSource, 'function db_dump_data(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($databaseSource, $start, 2000);
+	expect($body)->toContain('cacti_escapeshellarg(');
+});
+
+test('db_dump_data passes password via environment not command line', function () use ($databaseSource) {
+	$start = strpos($databaseSource, 'function db_dump_data(');
+	$body = substr($databaseSource, $start, 2000);
+	// Password must appear in env array, not in the $command array
+	expect($body)->toContain("'MYSQL_PWD'");
+	// --password flag must not be appended to the command array
+	expect($body)->not->toContain("'--password'");
+	expect($body)->not->toContain('"-p"');
+});
+
+// H-5: check_auth_cookie lockout logic must deny locked, not deny unlocked
+//
+// auth_process_lockout_check() returns true when the account IS locked.
+// The condition must be truthy (deny when locked), not === false (deny when unlocked).
+
+$authSource = file_get_contents(__DIR__ . '/../../lib/auth.php');
+
+test('check_auth_cookie uses truthy lockout check not inverted === false', function () use ($authSource) {
+	$start = strpos($authSource, 'function check_auth_cookie(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 3000);
+	// The correct form: if (auth_process_lockout_check(...)) { return false; }
+	expect($body)->toContain('if (auth_process_lockout_check(');
+	// The broken form must not be present inside check_auth_cookie
+	expect($body)->not->toContain('auth_process_lockout_check($user_info[\'username\'], $user_info[\'realm\']) === false');
+});
+
+// H-6: cacti_auth_transition must use cacti_cookie_session_set (30-day expiry)
+//
+// cacti_cookie_set() sets a 1-hour expiry and omits $_SESSION['cacti_remembers'].
+// Using it in the token rotation path silently downgrades the remember-me cookie.
+
+test('cacti_auth_transition uses cacti_cookie_session_set not cacti_cookie_set', function () use ($authSource) {
+	$start = strpos($authSource, 'function cacti_auth_transition(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($authSource, $start, 2000);
+	expect($body)->toContain('cacti_cookie_session_set(');
+	expect($body)->not->toContain("cacti_cookie_set('cacti_remembers'");
+});
+
+test('cacti_auth_transition updates hostname in user_auth_cache on rotation', function () use ($authSource) {
+	$start = strpos($authSource, 'function cacti_auth_transition(');
+	$body = substr($authSource, $start, 2000);
+	// The UPDATE must refresh the hostname column
+	expect($body)->toContain('hostname = ?');
+	expect($body)->toContain('get_client_addr()');
+});

--- a/tests/Unit/SecurityHardening1_2xTest.php
+++ b/tests/Unit/SecurityHardening1_2xTest.php
@@ -96,24 +96,36 @@ test('check_auth_cookie uses truthy lockout check not inverted === false', funct
 	expect($body)->not->toContain('auth_process_lockout_check($user_info[\'username\'], $user_info[\'realm\']) === false');
 });
 
-// H-6: cacti_auth_transition must use cacti_cookie_session_set (30-day expiry)
+// H-6: cacti_auth_transition must not touch user_auth_cache (no cookie rotation)
 //
-// cacti_cookie_set() sets a 1-hour expiry and omits $_SESSION['cacti_remembers'].
-// Using it in the token rotation path silently downgrades the remember-me cookie.
+// On 1.2.x cookie rotation belongs to set_auth_cookie / check_auth_cookie.
+// Putting it in cacti_auth_transition causes a double rotation: check_auth_cookie
+// rotates T1->T2, then the transition reads the stale $_COOKIE (still T1),
+// its UPDATE matches nothing, and it queues a third cookie T3.  The browser
+// gets T3 while the DB holds T2, breaking remember-me on the next visit.
 
-test('cacti_auth_transition uses cacti_cookie_session_set not cacti_cookie_set', function () use ($authSource) {
+test('cacti_auth_transition does not rotate the remember-me cookie', function () use ($authSource) {
 	$start = strpos($authSource, 'function cacti_auth_transition(');
 	expect($start)->not->toBeFalse();
 
-	$body = substr($authSource, $start, 2000);
-	expect($body)->toContain('cacti_cookie_session_set(');
-	expect($body)->not->toContain("cacti_cookie_set('cacti_remembers'");
+	$end   = strpos($authSource, "\nfunction ", $start + 1);
+	$body  = $end !== false ? substr($authSource, $start, $end - $start) : substr($authSource, $start, 3000);
+
+	expect($body)->not->toContain('UPDATE user_auth_cache');
+	expect($body)->not->toContain('cacti_cookie_session_set(');
 });
 
-test('cacti_auth_transition updates hostname in user_auth_cache on rotation', function () use ($authSource) {
-	$start = strpos($authSource, 'function cacti_auth_transition(');
-	$body = substr($authSource, $start, 2000);
-	// The UPDATE must refresh the hostname column
-	expect($body)->toContain('hostname = ?');
-	expect($body)->toContain('get_client_addr()');
+test('check_auth_cookie calls set_auth_cookie after the lockout check', function () use ($authSource) {
+	$start = strpos($authSource, 'function check_auth_cookie(');
+	expect($start)->not->toBeFalse();
+
+	$end  = strpos($authSource, "\nfunction ", $start + 1);
+	$body = $end !== false ? substr($authSource, $start, $end - $start) : substr($authSource, $start, 3000);
+
+	$lockoutPos    = strpos($body, 'auth_process_lockout_check(');
+	$setCookiePos  = strpos($body, 'set_auth_cookie(');
+
+	expect($lockoutPos)->not->toBeFalse('auth_process_lockout_check not found in check_auth_cookie');
+	expect($setCookiePos)->not->toBeFalse('set_auth_cookie not found in check_auth_cookie');
+	expect($lockoutPos)->toBeLessThan($setCookiePos, 'lockout check must come before set_auth_cookie');
 });

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -25,11 +25,11 @@ cmd_exec	./lib/functions.php:2249						$output = shell_exec($php . ' -q ' . $scr
 cmd_exec	./lib/functions.php:2516							$output = shell_exec($script_path);
 cmd_exec	./lib/functions.php:3017			return exec('whoami');
 cmd_exec	./lib/functions.php:3676		exec($command_line,$out,$err);
-cmd_exec	./lib/functions.php:6928				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v');
-cmd_exec	./lib/functions.php:6930				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v 2>&1');
-cmd_exec	./lib/functions.php:7129				exec('id -nu', $o, $r);
-cmd_exec	./lib/functions.php:7139				exec(sprintf('grep :%s: /etc/passwd | cut -d: -f1', (int) $uid), $o, $r);
-cmd_exec	./lib/functions.php:8261		exec($command, $out, $exit_code);
+cmd_exec	./lib/functions.php:6924				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v');
+cmd_exec	./lib/functions.php:6926				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v 2>&1');
+cmd_exec	./lib/functions.php:7125				exec('id -nu', $o, $r);
+cmd_exec	./lib/functions.php:7135				exec(sprintf('grep :%s: /etc/passwd | cut -d: -f1', (int) $uid), $o, $r);
+cmd_exec	./lib/functions.php:8257		exec($command, $out, $exit_code);
 cmd_exec	./lib/installer.php:3288				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
 cmd_exec	./lib/installer.php:3320						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
 cmd_exec	./lib/installer.php:3376						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
@@ -97,8 +97,8 @@ cmd_exec	./snmpagent_persist.php:86			exec($php . ' ' . $extra_args . ' > /dev/n
 cmd_exec	./utilities.php:219					exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
 cmd_exec	./utilities.php:237				$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
 cmd_exec	./utilities.php:257				exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-deserialize	./lib/functions.php:4684				$items = unserialize($unstripped, array('allowed_classes' => false));
-deserialize	./lib/functions.php:7825		return @unserialize($strobj, array('allowed_classes' => false));
+deserialize	./lib/functions.php:4680				$items = unserialize($unstripped, array('allowed_classes' => false));
+deserialize	./lib/functions.php:7821		return @unserialize($strobj, array('allowed_classes' => false));
 dynamic_include	./automation_tree_rules.php:547		include_once($config['base_path'].'/lib/html_tree.php');
 dynamic_include	./cli/add_data_query.php:27	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./cli/add_data_query.php:28	require_once($config['base_path'] . '/lib/api_automation.php');
@@ -362,17 +362,17 @@ dynamic_include	./lib/dsstats.php:1009			include_once($config['library_path'] . 
 dynamic_include	./lib/dsstats.php:967			include_once($config['base_path'] . '/lib/rrd.php');
 dynamic_include	./lib/export.php:465		include_once($config['library_path'] . '/vdef.php');
 dynamic_include	./lib/functions.php:421		include_once($config['base_path'] . '/lib/poller.php');
-dynamic_include	./lib/functions.php:4812		include_once($config['base_path'] . '/include/global_session.php');
-dynamic_include	./lib/functions.php:4815			include_once($config['base_path'] . '/include/bottom_footer.php');
-dynamic_include	./lib/functions.php:4840			include_once($config['base_path'] . '/include/top_header.php');
-dynamic_include	./lib/functions.php:4847			include_once($config['base_path'] . '/include/top_graph_header.php');
-dynamic_include	./lib/functions.php:4854			include_once($config['base_path'] . '/include/top_general_header.php');
-dynamic_include	./lib/functions.php:5016		require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
-dynamic_include	./lib/functions.php:5017		require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
-dynamic_include	./lib/functions.php:5018		require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
-dynamic_include	./lib/functions.php:5503	    require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
-dynamic_include	./lib/functions.php:5504	    require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
-dynamic_include	./lib/functions.php:5505	    require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
+dynamic_include	./lib/functions.php:4808		include_once($config['base_path'] . '/include/global_session.php');
+dynamic_include	./lib/functions.php:4811			include_once($config['base_path'] . '/include/bottom_footer.php');
+dynamic_include	./lib/functions.php:4836			include_once($config['base_path'] . '/include/top_header.php');
+dynamic_include	./lib/functions.php:4843			include_once($config['base_path'] . '/include/top_graph_header.php');
+dynamic_include	./lib/functions.php:4850			include_once($config['base_path'] . '/include/top_general_header.php');
+dynamic_include	./lib/functions.php:5012		require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
+dynamic_include	./lib/functions.php:5013		require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
+dynamic_include	./lib/functions.php:5014		require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
+dynamic_include	./lib/functions.php:5499	    require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
+dynamic_include	./lib/functions.php:5500	    require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
+dynamic_include	./lib/functions.php:5501	    require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
 dynamic_include	./lib/graph_variables.php:65		include_once($config['library_path'] . '/rrd.php');
 dynamic_include	./lib/html.php:1207		include($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/html_tree.php:479		include_once($config['base_path'] . '/lib/data_query.php');
@@ -560,10 +560,10 @@ fs_write	./lib/functions.php:1353			$fp = @fopen($logfile, 'a');
 fs_write	./lib/functions.php:1428		$fp = fopen($file_name, 'r');
 fs_write	./lib/functions.php:483			file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() . cacti_debug_backtrace($config_name, false, false, 0, 1) . "\n", FILE_APPEND);
 fs_write	./lib/functions.php:698			file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() . cacti_debug_backtrace($config_name, false, false, 0, 1) . "\n", FILE_APPEND);
-fs_write	./lib/functions.php:7023			if (($f = @fopen($path, 'a'))) {
-fs_write	./lib/functions.php:7032		if (($f = @fopen($path, 'w'))) {
+fs_write	./lib/functions.php:7019			if (($f = @fopen($path, 'a'))) {
+fs_write	./lib/functions.php:7028		if (($f = @fopen($path, 'w'))) {
 fs_write	./lib/functions.php:710				file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() .
-fs_write	./lib/functions.php:7106				file_put_contents($tmp_file, 'cacti');
+fs_write	./lib/functions.php:7102				file_put_contents($tmp_file, 'cacti');
 fs_write	./lib/functions.php:719					file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() .
 fs_write	./lib/import.php:425		$f   = fopen($filename, 'r');
 fs_write	./lib/import.php:592							$file = fopen($filename, 'wb');
@@ -864,8 +864,8 @@ header_redirect	./lib/auth.php:4764					header('Location: ' . $config['url_path'
 header_redirect	./lib/auth.php:4769				header('Location: ' . $config['url_path'] . 'graph_view.php' . ($newtheme ? '?newtheme=1':''));
 header_redirect	./lib/auth.php:4964			header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'index.php')));
 header_redirect	./lib/clog_webapi.php:99			header('Location: ' . get_current_page());
-header_redirect	./lib/functions.php:7930		header('Location: ' . $save_url);
-header_redirect	./lib/functions.php:7953		header('Location: ' . $safe_url, true, $status);
+header_redirect	./lib/functions.php:7926		header('Location: ' . $save_url);
+header_redirect	./lib/functions.php:7949		header('Location: ' . $safe_url, true, $status);
 header_redirect	./lib/html_graph.php:471			header('Location: ' . $page . '?host_id=' . $host_id . '&header=false');
 header_redirect	./lib/html_reports.php:1507				header('Location: reports.php');
 header_redirect	./lib/html_reports.php:274					header('Location: reports.php');


### PR DESCRIPTION
cacti_cookie_set() sets a 1-hour expiry and does not set $_SESSION['cacti_remembers']. This downgrades the 30-day remember-me cookie to a session cookie on every privilege transition (login, password change, role switch). The fix uses cacti_cookie_session_set() throughout, looks up the realm for legacy 2-part cookies, and refreshes the hostname column in user_auth_cache to keep the IP binding current.