### PR TITLE
fix: Auth issues with cookies

### DIFF
--- a/include/auth.php
+++ b/include/auth.php
@@ -75,8 +75,9 @@ if ($auth_method != 0) {
 		/* check for remember me functionality */
 		if (!isset($_SESSION['sess_user_id'])) {
 			$cookie_user = check_auth_cookie();
-			if ($cookie_user !== false) {
+			if ($cookie_user > 0) {
 				/* GHSA-273r-qr93-wgcp: regenerate session id on auth transition */
+
 				if (cacti_auth_transition((int)$cookie_user, 'cookie_restore')) {
 					$_SESSION['sess_user_id'] = $cookie_user;
 				}
@@ -103,6 +104,7 @@ if ($auth_method != 0) {
 				if (!cacti_auth_transition((int)$current_user['id'], 'basic_auth')) {
 					return false;
 				}
+
 				$_SESSION['sess_user_id'] = $current_user['id'];;
 
 				$client_addr = get_client_addr();

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -178,6 +178,11 @@ function check_auth_cookie() {
 				if (empty($found)) {
 					return false;
 				} else {
+					/* verify account is not locked out */
+					if (auth_process_lockout_check($user_info['username'], $user_info['realm']) === true) {
+						return false;
+					}
+
 					set_auth_cookie($user_info);
 
 					cacti_log("LOGIN: User '" . $user_info['username'] . "' with ID '" . $user_info['id'] . "' Authenticated via Authentication Cookie", false, 'AUTH');
@@ -188,11 +193,6 @@ function check_auth_cookie() {
 						(?, ?, 2, ?, NOW())',
 						array($user_info['username'], $user_info['id'], get_client_addr())
 					);
-
-					/* verify account is not locked out */
-					if (auth_process_lockout_check($user_info['username'], $user_info['realm']) === true) {
-						return false;
-					}
 
 					return $user_info['id'];
 				}

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -52,13 +52,13 @@ function clear_auth_cookie() {
 				$user_id = db_fetch_cell_prepared('SELECT id
 					FROM user_auth
 					WHERE username = ?
-					AND realm_id = 0',
+					AND realm = 0',
 					array($user_id));
 			} else {
 				$user_id = db_fetch_cell_prepared('SELECT id
 					FROM user_auth
 					WHERE username = ?
-					AND realm_id = ?',
+					AND realm = ?',
 					array($user_id, $realm_id));
 			}
 		}

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -47,10 +47,20 @@ function clear_auth_cookie() {
 
 		// Legacy support which leaked usernames
 		if (!is_numeric($user_id)) {
-			$user_id = db_fetch_cell_prepared('SELECT id
-				FROM user_auth
-				WHERE username = ?',
-				array($user_id));
+			if ($realm_id == -1) {
+				// Assume local realm for tokens without a realm_id
+				$user_id = db_fetch_cell_prepared('SELECT id
+					FROM user_auth
+					WHERE username = ?
+					AND realm_id = 0',
+					array($user_id));
+			} else {
+				$user_id = db_fetch_cell_prepared('SELECT id
+					FROM user_auth
+					WHERE username = ?
+					AND realm_id = ?',
+					array($user_id, $realm_id));
+			}
 		}
 
 		if ($user_id > 0) {
@@ -89,7 +99,7 @@ function set_auth_cookie($user) {
 
 		$secret = hash('sha512', $nssecret, false);
 
-		db_execute_prepared('REPLACE INTO user_auth_cache
+		db_execute_prepared('INSERT INTO user_auth_cache
 			(user_id, hostname, last_update, token)
 			VALUES
 			(?, ?, NOW(), ?);',
@@ -123,17 +133,28 @@ function check_auth_cookie() {
 
 		// Legacy support which leaked usernames
 		if (!is_numeric($user_id)) {
-			$user_id = db_fetch_cell_prepared('SELECT id
-				FROM user_auth
-				WHERE username = ?',
-				array($user_id));
+			if ($realm_id == -1) {
+				// Assume local realm for tokens without a realm_id
+				$user_id = db_fetch_cell_prepared('SELECT id
+					FROM user_auth
+					WHERE username = ?
+					AND realm = 0',
+					array($user_id));
+			} else {
+				$user_id = db_fetch_cell_prepared('SELECT id
+					FROM user_auth
+					WHERE username = ?
+					AND realm = ?',
+					array($user_id, $realm_id));
+			}
 		}
 
 		if ($user_id > 0 && $user_id != get_guest_account()) {
 			if ($realm_id == -1) {
 				$user_info = db_fetch_row_prepared('SELECT id, realm, username
 					FROM user_auth
-					WHERE id = ?',
+					WHERE id = ?
+					AND realm = 0',
 					array($user_id));
 			} else {
 				$user_info = db_fetch_row_prepared('SELECT id, realm, username
@@ -149,8 +170,9 @@ function check_auth_cookie() {
 				$found  = db_fetch_cell_prepared('SELECT user_id
 					FROM user_auth_cache
 					WHERE user_id = ?
-					AND token = ?',
-					array($user_info['id'], $secret)
+					AND token = ?
+					AND hostname = ?',
+					array($user_info['id'], $secret, get_client_addr())
 				);
 
 				if (empty($found)) {
@@ -158,7 +180,7 @@ function check_auth_cookie() {
 				} else {
 					set_auth_cookie($user_info);
 
-					cacti_log("LOGIN: User '" . $user_info['username'] . "' Authenticated via Authentication Cookie", false, 'AUTH');
+					cacti_log("LOGIN: User '" . $user_info['username'] . "' with ID '" . $user_info['id'] . "' Authenticated via Authentication Cookie", false, 'AUTH');
 
 					db_execute_prepared('INSERT IGNORE INTO user_log
 						(username, user_id, result, ip, time)
@@ -168,7 +190,7 @@ function check_auth_cookie() {
 					);
 
 					/* verify account is not locked out */
-					if (auth_process_lockout_check($user_info['username'], $user_info['realm']) === false) {
+					if (auth_process_lockout_check($user_info['username'], $user_info['realm']) === true) {
 						return false;
 					}
 
@@ -3519,16 +3541,15 @@ function auth_process_lockout_check($username, $realm) {
 				FROM user_auth
 				WHERE username = ?
 				AND realm = ?
+				AND locked = 'on'
 				AND enabled = 'on'",
 				array($username, $realm));
 
 			if (cacti_sizeof($user)) {
-				if ($user['locked'] == 'on') {
-					$error     = true;
-					$error_msg = __('Your account has been locked.  Please contact your Administrator.');
+				$error     = true;
+				$error_msg = __('Your account has been locked.  Please contact your Administrator.');
 
-					return true;
-				}
+				return true;
 			}
 		}
 	}
@@ -4820,8 +4841,10 @@ function auth_login_create_user_from_template($username, $realm) {
 					user_copy($user_template['username'], $username, $user_template['realm'], $realm, false, $data_override);
 				} else {
 					$ldap_response = (isset($ldap_cn_search_response[0]) ? $ldap_cn_search_response[0] : '(no response given)');
-					$ldap_code = (isset($ldap_cn_search_response['error_num']) ? $ldap_cn_search_response['error_num'] : '(no code given)');
+					$ldap_code     = (isset($ldap_cn_search_response['error_num']) ? $ldap_cn_search_response['error_num'] : '(no code given)');
+
 					cacti_log('LOGIN: Email Address and Full Name fields not found, reason: ' . $ldap_response . 'code: ' . $ldap_code, false, 'AUTH');
+
 					user_copy($user_template['username'], $username, $user_template['realm'], $realm);
 				}
 			} else {
@@ -4904,12 +4927,15 @@ function check_reset_no_authentication($auth_method) {
 
 			cacti_log('SQL query ' . $admin_sql_query, true, 'AUTH_NONE', POLLER_VERBOSITY_DEVDBG);
 			cacti_log('SQL param ' . implode(',', $admin_sql_params), true, 'AUTH_NONE', POLLER_VERBOSITY_DEVDBG);
+
 			$admin_id = db_fetch_cell_prepared($admin_sql_query, $admin_sql_params);
+
 			cacti_log('SQL result ' . $admin_id, true, 'AUTH_NONE', POLLER_VERBOSITY_DEVDBG);
 		}
 
 		if (!$admin_id) {
 			$admin_id = db_fetch_cell('SELECT id FROM user_auth WHERE username = \'admin\'');
+
 			cacti_log('Final attempt ' . $admin_id, true, 'AUTH_NONE', POLLER_VERBOSITY_DEVDBG);
 		}
 
@@ -4963,7 +4989,7 @@ function cacti_auth_transition($user_id, $reason = 'login') {
 		array($user_id));
 
 	if ($locked == 'on') {
-		cacti_log('SECURITY: auth transition blocked for locked user ' . $user_id . ' reason=' . $reason, false, 'AUTH');
+		cacti_log('SECURITY: auth transition blocked for locked user: ' . $user_id . ' reason: ' . $reason, false, 'AUTH');
 
 		return false;
 	}
@@ -4973,41 +4999,12 @@ function cacti_auth_transition($user_id, $reason = 'login') {
 		session_regenerate_id(true);
 	}
 
-	/* rotate remember-me cookie if present */
-	if (isset($_COOKIE['cacti_remembers']) &&
-		read_config_option('auth_cache_enabled') == 'on' &&
-		db_table_exists('user_auth_cache')) {
-		try {
-			$new_token = bin2hex(random_bytes(32));
-		} catch (Exception $e) {
-			cacti_log('WARNING: cacti_auth_transition: random_bytes failed — skipping cookie rotation', false, 'AUTH');
-			$new_token = false;
-		}
-
-		if ($new_token !== false) {
-			$secret = hash('sha512', $new_token, false);
-
-			db_execute_prepared('UPDATE user_auth_cache
-				SET token = ?, last_update = NOW()
-				WHERE user_id = ?',
-				array($secret, $user_id));
-
-			$parts = explode(',', $_COOKIE['cacti_remembers']);
-
-			if (cacti_sizeof($parts) == 2) {
-				cacti_cookie_set('cacti_remembers', $user_id . ',' . $new_token);
-			} elseif (cacti_sizeof($parts) >= 3) {
-				cacti_cookie_set('cacti_remembers', $user_id . ',' . $parts[1] . ',' . $new_token);
-			}
-		}
-	}
-
 	/* invalidate cached permissions so fresh checks occur */
 	kill_session_var('sess_user_realms');
 	kill_session_var('sess_user_config_array');
 	kill_session_var('sess_config_array');
 
-	cacti_log('NOTE: auth transition completed for user ' . $user_id . ' reason=' . $reason, false, 'AUTH');
+	cacti_log('NOTE: auth transition completed for user ' . $user_id . ' reason=' . $reason, false, 'AUTH', POLLER_VERBOSITY_MEDIUM);
 
 	return true;
 }

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -272,8 +272,8 @@ dynamic_include	./color_templates.php:379		include_once($config['base_path'] . '
 dynamic_include	./color_templates.php:429		include_once($config['base_path'] . '/lib/api_aggregate.php');
 dynamic_include	./color_templates.php:485		include_once($config['base_path'] . '/lib/api_aggregate.php');
 dynamic_include	./graph_realtime.php:382	    <?php include($config['base_path'] . '/include/global_session.php'); ?>
-dynamic_include	./include/auth.php:119					require_once($config['base_path'] . '/auth_login.php');
-dynamic_include	./include/auth.php:174				require_once($config['base_path'] . '/auth_login.php');
+dynamic_include	./include/auth.php:121					require_once($config['base_path'] . '/auth_login.php');
+dynamic_include	./include/auth.php:176				require_once($config['base_path'] . '/auth_login.php');
 dynamic_include	./include/csrf.php:25	require_once($config['include_path'] .'/vendor/csrf/csrf-conf.php');
 dynamic_include	./include/csrf.php:56	include_once($config['include_path'] . '/vendor/csrf/csrf-magic.php');
 dynamic_include	./include/global.php:277	include_once($config['library_path'] . '/database.php');

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -272,8 +272,8 @@ dynamic_include	./color_templates.php:379		include_once($config['base_path'] . '
 dynamic_include	./color_templates.php:429		include_once($config['base_path'] . '/lib/api_aggregate.php');
 dynamic_include	./color_templates.php:485		include_once($config['base_path'] . '/lib/api_aggregate.php');
 dynamic_include	./graph_realtime.php:382	    <?php include($config['base_path'] . '/include/global_session.php'); ?>
-dynamic_include	./include/auth.php:119					require_once($config['base_path'] . '/auth_login.php');
-dynamic_include	./include/auth.php:174				require_once($config['base_path'] . '/auth_login.php');
+dynamic_include	./include/auth.php:121					require_once($config['base_path'] . '/auth_login.php');
+dynamic_include	./include/auth.php:176				require_once($config['base_path'] . '/auth_login.php');
 dynamic_include	./include/csrf.php:25	require_once($config['include_path'] .'/vendor/csrf/csrf-conf.php');
 dynamic_include	./include/csrf.php:56	include_once($config['include_path'] . '/vendor/csrf/csrf-magic.php');
 dynamic_include	./include/global.php:277	include_once($config['library_path'] . '/database.php');
@@ -855,14 +855,14 @@ header_redirect	./include/themes/sunrise/images/index.php:25	header("Location:..
 header_redirect	./include/themes/sunrise/index.php:25	header("Location:../index.php");
 header_redirect	./include/vendor/index.php:25	header("Location:../index.php");
 header_redirect	./install/upgrades/index.php:25	header("Location:../../index.php");
-header_redirect	./lib/auth.php:4267				header('Location: auth_changepassword.php?header=false');
-header_redirect	./lib/auth.php:4727					header('Location: ' . $referer);
-header_redirect	./lib/auth.php:4731					header('Location: graph_view.php');
-header_redirect	./lib/auth.php:4735					header('Location: index.php');
-header_redirect	./lib/auth.php:4741					header('Location: ' . $config['url_path'] . 'graph_view.php' . ($newtheme ? '?newtheme=1':''));
-header_redirect	./lib/auth.php:4743					header('Location: ' . $config['url_path'] . 'index.php' . ($newtheme ? '?newtheme=1':''));
-header_redirect	./lib/auth.php:4748				header('Location: ' . $config['url_path'] . 'graph_view.php' . ($newtheme ? '?newtheme=1':''));
-header_redirect	./lib/auth.php:4938			header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'index.php')));
+header_redirect	./lib/auth.php:4288				header('Location: auth_changepassword.php?header=false');
+header_redirect	./lib/auth.php:4748					header('Location: ' . $referer);
+header_redirect	./lib/auth.php:4752					header('Location: graph_view.php');
+header_redirect	./lib/auth.php:4756					header('Location: index.php');
+header_redirect	./lib/auth.php:4762					header('Location: ' . $config['url_path'] . 'graph_view.php' . ($newtheme ? '?newtheme=1':''));
+header_redirect	./lib/auth.php:4764					header('Location: ' . $config['url_path'] . 'index.php' . ($newtheme ? '?newtheme=1':''));
+header_redirect	./lib/auth.php:4769				header('Location: ' . $config['url_path'] . 'graph_view.php' . ($newtheme ? '?newtheme=1':''));
+header_redirect	./lib/auth.php:4964			header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'index.php')));
 header_redirect	./lib/clog_webapi.php:99			header('Location: ' . get_current_page());
 header_redirect	./lib/functions.php:7930		header('Location: ' . $save_url);
 header_redirect	./lib/functions.php:7953		header('Location: ' . $safe_url, true, $status);


### PR DESCRIPTION
* Auth tokens are automatically rotated each time a user attempts to login to Cacti via the cookie, so the transition logic is not required.
* User lockout was not being handled correctly.  All only locked out cookie users were able to use their cookie
* If the realm_id is not set in the cookie, we assume the realm is 0 (local) by design.  This is legacy behavior.