### PR TITLE
fix: Remove most of inline reports in Cacti

### DIFF
--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -865,7 +865,7 @@ function graph_edit() {
 					$('#row_spacer0').hide();
 				}
 
-				$('input[id^="agg_total"], input[id^="agg_skip"]').click(function() {
+				$('input[id^="agg_total"], input[id^="agg_skip"]').on('click', function() {
 					id = $(this).attr('id');
 
 					if (id.indexOf('skip') > 0) {
@@ -885,15 +885,15 @@ function graph_edit() {
 					updateSaveButton();
 				});
 
-				$('#total').change(function() {
+				$('#total').on('change', function() {
 					changeTotals();
 				});
 
-				$('#total_type').change(function() {
+				$('#total_type').on('change', function() {
 					changeTotalsType();
 				});
 
-				$('#template_propogation').change(function() {
+				$('#template_propogation').on('change', function() {
 					if (!$('#template_propogation').is(':checked')) {
 						for (var i = 0; i < templated_selectors.length; i++) {
 							$(templated_selectors[i]).prop('disabled', false);
@@ -1020,7 +1020,7 @@ function graph_edit() {
 			}
 		});
 
-		$('#toggle_items').click(function() {
+		$('#toggle_items').on('click', function() {
 			if ($('#toggle_items').is(":contains('<?php print __('Show');?>')")) {
 				$('#local_graph_template_graph_id').next('table').css('display', '');
 				$('#toggle_items').text('<?php print __('Hide Item Details');?>');
@@ -1211,15 +1211,15 @@ function aggregate_items() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rfilter').change(function() {
+		$('#rfilter').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -1492,11 +1492,11 @@ function aggregate_graph() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -354,7 +354,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Graph(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Graph(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '2') { // migrate to aggregate
 			/* determine the common graph template if any */
 			foreach ($_POST as $var => $val) {
@@ -390,7 +390,7 @@ function form_actions() {
 					</td>
 				</tr>";
 
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Return') . "' onClick='cactiReturnTo()'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
 			} elseif (cacti_sizeof($graph_templates) == 0) {
 				print "<tr>
 					<td class='textArea'>
@@ -427,7 +427,7 @@ function form_actions() {
 						</td>
 					</tr>";
 
-					$save_html = "<tr><td colspan='2' class='right'><input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel'). "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Graph(s)') . "'></td></tr>";
+					$save_html = "<tr><td colspan='2' class='right'><input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel'). "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Graph(s)') . "'></td></tr>";
 				} else {
 					print "<tr>
 						<td class='textArea'>
@@ -438,7 +438,7 @@ function form_actions() {
 						</td>
 					</tr>";
 
-					$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Return') . "' onClick='cactiReturnTo()'>";
+					$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
 				}
 			}
 		} elseif (get_request_var('drp_action') == '3') { // create aggregate from aggregates
@@ -452,7 +452,7 @@ function form_actions() {
 			print "	<tr><td class='textArea' width='170'>" . __('Aggregate Name:') . "</td></tr>";
 			print "	<tr><td class='textArea'><input type='text' class='ui-state-default ui-corner-all' name='aggregate_name' size='40' value='" . __esc('New Aggregate') . "'></td></tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Graph(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Graph(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '4') {
 			global $alignment, $graph_timespans;
 
@@ -481,10 +481,10 @@ function form_actions() {
 				form_dropdown('align',$alignment, '', '', '', '', REPORTS_ALIGN_CENTER);
 				print "</td></tr>";
 
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Add Graphs to Report') . "'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Add Graphs to Report') . "'>";
 			} else {
 				print "<tr><td class='even'><span class='textError'>" . __('You currently have no reports defined.') . "</span></td></tr>";
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Return') . "' onClick='cactiReturnTo()'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
 			}
 		} elseif (get_request_var('drp_action') == '5') { // convert to a normal graph
 			print "<tr>
@@ -494,7 +494,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Convert to normal Graph(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Convert to normal Graph(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '10') { // associate with aggregate
 			print "<tr>
 				<td class='textArea'>
@@ -503,7 +503,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Associate Graph(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Associate Graph(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '11') { // dis-associate with aggregate
 			print "<tr>
 				<td class='textArea'>
@@ -512,7 +512,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Dis-Associate Graph(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Dis-Associate Graph(s)') . "'>";
 		} elseif (preg_match("/^tr_([0-9]+)$/", get_request_var('drp_action'), $matches)) { // place on tree
 			print "<tr>
 				<td class='textArea'>
@@ -523,7 +523,7 @@ function form_actions() {
 			</tr>
 			<input type='hidden' name='tree_id' value='" . html_escape($matches[1]) . "'>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Place Graph(s) on Tree') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Place Graph(s) on Tree') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -1207,6 +1207,10 @@ function aggregate_items() {
 			$('#agg_preview').show();
 		}
 
+		$('#rfilter, #rows, #matching').on('change', function() {
+			applyFilter();
+		});
+
 		$('#clear').click(function() {
 			clearFilter();
 		});
@@ -1235,13 +1239,13 @@ function aggregate_items() {
 						<?php print __('Search');?>
 					</td>
 					<td>
-						<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='45' onChange='applyFilter()' value='<?php print html_escape_request_var('rfilter');?>'>
+						<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='45' value='<?php print html_escape_request_var('rfilter');?>'>
 					</td>
 					<td>
 						<?php print __('Graphs');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {
@@ -1254,14 +1258,14 @@ function aggregate_items() {
 					</td>
 					<td>
 						<span>
-							<input type='checkbox' id='matching' onChange='applyFilter()' <?php print (get_request_var('matching') == 'on' || get_request_var('matching') == 'true' ? ' checked':'');?>>
+							<input type='checkbox' id='matching' <?php print (get_request_var('matching') == 'on' || get_request_var('matching') == 'true' ? ' checked':'');?>>
 							<label for='matching'><?php print __('Part of Aggregate');?></label>
 						</span>
 					</td>
 					<td>
 						<span>
 							<input type='submit' class='ui-button ui-corner-all ui-widget' id='go' value='<?php print __esc('Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
-							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' onClick='clearFilter()' value='<?php print __esc('Clear');?>' title='<?php print __esc('Clear Filters');?>'>
+							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __esc('Clear');?>' title='<?php print __esc('Clear Filters');?>'>
 						</span>
 					</td>
 				</tr>
@@ -1484,6 +1488,10 @@ function aggregate_graph() {
 			$('#agg_preview').show();
 		}
 
+		$('#template_id, #rows').on('change', function() {
+			applyFilter();
+		});
+
 		$('#clear').click(function() {
 			clearFilter();
 		});
@@ -1515,7 +1523,7 @@ function aggregate_graph() {
 						<?php print __('Template');?>
 					</td>
 					<td>
-						<select id='template_id' name='template_id' onChange='applyFilter()'>
+						<select id='template_id' name='template_id'>
 							<option value='-1'<?php if (get_request_var('template_id') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 							<option value='0'<?php if (get_request_var('template_id') == '0') {?> selected<?php }?>><?php print __('None');?></option>
 							<?php
@@ -1537,7 +1545,7 @@ function aggregate_graph() {
 						<?php print __('Graphs');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {

--- a/aggregate_templates.php
+++ b/aggregate_templates.php
@@ -320,7 +320,7 @@ function aggregate_form_actions() {
 					</td>
 				</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Color Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Color Template(s)') . "'>";
 		}
 	} else {
 		raise_message(40);

--- a/aggregate_templates.php
+++ b/aggregate_templates.php
@@ -451,7 +451,7 @@ function aggregate_template_edit() {
 			$('#row_total_prefix').hide();
 			$('#row_order_type').hide();
 
-			$('#graph_template_id').change(function() {
+			$('#graph_template_id').on('change', function() {
 				$('#template_edit').submit();
 			});
 
@@ -463,15 +463,15 @@ function aggregate_template_edit() {
 			}
 		}
 
-		$('#total').change(function() {
+		$('#total').on('change', function() {
 			changeTotals();
 		});
 
-		$('#total_type').change(function() {
+		$('#total_type').on('change', function() {
 			changeTotalsType();
 		});
 
-		$('input[id^="agg_total"], input[id^="agg_skip"]').click(function() {
+		$('input[id^="agg_total"], input[id^="agg_skip"]').on('click', function() {
 			id = $(this).attr('id');
 
 			if (id.indexOf('skip') > 0) {
@@ -762,16 +762,16 @@ function aggregate_template() {
 	}
 
 	$(function() {
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#template').submit(function(event) {
+		$('#template').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});

--- a/auth_changepassword.php
+++ b/auth_changepassword.php
@@ -376,7 +376,7 @@ if ($skip_current) {
 						<tr>
 							<td class='nowrap' colspan='2'><input type='submit' class='ui-button ui-corner-all ui-widget' value='<?php print __esc('Save'); ?>'>
 								<?php if ($user['must_change_password'] != 'on') { ?>
-								<input type='button' class='ui-button ui-corner-all ui-widget' onClick='document.location=<?php print json_encode((string) $return); ?>' value='<?php print __esc('Return'); ?>'>
+								<input type='button' class='ui-button ui-corner-all ui-widget passwordReturn' data-location='<?php print $return;?>' value='<?php print __esc('Return'); ?>'>
 								<?php } ?>
 							</td>
 						</tr>
@@ -435,17 +435,23 @@ if ($skip_current) {
 	var password_change = $('#password_change').is(':checked');
 
 	$(function() {
+		$('.passwordReturn').on('click', function() {
+			var url = $(this).data('location');
+
+			document.location = url;
+		});
+
 		$('#current').focus();
 
 		/* clear passwords */
 		$('#password').val('');
 		$('#password_confirm').val('');
 
-		$('#password').keyup(function() {
+		$('#password').on('keyup', function() {
 			checkPassword();
 		});
 
-		$('#password_confirm').keyup(function() {
+		$('#password_confirm').on('keyup', function() {
 			checkPasswordConfirm();
 		});
 	});

--- a/auth_login.php
+++ b/auth_login.php
@@ -433,7 +433,7 @@ $selectedTheme = get_selected_theme();
 		}
 
 		// Control submit in order to store preferred realm
-		$('#login').submit(function(event) {
+		$('#login').on('submit', function(event) {
 			event.preventDefault();
 			if ($('#realm').length) {
 				storage.set('user_realm', $('#realm').val());

--- a/auth_profile.php
+++ b/auth_profile.php
@@ -557,7 +557,7 @@ function settings_javascript() {
 		$('#navigation, #navigation_right').show();
 		$('#tabs').find('li a.selected').removeClass('selected');
 
-		$('input[value="<?php print __esc('Save');?>"]').unbind().click(function(event) {
+		$('input[value="<?php print __esc('Save');?>"]').on('click', function(event) {
 			event.preventDefault();
 			$.post('auth_profile.php?header=false', $('input, select, textarea').serialize()).done(function(data) {
 				loadPageNoHeader('auth_profile.php?action=noreturn&header=false');
@@ -609,7 +609,7 @@ function settings_javascript() {
 			}
 		});
 
-		$('select, input[type!="button"]').unbind().keyup(function() {
+		$('select, input[type!="button"]').on('keyup', function() {
 			name  = $(this).attr('id');
 			if ($(this).attr('type') == 'checkbox') {
 				if ($(this).is(':checked')) {
@@ -626,7 +626,7 @@ function settings_javascript() {
 				name: name,
 				value: value
 			});
-		}).change(function() {
+		}).on('change', function() {
 			name  = $(this).attr('id');
 			if ($(this).attr('type') == 'checkbox') {
 				if ($(this).is(':checked')) {

--- a/auth_profile.php
+++ b/auth_profile.php
@@ -649,7 +649,7 @@ function settings_javascript() {
 			});
 		});
 
-		$('#return').click(function() {
+		$('#return').on('click', function() {
 			document.location = <?php print json_encode($_SESSION['profile_referer'] ?? '');?>;
 		});
 

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -220,7 +220,7 @@ function form_actions() {
 
 			print "</td></tr></table></td></tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Add Device(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Add Device(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '2') { /* remove */
 			print "<tr>
 				<td class='textArea odd'>
@@ -229,7 +229,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Device(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Device(s)') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -507,7 +507,7 @@ function draw_filter() {
 						</select>
 					<td>
 						<span>
-							<input type='button' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __esc('Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
+							<input type='submit' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __esc('Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
 							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __esc('Clear');?>' title='<?php print __esc('Reset fields to defaults');?>'>
 						</span>
 					</td>
@@ -587,7 +587,7 @@ function draw_filter() {
 		<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 
 		$(function() {
-			$('#refresh').click(function() {
+			$('#refresh').on('click', function() {
 				applyFilter();
 			});
 
@@ -595,20 +595,20 @@ function draw_filter() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#clear').on('click', function() {
 				clearFilter();
 			});
 
-			$('#form_devices').submit(function(event) {
+			$('#form_devices').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});
 
-			$('#purge').click(function() {
+			$('#purge').on('click', function() {
 				loadPageNoHeader('automation_devices.php?header=false&action=purge&network_id='+$('#network').val());
 			});
 
-			$('#export').click(function() {
+			$('#export').on('click', function() {
 				document.location = 'automation_devices.php?action=export';
 				Pace.stop();
 			});

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -495,7 +495,7 @@ function draw_filter() {
 						<?php print __('Network');?>
 					</td>
 					<td>
-						<select id='network' onChange='applyFilter()'>
+						<select id='network'>
 							<option value='-1' <?php if (get_request_var('network') == -1) {?> selected<?php }?>><?php print __('Any');?></option>
 							<?php
 							if (cacti_sizeof($networks)) {
@@ -525,7 +525,7 @@ function draw_filter() {
 						<?php print __('Status');?>
 					</td>
 					<td>
-						<select id='status' onChange='applyFilter()'>
+						<select id='status'>
 							<option value='-1' <?php if (get_request_var('status') == '') {?> selected<?php }?>><?php print __('Any');?></option>
 							<?php
 							if (cacti_sizeof($status_arr)) {
@@ -540,7 +540,7 @@ function draw_filter() {
 						<?php print __('OS');?>
 					</td>
 					<td>
-						<select id='os' onChange='applyFilter()'>
+						<select id='os'>
 							<option value='-1' <?php if (get_request_var('os') == '') {?> selected<?php }?>><?php print __('Any');?></option>
 							<?php
 							if (cacti_sizeof($os_arr)) {
@@ -555,7 +555,7 @@ function draw_filter() {
 						<?php print __('SNMP');?>
 					</td>
 					<td>
-						<select id='snmp' onChange='applyFilter()'>
+						<select id='snmp'>
 							<option value='-1' <?php if (get_request_var('snmp') == '') {?> selected<?php }?>><?php print __('Any');?></option>
 							<?php
 							if (cacti_sizeof($status_arr)) {
@@ -570,7 +570,7 @@ function draw_filter() {
 						<?php print __('Devices');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {
@@ -588,6 +588,10 @@ function draw_filter() {
 
 		$(function() {
 			$('#refresh').click(function() {
+				applyFilter();
+			});
+
+			$('#network, #status, #os, #snmp, #rows').on('change', function() {
 				applyFilter();
 			});
 

--- a/automation_graph_rules.php
+++ b/automation_graph_rules.php
@@ -324,7 +324,7 @@ function automation_graph_rules_form_actions() {
 		header('Location: automation_graph_rules.php?header=false');
 		exit;
 	} else {
-		$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Apply requested action') . "'>";
+		$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Apply requested action') . "'>";
 	}
 
 	print "	<tr>

--- a/automation_graph_rules.php
+++ b/automation_graph_rules.php
@@ -854,15 +854,15 @@ function automation_graph_rules() {
 		}
 
 		$(function() {
-			$('#refresh, #rules, #rows, #status, #snmp_query_id').change(function() {
+			$('#refresh, #rules, #rows, #status, #snmp_query_id').on('change', function() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#clear').on('click', function() {
 				clearFilter();
 			});
 
-			$('#form_automation').submit(function(event) {
+			$('#form_automation').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -398,8 +398,8 @@ function form_actions() {
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($networks_array) ? serialize($networks_array) : '') . "'>
 			<input type='hidden' name='drp_action' value='" . html_escape(get_nfilter_request_var('drp_action')) . "'>" . ($save_html != '' ? "
-			<input type='button' class='ui-button ui-corner-all ui-widget' onClick='cactiReturnTo()' name='cancel' value='" . __esc('Cancel') . "'>
-			$save_html" : "<input type='button' class='ui-button ui-corner-all ui-widget' onClick='cactiReturnTo()' name='cancel' value='" . __esc('Return') . "'>") . "
+			<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' name='cancel' value='" . __esc('Cancel') . "'>
+			$save_html" : "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' name='cancel' value='" . __esc('Return') . "'>") . "
 		</td>
 	</tr>";
 
@@ -1201,7 +1201,7 @@ function networks_filter() {
 						<?php print __('Networks');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php if (get_request_var('rows') == '-1') {?> selected<?php }?>><?php print __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -1216,7 +1216,7 @@ function networks_filter() {
 						<?php print __('Refresh');?>
 					</td>
 					<td>
-						<select id='refresh' onChange='applyFilter()'>
+						<select id='refresh'>
 							<?php
 							$frequency = array(
 								10  => __('%d Seconds', 10),
@@ -1252,6 +1252,10 @@ function networks_filter() {
 
 				loadPageNoHeader(strURL);
 			}
+
+			$('#network, #refresh').on('change', function() {
+				applyFilter();
+			});
 
 			function clearFilter() {
 				strURL = '?clear=true&header=false';

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -853,19 +853,19 @@ function network_edit() {
 			minDateTime: new Date(<?php print date("Y") . ', ' . (date("m")-1) . ', ' . date("d, H") . ', ' . date('i', ceil(time()/300)*300) . ', 0, 0';?>)
 		});
 
-		$('#sched_type').change(function() {
+		$('#sched_type').on('change', function() {
 			setSchedule();
 		});
 
 		setSchedule();
 
-		$('#notification_enabled').click(function() {
+		$('#notification_enabled').on('click', function() {
 			setNotification();
 		});
 
 		setNotification();
 
-		$('#ping_method').change(function() {
+		$('#ping_method').on('change', function() {
 			setPing();
 		});
 
@@ -1264,15 +1264,15 @@ function networks_filter() {
 			}
 
 			$(function() {
-				$('#go').click(function() {
+				$('#go').on('click', function() {
 					applyFilter();
 				});
 
-				$('#clear').click(function() {
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#networks').submit(function(event) {
+				$('#networks').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});

--- a/automation_snmp.php
+++ b/automation_snmp.php
@@ -609,7 +609,7 @@ function automation_snmp_edit() {
 		$('.cdialog').remove();
 		$('#main').append("<div class='cdialog' id='cdialog'></div>");
 		$('#automation_snmp_edit2_child').attr('id', 'snmp_item');
-        $('img.action').click(function() {
+        $('img.action').on('click', function() {
             strURL = $(this).attr('href');
 			loadPageNoHeader(strURL);
         });
@@ -622,7 +622,7 @@ function automation_snmp_edit() {
         });
 		<?php } ?>
 
-		$('.delete').click(function (event) {
+		$('.delete').on('click', function (event) {
 			event.preventDefault();
 
 			id = $(this).attr('id').split('_');

--- a/automation_snmp.php
+++ b/automation_snmp.php
@@ -252,7 +252,7 @@ function form_automation_snmp_actions() {
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($automation_array) ? serialize($automation_array) : '') . "'>
 			<input type='hidden' name='drp_action' value='" . html_escape(get_nfilter_request_var('drp_action')) . "'>
-			<input type='button' class='ui-button ui-corner-all ui-widget' onClick='cactiReturnTo()' value='" . ($save_html == '' ? __esc('Return'):__esc('Cancel')) . "' name='cancel'>
+			<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . ($save_html == '' ? __esc('Return'):__esc('Cancel')) . "' name='cancel'>
 			$save_html
 		</td>
 	</tr>";
@@ -366,7 +366,7 @@ function automation_snmp_item_remove_confirm() {
     </tr>
     <tr>
         <td class='right'>
-            <input type='button' class='ui-button ui-corner-all ui-widget' id='cancel' value='<?php print __esc('Cancel');?>' onClick='$("#cdialog").dialog("close");' name='cancel'>
+            <input type='button' class='ui-button ui-corner-all ui-widget' id='cancel' value='<?php print __esc('Cancel');?>' name='cancel'>
             <input type='button' class='ui-button ui-corner-all ui-widget' id='continue' value='<?php print __esc('Continue');?>' name='continue' title='<?php print __esc('Remove SNMP Item');?>'>
         </td>
     </tr>
@@ -379,7 +379,11 @@ function automation_snmp_item_remove_confirm() {
     ?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
     $(function() {
-    	$('#continue').click(function(data) {
+		$('#cancel').on('click', function() {
+			$('#cdialog').dialog('close');
+		});
+
+    	$('#continue').on('click', function(data) {
 			$.post('automation_snmp.php?action=item_remove', {
 				__csrf_magic: csrfMagicToken,
 				item_id: <?php print get_request_var('item_id');?>,
@@ -702,7 +706,7 @@ function automation_snmp() {
 						<?php print __('SNMP Rules');?>
 					</td>
                     <td>
-                        <select id='rows' onChange='applyFilter()'>
+                        <select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
                             <?php
                             if (cacti_sizeof($item_rows)) {
@@ -738,15 +742,19 @@ function automation_snmp() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#rows').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#snmp_form').submit(function(event) {
+		$('#snmp_form').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});

--- a/automation_templates.php
+++ b/automation_templates.php
@@ -564,7 +564,7 @@ function template() {
 	$(function() {
         $('#automation_templates2_child').attr('id', 'template_ids');
 
-		$('img.action').click(function() {
+		$('img.action').on('click', function() {
 			strURL = $(this).attr('href');
 			loadPageNoHeader(strURL);
 		});

--- a/automation_templates.php
+++ b/automation_templates.php
@@ -164,7 +164,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Automation Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Automation Template(s)') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -399,7 +399,7 @@ function template() {
 						<?php print __('Templates');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {
@@ -435,15 +435,19 @@ function template() {
 			}
 
 			$(function() {
-				$('#refresh').click(function() {
+				$('#refresh').on('click', function() {
 					applyFilter();
 				});
 
-				$('#clear').click(function() {
+				$('#rows').on('change', function() {
+					applyFilter();
+				});
+
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#form_at').submit(function(event) {
+				$('#form_at').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});

--- a/automation_tree_rules.php
+++ b/automation_tree_rules.php
@@ -325,7 +325,7 @@ function automation_tree_rules_form_actions() {
 		header('Location: automation_tree_rules.php?header=false');
 		exit;
 	}else {
-		$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Apply requested action') . "'>";
+		$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Apply requested action') . "'>";
 	}
 
 	print "<tr>
@@ -899,19 +899,19 @@ function automation_tree_rules() {
 			}
 
 			$(function() {
-				$('#rows, #status').change(function() {
+				$('#rows, #status').on('change', function() {
 					applyFilter();
 				});
 
-				$('#refresh').click(function() {
+				$('#refresh').on('click', function() {
 					applyFilter();
 				});
 
-				$('#clear').click(function() {
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#form_automation').submit(function(event) {
+				$('#form_automation').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});

--- a/cdef.php
+++ b/cdef.php
@@ -273,7 +273,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete CDEF', 'Delete CDEFs', cacti_sizeof($cdef_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete CDEF', 'Delete CDEFs', cacti_sizeof($cdef_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '2') { /* duplicate */
 			print "<tr>
 				<td class='textArea'>
@@ -284,7 +284,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate CDEF', 'Duplicate CDEFs', cacti_sizeof($cdef_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate CDEF', 'Duplicate CDEFs', cacti_sizeof($cdef_array)) . "'>";
 		}
 	} else {
 		raise_message(40);

--- a/cdef.php
+++ b/cdef.php
@@ -497,7 +497,7 @@ function item_edit() {
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	$(function() {
-		$('#type_select').unbind().change(function() {
+		$('#type_select').on('change', function() {
 			strURL  = 'cdef.php?action=item_edit';
 			strURL += '&id=' + $('#id').val();
 			strURL += '&cdef_id=' + $('#cdef_id').val();
@@ -651,7 +651,7 @@ function cdef_edit() {
 		});
 		<?php } ?>
 
-		$('.delete').click(function(event) {
+		$('.delete').on('click', function(event) {
 			event.preventDefault();
 
 			id = $(this).attr('id').split('_');
@@ -753,7 +753,7 @@ function cdef() {
 						<?php print __('CDEFs');?>
 					</td>
 					<td>
-						<select id='rows' name='rows' onChange='applyFilter()'>
+						<select id='rows' name='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {
@@ -795,19 +795,19 @@ function cdef() {
 			}
 
 			$(function() {
-				$('#refresh').click(function() {
+				$('#refresh, #has_graphs').on('click', function() {
 					applyFilter();
 				});
 
-				$('#has_graphs').click(function() {
+				$('#rows').on('change', function() {
 					applyFilter();
 				});
 
-				$('#clear').click(function() {
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#form_cdef').submit(function(event) {
+				$('#form_cdef').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});

--- a/color.php
+++ b/color.php
@@ -439,11 +439,11 @@ function color_edit() {
 		checkReadonly();
 
 		$('#hex').colorpicker().css({'width':'60px'});
-		$('#read_only').click(function() {
+		$('#read_only').on('click', function() {
 			checkReadonly();
 		});
 
-		$('#name').keyup(function() {
+		$('#name').on('keyup', function() {
 			$('#hidden_name').val($(this).val());
 		});
 

--- a/color.php
+++ b/color.php
@@ -189,7 +189,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Color', 'Delete Colors', cacti_sizeof($color_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Color', 'Delete Colors', cacti_sizeof($color_array)) . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -535,7 +535,7 @@ function color() {
 						<?php print __('Colors');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {
@@ -589,33 +589,29 @@ function color() {
 			}
 
 			$(function() {
-				$('#refresh').click(function() {
+				$('#refresh, #has_graphs, #named').on('click', function() {
 					applyFilter();
 				});
 
-				$('#has_graphs').click(function() {
+				$('#rows').on('change', function() {
 					applyFilter();
 				});
 
-				$('#named').click(function() {
-					applyFilter();
-				});
-
-				$('#clear').click(function() {
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#form_color').submit(function(event) {
+				$('#form_color').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});
 
-				$('#import').click(function(event) {
+				$('#import').on('click', function(event) {
 					strURL = 'color.php?action=import&header=false';
 					loadPageNoHeader(strURL);
 				});
 
-				$('#export').click(function(event) {
+				$('#export').on('click', function(event) {
 					strURL = 'color.php?action=export&header=false';
 					document.location = strURL;
 					Pace.stop();

--- a/color_templates.php
+++ b/color_templates.php
@@ -240,7 +240,7 @@ function aggregate_color_form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Color Template', 'Delete Color Templates', cacti_sizeof($color_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Color Template', 'Delete Color Templates', cacti_sizeof($color_array)) . "'>";
 		} elseif (get_request_var('drp_action') == '2') { // duplicate
 			print "<tr>
 				<td class='textArea'>
@@ -252,7 +252,7 @@ function aggregate_color_form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate Color Template', 'Duplicate Color Templates', cacti_sizeof($color_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate Color Template', 'Duplicate Color Templates', cacti_sizeof($color_array)) . "'>";
 		} elseif (get_request_var('drp_action') == '3') { // sync
 			print "<tr>
 				<td class='textArea'>
@@ -261,7 +261,7 @@ function aggregate_color_form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Synchronize Color Template', 'Synchronize Color Templates', cacti_sizeof($color_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Synchronize Color Template', 'Synchronize Color Templates', cacti_sizeof($color_array)) . "'>";
 		}
 	} else {
 		raise_message(40);

--- a/color_templates.php
+++ b/color_templates.php
@@ -339,7 +339,7 @@ function aggregate_color_item() {
 		});
 		<?php } ?>
 
-		$('.delete').click(function (event) {
+		$('.delete').on('click', function (event) {
 			event.preventDefault();
 
 			id = $(this).attr('id').split('_');
@@ -718,11 +718,11 @@ function aggregate_color_template() {
 	}
 
 	$(function() {
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_template').submit(function(event) {
+		$('#form_template').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});

--- a/color_templates_items.php
+++ b/color_templates_items.php
@@ -296,7 +296,7 @@ function aggregate_color_item_remove_confirm() {
 	</tr>
 	<tr>
 		<td class='right'>
-			<input type='button' class='ui-button ui-corner-all ui-widget' id='cancel' value='<?php print __esc('Cancel');?>' onClick='$("#cdialog").dialog("close");' name='cancel'>
+			<input type='button' class='ui-button ui-corner-all ui-widget' id='cancel' value='<?php print __esc('Cancel');?>' name='cancel'>
 			<input type='button' class='ui-button ui-corner-all ui-widget' id='continue' value='<?php print __esc('Continue');?>' name='continue' title='<?php print __esc('Remove Color Item');?>'>
 		</td>
 	</tr>
@@ -309,7 +309,11 @@ function aggregate_color_item_remove_confirm() {
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	$(function() {
-		$('#continue').click(function(data) {
+		$('#clear').on('click', function() {
+			$('#cdialog').dialog('close');
+		});
+
+		$('#continue').on('click', function(data) {
 			$.post('color_templates_items.php?action=item_remove', {
 				__csrf_magic: csrfMagicToken,
 				color_id: <?php print get_request_var('color_id');?>,
@@ -324,7 +328,6 @@ function aggregate_color_item_remove_confirm() {
 	<?php
 }
 
-
 /**
  * aggregate_color_item_remove		remove item
  */
@@ -338,7 +341,6 @@ function aggregate_color_item_remove() {
 		WHERE color_template_item_id = ?',
 		array(get_request_var('color_id')));
 }
-
 
 /**
  * aggregate_color_item_edit		edit item

--- a/data_debug.php
+++ b/data_debug.php
@@ -1025,7 +1025,7 @@ function data_debug_filter() {
 						<?php print __('Template');?>
 					</td>
 					<td>
-						<select id='template_id' name='template_id' onChange='applyFilter()'>
+						<select id='template_id' name='template_id'>
 							<option value='-1'<?php if (get_request_var('template_id') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 							<option value='0'<?php if (get_request_var('template_id') == '0') {?> selected<?php }?>><?php print __('None');?></option>
 							<?php
@@ -1062,7 +1062,7 @@ function data_debug_filter() {
 						<?php print __('Profile');?>
 					</td>
 					<td>
-						<select id='profile' name='profile' onChange='applyFilter()'>
+						<select id='profile' name='profile'>
 							<option value='-1'<?php print (get_request_var('profile') == '-1' ? ' selected>':'>') . __('All');?></option>
 							<?php
 							$profiles = array_rekey(db_fetch_assoc('SELECT id, name FROM data_source_profiles ORDER BY name'), 'id', 'name');
@@ -1078,7 +1078,7 @@ function data_debug_filter() {
 						<?php print __('Status');?>
 					</td>
 					<td>
-						<select id='status' name='status' onChange='applyFilter()'>
+						<select id='status' name='status'>
 							<option value='-1'<?php if (get_request_var('status') == '-1') {?> selected<?php }?>><?php print __('All');?></option>
 							<option value='0'<?php if (get_request_var('status') == '0') {?> selected<?php }?>><?php print __('Failed');?></option>
 							<option value='1'<?php if (get_request_var('status') == '1') {?> selected<?php }?>><?php print __('Enabled');?></option>
@@ -1089,7 +1089,7 @@ function data_debug_filter() {
 						<?php print __('Debugging');?>
 					</td>
 					<td>
-						<select id='debug' name='debug' onChange='applyFilter()'>
+						<select id='debug' name='debug'>
 							<option value='-1'<?php print (get_request_var('debug') == '-1' ? ' selected>':'>') . __('All');?></option>
 							<option value='1'<?php print (get_request_var('debug') == '1' ? ' selected>':'>') . __('Debugging');?></option>
 							<option value='0'<?php print (get_request_var('debug') == '0' ? ' selected>':'>') . __('Not Debugging');?></option>
@@ -1099,7 +1099,7 @@ function data_debug_filter() {
 						<?php print __('Refresh');?>
 					</td>
 					<td>
-						<select id='refresh' name='refresh' onChange='applyFilter()'>
+						<select id='refresh' name='refresh'>
 							<?php
 							unset($page_refresh_interval[5]);
 							unset($page_refresh_interval[10]);
@@ -1123,13 +1123,13 @@ function data_debug_filter() {
 						<?php print __('Search');?>
 					</td>
 					<td>
-						<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='30' value='<?php print html_escape_request_var('rfilter');?>' onChange='applyFilter()'>
+						<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='30' value='<?php print html_escape_request_var('rfilter');?>'>
 					</td>
 					<td>
 						<?php print __('Data Sources');?>
 					</td>
 					<td>
-						<select id='rows' name='rows' onChange='applyFilter()'>
+						<select id='rows' name='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {
@@ -1175,23 +1175,27 @@ function data_debug_filter() {
 		}
 
 		$(function() {
-			$('#go').click(function() {
+			$('#go').on('click', function() {
 				applyFilter()
 			});
 
-			$('#clear').click(function() {
+			$('#rfilter, #status, #rows, #debug, #refresh, #profile, #site_id, #host_id, #template_id').on('change', function() {
+				applyFilter();
+			});
+
+			$('#clear').on('click', function() {
 				clearFilter()
 			});
 
-			$('#purge').click(function() {
+			$('#purge').on('click', function() {
 				purgeFilter()
 			});
 
-			$('#runall').click(function() {
+			$('#runall').on('click', function() {
 				runallFilter()
 			});
 
-			$('#form_data_debug').submit(function(event) {
+			$('#form_data_debug').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/data_debug.php
+++ b/data_debug.php
@@ -931,18 +931,18 @@ function debug_view() {
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	$(function() {
-		$('.repairme').click(function(event) {
+		$('.repairme').on('click', function(event) {
 			event.preventDefault();
 			id = $(this).attr('data-id');
 			loadPage('data_debug.php?action=run_repair&id=' + id);
 		});
 
-		$('.reloadquery').click(function() {
+		$('.reloadquery').on('click', function() {
 			id = $(this).attr('data-id');
 			loadPage('data_debug.php?action=view&id=' + id);
 		});
 
-		$('.rerun').click(function(event) {
+		$('.rerun').on('click', function(event) {
 			event.preventDefault();
 			id = $(this).attr('data-id');
 			loadPage('data_debug.php?action=run_debug&id=' + id);

--- a/data_input.php
+++ b/data_input.php
@@ -266,7 +266,7 @@ function form_actions() {
 			</tr>\n";
 		}
 
-		$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Input Method', 'Delete Data Input Methods', cacti_sizeof($di_array)) . "'>";
+		$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Input Method', 'Delete Data Input Methods', cacti_sizeof($di_array)) . "'>";
 	} else {
 		raise_message(40);
 		header('Location: data_input.php?header=none');
@@ -331,7 +331,7 @@ function field_remove_confirm() {
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	$(function() {
-		$('#continue').unbind('click').click(function(data) {
+		$('#continue').on('click', function(data) {
 			$.post('data_input.php?action=field_remove', {
 				__csrf_magic: csrfMagicToken,
 				data_input_id: <?php print get_request_var('data_input_id');?>,
@@ -679,7 +679,7 @@ function data_edit() {
 		$('.cdialog').remove();
 		$('#main').append("<div id='cdialog' class='cdialog'></div>");
 
-		$('.delete').unbind().click(function (event) {
+		$('.delete').on('click', function (event) {
 			event.preventDefault();
 
 			request = $(this).attr('href');
@@ -765,7 +765,7 @@ function data() {
 						<?php print __('Input Methods');?>
 					</td>
 					<td>
-						<select id='rows' name='rows' onChange='applyFilter()'>
+						<select id='rows' name='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {
@@ -800,15 +800,19 @@ function data() {
 		}
 
 		$(function() {
-			$('#refresh').click(function() {
+			$('#refresh').on('click', function() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#rows').on('change', function() {
+				applyFilter();
+			});
+
+			$('#clear').on('click', function() {
 				clearFilter();
 			});
 
-			$('#form_data_input').submit(function(event) {
+			$('#form_data_input').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/data_queries.php
+++ b/data_queries.php
@@ -409,7 +409,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Query', 'Delete Data Queries', cacti_sizeof($dq_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Query', 'Delete Data Queries', cacti_sizeof($dq_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '2') { /* duplicatie */
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -423,7 +423,7 @@ function form_actions() {
                 </td>
             </tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate Data Query', 'Duplicate Data Queries', cacti_sizeof($dq_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate Data Query', 'Duplicate Data Queries', cacti_sizeof($dq_array)) . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -986,7 +986,7 @@ function data_query_item_edit() {
 		href=$(this).attr('href');
 		$.get(href)
 			.done(function(data) {
-				$('form[action="data_queries.php"]').unbind();
+				$('form[action="data_queries.php"]').off();
 				$('#main').html(data);
 				applySkin();
 			})
@@ -1314,7 +1314,7 @@ function data_query() {
 						<?php print __('Data Queries');?>
 					</td>
 					<td>
-						<select id='rows' name='rows' onChange='applyFilter()'>
+						<select id='rows' name='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -1348,15 +1348,19 @@ function data_query() {
 		}
 
 		$(function() {
-			$('#refresh').click(function() {
+			$('#refresh').on('click', function() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#rows').on('change', function() {
+				applyFilter();
+			});
+
+			$('#clear').on('click', function() {
 				clearFilter();
 			});
 
-			$('#form_data_queries').submit(function(event) {
+			$('#form_data_queries').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/data_queries.php
+++ b/data_queries.php
@@ -673,7 +673,7 @@ function data_query_item_edit() {
 	}
 
 	$(function() {
-		$('form#data_queries').find('#graph_template_id').change(function() {
+		$('form#data_queries').find('#graph_template_id').on('change', function() {
 			assignDataQueryGraphName(false);
 		});
 		assignDataQueryGraphName(true);
@@ -981,7 +981,7 @@ function data_query_item_edit() {
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	var graph_template_id_prev=<?php print $item;?>;
 
-	$('.remover').click(function(event) {
+	$('.remover').on('click', function(event) {
 		event.preventDefault();
 		href=$(this).attr('href');
 		$.get(href)
@@ -995,7 +995,7 @@ function data_query_item_edit() {
 			});
 	});
 
-	$('input[id="svg_x"]').click(function() {
+	$('input[id="svg_x"]').on('click', function() {
 		$.post('data_queries.php', {
 			action: 'save',
 			save_component_svg: '1',
@@ -1012,7 +1012,7 @@ function data_query_item_edit() {
 		});
 	});
 
-    $('.svds_x').click(function() {
+    $('.svds_x').on('click', function() {
 		// Get the dsid value
 		var id    = $(this).attr('id');
 		var parts = id.split('_');
@@ -1218,7 +1218,7 @@ function data_query_edit() {
 
 		$('.noLinkEditMain').tooltip();
 
-		$('.delete').click(function (event) {
+		$('.delete').on('click', function (event) {
 			event.preventDefault();
 
 			request = $(this).attr('href');
@@ -1228,7 +1228,7 @@ function data_query_edit() {
 
 					applySkin();
 
-					$('#continue').click(function(data) {
+					$('#continue').on('click', function(data) {
 						$.post('data_queries.php?action=item_remove', {
 							__csrf_magic: csrfMagicToken,
 							snmp_query_id: snmp_query_id,

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -536,12 +536,12 @@ function item_edit() {
 		get_span();
 		get_size();
 
-		$('#steps').change(function() {
+		$('#steps').on('change', function() {
 			get_span();
 			get_size();
 		});
 
-        $('#rows').keyup(function() {
+        $('#rows').on('keyup', function() {
             if (rows_to) { clearTimeout(rows_to); }
             rows_to = setTimeout(function () { get_span(); get_size() }, 250);
         });
@@ -702,7 +702,7 @@ function profile_edit() {
         });
 
 		get_size();
-		$('consolidation_function_id').change(function() {
+		$('consolidation_function_id').on('change', function() {
 			get_size();
 		});
 

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -302,7 +302,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Source Profile', 'Delete Data Source Profiles', cacti_sizeof($profile_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Source Profile', 'Delete Data Source Profiles', cacti_sizeof($profile_array)) . "'>";
 		} elseif (get_request_var('drp_action') == '2') { // duplicate
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -312,7 +312,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate Data Source Profile', 'Duplicate Date Source Profiles', cacti_sizeof($profile_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate Data Source Profile', 'Duplicate Date Source Profiles', cacti_sizeof($profile_array)) . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -707,7 +707,7 @@ function profile_edit() {
 		});
 
 		<?php if (!$readonly) {?>
-		$('.delete').click(function (event) {
+		$('.delete').on('click', function (event) {
 			event.preventDefault();
 
 			id = $(this).attr('id').split('_');
@@ -918,7 +918,7 @@ function profile() {
 						<?php print __('Profiles');?>
 					</td>
 					<td>
-						<select id='rows' name='rows' onChange='applyFilter()'>
+						<select id='rows' name='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {
@@ -960,15 +960,19 @@ function profile() {
 			}
 
 			$(function() {
-				$('#has_data').click(function() {
+				$('#has_data').on('click', function() {
 					applyFilter();
 				});
 
-				$('#clear').click(function() {
+				$('#rows').on('change', function() {
+					applyFilter();
+				});
+
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#form_dsp').submit(function(event) {
+				$('#form_dsp').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});

--- a/data_sources.php
+++ b/data_sources.php
@@ -532,7 +532,7 @@ function form_actions() {
 			print "</td>
 				</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Source', 'Delete Data Sources', cacti_sizeof($ds_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Source', 'Delete Data Sources', cacti_sizeof($ds_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '3') { // change host
 			print "<tr>
 				<td class='textArea'>
@@ -542,7 +542,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Device') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Device') . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '6') { // data source enable
 			print "<tr>
 				<td class='textArea'>
@@ -551,7 +551,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enable Data Source', 'Enable Data Sources', cacti_sizeof($ds_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enable Data Source', 'Enable Data Sources', cacti_sizeof($ds_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '7') { // data source disable
 			print "<tr>
 				<td class='textArea'>
@@ -560,7 +560,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Disable Data Source', 'Disable Data Sources', cacti_sizeof($ds_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Disable Data Source', 'Disable Data Sources', cacti_sizeof($ds_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '8') { // reapply suggested data source naming
 			print "<tr>
 				<td class='textArea'>
@@ -569,13 +569,13 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Reapply Suggested Naming to Data Source', 'Reapply Suggested Naming to Data Sources', cacti_sizeof($ds_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Reapply Suggested Naming to Data Source', 'Reapply Suggested Naming to Data Sources', cacti_sizeof($ds_array)) . "'>";
 		} else {
 			$save['drp_action'] = get_nfilter_request_var('drp_action');
 			$save['ds_list'] = $ds_list;
 			$save['ds_array'] = (isset($ds_array)? $ds_array : array());
 			api_plugin_hook_function('data_source_action_prepare', $save);
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -1327,15 +1327,19 @@ function ds() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter()
 		});
 
-		$('#clear').click(function() {
+		$('#host_id, #site_id, #rows, #status, #profile, #orphans, #template_id').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter()
 		});
 
-		$('#form_data_sources').submit(function(event) {
+		$('#form_data_sources').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -1384,7 +1388,7 @@ function ds() {
 						<?php print __('Template');?>
 					</td>
 					<td>
-						<select id='template_id' name='template_id' onChange='applyFilter()'>
+						<select id='template_id' name='template_id'>
 							<option value='-1'<?php if (get_request_var('template_id') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 							<option value='0'<?php if (get_request_var('template_id') == '0') {?> selected<?php }?>><?php print __('None');?></option>
 							<?php
@@ -1419,7 +1423,7 @@ function ds() {
 						<?php print __('Profile');?>
 					</td>
 					<td>
-						<select id='profile' name='profile' onChange='applyFilter()'>
+						<select id='profile' name='profile'>
 							<option value='-1'<?php print (get_request_var('profile') == '-1' ? ' selected>':'>') . __('All');?></option>
 							<?php
 							$profiles = array_rekey(db_fetch_assoc('SELECT id, name FROM data_source_profiles ORDER BY name'), 'id', 'name');
@@ -1436,7 +1440,7 @@ function ds() {
 						<?php print __('Status');?>
 					</td>
 					<td>
-						<select id='status' name='status' onChange='applyFilter()'>
+						<select id='status' name='status'>
 							<option value='-1'<?php if (get_request_var('status') == '-1') {?> selected<?php }?>><?php print __('All');?></option>
 							<option value='1'<?php if (get_request_var('status') == '1') {?> selected<?php }?>><?php print __('Enabled');?></option>
 							<option value='2'<?php if (get_request_var('status') == '2') {?> selected<?php }?>><?php print __('Disabled');?></option>
@@ -1445,7 +1449,7 @@ function ds() {
 					</td>
 					<td>
 						<span>
-							<input type='checkbox' id='orphans' onChange='applyFilter()' <?php print (get_request_var('orphans') == 'true' || get_request_var('orphans') == 'on' ? 'checked':'');?>>
+							<input type='checkbox' id='orphans' <?php print (get_request_var('orphans') == 'true' || get_request_var('orphans') == 'on' ? 'checked':'');?>>
    	                    	<label for='orphans' title='<?php print __esc('Note that this query may take some time to run.');?>'><?php print __('Orphaned');?></label>
 						</span>
 					</td>
@@ -1457,13 +1461,13 @@ function ds() {
 						<?php print __('Search');?>
 					</td>
 					<td>
-						<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='55' value='<?php print html_escape_request_var('rfilter');?>' onChange='applyFilter()'>
+						<input type='text' class='ui-state-default ui-corner-all' id='rfilter' size='55' value='<?php print html_escape_request_var('rfilter');?>'>
 					</td>
 					<td>
 						<?php print __('Data Sources');?>
 					</td>
 					<td>
-						<select id='rows' name='rows' onChange='applyFilter()'>
+						<select id='rows' name='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {

--- a/data_templates.php
+++ b/data_templates.php
@@ -464,7 +464,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Data Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Data Template(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '2') { // duplicate
 			print "<tr>
 				<td class='textArea'>
@@ -474,7 +474,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Duplicate Data Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Duplicate Data Template(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '3') { // change profile
 			print "<tr>
 				<td class='textArea'>
@@ -490,7 +490,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Data Source Profile') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Data Source Profile') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -1048,7 +1048,7 @@ function template() {
 						<?php print __('Profile');?>
 					</td>
 					<td>
-						<select id='profile' onChange='applyFilter()'>
+						<select id='profile'>
 							<option value='-1'<?php print (get_request_var('profile') == '-1' ? ' selected>':'>') . __('All');?></option>
 							<?php
 							$profiles = array_rekey(db_fetch_assoc('SELECT id, name FROM data_source_profiles ORDER BY name'), 'id', 'name');
@@ -1064,7 +1064,7 @@ function template() {
 						<?php print __('Data Templates');?>
 					</td>
 					<td>
-						<select id='rows' name='rows' onChange='applyFilter()'>
+						<select id='rows' name='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -1107,19 +1107,19 @@ function template() {
 		}
 
 		$(function() {
-			$('#has_data').click(function() {
+			$('#has_data, #refresh').on('click', function() {
 				applyFilter();
 			});
 
-			$('#refresh').click(function() {
+			$('#rows, #profile').on('change', function() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#clear').on('click', function() {
 				clearFilter();
 			});
 
-			$('#form_data_template').submit(function(event) {
+			$('#form_data_template').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/gprint_presets.php
+++ b/gprint_presets.php
@@ -150,7 +150,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') ."' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete GPRINT Preset(s)') ."'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') ."'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete GPRINT Preset(s)') ."'>";
 		}
 	} else {
 		raise_message(40);
@@ -277,7 +277,7 @@ function gprint_presets() {
 						<?php print __('GPRINTs');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -319,19 +319,19 @@ function gprint_presets() {
 			}
 
 			$(function() {
-				$('#refresh').click(function() {
+				$('#refresh, #has_graphs').on('click', function() {
 					applyFilter();
 				});
 
-				$('#has_graphs').click(function() {
+				$('#rows').on('change', function() {
 					applyFilter();
 				});
 
-				$('#clear').click(function() {
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#form_gprint').submit(function(event) {
+				$('#form_gprint').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});

--- a/graph.php
+++ b/graph.php
@@ -477,7 +477,7 @@ case 'zoom':
 				$('#data').html(data);
 				resizeWrapper();
 
-				$('.download').click(function(event) {
+				$('.download').on('click', function(event) {
 					event.preventDefault;
 					graph_id = $(this).attr('id').replace('graph_','');
 					document.location = urlPath+'graph_xport.php?local_graph_id='+graph_id+'&rra_id=0&view_type=tree&graph_start='+$('#graph_start').val()+'&graph_end='+$('#graph_end').val();
@@ -562,12 +562,12 @@ case 'zoom':
 				});
 		});
 
-		$('a[id$="_properties"]').unbind('click').click(function() {
+		$('a[id$="_properties"]').unbind('click').on('click', function() {
 			graph_id = $(this).attr('id').replace('graph_', '').replace('_properties', '');
 			graphProperties();
 		});
 
-		$('a[id$="_csv"]').unbind('click').click(function() {
+		$('a[id$="_csv"]').unbind('click').on('click', function() {
 			graph_id = $(this).attr('id').replace('graph_', '').replace('_csv', '');
 			graphXport();
 		});

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -371,9 +371,9 @@ function form_actions() {
 					<p>" . __('Click \'Continue\' to delete the following Graph Template(s).  Any Graph(s) associated with the Template(s) will become individual Graph(s).') . "</p>
 					<div class='itemlist'><ul>$graph_list</ul></div>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Graph Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Graph Template(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '2') { // duplicate
 			print "<tr>
 				<td class='textArea'>
@@ -381,9 +381,9 @@ function form_actions() {
 					<div class='itemlist'><ul>$graph_list</ul></div>
 					<p><strong>" . __('Title Format:'). "</strong><br>"; form_text_box('title_format', '<template_title> (1)', '', '255', '30', 'text'); print "</p>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue'). "' title='" . __esc('Duplicate Graph Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue'). "' title='" . __esc('Duplicate Graph Template(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '3') { // resize
 			print "<tr>
 				<td class='textArea'>
@@ -403,27 +403,27 @@ function form_actions() {
 			print '</td></tr><tr><td>' . __('Image Format') . '</td><td>';
 			form_dropdown('image_format_id', $image_types, '', '', read_config_option('default_image_format'), '', '');
 
-			print "</td></tr></table><div class='break'></div><table style='width:100%'>\n";
+			print "</td></tr></table><div class='break'></div><table style='width:100%'>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Resize Selected Graph Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Resize Selected Graph Template(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '4') { // retemplate
 			print "<tr>
 				<td class='textArea'>
 					<p>" . __('Click \'Continue\' to perform a Full Synchronization between your Graphs and the chosen Graph Templates(s). If you simply have a situation where the Graph Items don\'t match the Graph Template, try the Quick Sync Graphs option first as it will take much less time.  This function is important if you have Graphs that exist with multiple versions of a Graph Template and wish to make them all common in appearance.') . "</p>
 					<div class='itemlist'><ul>$graph_list</ul></div>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue'). "' title='" . __esc('Synchronize Graphs to Graph Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue'). "' title='" . __esc('Synchronize Graphs to Graph Template(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '5') { // retemplate only where sequences are off
 			print "<tr>
 				<td class='textArea'>
 					<p>" . __('Click \'Continue\' to perform a Quick Synchronization of your Graphs for the following Graph Template(s). Use this option if your Graphs have Graph Items that do not match your Graph Template.  If this option does not work, use the Full Sync Graphs option, which will take more time to complete.') . "</p>
 					<div class='itemlist'><ul>$graph_list</ul></div>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue'). "' title='" . __esc('Synchronize Graphs to Graph Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue'). "' title='" . __esc('Synchronize Graphs to Graph Template(s)') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -438,7 +438,7 @@ function form_actions() {
 			<input type='hidden' name='drp_action' value='" . html_escape(get_nfilter_request_var('drp_action')) . "'>
 			$save_html
 		</td>
-	</tr>\n";
+	</tr>";
 
 	html_end_box();
 
@@ -524,7 +524,7 @@ function item() {
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	$(function() {
-		$('.deleteMarker, .moveArrow').click(function(event) {
+		$('.deleteMarker, .moveArrow').on('click', function(event) {
 			event.preventDefault();
 			loadPageNoHeader($(this).attr('href'));
 		});
@@ -635,6 +635,7 @@ function template_edit() {
 	function dynamic() {
 		$('#t_scale_log_units').prop('disabled', true);
 		$('#scale_log_units').prop('disabled', true);
+
 		if ($('#auto_scale_log').is(':checked')) {
 			$('#t_scale_log_units').prop('disabled', false);
 			$('#scale_log_units').prop('disabled', false);
@@ -644,6 +645,7 @@ function template_edit() {
 	function changeScaleLog() {
 		$('#t_scale_log_units').prop('disabled', true);
 		$('#scale_log_units').prop('disabled', true);
+
 		if ($('#auto_scale_log').is(':checked')) {
 			$('#t_scale_log_units').prop('disabled', false);
 			$('#scale_log_units').prop('disabled', false);
@@ -717,12 +719,12 @@ function template() {
 						<?php print __('Graph Templates');?>
 					</td>
 					<td>
-						<select id='rows' name='rows' onChange='applyFilter()'>
+						<select id='rows' name='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
 								foreach ($item_rows as $key => $value) {
-									print "<option value='" . $key . "'"; if (get_request_var('rows') == $key) { print ' selected'; } print '>' . html_escape($value) . "</option>\n";
+									print "<option value='" . $key . "'"; if (get_request_var('rows') == $key) { print ' selected'; } print '>' . html_escape($value) . "</option>";
 								}
 							}
 							?>
@@ -760,19 +762,19 @@ function template() {
 		}
 
 		$(function() {
-			$('#refresh').click(function() {
+			$('#refresh, #has_graphs').on('click', function() {
 				applyFilter();
 			});
 
-			$('#has_graphs').click(function() {
+			$('#rows').on('change', function() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#clear').on('click', function() {
 				clearFilter();
 			});
 
-			$('#form_graph_template').submit(function(event) {
+			$('#form_graph_template').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});
@@ -908,7 +910,7 @@ function template() {
 			form_end_row();
 		}
 	} else {
-		print "<tr class='tableRow'><td colspan='" . (cacti_sizeof($display_text)+1) . "'><em>" . __('No Graph Templates Found') . "</em></td></tr>\n";
+		print "<tr class='tableRow'><td colspan='" . (cacti_sizeof($display_text)+1) . "'><em>" . __('No Graph Templates Found') . "</em></td></tr>";
 	}
 	html_end_box(false);
 

--- a/graph_templates_items.php
+++ b/graph_templates_items.php
@@ -594,7 +594,7 @@ function item_edit() {
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 
 	$(function() {
-		$('#shift').click(function(data) {
+		$('#shift').on('click', function(data) {
 			if ($('#shift').is(':checked')) {
 				$('#row_value').show();
 			} else {
@@ -602,7 +602,7 @@ function item_edit() {
 			}
 		});
 
-		$('#data_template_id').change(function() {
+		$('#data_template_id').on('change', function() {
 			$.get(urlPath+'graph_templates_items.php'+
 				'?action=ajax_data_sources'+
 				'&data_template_id='+$('#data_template_id').val()+
@@ -618,7 +618,7 @@ function item_edit() {
 		});
 
 		setRowVisibility();
-		$('#graph_type_id').change(function(data) {
+		$('#graph_type_id').on('change', function(data) {
 			setRowVisibility();
 		});
 	});

--- a/graph_view.php
+++ b/graph_view.php
@@ -660,8 +660,8 @@ case 'list':
 					<td>
 						<span>
 							<input type='submit' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __esc('Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
-							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __esc('Clear');?>' title='<?php print __esc('Clear Filters');?>' onClick='clearFilter()'>
-							<input type='button' class='ui-button ui-corner-all ui-widget' value='<?php print __esc('View');?>' title='<?php print __esc('View Graphs');?>' onClick='viewGraphs()'>
+							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __esc('Clear');?>' title='<?php print __esc('Clear Filters');?>'>
+							<input type='button' class='ui-button ui-corner-all ui-widget' id='view' value='<?php print __esc('View');?>' title='<?php print __esc('View Graphs');?>''>
 							<?php if (cacti_sizeof($reports)) {?>
 							<input type='button' class='ui-button ui-corner-all ui-widget' id='addreport' value='<?php print __esc('Report');?>' title='<?php print __esc('Add to a Report');?>'>
 							<?php } ?>
@@ -680,7 +680,7 @@ case 'list':
 						$loc_where = '';
 					}
 
-					html_location_filter(get_request_var('location'), 'applyFilter', $loc_where);
+					html_location_filter(get_request_var('location'), '', $loc_where);
 					?>
 					<td>
 						<?php print __('Template');?>
@@ -724,7 +724,7 @@ case 'list':
 						<?php print __('Graphs');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -908,7 +908,7 @@ case 'list':
 	<div class='break'></div>
 	<div class='cactiTable'>
 		<div style='float:left'><img src='images/arrow.gif' alt=''>&nbsp;</div>
-		<div style='float:right'><input type='button' class='ui-button ui-corner-all ui-widget' value='<?php print __esc('View');?>' title='<?php print __esc('View Graphs');?>' onClick='viewGraphs()'></div>
+		<div style='float:right'><input type='button' class='ui-button ui-corner-all ui-widget' id='view' value='<?php print __esc('View');?>' title='<?php print __esc('View Graphs');?>'></div>
 	</div>
 	<?php print $report_text;?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
@@ -1070,16 +1070,23 @@ case 'list':
 
 		initializeChecks();
 
-		$('#addreport').click(function() {
+		$('#site_id, #rows, #location, #host_id').on('change', function() {
+			applyFilter();
+		});
+
+		$('#addreport').on('click', function() {
 			addReport();
 		});
 
-		<?php html_graph_template_multiselect('list');?>
-
-		$('#chk').unbind().on('submit', function(event) {
-			event.preventDefault();
-			applyFilter();
+		$('#clear').on('click', function() {
+			clearFilter();
 		});
+
+		$('#view').on('click', function() {
+			viewGraphs();
+		});
+
+		<?php html_graph_template_multiselect('list');?>
 	});
 	</script>
 	<?php

--- a/graph_xport.php
+++ b/graph_xport.php
@@ -315,7 +315,7 @@ if (isset($xport_array['data']) && is_array($xport_array['data'])) {
 				$('.wrapperTop').scrollLeft($('.wrapperMain').scrollLeft());
 			});
 
-			$(window).resize(function() {
+			$(window).on('resize', function() {
 				resizeWrapper();
 			});
 		});

--- a/graphs.php
+++ b/graphs.php
@@ -1797,7 +1797,7 @@ function graph_edit() {
 			loadPageNoHeader('graphs.php?action=lock&header=false&id='+$('#local_graph_id').val());
 		});
 
-		$(window).resize(function() {
+		$(window).on('resize', function() {
 			imageWidth    = $('.cactiGraphImage').width();
 			imageHeight   = $('.cactiGraphImage').height();
 			aspectRatio   = imageWidth/imageHeight;

--- a/graphs.php
+++ b/graphs.php
@@ -885,11 +885,11 @@ function form_actions() {
 					<div class='itemlist'><ul>$graph_list</ul></div>";
 
 			if (isset($data_sources) && cacti_sizeof($data_sources)) {
-				print "<tr><td class='textArea'><p>" . __('The following Data Source(s) are in use by these Graph(s).') . "</p>\n";
+				print "<tr><td class='textArea'><p>" . __('The following Data Source(s) are in use by these Graph(s).') . "</p>";
 
 				print '<div class="itemlist"><ul>';
 				foreach ($data_sources as $data_source) {
-					print '<li>' . html_escape($data_source['name_cache']) . "</li>\n";
+					print '<li>' . html_escape($data_source['name_cache']) . "</li>";
 				}
 				print '</ul></div><br>';
 
@@ -912,9 +912,9 @@ function form_actions() {
 				print '</td></tr>';
 			}
 
-			print "</td></tr>\n";
+			print "</td></tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') ."' title='" . __esc('Delete Graph(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') ."' title='" . __esc('Delete Graph(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '2') { // change graph template
 			print "<tr>
 				<td class='textArea'>
@@ -928,9 +928,9 @@ function form_actions() {
 
 					print "</p>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Graph Template') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Graph Template') . "'>";
 		} elseif (get_request_var('drp_action') == '3') { // duplicate
 			print "<tr>
 				<td class='textArea'>
@@ -940,8 +940,8 @@ function form_actions() {
 			form_text_box('title_format', __('<graph_title> (1)'), '', '255', '30', 'text');
 			print "</p>
 				</td>
-			</tr>\n";
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Duplicate Graph(s)') . "'>";
+			</tr>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Duplicate Graph(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '4') { // graph -> graph template
 			print "<tr>
 				<td class='textArea'>
@@ -951,8 +951,8 @@ function form_actions() {
 			form_text_box('title_format', __('<graph_title> Template'), '', '255', '30', 'text');
 			print "</p>
 				</td>
-			</tr>\n";
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Convert to Graph Template') . "'>";
+			</tr>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Convert to Graph Template') . "'>";
 		} elseif (preg_match('/^tr_([0-9]+)$/', get_request_var('drp_action'), $matches)) { // place on tree
 			print "<tr>
 				<td class='textArea'>
@@ -965,9 +965,9 @@ function form_actions() {
 			print "</p>
 				</td>
 				</tr>
-				<input type='hidden' name='tree_id' value='" . html_escape($matches[1]) . "'>\n";
+				<input type='hidden' name='tree_id' value='" . html_escape($matches[1]) . "'>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Place Graph(s) on Tree') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Place Graph(s) on Tree') . "'>";
 		} elseif (get_request_var('drp_action') == '5') { // change host
 			print "<tr>
 				<td class='textArea'>
@@ -979,18 +979,18 @@ function form_actions() {
 
 			print "</p>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Graph(s) Associated Device') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Graph(s) Associated Device') . "'>";
 		} elseif (get_request_var('drp_action') == '6') { // reapply suggested naming to host
 			print "<tr>
 				<td class='textArea'>
 					<p>" . __('Click \'Continue\' to re-apply suggested naming to the following Graph(s).') . "</p>
 					<div class='itemlist'><ul>$graph_list</ul></div>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Reapply Suggested Naming to Graph(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Reapply Suggested Naming to Graph(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '9') {
 			include_once('./lib/api_aggregate.php');
 
@@ -1154,15 +1154,15 @@ function form_actions() {
 				}
 
 				$(function() {
-					$('#aggregate_total').change(function() {
+					$('#aggregate_total').on('change', function() {
 						changeTotals();
 					});
 
-					$('#aggregate_total_type').change(function() {
+					$('#aggregate_total_type').on('change', function() {
 						changeTotalsType();
 					});
 
-					$('input[id^="agg_total"], input[id^="agg_skip"]').click(function() {
+					$('input[id^="agg_total"], input[id^="agg_skip"]').on('click', function() {
 						id = $(this).attr('id');
 
 						if (id.indexOf('skip') > 0) {
@@ -1190,9 +1190,9 @@ function form_actions() {
 				</script>
 				<?php
 
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Create Aggregate Graph') . "'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Create Aggregate Graph') . "'>";
 			} else {
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Return') . "' onClick='cactiReturnTo()'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
 			}
 		} elseif (get_request_var('drp_action') == '10') { // aggregate template
 			include_once('./lib/api_aggregate.php');
@@ -1215,7 +1215,7 @@ function form_actions() {
 							<p>" . __('Select the Aggregate Template to use and press \'Continue\' to create your Aggregate Graph.  Otherwise press \'Cancel\' to return.') . "</p>
 							<div class='itemlist'><ul>" . $graph_list . "</ul></div>
 						</td>
-					</tr>\n";
+					</tr>";
 
 					print "<tr><td><table>
 						<tr>
@@ -1225,27 +1225,27 @@ function form_actions() {
 						<tr>
 							<td>" . __('Aggregate Template') . "</td>
 							<td>
-								<select name='aggregate_template_id'>\n";
+								<select name='aggregate_template_id'>";
 
 					html_create_list($aggregate_templates, 'name', 'id', $aggregate_templates[0]['id']);
 
 					print "</select>
 						</td>
-					</tr></table></td></tr>\n";
+					</tr></table></td></tr>";
 
-					$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Create Aggregate from Template') . "'>";
+					$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Create Aggregate from Template') . "'>";
 				} else {
 					print "<tr>
 						<td class='textArea'>
 							<p>" . __('There are presently no Aggregate Templates defined for this Graph Template.  Please either first create an Aggregate Template for the selected Graphs Graph Template and try again, or simply crease an un-templated Aggregate Graph.') . "</p>
 							<p>" . __('Press \'Return\' to return and select different Graphs.') . "</p>
 						</td>
-					</tr>\n";
+					</tr>";
 
-					$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Return') . "' onClick='cactiReturnTo()'>";
+					$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
 				}
 			} else {
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Return') . "' onClick='cactiReturnTo()'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
 			}
 		} elseif (get_request_var('drp_action') == 8) { // automation
 			print "<tr>
@@ -1253,9 +1253,9 @@ function form_actions() {
 					<p>" . __('Click \'Continue\' to apply Automation Rules to the following Graphs.') . "</p>
 					<div class='itemlist'><ul>$graph_list</ul></div>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Apply Automation Rules') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Apply Automation Rules') . "'>";
 		} elseif (get_request_var('drp_action') == '11') {
 			global $alignment, $graph_timespans;
 
@@ -1282,12 +1282,12 @@ function form_actions() {
 
 				print '<tr><td>' . __('Align') . '<br>';
 				form_dropdown('align',$alignment, '', '', '', '', REPORTS_ALIGN_CENTER);
-				print "</td></tr>\n";
+				print '</td></tr>';
 
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Add Graphs to Report') . "'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Add Graphs to Report') . "'>";
 			} else {
-				print "<tr><td class='even'><span class='textError'>" . __('You currently have no reports defined.') . "</span></td></tr>\n";
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Return') . "' onClick='cactiReturnTo()'>";
+				print "<tr><td class='even'><span class='textError'>" . __('You currently have no reports defined.') . "</span></td></tr>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
 			}
 		} else {
 			$save['drp_action'] = get_nfilter_request_var('drp_action');
@@ -1296,7 +1296,7 @@ function form_actions() {
 
 			api_plugin_hook_function('graphs_action_prepare', $save);
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -1311,7 +1311,7 @@ function form_actions() {
 			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
 			$save_html
 		</td>
-	</tr>\n";
+	</tr>";
 
 	html_end_box();
 
@@ -1386,7 +1386,7 @@ function item() {
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	$(function() {
-		$('.deleteMarker, .moveArrow').unbind().click(function(event) {
+		$('.deleteMarker, .moveArrow').on('click', function(event) {
 			event.preventDefault();
 			loadPageNoHeader($(this).attr('href'));
 		});
@@ -1765,7 +1765,7 @@ function graph_edit() {
 	$(function() {
 		dynamic();
 
-		$('#unlockid').click(function(event) {
+		$('#unlockid').on('click', function(event) {
 			event.preventDefault;
 
 			$('body').append("<div id='modal' class='ui-widget-overlay ui-front' style='z-index: 100;'><i style='position:absolute;top:50%;left:50%;' class='fa fa-spin fa-circle-notch'/></div>");
@@ -1791,7 +1791,7 @@ function graph_edit() {
 			});
 
 
-		$('#lockid').click(function(event) {
+		$('#lockid').on('click', function(event) {
 			event.preventDefault;
 
 			loadPageNoHeader('graphs.php?action=lock&header=false&id='+$('#local_graph_id').val());
@@ -1949,15 +1949,15 @@ function graph_management() {
 	}
 
 	$(function() {
-		$('#clear').unbind().on('click', function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#filter').unbind().on('change', function() {
+		$('#host_id, #site_id, #rows, #source, #orphans, #rfilter, #template_id').on('change', function() {
 			applyFilter();
 		});
 
-		$('#form_graphs').unbind().on('submit', function(event) {
+		$('#form_graphs').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2003,7 +2003,7 @@ function graph_management() {
 						<?php print __('Template');?>
 					</td>
 					<td>
-						<select id='template_id' onChange='applyFilter()'>
+						<select id='template_id'>
 							<option value='-1'<?php if (get_request_var('template_id') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 							<option value='0'<?php if (get_request_var('template_id') == '0') {?> selected<?php }?>><?php print __('None');?></option>
 							<?php
@@ -2021,7 +2021,7 @@ function graph_management() {
 
 							if (cacti_sizeof($templates)) {
 								foreach ($templates as $template) {
-									print "<option value='" . $template['id'] . "'"; if (get_request_var('template_id') == $template['id']) { print ' selected'; } print '>' . html_escape($template['name']) . "</option>\n";
+									print "<option value='" . $template['id'] . "'"; if (get_request_var('template_id') == $template['id']) { print ' selected'; } print '>' . html_escape($template['name']) . "</option>";
 								}
 							}
 							?>
@@ -2029,7 +2029,7 @@ function graph_management() {
 					</td>
 					<td>
 						<span>
-							<input type='checkbox' id='orphans' onChange='applyFilter()' <?php print (get_request_var('orphans') == 'true' || get_request_var('orphans') == 'on' ? 'checked':'');?>>
+							<input type='checkbox' id='orphans' <?php print (get_request_var('orphans') == 'true' || get_request_var('orphans') == 'on' ? 'checked':'');?>>
    	                    	<label for='orphans' title='<?php print __esc('Note that this query may take some time to run.');?>'><?php print __('Orphaned');?></label>
 						</span>
 					</td>
@@ -2053,7 +2053,7 @@ function graph_management() {
 						<?php print __('Graph Source');?>
 					</td>
 					<td>
-						<select id='source' onChange='applyFilter()'>
+						<select id='source'>
 							<option value='-1'<?php print (get_request_var('source') == '-1' ? ' selected>':'>') . __('All');?></option>
 							<option value='0'<?php print (get_request_var('source') == '0' ? ' selected>':'>') . __('Non Templated');?></option>
 							<option value='1'<?php print (get_request_var('source') == '1' ? ' selected>':'>') . __('Graph Template');?></option>
@@ -2064,12 +2064,12 @@ function graph_management() {
 						<?php print __('Graphs');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
 								foreach ($item_rows as $key => $value) {
-									print "<option value='" . $key . "'"; if (get_request_var('rows') == $key) { print ' selected'; } print '>' . html_escape($value) . "</option>\n";
+									print "<option value='" . $key . "'"; if (get_request_var('rows') == $key) { print ' selected'; } print '>' . html_escape($value) . "</option>";
 								}
 							}
 							?>

--- a/graphs_items.php
+++ b/graphs_items.php
@@ -536,7 +536,7 @@ function item_edit() {
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 
 	$(function() {
-		$('#shift').click(function(data) {
+		$('#shift').on('click', function(data) {
 			if ($('#shift').is(':checked')) {
 				$('#row_value').show();
 			} else {
@@ -555,12 +555,12 @@ function item_edit() {
 				}
 			});
 		} else {
-			$('#cdef_id').click(function() {
+			$('#cdef_id').on('click', function() {
 				cdefAlignment();
 			});
 		}
 
-		$('#graph_type_id').change(function(data) {
+		$('#graph_type_id').on('change', function(data) {
 			setRowVisibility();
 		});
 	});

--- a/graphs_new.php
+++ b/graphs_new.php
@@ -390,20 +390,24 @@ function graphs() {
 	}
 
 	$(function() {
-		$('[id^="reload"]').click(function(data) {
+		$('[id^="reload"]').on('click', function(data) {
 			$(this).addClass('fa-spin');
 			loadPageNoHeader('graphs_new.php?action=query_reload&header=false&id='+$(this).attr('data-id')+'&host_id='+$('#host_id').val());
 		});
 
-		$('#clear').click(function() {
+		$('#graph_type, #rows').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#save').click(function() {
+		$('#save').on('click', function() {
 			saveFilter();
 		});
 
-		$('#graphs_new').submit(function(event) {
+		$('#graphs_new').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -420,7 +424,7 @@ function graphs() {
 							<?php print __('Graph Types');?>
 						</td>
 						<td>
-							<select id='graph_type' name='graph_type' onChange='applyFilter()'>
+							<select id='graph_type' name='graph_type'>
 								<option value='-2'<?php if (get_request_var('graph_type') == '-2') {?> selected<?php }?>><?php print __('All');?></option>
 								<option value='-1'<?php if (get_request_var('graph_type') == '-1') {?> selected<?php }?>><?php print __('Graph Template Based');?></option>
 								<?php
@@ -463,7 +467,7 @@ function graphs() {
 							<?php print __('Rows');?>
 						</td>
 						<td>
-							<select id='rows' name='rows' onChange='applyFilter()'>
+							<select id='rows' name='rows'>
 								<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 								<?php
 								if (cacti_sizeof($item_rows) > 0) {
@@ -563,7 +567,7 @@ function graphs() {
 
 		print "<tr class='tableHeader'>
 				<th class='tableSubHeaderColumn'>" . __('Graph Template Name') . "</th>
-				<th class='tableSubHeaderCheckbox'><input class='checkbox' type='checkbox' id='all_cg' title='" . __esc('Select All') . "' onClick='selectAll(\"sg\",this.checked)'><label class='formCheckboxLabel' title='" . __esc('Select All Rows'). "' for='all_cg'></label></th>
+				<th class='tableSubHeaderCheckbox'><input class='checkbox' type='checkbox' id='all_cg' title='" . __esc('Select All') . "' data-prefix='sg'><label class='formCheckboxLabel' title='" . __esc('Select All Rows'). "' for='all_cg'></label></th>
 			</tr>";
 
 		if (get_request_var('filter') != '') {
@@ -861,7 +865,7 @@ function graphs() {
 						} else {
 							print "<tr class='tableHeader'>
 									$html_dq_header
-									<th class='tableSubHeaderCheckbox'><input class='checkbox' id='all_" . $snmp_query['id'] . "' type='checkbox' name='all_" . $snmp_query['id'] . "' title='" . __esc('Select All') . "' onClick='selectAll(\"sg_" . $snmp_query['id'] . "\",this.checked)'><label class='formCheckboxLabel' title='" . __esc('Select All Rows'). "' for='all_" . $snmp_query['id'] . "'></label></th>
+									<th class='tableSubHeaderCheckbox'><input class='checkbox' id='all_" . $snmp_query['id'] . "' type='checkbox' name='all_" . $snmp_query['id'] . "' title='" . __esc('Select All') . "' data-prefix='sg_" . $snmp_query['id'] . "'><label class='formCheckboxLabel' title='" . __esc('Select All Rows'). "' for='all_" . $snmp_query['id'] . "'></label></th>
 								</tr>";
 						}
 
@@ -959,7 +963,7 @@ function graphs() {
 							<input type='button' class='ui-button ui-corner-all ui-widget default' id='default_" .  $snmp_query['id'] . "' value='" . __esc('Set Default') . "' title='" . __esc('Make selection default') . "'>
 						</td>
 						<td class='right'>
-							<select class='dqselect' name='sgg_" . $snmp_query['id'] . "' id='sgg_" . $snmp_query['id'] . "' onChange='dqUpdateDeps(" . $snmp_query['id'] . ',' . (isset($column_counter) ? $column_counter:'') . ");'>
+							<select class='dqselect' name='sgg_" . $snmp_query['id'] . "' id='sgg_" . $snmp_query['id'] . "' data-prefix='" . $snmp_query['id'] . ',' . (isset($column_counter) ? $column_counter:'') . "'>
 								"; html_create_list($data_query_graphs, 'name', 'id', $selected); print "
 							</select>
 						</td>
@@ -974,7 +978,22 @@ function graphs() {
 	}
 
 	if ($script != '') {
-		$script .= "$('.default').click(function() { $.get('graphs_new.php?action=ajax_save&query=" . (isset($snmp_query['id']) ? $snmp_query['id']:'') . "'+'&item='+$(\".dqselect\").val()).fail(function(data) { getPresentHTTPError(data); });}); $('tr.notemplate').tooltip();</script>";
+		$script .= "
+			$('.default').on('click', function() {
+				$.get('graphs_new.php?action=ajax_save&query=" . (isset($snmp_query['id']) ? $snmp_query['id']:'') . "'+'&item='+$(\".dqselect\").val())
+				.fail(function(data) {
+						getPresentHTTPError(data);
+				});
+			});
+
+			$('tr.notemplate').tooltip();
+
+			$('.dqselect').on('change', function() {
+				var prefix = $(this).data('prefix');
+				dqUpdateDeps(prefix);
+			});
+		</script>";
+
 		print $script;
 	}
 

--- a/host.php
+++ b/host.php
@@ -403,7 +403,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Enable Device(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Enable Device(s)') . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '3') { // Disable Devices
 			print "	<tr>
 				<td colspan='2' class='textArea'>
@@ -412,7 +412,7 @@ function form_actions() {
 				</td>
 				</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Disable Device(s)') ."'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Disable Device(s)') ."'>";
 		} elseif (get_nfilter_request_var('drp_action') == '4') { // Change Device options
 			print "<tr>
 				<td colspan='2' class='textArea'>
@@ -459,7 +459,7 @@ function form_actions() {
 
 			device_change_javascript();
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Device(s) SNMP Options') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Change Device(s) SNMP Options') . "'>";
 		} elseif (get_request_var('drp_action') == '5') { // Clear Statistics for Selected Devices
 			print "<tr>
 				<td colspan='2' class='textArea'>
@@ -468,7 +468,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Clear Statistics on Device(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Clear Statistics on Device(s)') . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '7') { // sync device template
 			print "	<tr>
 				<td colspan='2' class='textArea'>
@@ -477,7 +477,7 @@ function form_actions() {
 				</td>
 				</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Synchronize Device(s)') ."'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Synchronize Device(s)') ."'>";
 		} elseif (get_request_var('drp_action') == '1') { // Delete
 			print "<tr>
 				<td class='textArea'>
@@ -491,7 +491,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Device(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Device(s)') . "'>";
 		} elseif (preg_match('/^tr_([0-9]+)$/', get_request_var('drp_action'), $matches)) { // place on tree
 			print "<tr>
 				<td class='textArea'>
@@ -505,7 +505,7 @@ function form_actions() {
 			</tr>
 			<input type='hidden' name='tree_id' value='" . $matches[1] . "'>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Place Device(s) on Tree') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Place Device(s) on Tree') . "'>";
 		} elseif (get_request_var('drp_action') == 6) { // automation
 			print "<tr>
 				<td class='textArea'>
@@ -514,7 +514,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel'). "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Run Automation on Device(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel'). "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Run Automation on Device(s)') . "'>";
         } elseif (get_request_var('drp_action') == '8') {
 			global $alignment, $graph_timespans;
 
@@ -541,12 +541,12 @@ function form_actions() {
 
 				print '<tr><td>' . __('Align') . '<br>';
 				form_dropdown('align', $alignment, '', '', '', '', REPORTS_ALIGN_CENTER);
-				print "</td></tr>\n";
+				print "</td></tr>";
 
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Add Devices to Report') . "'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Add Devices to Report') . "'>";
             } else {
-                print "<tr><td class='even'><span class='textError'>" . __('You currently have no Reports defined.') . "</span></td></tr>\n";
-                $save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Return') . "' onClick='cactiReturnTo()'>";
+                print "<tr><td class='even'><span class='textError'>" . __('You currently have no Reports defined.') . "</span></td></tr>";
+                $save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
             }
 		} else {
 			$save['drp_action'] = get_request_var('drp_action');
@@ -555,7 +555,7 @@ function form_actions() {
 
 			api_plugin_hook_function('device_action_prepare', $save);
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -1072,7 +1072,7 @@ function device_change_javascript() {
 	}
 
 	$(function() {
-		$('input[id^="t_"]').click(function() {
+		$('input[id^="t_"]').on('click', function() {
 			id = $(this).attr('id').substring(2);
 			if ($(this).is(':checked')) {
 				enableField(id);
@@ -1249,7 +1249,7 @@ function device_javascript() {
 		$('#cdialog').remove();
 		$('#main').append("<div id='cdialog' class='cdialog'></div>");
 
-		$('.delete').click(function (event) {
+		$('.delete').on('click', function (event) {
 			event.preventDefault();
 
 			request = $(this).attr('href');
@@ -1297,29 +1297,29 @@ function device_javascript() {
 			}
 		}
 
-		$('[id^="reload"]').click(function(data) {
+		$('[id^="reload"]').on('click', function(data) {
 			$(this).addClass('fa-spin');
 			strURL = 'host.php?action=query_reload&id='+$(this).attr('data-id')+'&host_id='+$('#id').val()+'&nostate=true';
 			hostPageLoad(strURL);
 		});
 
-		$('[id^="verbose"]').click(function(data) {
+		$('[id^="verbose"]').on('click', function(data) {
 			$(this).addClass('fa-spin');
 			var strURL = 'host.php?action=query_verbose&id='+$(this).attr('data-id')+'&host_id='+$('#id').val()+'&nostate=true';
 			loadPageNoHeader(strURL, true);
 		});
 
-		$('[id^="remove"]').click(function(data) {
+		$('[id^="remove"]').on('click', function(data) {
 			var strURL = 'host.php?action=query_remove&id='+$(this).attr('data-id')+'&host_id='+$('#id').val()+'&nostate=true';
 			hostPageLoad(strURL);
 		});
 
-		$('[id^="gtremove"]').click(function(data) {
+		$('[id^="gtremove"]').on('click', function(data) {
 			strURL = 'host.php?action=gt_remove&id='+$(this).attr('data-id')+'&host_id='+$('#id').val()+'&nostate=true';
 			hostPageLoad(strURL);
 		});
 
-		$('#add_dq').click(function() {
+		$('#add_dq').on('click', function() {
 			scrollTop = $(window).scrollTop();
 			Pace.start();
 			$.post('host.php?action=query_add', {
@@ -1334,7 +1334,7 @@ function device_javascript() {
 			});
 		});
 
-		$('#add_gt').click(function() {
+		$('#add_gt').on('click', function() {
 			scrollTop = $(window).scrollTop();
 			$.post('host.php?action=gt_add', {
 				host_id: $('#id').val(),
@@ -1347,7 +1347,7 @@ function device_javascript() {
 		});
 
 		changeHostForm();
-		$('#dbghide').click(function(data) {
+		$('#dbghide').on('click', function(data) {
 			$('#dqdebug').empty().fadeOut('fast');
 		});
 
@@ -1356,7 +1356,7 @@ function device_javascript() {
 			$('.cactiConsoleContentArea').scrollTop(dbgloc);
 		}
 
-		$('[id$="spacer"]').click(function() {
+		$('[id$="spacer"]').on('click', function() {
 			changeHostForm();
 		});
 
@@ -1749,15 +1749,15 @@ function host() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#clear').on('click', function() {
 				clearFilter();
 			});
 
-			$('#export').click(function() {
+			$('#export').on('click', function() {
 				exportRecords();
 			});
 
-			$('#form_devices').submit(function(event) {
+			$('#form_devices').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/host.php
+++ b/host.php
@@ -1360,12 +1360,12 @@ function device_javascript() {
 			changeHostForm();
 		});
 
-		$('#snmp_version').change(function() {
+		$('#snmp_version').on('change', function() {
 			setAvailability();
 			setPing();
 		});
 
-		$('#location_input').keyup(function() {
+		$('#location_input').on('keyup', function() {
 			$('#location').val($('#location_input').val());
 		}).mouseup(function() {
 			$('#location').val($('#location_input').val());
@@ -1380,7 +1380,7 @@ function device_javascript() {
 				getPresentHTTPError(data);
 			});
 
-		$('input[id^="reindex_"]').change(function() {
+		$('input[id^="reindex_"]').on('change', function() {
 			strURL  = urlPath+'host.php?action=query_change&header=false';
 			strURL += '&host_id='+$(this).attr('data-device-id');
 			strURL += '&data_query_id='+$(this).attr('data-query-id');
@@ -1745,7 +1745,7 @@ function host() {
 		}
 
 		$(function() {
-			$('#rows, #site_id, #poller_id, #location, #host_template_id, #host_status').change(function() {
+			$('#rows, #site_id, #poller_id, #location, #host_template_id, #host_status').on('change', function() {
 				applyFilter();
 			});
 

--- a/host_templates.php
+++ b/host_templates.php
@@ -225,7 +225,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Device Template(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete Device Template(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '2') { // duplicate
 			print "<tr>
 				<td class='textArea'>
@@ -239,7 +239,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') ."' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Duplicate Device Template(s)') ."'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') ."'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Duplicate Device Template(s)') ."'>";
 		} elseif (get_request_var('drp_action') == '3') { // sync devices
 			print "<tr>
 				<td class='textArea'>
@@ -250,7 +250,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') ."' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Sync Devices to Device Template(s)') ."'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') ."'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Sync Devices to Device Template(s)') ."'>";
 		}
 	} else {
 		raise_message(40);
@@ -302,7 +302,7 @@ function template_item_remove_gt_confirm() {
 	</tr>
 	<tr>
 		<td class='right'>
-			<input type='button' class='ui-button ui-corner-all ui-widget' id='cancel' value='<?php print __esc('Cancel');?>' onClick='$("#cdialog").dialog("close")' name='cancel'>
+			<input type='button' class='ui-button ui-corner-all ui-widget' id='cancel' value='<?php print __esc('Cancel');?>' name='cancel'>
 			<input type='button' class='ui-button ui-corner-all ui-widget' id='continue' value='<?php print __esc('Continue');?>' name='continue' title='<?php print __esc('Remove Data Input Field');?>'>
 		</td>
 	</tr>
@@ -314,16 +314,22 @@ function template_item_remove_gt_confirm() {
 
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
-	$('#continue').click(function(data) {
-		$.post('host_templates.php?action=item_remove_gt', {
-			__csrf_magic: csrfMagicToken,
-			host_template_id: <?php print get_request_var('host_template_id');?>,
-			id: <?php print get_request_var('id');?>
-		}, function(data) {
+	$(function() {
+		$('#cancel').on('click', function() {
 			$('#cdialog').dialog('close');
-			$('div[class^="ui-"]').remove();
-			$('#main').html(data);
-			applySkin();
+		});
+
+		$('#continue').on('click', function(data) {
+			$.post('host_templates.php?action=item_remove_gt', {
+				__csrf_magic: csrfMagicToken,
+				host_template_id: <?php print get_request_var('host_template_id');?>,
+				id: <?php print get_request_var('id');?>
+			}, function(data) {
+				$('#cdialog').dialog('close');
+				$('div[class^="ui-"]').remove();
+				$('#main').html(data);
+				applySkin();
+			});
 		});
 	});
 	</script>
@@ -365,7 +371,7 @@ function template_item_remove_dq_confirm() {
 	</tr>
 	<tr>
 		<td class='right'>
-			<input type='button' class='ui-button ui-corner-all ui-widget' id='cancel' value='<?php print __esc('Cancel');?>' onClick='$("#cdialog").dialog("close")' name='cancel'>
+			<input type='button' class='ui-button ui-corner-all ui-widget' id='cancel' value='<?php print __esc('Cancel');?>' name='cancel'>
 			<input type='button' class='ui-button ui-corner-all ui-widget' id='continue' value='<?php print __esc('Continue');?>' name='continue' title='<?php print __esc('Remove Data Input Field');?>'>
 		</td>
 	</tr>
@@ -377,16 +383,22 @@ function template_item_remove_dq_confirm() {
 
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
-	$('#continue').click(function(data) {
-		$.post('host_templates.php?action=item_remove_dq', {
-			__csrf_magic: csrfMagicToken,
-			host_template_id: <?php print get_request_var('host_template_id');?>,
-			id: <?php print get_request_var('id');?>
-		}, function(data) {
+	$(function() {
+		$('#cancel').on('click', function() {
 			$('#cdialog').dialog('close');
-			$('div[class^="ui-"]').remove();
-			$('#main').html(data);
-			applySkin();
+		});
+
+		$('#continue').on('click', function(data) {
+			$.post('host_templates.php?action=item_remove_dq', {
+				__csrf_magic: csrfMagicToken,
+				host_template_id: <?php print get_request_var('host_template_id');?>,
+				id: <?php print get_request_var('id');?>
+			}, function(data) {
+				$('#cdialog').dialog('close');
+				$('div[class^="ui-"]').remove();
+				$('#main').html(data);
+				applySkin();
+			});
 		});
 	});
 	</script>
@@ -570,7 +582,7 @@ function template_edit() {
 		$('#cdialog').remove();
 		$('#main').append("<div id='cdialog' class='cdialog'></div>");
 
-		$('.delete').click(function (event) {
+		$('.delete').on('click', function (event) {
 			event.preventDefault();
 
 			request = $(this).attr('href');
@@ -592,7 +604,7 @@ function template_edit() {
 				});
 		}).css('cursor', 'pointer');
 
-		$('#add_dq').click(function() {
+		$('#add_dq').on('click', function() {
 			$.post('host_templates.php?action=item_add_dq', {
 				host_template_id: $('#id').val(),
 				snmp_query_id: $('#snmp_query_id').val(),
@@ -605,7 +617,7 @@ function template_edit() {
 			});
 		});
 
-		$('#add_gt').click(function() {
+		$('#add_gt').on('click', function() {
 			$.post('host_templates.php?action=item_add_gt', {
 				host_template_id: $('#id').val(),
 				graph_template_id: $('#graph_template_id').val(),
@@ -814,19 +826,19 @@ function template() {
 		}
 
 		$(function() {
-			$('#graph_template, #class, #rows').change(function() {
+			$('#graph_template, #class, #rows').on('change', function() {
 				applyFilter();
 			});
 
-			$('#refresh, #has_hosts').click(function() {
+			$('#refresh, #has_hosts').on('click', function() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#clear').on('click', function() {
 				clearFilter();
 			});
 
-			$('#form_host_template').submit(function(event) {
+			$('#form_host_template').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/include/layout.js
+++ b/include/layout.js
@@ -762,6 +762,20 @@ function handleTableNav() {
 			}
 		});
 	});
+
+	$('.tableSubHeaderCheckbox > input[type="checkbox"]').on('click', function() {
+		var prefix = $(this).data('prefix');
+		selectAll(prefix, $(this).is(':checked'));
+	});
+
+	$('.selectAllRealms').on('click', function() {
+		selectAllRealms($(this).is(':checked'));
+	});
+
+	$('.cactiReturnTo').on('click', function() {
+		var url = $(this).data('url');
+		cactiReturnTo(url);
+	});
 }
 
 /** applySkin - This function re-asserts all javascript behavior to a page
@@ -780,7 +794,7 @@ function applySkin() {
 		theme = 'classic';
 
 		// debounce submits
-		$('form').submit(function() {
+		$('form').on('submit', function() {
 			$('input[type="submit"], button[type="submit"]').not('.import, .export').prop('disabled', true);
 		});
 	} else {
@@ -790,7 +804,7 @@ function applySkin() {
 		$('fieldset.reindex_methods').buttonset();
 
 		// debounce submits
-		$('form').submit(function() {
+		$('form').on('submit', function() {
 			$('input[type="submit"], button[type="submit"]').not('.import, .export').button('disable');
 		});
 	}
@@ -1269,7 +1283,7 @@ function makeFiltersResponsive() {
 	}
 
 	if ($('#form_graph_view').length) {
-		$('#form_graph_view').filter('input, select').not('#date1, #date2').click(function() {
+		$('#form_graph_view').filter('input, select').not('#date1, #date2').on('click', function() {
 			closeDateFilters();
 		});
 	}
@@ -2807,7 +2821,7 @@ function setupSortable() {
 }
 
 function setupBreadcrumbs() {
-	$('#breadcrumbs > li > a').click(function(event) {
+	$('#breadcrumbs > li > a').on('click', function(event) {
 		event.preventDefault();
 		event.stopPropagation();
 
@@ -3064,7 +3078,7 @@ $(function() {
 		handlePopState();
 	}
 
-	$('#filter, #rfilter').keydown(function(event) {
+	$('#filter, #rfilter').on('keydown', function(event) {
 		if (event.keyCode == 8 && $(this).val() == '') {
 			handlePopState();
 		}
@@ -3174,7 +3188,7 @@ function setupEllipsis() {
 }
 
 function keepWindowSize() {
-	$(window).resize(function (event) {
+	$(window).on('resize', function (event) {
 		waitForFinalEvent(function() {
 			$('.cactiGraphContentArea').show();
 
@@ -3876,7 +3890,7 @@ function initializeGraphs(disable_cache) {
 	$('#form_graph_view').off('submit').on('submit', function(event) {
 		event.preventDefault();
 		event.stopPropagation();
-		applyFilter();
+		applyGraphFilter();
 	});
 
 	var mainWidth = getMainWidth() - 30;
@@ -4523,19 +4537,19 @@ function setSNMPSecurity() {
 				$('#snmp_security_level').selectmenu('refresh');
 			}
 
-			$('#snmp_password').keyup(function() {
+			$('#snmp_password').on('keyup', function() {
 				checkSNMPPassphrase('auth');
 			});
 
-			$('#snmp_password_confirm').keyup(function() {
+			$('#snmp_password_confirm').on('keyup', function() {
 				checkSNMPPassphraseConfirm('auth');
 			});
 
-			$('#snmp_priv_passphrase').keyup(function() {
+			$('#snmp_priv_passphrase').on('keyup', function() {
 				checkSNMPPassphrase('priv');
 			});
 
-			$('#snmp_priv_passphrase_confirm').keyup(function() {
+			$('#snmp_priv_passphrase_confirm').on('keyup', function() {
 				checkSNMPPassphraseConfirm('priv');
 			});
 		}

--- a/include/top_general_header.php
+++ b/include/top_general_header.php
@@ -57,7 +57,7 @@ if (!isset_request_var('headercontent')) { ?>
 				<?php draw_menu($user_menu);?>
 				<tr>
 					<td style='text-align:center;'>
-						<div class='cactiLogo' onclick='loadPage("<?php print $config['url_path'];?>about.php")'></div>
+						<a class='cactiLogo pic' href='<?php print html_escape($config['url_path'] . 'about.php');?>'></a>
 					</td>
 				</tr>
 			</table>

--- a/include/top_header.php
+++ b/include/top_header.php
@@ -56,7 +56,7 @@ if (!isset_request_var('headercontent')) {?>
 				<?php draw_menu();?>
 				<tr>
 					<td style='text-align:center;'>
-						<div class='cactiLogo' onclick='loadPage("<?php print $config['url_path'];?>about.php")'></div>
+						<a class='cactiLogo pic' href='<?php print html_escape($config['url_path'] . 'about.php');?>'></a>
 					</td>
 				</tr>
 			</table>

--- a/index.php
+++ b/index.php
@@ -108,7 +108,7 @@ api_plugin_hook('console_after');
 <script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 $(function() {
 	resizeWindow();
-	$(window).resize(function() {
+	$(window).on('resize', function() {
 		resizeWindow();
 	});
 });

--- a/install/install.js
+++ b/install/install.js
@@ -318,7 +318,7 @@ function collapseHeadings(headingStates) {
 
 			element.append('<div class="cactiInstallValid"><i class="' + fa_icon + '"></i></div>');
 
-			element.click(function(e) {
+			element.on('click', function(e) {
 				toggleHeader(e.currentTarget);
 			});
 		} else {
@@ -386,16 +386,16 @@ function processStepWelcome(StepData) {
 			}
 		}).iconselectmenu( "menuWidget" ).addClass( "ui-menu-icons customicons" );
 	} else {
-		$('#theme').change(function() {
+		$('#theme').on('change', function() {
 			performStep(STEP_WELCOME, undefined, true);
 		});
-		$('#language').change(function() {
+		$('#language').on('change', function() {
 			performStep(STEP_WELCOME, undefined, true);
 		});
 	}
 
 	if ($('#accept').length) {
-		$('#accept').click(function() {
+		$('#accept').on('click', function() {
 			performStep(STEP_WELCOME);
 			if ($('#accept').is(':checked')) {
 				$('#buttonNext').button('enable');
@@ -435,7 +435,7 @@ function processStepInstallType(StepData) {
 				}
 			});
 		} else {
-			$('#install_type').change(function() {
+			$('#install_type').on('change', function() {
 				performStep(STEP_INSTALL_TYPE);
 			});
 		}
@@ -460,7 +460,7 @@ function processStepProfileAndAutomation(StepData) {
 
 	element = $('#automation_override');
 	if (element != null && element.length > 0) {
-		element.change(function() {
+		element.on('change', function() {
 			setSNMPOverride();
 		});
 	}
@@ -496,7 +496,7 @@ function processStepCheckTables(StepData) {
 
 function processStepInputValidation(StepData) {
 	if ($('#confirm').length) {
-		$('#confirm').click(function() {
+		$('#confirm').on('click', function() {
 			if ($(this).is(':checked')) {
 				$('#buttonNext').button('enable');
 			} else {
@@ -514,7 +514,7 @@ function processStepInputValidation(StepData) {
 
 function processStepInstallConfirm(StepData) {
 	if ($('#confirm').length) {
-		$('#confirm').click(function() {
+		$('#confirm').on('click', function() {
 			if ($(this).is(':checked')) {
 				$('#buttonNext').button('enable');
 			} else {
@@ -855,7 +855,7 @@ $(function() {
 		$('#installData').data('debug', true);
 	}
 
-	$('.installButton').click(function(e) {
+	$('.installButton').on('click', function(e) {
 		button = $(e.currentTarget);
 		if (button != null) {
 			buttonData = button.data('buttonData');
@@ -881,7 +881,7 @@ $(function() {
 
 	waitForFinalEvent(function() {
 		installTimer = setTimeout(function() {
-			$('#installRefresh').click(function() {
+			$('#installRefresh').on('click', function() {
 				performStep();
 			});
 

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -110,15 +110,19 @@ function display_matching_hosts($rule, $rule_type, $url) {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyDeviceFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#host_template_id, #host_status, #rowsd').on('change', function() {
+			applyDeviceFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearDeviceFilter();
 		});
 
-		$('#form_automation_host').submit(function(event) {
+		$('#form_automation_host').on('submit', function(event) {
 			event.preventDefault();
 			applyDeviceFilter();
 		});
@@ -146,7 +150,7 @@ function display_matching_hosts($rule, $rule_type, $url) {
 							<?php print __('Type');?>
 						</td>
 						<td>
-							<select id='host_template_id' onChange='applyDeviceFilter()'>
+							<select id='host_template_id'>
 								<option value='-1'<?php if (get_request_var('host_template_id') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 								<option value='0'<?php if (get_request_var('host_template_id') == '0') {?> selected<?php }?>><?php print __('None');?></option>
 								<?php
@@ -164,7 +168,7 @@ function display_matching_hosts($rule, $rule_type, $url) {
 							<?php print __('Status');?>
 						</td>
 						<td>
-							<select id='host_status' onChange='applyDeviceFilter()'>
+							<select id='host_status'>
 								<option value='-1'<?php if (get_request_var('host_status') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 								<option value='-3'<?php if (get_request_var('host_status') == '-3') {?> selected<?php }?>><?php print __('Enabled');?></option>
 								<option value='-2'<?php if (get_request_var('host_status') == '-2') {?> selected<?php }?>><?php print __('Disabled');?></option>
@@ -179,7 +183,7 @@ function display_matching_hosts($rule, $rule_type, $url) {
 							<?php print __('Devices');?>
 						</td>
 						<td>
-							<select id='rowsd' onChange='applyDeviceFilter()'>
+							<select id='rowsd'>
 								<option value='-1'<?php if (get_request_var('rowsd') == '-1') {?> selected<?php }?>><?php print __('Default');?></option>
 								<?php
 								if (cacti_sizeof($item_rows)) {
@@ -395,19 +399,19 @@ function display_matching_graphs($rule, $rule_type, $url) {
 	}
 
 	$(function() {
-		$('#host_id, #template_id, #rows, #filter').change(function() {
+		$('#host_id, #template_id, #rows, #filter').on('change', function() {
 			applyFilter();
 		});
 
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_graphs').submit(function(event) {
+		$('#form_graphs').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -680,19 +684,19 @@ function display_new_graphs($rule, $url) {
 	}
 
 	$(function() {
-		$('#orefresh').click(function() {
+		$('#orefresh').on('click', function() {
 			applyObjectFilter();
 		});
 
-		$('#oclear').click(function() {
+		$('#oclear').on('click', function() {
 			clearObjectFilter();
 		});
 
-		$('#orows').change(function() {
+		$('#orows').on('change', function() {
 			applyObjectFilter();
 		});
 
-		$('#form_automation_objects').submit(function(event) {
+		$('#form_automation_objects').on('submit', function(event) {
 			event.preventDefault();
 			applyObjectFilter();
 		});
@@ -1041,15 +1045,19 @@ function display_matching_trees ($rule_id, $rule_type, $item, $url) {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#host_template_id, #host_status, #rows').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_automation_tree').submit(function(event) {
+		$('#form_automation_tree').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -1077,7 +1085,7 @@ function display_matching_trees ($rule_id, $rule_type, $item, $url) {
 						<?php print __('Type');?>
 					</td>
 					<td>
-						<select id='host_template_id' onChange='applyFilter()'>
+						<select id='host_template_id'>
 							<option value='-1'<?php if (get_request_var('host_template_id') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 							<option value='0'<?php if (get_request_var('host_template_id') == '0') {?> selected<?php }?>><?php print __('None');?></option>
 							<?php
@@ -1095,7 +1103,7 @@ function display_matching_trees ($rule_id, $rule_type, $item, $url) {
 						<?php print __('Status');?>
 					</td>
 					<td>
-						<select id='host_status' onChange='applyFilter()'>
+						<select id='host_status'>
 							<option value='-1'<?php if (get_request_var('host_status') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 							<option value='-3'<?php if (get_request_var('host_status') == '-3') {?> selected<?php }?>><?php print __('Enabled');?></option>
 							<option value='-2'<?php if (get_request_var('host_status') == '-2') {?> selected<?php }?>><?php print __('Disabled');?></option>
@@ -1110,7 +1118,7 @@ function display_matching_trees ($rule_id, $rule_type, $item, $url) {
 						<?php print __('Data Queries');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php if (get_request_var('rows') == '-1') {?> selected<?php }?>><?php print __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -1123,7 +1131,7 @@ function display_matching_trees ($rule_id, $rule_type, $item, $url) {
 					</td>
 					<td>
 						<span>
-							<input type='button' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __esc('Go');?>'>
+							<input type='submit' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __esc('Go');?>'>
 							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __esc('Clear');?>'>
 						</span>
 					</td>

--- a/lib/clog_webapi.php
+++ b/lib/clog_webapi.php
@@ -232,12 +232,12 @@ function clog_view_logfile() {
 				<input type='button' class='ui-button ui-corner-all ui-widget' id='cancel' value='" . __esc('Cancel') . "'>&nbsp
 				<input type='button' class='ui-button ui-corner-all ui-widget' id='pc' name='purge_continue' value='" . __esc('Continue') . "' title='" . __esc('Purge Log') . "'>
 				<script type='text/javascript' " . CactiSecureHeaders::getNonceAttribute() . ">
-				$('#pc').click(function() {
+				$('#pc').on('click', function() {
 					strURL = location.pathname+'?purge_continue=1&header=false&filename=" . basename($logfile) . "';
 					loadPageNoHeader(strURL);
 				});
 
-				$('#cancel').click(function() {
+				$('#cancel').on('click', function() {
 					strURL = location.pathname+'?header=false';
 					loadPageNoHeader(strURL);
 				});
@@ -622,21 +622,21 @@ function filter($clogAdmin, $selectedFile) {
 		<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 
 		$(function() {
-			$('#rfilter, #reverse, #refresh, #message_type, #filename, #tail_lines, #matches').unbind().change(function() {
+			$('#rfilter, #reverse, #refresh, #message_type, #filename, #tail_lines, #matches').on('change', function() {
 				applyFilter();
 			});
 
-			$('#clear').unbind().click(function() {
+			$('#clear').on('click', function() {
 				strURL = basename(location.pathname) + '?clear=true&header=false';
 				loadPageNoHeader(strURL);
 			});
 
-			$('#purge').unbind().click(function() {
+			$('#purge').on('click', function() {
 				strURL = basename(location.pathname) + '?purge=true&header=false&filename=' + $('#filename').val();
 				loadPageNoHeader(strURL);
 			});
 
-			$('#logfile').submit(function(event) {
+			$('#logfile').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/lib/headers_secure.php
+++ b/lib/headers_secure.php
@@ -141,7 +141,7 @@ class CactiSecureHeaders {
 			. "img-src 'self' {$alternates} data: blob:; "
 			. "font-src 'self' {$alternates}; "
 			. "connect-src 'self' {$alternates}; "
-			. "frame-src 'self' {$alternatives}; "
+			. "frame-src 'self' {$alternates}; "
 			. "frame-ancestors 'self'; "
 			. "worker-src 'self' {$alternates}; "
 			. "object-src 'none'; "

--- a/lib/headers_secure.php
+++ b/lib/headers_secure.php
@@ -141,7 +141,7 @@ class CactiSecureHeaders {
 			. "img-src 'self' {$alternates} data: blob:; "
 			. "font-src 'self' {$alternates}; "
 			. "connect-src 'self' {$alternates}; "
-			. "frame-src 'self'; "
+			. "frame-src 'self' {$alternatives}; "
 			. "frame-ancestors 'self'; "
 			. "worker-src 'self' {$alternates}; "
 			. "object-src 'none'; "

--- a/lib/html.php
+++ b/lib/html.php
@@ -969,7 +969,7 @@ function html_header_sort_checkbox($header_items, $sort_column, $sort_direction,
 		}
 	}
 
-	print "<th class='tableSubHeaderCheckbox'><input id='selectall' class='checkbox' type='checkbox' title='" . __esc('Select All Rows'). "' onClick='selectAll(\"$prefix\",this.checked)'><label class='formCheckboxLabel' title='" . __esc('Select All Rows') . "' for='selectall'></label></th>" . ($include_form ? "<th style='display:none;'><form id='$prefix' name='$prefix' method='post' action='$form_action'></th>":'');
+	print "<th class='tableSubHeaderCheckbox'><input id='selectall' class='checkbox' type='checkbox' title='" . __esc('Select All Rows'). "' data-prefix='$prefix'><label class='formCheckboxLabel' title='" . __esc('Select All Rows') . "' for='selectall'></label></th>" . ($include_form ? "<th style='display:none;'><form id='$prefix' name='$prefix' method='post' action='$form_action'></th>":'');
 	print '</tr>';
 
 	$page_count++;
@@ -1068,7 +1068,7 @@ function html_header_checkbox($header_items, $include_form = true, $form_action 
 		}
 	}
 
-	print "<th class='tableSubHeaderCheckbox'><input id='selectall' class='checkbox' type='checkbox' title='" . __esc('Select All Rows'). "' onClick='selectAll(\"$prefix\",this.checked)'><label class='formCheckboxLabel' title='" . __esc('Select All') . "' for='selectall'></label></th>" . ($include_form ? "<th style='display:none;'><form id='$prefix' name='$prefix' method='post' action='$form_action'></th>":'');
+	print "<th class='tableSubHeaderCheckbox'><input id='selectall' class='checkbox' type='checkbox' title='" . __esc('Select All Rows'). "' data-prefix='$prefix'><label class='formCheckboxLabel' title='" . __esc('Select All') . "' for='selectall'></label></th>" . ($include_form ? "<th style='display:none;'><form id='$prefix' name='$prefix' method='post' action='$form_action'></th>":'');
 	print '</tr>';
 }
 
@@ -1627,7 +1627,7 @@ function draw_actions_dropdown($actions_array, $delete_action = 1) {
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 
 	function setDisabled() {
-		$('tr[id^="line"]').addClass('selectable').prop('disabled', false).removeClass('disabled_row').unbind('click').prop('disabled', false);
+		$('tr[id^="line"]').addClass('selectable').prop('disabled', false).removeClass('disabled_row').off('click').prop('disabled', false);
 
 		if ($('#drp_action').val() == <?php print $delete_action;?>) {
 			$(':checkbox.disabled').each(function(data) {
@@ -1668,7 +1668,7 @@ function draw_actions_dropdown($actions_array, $delete_action = 1) {
 			});
 		}
 
-		$('tr[id^="line"]').filter(':not(.disabled_row)').off('click').on('click', function(event) {
+		$('tr[id^="line"]').filter(':not(.disabled_row)').on('click', function(event) {
 			selectUpdateRow(event, $(this));
 		});
 	}
@@ -1676,7 +1676,7 @@ function draw_actions_dropdown($actions_array, $delete_action = 1) {
 	$(function() {
 		setDisabled();
 
-		$('#drp_action').change(function() {
+		$('#drp_action').on('change', function() {
 			setDisabled();
 		});
 	});
@@ -2135,7 +2135,7 @@ function html_host_filter($host_id = '-1', $call_back = 'applyFilter', $sql_wher
 			<?php print __('Device');?>
 		</td>
 		<td>
-			<select id='host_id' name='host_id' onChange='<?php print $call_back;?>'>
+			<select id='host_id' name='host_id'>
 				<?php if (!$noany) {?><option value='-1'<?php if ($host_id == '-1') {?> selected<?php }?>><?php print __('Any');?></option><?php }?>
 				<?php if (!$nonone) {?><option value='0'<?php if ($host_id == '0') {?> selected<?php }?>><?php print __('None');?></option><?php }?>
 				<?php
@@ -2196,7 +2196,7 @@ function html_site_filter($site_id = '-1', $call_back = 'applyFilter', $sql_wher
 		<?php print __('Site');?>
 	</td>
 	<td>
-		<select id='site_id' onChange='<?php print $call_back;?>'>
+		<select id='site_id'>
 			<?php if (!$noany) {?><option value='-1'<?php if ($site_id == '-1') {?> selected<?php }?>><?php print __('Any');?></option><?php }?>
 			<?php if (!$nonone) {?><option value='0'<?php if ($site_id == '0') {?> selected<?php }?>><?php print __('None');?></option><?php }?>
 			<?php
@@ -2226,7 +2226,7 @@ function html_location_filter($location = '', $call_back = 'applyFilter', $sql_w
 		<?php print __('Location');?>
 	</td>
 	<td>
-		<select id='location' onChange='<?php print $call_back;?>'>
+		<select id='location'>
 			<?php if (!$noany) {?><option value='-1'<?php if ($location == '-1') {?> selected<?php }?>><?php print __('Any');?></option><?php }?>
 			<?php if (!$nonone) {?><option value='0'<?php if ($location == '0') {?> selected<?php }?>><?php print __('None');?></option><?php }?>
 			<?php
@@ -2362,7 +2362,7 @@ function html_spikekill_js() {
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	spikeKillOpen = false;
 	$(function() {
-		$(document).click(function() {
+		$(document).on('click', function() {
 			if (spikeKillOpen) {
 				$(this).find('.spikekillMenu').menu('destroy').parent().remove();
 				spikeKillOpen = false;
@@ -2373,7 +2373,7 @@ function html_spikekill_js() {
 			return false;
 		});
 
-		$('span.spikekill').unbind().click(function() {
+		$('span.spikekill').on('click', function() {
 			if (spikeKillOpen == false) {
 				local_graph_id = $(this).attr('data-graph');
 
@@ -2413,37 +2413,37 @@ function html_spikekill_js() {
 	});
 
 	function spikeKillActions() {
-		$('.rstddev').unbind().click(function() {
+		$('.rstddev').on('click', function() {
 			removeSpikes('stddev', false, $(this).attr('data-graph'));
 			$(this).find('.spikekillMenu').menu('destroy').parent().remove();
 		});
 
-		$('.dstddev').unbind().click(function() {
+		$('.dstddev').on('click', function() {
 			removeSpikes('stddev', true, $(this).attr('data-graph'));
 			$(this).find('.spikekillMenu').menu('destroy').parent().remove();
 		});
 
-		$('.rfill').unbind().click(function() {
+		$('.rfill').on('click', function() {
 			removeSpikes('fill', false, $(this).attr('data-graph'));
 			$(this).find('.spikekillMenu').menu('destroy').parent().remove();
 		});
 
-		$('.dfill').unbind().click(function() {
+		$('.dfill').on('click', function() {
 			removeSpikes('fill', true, $(this).attr('data-graph'));
 			$(this).find('.spikekillMenu').menu('destroy').parent().remove();
 		});
 
-		$('.rfloat').unbind().click(function() {
+		$('.rfloat').on('click', function() {
 			removeSpikes('float', false, $(this).attr('data-graph'));
 			$(this).find('.spikekillMenu').menu('destroy').parent().remove();
 		});
 
-		$('.dfloat').unbind().click(function() {
+		$('.dfloat').on('click', function() {
 			removeSpikes('float', true, $(this).attr('data-graph'));
 			$(this).find('.spikekillMenu').menu('destroy').parent().remove();
 		});
 
-		$('.skmethod').unbind().click(function() {
+		$('.skmethod').on('click', function() {
 			$('.skmethod').find('i').removeClass('fa fa-check');
 			$(this).find('i:first').addClass('fa fa-check');
 			$(this).find('.spikekillMenu').menu('destroy').parent().remove();
@@ -2455,7 +2455,7 @@ function html_spikekill_js() {
 				});
 		});
 
-		$('.skills').unbind().click(function() {
+		$('.skills').on('click', function() {
 			$('.skills').find('i').removeClass('fa fa-check');
 			$(this).find('i:first').addClass('fa fa-check');
 			$(this).find('.spikekillMenu').menu('destroy').parent().remove();
@@ -2467,7 +2467,7 @@ function html_spikekill_js() {
 				});
 		});
 
-		$('.skstddev').unbind().click(function() {
+		$('.skstddev').on('click', function() {
 			$('.skstddev').find('i').removeClass('fa fa-check');
 			$(this).find('i:first').addClass('fa fa-check');
 			$(this).find('.spikekillMenu').menu('destroy').parent().remove();

--- a/lib/html_filter.php
+++ b/lib/html_filter.php
@@ -266,11 +266,11 @@ class CactiTableFilter {
 				applyFilter();
 			});
 
-			$('<?php print $changeChain;?>').change(function() {
+			$('<?php print $changeChain;?>').on('change', function() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#clear').on('click', function() {
 				clearFilter();
 			})
 		});

--- a/lib/html_filter.php
+++ b/lib/html_filter.php
@@ -261,7 +261,7 @@ class CactiTableFilter {
 		}
 
 		$(function() {
-			$('#<?php print html_escape($this->form_id);?>').submit(function(event) {
+			$('#<?php print html_escape($this->form_id);?>').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/lib/html_form.php
+++ b/lib/html_form.php
@@ -1473,7 +1473,7 @@ function form_end($ajax = true) {
 			formArray['<?php print $form_id;?>'] = $('#<?php print $form_id;?>').serializeForm();
 			changed = false;
 
-			$('#<?php print $form_id;?>').submit(function(event) {
+			$('#<?php print $form_id;?>').on('submit', function(event) {
 				event.preventDefault();
 
 				// Enable the form if it's disabled

--- a/lib/html_form.php
+++ b/lib/html_form.php
@@ -1307,8 +1307,8 @@ function form_confirm_buttons($action_url, $cancel_url) {
 	?>
 	<tr>
 		<td class='right'>
-			<input type='button' class='ui-button ui-corner-all ui-widget' onClick='cactiReturnTo("<?php print html_escape($config['url_path'] . $cancel_url);?>")' value='<?php print __esc('Cancel');?>'>
-			<input type='button' class='ui-button ui-corner-all ui-widget' onClick='cactiReturnTo("<?php print html_escape($config['url_path'] . $action_url . '&confirm=true');?>")' value='<?php print __esc('Delete');?>'>
+			<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' data-url='<?php print html_escape($config['url_path'] . $cancel_url);?>' value='<?php print __esc('Cancel');?>'>
+			<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' data-url='<?php print html_escape($config['url_path'] . $action_url . '&confirm=true');?>' value='<?php print __esc('Delete');?>'>
 		</td>
 	</tr>
 <?php }
@@ -1346,7 +1346,7 @@ function form_save_button($cancel_url, $force_type = '', $key_field = 'id', $aja
 	}
 
 	if ($force_type != 'import' && $force_type != 'export' && $force_type != 'save' && $force_type != 'close' && $cancel_url != '') {
-		$cancel_action = "<input type='button' class='ui-button ui-corner-all ui-widget' onClick='cactiReturnTo(\"" . html_escape(sanitize_uri($cancel_url)) . "\")' value='" . $calt . "'>";
+		$cancel_action = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' data-url='" . html_escape(sanitize_uri($cancel_url)) . "' value='" . $calt . "'>";
 	} else {
 		$cancel_action = '';
 	}

--- a/lib/html_graph.php
+++ b/lib/html_graph.php
@@ -145,7 +145,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 	?>
 	<tr class='even noprint'>
 		<td class='noprint'>
-		<form id='form_graph_view' method='post' action='<?php print $page;?>?action=<?php print $action;?>'>
+		<form id='form_graph_view'>
 			<table id='device' class='filterTable'>
 				<tr>
 					<?php print html_host_filter(get_request_var('host_id'), 'applyGraphFilter', $devices_where);?>
@@ -187,7 +187,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 					</td>
 					<td>
 						<span>
-							<input type='submit' class='ui-button ui-corner-all ui-widget' id='go' value='<?php print __esc('Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
+							<input type='submit' class='ui-button ui-corner-all ui-widget' id='previewgo' value='<?php print __esc('Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
 							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __esc('Clear');?>' title='<?php print __esc('Clear Filters');?>'>
 							<?php if (is_view_allowed('graph_settings')) {?>
 							<input type='button' class='ui-button ui-corner-all ui-widget' id='save' value='<?php print __esc('Save');?>' title='<?php print __esc('Save the current Graphs, Columns, Thumbnail, Preset, and Timeshift preferences to your profile');?>'>
@@ -209,7 +209,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 						<?php print __('Graphs');?>
 					</td>
 					<td>
-						<select id='graphs' onChange='applyGraphFilter()'>
+						<select id='graphs'>
 							<?php
 							if (cacti_sizeof($graphs_per_page)) {
 								foreach ($graphs_per_page as $key => $value) {
@@ -223,7 +223,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 						<?php print __('Columns');?>
 					</td>
 					<td>
-						<select id='columns' onChange='applyGraphFilter()'>
+						<select id='columns'>
 							<option value='1'<?php if (get_request_var('columns') == '1') {?> selected<?php }?>><?php print __('%d Column', 1);?></option>
 							<option value='2'<?php if (get_request_var('columns') == '2') {?> selected<?php }?>><?php print __('%d Columns', 2);?></option>
 							<option value='3'<?php if (get_request_var('columns') == '3') {?> selected<?php }?>><?php print __('%d Columns', 3);?></option>
@@ -234,7 +234,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 					</td>
 					<td>
 						<span>
-							<input id='thumbnails' type='checkbox' onClick='applyGraphFilter()' <?php print ((get_request_var('thumbnails') == 'true') ? 'checked':'');?>>
+							<input id='thumbnails' type='checkbox' <?php print ((get_request_var('thumbnails') == 'true') ? 'checked':'');?>>
 							<label for='thumbnails'><?php print __('Thumbnails');?></label>
 						</span>
 					</td>
@@ -252,7 +252,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 						<?php print __('Presets');?>
 					</td>
 					<td>
-						<select id='predefined_timespan' onChange='applyGraphTimespan()'>
+						<select id='predefined_timespan'>
 							<?php
 							$graph_timespans = array_merge(array(GT_CUSTOM => __('Custom')), $graph_timespans);
 
@@ -287,7 +287,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 					</td>
 					<td>
 						<span>
-							<i class='shiftArrow fa fa-backward' onClick='timeshiftGraphFilterLeft()' title='<?php print __esc('Shift Time Backward');?>'></i>
+							<i class='shiftArrow fa fa-backward' id='shiftLeft' title='<?php print __esc('Shift Time Backward');?>'></i>
 							<select id='predefined_timeshift' name='predefined_timeshift' title='<?php print __esc('Define Shifting Interval');?>'>
 								<?php
 								$start_val = 1;
@@ -299,13 +299,13 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 								}
 								?>
 							</select>
-							<i class='shiftArrow fa fa-forward' onClick='timeshiftGraphFilterRight()' title='<?php print __esc('Shift Time Forward');?>'></i>
+							<i class='shiftArrow fa fa-forward' id='shiftRight' title='<?php print __esc('Shift Time Forward');?>'></i>
 						</span>
 					</td>
 					<td>
 						<span>
-							<input id='tsrefresh' type='button' class='ui-button ui-corner-all ui-widget' value='<?php print __esc('Refresh');?>' name='button_refresh_x' title='<?php print __esc('Refresh selected time span');?>' onClick='refreshGraphTimespanFilter()'>
-							<input id='tsclear' type='button' class='ui-button ui-corner-all ui-widget' value='<?php print __esc('Clear');?>' title='<?php print __esc('Return to the default time span');?>' onClick='clearGraphTimespanFilter()'>
+							<input id='tsrefresh' type='button' class='ui-button ui-corner-all ui-widget' value='<?php print __esc('Refresh');?>' name='button_refresh_x' title='<?php print __esc('Refresh selected time span');?>'>
+							<input id='tsclear' type='button' class='ui-button ui-corner-all ui-widget' value='<?php print __esc('Clear');?>' title='<?php print __esc('Return to the default time span');?>'>
 						</span>
 					</td>
 				</tr>
@@ -316,7 +316,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 						<?php print __('Window');?>
 					</td>
 					<td>
-						<select name='graph_start' id='graph_start' onChange='realtimeGrapher()'>
+						<select name='graph_start' id='graph_start'>
 						<?php
 						foreach ($realtime_window as $interval => $text) {
 							printf('<option value="%d"%s>%s</option>', $interval, $interval == $_SESSION['sess_realtime_window'] ? 'selected="selected"' : '', $text);
@@ -328,7 +328,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 						<?php print __('Interval');?>
 					</td>
 					<td>
-						<select name='ds_step' id='ds_step' onChange="realtimeGrapher()">
+						<select name='ds_step' id='ds_step'>
 							<?php
 							foreach ($realtime_refresh as $interval => $text) {
 								printf('<option value="%d"%s>%s</option>', $interval, $interval == $_SESSION['sess_realtime_dsstep'] ? ' selected="selected"' : '', $text);
@@ -361,7 +361,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 		function initPage() {
 			<?php html_graph_template_multiselect();?>
 
-			$('#startDate').click(function() {
+			$('#startDate').on('click', function() {
 				if (date1Open) {
 					date1Open = false;
 					$('#date1').datetimepicker('hide');
@@ -371,7 +371,7 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 				}
 			});
 
-			$('#endDate').click(function() {
+			$('#endDate').on('click', function() {
 				if (date2Open) {
 					date2Open = false;
 					$('#date2').datetimepicker('hide');
@@ -409,16 +409,43 @@ function html_graph_preview_filter($page, $action, $devices_where = '', $templat
 
 			setupPageTimeout();
 
-			$('#go').off('click').on('click', function(event) {
-				event.preventDefault();
+			$('#graphs, #columns').on('change', function() {
 				applyGraphFilter();
 			});
 
-			$('#clear').off('click').on('click', function() {
+			$('#shiftLeft').on('click', function() {
+				timeshiftGraphFilterLeft();
+			});
+
+			$('#shiftRight').on('click', function() {
+				timeshiftGraphFilterRight();
+			});
+
+			$('#tsrefresh').on('click', function() {
+				refreshGraphTimespanFilter();
+			});
+
+			$('#graph_start, #ds_step').on('change', function() {
+				realtimeGrapher();
+			});
+
+			$('#predefined_timespan').on('change', function() {
+				applyGraphTimespan();
+			});
+
+			$('#thumbnails').on('click', function() {
+				applyGraphFilter();
+			});
+
+			$('#clear').on('click', function() {
 				clearGraphFilter();
 			});
 
-			$('#save').off('click').on('click', function() {
+			$('#tsclear').on('click', function() {
+				clearGraphTimespanFilter();
+			});
+
+			$('#save').on('click', function() {
 				 saveGraphFilter('preview');
 			});
 

--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -581,7 +581,7 @@ function reports_form_actions() {
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($reports_array) ? serialize($reports_array) : '') . "'>
 			<input type='hidden' name='drp_action' value='" . html_escape(get_nfilter_request_var('drp_action')) . "'>
-			<input type='button' class='ui-button ui-corner-all ui-widget' onClick='cactiReturnTo()' value='" . ($save_html == '' ? 'Return':'Cancel') . "' name='cancel'>
+			<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . ($save_html == '' ? __esc('Return') : __esc('Cancel')) . "' name='cancel'>
 			$save_html
 		</td>
 	</tr>\n";
@@ -1566,7 +1566,7 @@ function reports_edit() {
 				dateFormat: 'yy-mm-dd'
 			});
 
-			$('#cformat').click(function() {
+			$('#cformat').on('click', function() {
 				changeFormat();
 			});
 
@@ -1893,7 +1893,7 @@ function reports() {
 						" . __('Status') . "
 					</td>
 					<td>
-						<select id='status' onChange='applyFilter()'>
+						<select id='status'>
 							<option value='-1'" . (get_request_var('status') == '-1' ? ' selected':'') . ">" . __('Any') . "</option>
 							<option value='-2'" . (get_request_var('status') == '-2' ? ' selected':'') . ">" . __('Enabled') . "</option>
 							<option value='-3'" . (get_request_var('status') == '-3' ? ' selected':'') . ">" . __('Disabled') . "</option>
@@ -1903,7 +1903,7 @@ function reports() {
 						" . __('Reports') . "
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'" . (get_request_var('rows') == '-1' ? ' selected':'') . '>' . __('Default') . '</option>';
 							if (cacti_sizeof($item_rows)) {
 								foreach ($item_rows as $key => $value) {
@@ -2069,15 +2069,19 @@ function reports() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#rows, #status').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_report').submit(function(event) {
+		$('#form_report').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -311,7 +311,7 @@ function grow_dhtml_trees() {
 			});
 		});
 
-		$('#searcher').keyup(function() {
+		$('#searcher').on('keyup', function() {
 			if(search_to) { clearTimeout(search_to); }
 			search_to = setTimeout(function() {
 				var v = $('#searcher').val();

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -1039,7 +1039,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 						<?php print __('Graphs');?>
 					</td>
 					<td>
-						<select id='graphs' onChange='applyGraphFilter()'>
+						<select id='graphs'>
 							<?php
 							if (cacti_sizeof($graphs_per_page)) {
 								foreach ($graphs_per_page as $key => $value) {
@@ -1053,7 +1053,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 						<?php print __('Columns');?>
 					</td>
 					<td>
-						<select id='columns' onChange='applyGraphFilter()'>
+						<select id='columns'>
 							<option value='1' <?php print (get_request_var('columns') == '1' ? ' selected':'');?>><?php print __('%d Column', 1);?></option>
 							<option value='2' <?php print (get_request_var('columns') == '2' ? ' selected':'');?>><?php print __('%d Columns', 2);?></option>
 							<option value='3' <?php print (get_request_var('columns') == '3' ? ' selected':'');?>><?php print __('%d Columns', 3);?></option>
@@ -1082,7 +1082,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 						<?php print __('Presets');?>
 					</td>
 					<td>
-						<select id='predefined_timespan' onChange='applyGraphTimespan()'>
+						<select id='predefined_timespan'>
 							<?php
 							$graph_timespans = array_merge(array(GT_CUSTOM => __('Custom')), $graph_timespans);
 
@@ -1146,7 +1146,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 						<?php print __('Window');?>
 					</td>
 					<td>
-						<select id='graph_start' onChange='realtimeGrapher()'>
+						<select id='graph_start'>
 							<?php
 							foreach ($realtime_window as $interval => $text) {
 								printf('<option value="%d"%s>%s</option>', $interval, $interval == $_SESSION['sess_realtime_window'] ? ' selected="selected"' : '', $text);
@@ -1158,7 +1158,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 						<?php print __('Refresh');?>
 					</td>
 					<td>
-						<select id='ds_step' onChange="realtimeGrapher()">
+						<select id='ds_step'>
 							<?php
 							foreach ($realtime_refresh as $interval => $text) {
 								printf('<option value="%d"%s>%s</option>', $interval, $interval == $_SESSION['sess_realtime_dsstep'] ? ' selected="selected"' : '', $text);
@@ -1197,7 +1197,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 	function initPage() {
 		<?php html_graph_template_multiselect();?>
 
-		$('#startDate').click(function() {
+		$('#startDate').on('click', function() {
 			if (date1Open) {
 				date1Open = false;
 				$('#date1').datetimepicker('hide');
@@ -1207,7 +1207,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 			}
 		});
 
-		$('#endDate').click(function() {
+		$('#endDate').on('click', function() {
 			if (date2Open) {
 				date2Open = false;
 				$('#date2').datetimepicker('hide');
@@ -1246,16 +1246,28 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 	}
 
 	$(function() {
-		$('#go').off('click').on('click', function(event) {
+		$('#go').on('click', function(event) {
 			event.preventDefault();
 			applyGraphFilter();
 		});
 
-		$('#clear').off('click').on('click', function() {
+		$('#graphs, #columns').on('change', function() {
+			applyGraphFilter();
+		});
+
+		$('#graph_start, #ds_step').on('change', function() {
+			realtimeGrapher();
+		});
+
+		$('#predefined_timespan').on('change', function() {
+			applyGraphTimespan();
+		});
+
+		$('#clear').on('click', function() {
 			clearGraphFilter();
 		});
 
-		$('#save').off('click').on('click', function() {
+		$('#save').on('click', function() {
 			 saveGraphFilter('tree');
 		});
 

--- a/links.php
+++ b/links.php
@@ -609,7 +609,7 @@ function edit_page() {
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	$(function() {
 		// hide and show the extra console fields when necessary
-		$('#style').change(function() {
+		$('#style').on('change', function() {
 			if ($('#style').val() != 'CONSOLE') {
 				$('#row_consolesection').hide();
 				$('#row_consolenewsection').hide();

--- a/links.php
+++ b/links.php
@@ -197,27 +197,27 @@ function form_actions() {
 					<p>" . __('Click \'Continue\' to Enable the following Page(s).') . "</p>
 					<ul>" . $page_list . "</ul>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __('Continue') . "' title='" . __esc('Enable Page(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __('Continue') . "' title='" . __esc('Enable Page(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '2') { // Disable Pages
 			print "<tr>
 				<td colspan='2' class='textArea'>
 					<p>" . __('Click \'Continue\' to Disable the following Page(s).') . "</p>
 					<ul>" . $page_list . "</ul>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __('Continue') . "' title='" . __esc('Disable Page(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __('Continue') . "' title='" . __esc('Disable Page(s)') . "'>";
 		} elseif (get_request_var('drp_action') == '1') { // Delete Pages
 			print "<tr>
 				<td colspan='2' class='textArea'>
 					<p>" . __('Click \'Continue\' to Delete the following Page(s).') . "</p>
 					<ul>" . $page_list . "</ul>
 				</td>
-			</tr>\n";
+			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __('Continue') . "' title='" . __esc('Delete Page(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __('Continue') . "' title='" . __esc('Delete Page(s)') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -232,7 +232,7 @@ function form_actions() {
 			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
 			$save_html
 		</td>
-	</tr>\n";
+	</tr>";
 
 	html_end_box();
 
@@ -296,7 +296,15 @@ function pages() {
 	}
 
 	$(function() {
-		$('#links').submit(function(event) {
+		$('#rows').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
+			clearFilter();
+		});
+
+		$('#links').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -321,7 +329,7 @@ function pages() {
 						<?php print __('Links');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value=-1 <?php get_request_var('rows') == -1 ? 'selected':'';?>><?php print __('Default');?></option>
 							<?php
 							foreach ($item_rows as $key => $row) {
@@ -332,8 +340,8 @@ function pages() {
 					</td>
 					<td>
 						<span>
-							<input type='button' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __('Go');?>' title='<?php print __esc('Apply Filter');?>' onClick='applyFilter()'>
-							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __('Clear');?>' title='<?php print __esc('Reset filters');?>' onClick='clearFilter()'>
+							<input type='button' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __('Go');?>' title='<?php print __esc('Apply Filter');?>'>
+							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __('Clear');?>' title='<?php print __esc('Reset filters');?>'>
 						</span>
 					</td>
 				</tr>
@@ -432,7 +440,7 @@ function pages() {
 			$i++;
 		}
 	} else {
-		print "<tr><td colspan='" . (cacti_sizeof($nav) + 1) . "'><em>" . __('No Pages Found') . "</em></td></tr>\n";
+		print "<tr><td colspan='" . (cacti_sizeof($nav) + 1) . "'><em>" . __('No Pages Found') . "</em></td></tr>";
 	}
 
 	html_end_box(false);
@@ -611,13 +619,13 @@ function edit_page() {
 			}
 		}).change();
 
-		$('#filename').change(function() {
+		$('#filename').on('change', function() {
 			changeFilename();
 		}).change();
 
 		// if you change the section, make the 'new' textbox reflect it
 		// if you change it to 'new', then clear the textbox, and jump to it
-		$('#consolesection').change(function() {
+		$('#consolesection').on('change', function() {
 			setConsoleNewSectionVisibility();
 		}).change();
 	});

--- a/managers.php
+++ b/managers.php
@@ -121,15 +121,19 @@ function manager() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#rows').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_snmpagent_managers').submit(function(event) {
+		$('#form_snmpagent_managers').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -149,13 +153,13 @@ function manager() {
 							<?php print __('Search'); ?>
 						</td>
 						<td>
-							<input type='text' class='ui-state-default ui-corner-all' id='filter' size='25' value='<?php print html_escape_request_var('filter');?>' onChange='applyFilter()'>
+							<input type='text' class='ui-state-default ui-corner-all' id='filter' size='25' value='<?php print html_escape_request_var('filter');?>'>
 						</td>
 						<td>
 							<?php print __('Receivers'); ?>
 						</td>
 						<td>
-							<select id='rows' onChange='applyFilter()'>
+							<select id='rows'>
 								<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 								<?php
 								if (cacti_sizeof($item_rows)) {
@@ -238,7 +242,7 @@ function manager() {
 			$description = filter_value($item['description'], get_request_var('filter'));
 			$hostname    = filter_value($item['hostname'], get_request_var('filter'));
 			form_alternate_row('line' . $item['id'], false);
-			form_selectable_cell('<a class="linkEditMain" href="' . html_escape($config['url_path'] . 'managers.php?action=edit&id=' . $item['id']) . '">' . html_escape($description) . '</a>', $item['id']);
+			form_selectable_cell('<a class="linkEditMain" href="' . html_escape($config['url_path'] . 'managers.php?action=edit&id=' . $item['id']) . '">' . $description . '</a>', $item['id']);
 			form_selectable_cell($item['id'], $item['id']);
 			form_selectable_cell($item['disabled'] ? '<span class="deviceDown">' . __('Disabled') . '</span>' : '<span class="deviceUp">' . __('Enabled') . '</span>', $item['id']);
 			form_selectable_ecell($hostname, $item['id']);
@@ -310,7 +314,7 @@ function manager_edit() {
 		<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 
 		$(function() {
-			$('.subTab').find('a').click(function(event) {
+			$('.subTab').find('a').on('click', function(event) {
 				event.preventDefault();
 
 				strURL  = $(this).attr('href');
@@ -456,15 +460,19 @@ function manager_notifications($id, $header_label) {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#mib, #rows').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_snmpagent_managers').submit(function(event) {
+		$('#form_snmpagent_managers').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -480,7 +488,7 @@ function manager_notifications($id, $header_label) {
 							<?php print __('MIB');?>
 						</td>
 						<td>
-							<select id='mib' name='mib' onChange='applyFilter()'>
+							<select id='mib' name='mib'>
 								<option value='-1'<?php if (get_request_var('mib') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 								<?php
 								if (cacti_sizeof($mibs)) {
@@ -495,13 +503,13 @@ function manager_notifications($id, $header_label) {
 							<?php print __('Search');?>
 						</td>
 						<td>
-							<input type='text' class='ui-state-default ui-corner-all' id='filter' size='25' value='<?php print html_escape_request_var('filter');?>' onChange='applyFilter()'>
+							<input type='text' class='ui-state-default ui-corner-all' id='filter' size='25' value='<?php print html_escape_request_var('filter');?>'>
 						</td>
 						<td>
 							<?php print __('Receivers');?>
 						</td>
 						<td>
-							<select id='rows' name='rows' onChange='applyFilter()'>
+							<select id='rows' name='rows'>
 								<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 								<?php
 								if (cacti_sizeof($item_rows)) {
@@ -717,6 +725,16 @@ function manager_logs($id, $header_label) {
 		}
 	}
 
+	$(function() {
+		$('#severity').on('change', function() {
+			applyFilter();
+		});
+
+		$('#form_snmpagent_manager_logs').on('submit', function() {
+			applyFilter();
+		});
+	});
+
 	</script>
 	<tr class='even'>
 		<td>
@@ -733,7 +751,7 @@ function manager_logs($id, $header_label) {
 							<?php print __('Severity');?>
 						</td>
 						<td>
-							<select id='severity' onChange='applyFilter()'>
+							<select id='severity'>
 								<option value='-1'<?php if (get_request_var('severity') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 								<?php
 								foreach ($severity_levels as $level => $name) {
@@ -744,7 +762,7 @@ function manager_logs($id, $header_label) {
 						</td>
 						<td>
 							<span>
-								<input type='button' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __esc('Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
+								<input type='submit' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __esc('Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
 								<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __esc('Clear');?>' title='<?php print __esc('Clear Filters');?>'>
 								<input type='button' class='ui-button ui-corner-all ui-widget' id='purge' value='<?php print __esc('Purge');?>' title='<?php print __esc('Purge Notification Log');?>'>
 							</span>
@@ -1015,7 +1033,7 @@ function form_actions() {
 					</td>
 				</tr>";
 
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'><input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('%s Notification Receivers', $manager_actions[get_nfilter_request_var('drp_action')]) . "'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'><input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('%s Notification Receivers', $manager_actions[get_nfilter_request_var('drp_action')]) . "'>";
 			} else {
 				raise_message(40);
 				header('Location: managers.php?header=false');
@@ -1076,10 +1094,10 @@ function form_actions() {
 					</td>
 				</tr>";
 
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Disable Notification Objects') . "'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Disable Notification Objects') . "'>";
 			} else {
 				print "<tr><td><span class='textError'>" . __('You must select at least one notification object.') . "</span></td></tr>";
-				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Return') . "' onClick='cactiReturnTo()'>";
+				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
 			}
 
 			print "<tr>

--- a/package_import.php
+++ b/package_import.php
@@ -743,7 +743,7 @@ function import_display_package_data($templates, $files, $package_name, $xmlfile
 			});
 		}
 
-		$('.diffme').click(function(event) {
+		$('.diffme').on('click', function(event) {
 			event.preventDefault();
 
 			var url = $(this).attr('href');
@@ -999,7 +999,7 @@ function package_import() {
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 
 	$(function() {
-		$('#import_file').change(function() {
+		$('#import_file').on('change', function() {
 			$('#preview_only').val('on');
 
 			var form = $('#import')[0];

--- a/plugins.php
+++ b/plugins.php
@@ -431,15 +431,19 @@ function update_show_current () {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#rows, #state').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_plugins').submit(function(event) {
+		$('#form_plugins').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -465,7 +469,7 @@ function update_show_current () {
 						<?php print __('Status');?>
 					</td>
 					<td>
-						<select id='state' name='state' onChange='applyFilter()'>
+						<select id='state' name='state'>
 							<option value='-99'<?php if (get_request_var('state') == '-99') {?> selected<?php }?>><?php print __('All');?></option>
 							<option value='-98'<?php if (get_request_var('state') == '-98') {?> selected<?php }?>><?php print __('Plugin Error');?></option>
 							<option value='1'<?php if (get_request_var('state') == '1') {?> selected<?php }?>><?php print __('Active');?></option>
@@ -479,7 +483,7 @@ function update_show_current () {
 						<?php print __('Plugins');?>
 					</td>
 					<td>
-						<select id='rows' name='rows' onChange='applyFilter()'>
+						<select id='rows' name='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows) > 0) {
@@ -661,7 +665,7 @@ function update_show_current () {
 	var url = '';
 
 	$(function() {
-		$('.piuninstall').click(function(event) {
+		$('.piuninstall').on('click', function(event) {
 			event.preventDefault();
 			url = $(this).attr('href');
 

--- a/pollers.php
+++ b/pollers.php
@@ -710,11 +710,11 @@ function poller_edit() {
 
 			$(function() {
 				$('#row_dbsslca').after('<?php print $row_html;?>');
-				$('#dbssl').click(function() {
+				$('#dbssl').on('click', function() {
 					showHideRemoteDB();
 				});
 
-				$('#dbtest').click(function() {
+				$('#dbtest').on('click', function() {
 					ping_database();
 				});
 

--- a/pollers.php
+++ b/pollers.php
@@ -561,7 +561,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Collector', 'Delete Data Collectors', cacti_sizeof($poller_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Data Collector', 'Delete Data Collectors', cacti_sizeof($poller_array)) . "'>";
 		} elseif (get_request_var('drp_action') == '2') { // disable
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -570,7 +570,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Disable Data Collector', 'Disable Data Collectors', cacti_sizeof($poller_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Disable Data Collector', 'Disable Data Collectors', cacti_sizeof($poller_array)) . "'>";
 		} elseif (get_request_var('drp_action') == '3') { // enable
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -579,7 +579,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enable Data Collector', 'Enable Data Collectors', cacti_sizeof($poller_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enable Data Collector', 'Enable Data Collectors', cacti_sizeof($poller_array)) . "'>";
 		} elseif (get_request_var('drp_action') == '4') { // full sync
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -588,7 +588,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enable Data Collector', 'Synchronize Remote Data Collectors', cacti_sizeof($poller_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enable Data Collector', 'Synchronize Remote Data Collectors', cacti_sizeof($poller_array)) . "'>";
 		} elseif (get_request_var('drp_action') == '5') { // clear statistics
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -597,7 +597,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Clear Statistics for Data Collector', 'Clear Statistics for Data Collectors', cacti_sizeof($poller_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Clear Statistics for Data Collector', 'Clear Statistics for Data Collectors', cacti_sizeof($poller_array)) . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -890,7 +890,7 @@ function pollers() {
 						<?php print __('Collectors');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -905,7 +905,7 @@ function pollers() {
 						<?php print __('Refresh');?>
 					</td>
 					<td>
-						<select id='refresh' onChange='applyFilter()'>
+						<select id='refresh'>
 							<?php
 							$frequency = array(
 								5   => __('%d Seconds', 5),
@@ -949,11 +949,15 @@ function pollers() {
 			}
 
 			$(function() {
-				$('#clear').click(function() {
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#form_poller').submit(function(event) {
+				$('#refresh, #rows').on('change', function() {
+					applyFilter();
+				});
+
+				$('#form_poller').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});

--- a/rrdcheck.php
+++ b/rrdcheck.php
@@ -119,7 +119,9 @@ function rrdcheck_display_problems() {
 
 	if (get_request_var('filter') != '') {
 		$sql_where .= ' AND (
-			message LIKE '          . db_qstr('%' . get_request_var('filter') . '%') . ')';
+			message LIKE ' . db_qstr('%' . get_request_var('filter') . '%') . ' OR
+			dtd.name_cache LIKE ' . db_qstr('%' . get_request_var('filter') . '%') . ' OR
+			h.description LIKE ' . db_qstr('%' . get_request_var('filter') . '%') .  ')';
 	}
 
 	$total_rows = db_fetch_cell("SELECT COUNT(local_data_id)
@@ -232,7 +234,7 @@ function filter() {
 						<?php print __('Age');?>
 					</td>
 					<td>
-						<select id='age' onChange='refreshForm()'>
+						<select id='age'>
 							<option value='0'   <?php print (get_request_var('age') == '0'   ? ' selected':'');?>>&lt; <?php print __('%d hours', 2);?></option>
 							<option value='14400'   <?php print (get_request_var('age') == '14400'   ? ' selected':'');?>>&gt; <?php print __('%d hours', 4);?></option>
 							<option value='43200'  <?php print (get_request_var('age') == '43200'  ? ' selected':'');?>>&gt;  <?php print __('%d hours',12);?></option>
@@ -277,21 +279,21 @@ function filter() {
 			}
 
 			$(function() {
-				$('#form_rrdcheck').submit(function() {
+				$('#form_rrdcheck').on('submit', function() {
 					refreshForm();
 					return false;
 				});
 
-				$('#rows').change(function() {
+				$('#rows, #age').on('change', function() {
 					refreshForm();
 				});
 
-				$('#clear').click(function() {
+				$('#clear').on('click', function() {
 					strURL = 'rrdcheck.php?header=false&clear=1';
 					loadPageNoHeader(strURL);
 				});
 
-				$('#purge').click(function() {
+				$('#purge').on('click', function() {
 					strURL = 'rrdcheck.php?action=purge&header=false';
 					loadPageNoHeader(strURL);
 				});

--- a/rrdcleaner.php
+++ b/rrdcleaner.php
@@ -517,7 +517,7 @@ function filter() {
 						<?php print __('Time Since Update');?>
 					</td>
 					<td>
-						<select id='age' onChange='refreshForm()'>
+						<select id='age'>
 							<option value='0'   <?php print (get_request_var('age') == '0'   ? ' selected':'');?>>&lt; <?php print __('%d Week', 1);?></option>
 							<option value='604800'   <?php print (get_request_var('age') == '604800'   ? ' selected':'');?>>&gt; <?php print __('%d Week', 1);?></option>
 							<option value='1209600'  <?php print (get_request_var('age') == '1209600'  ? ' selected':'');?>>&gt; <?php print __('%d Weeks',2);?></option>
@@ -571,21 +571,21 @@ function filter() {
 			}
 
 			$(function() {
-				$('#form_rrdclean').submit(function() {
+				$('#form_rrdclean').on('submit', function() {
 					refreshForm();
 					return false;
 				});
 
-				$('#rows').change(function() {
+				$('#rows, #age').on('change', function() {
 					refreshForm();
 				});
 
-				$('#clear').click(function() {
+				$('#clear').on('click', function() {
 					strURL = 'rrdcleaner.php?header=false&clear=1';
 					loadPageNoHeader(strURL);
 				});
 
-				$('#rescan').click(function() {
+				$('#rescan').on('click', function() {
 					$('#text').text('Rebuilding RRDfile Listing');
 					pulsate('#text');
 					$.get('rrdcleaner.php?header=false&rescan=1&clear=1')
@@ -601,7 +601,7 @@ function filter() {
 						});
 				});
 
-				$('#arcall').click(function() {
+				$('#arcall').on('click', function() {
 					$('#text').text('Scheduling Archiving of All Unknowns');
 					pulsate('#text');
 					$.get('rrdcleaner.php?header=false&action=arcall&raction=3&clear=1')
@@ -617,7 +617,7 @@ function filter() {
 						});
 				});
 
-				$('#remall').click(function() {
+				$('#remall').on('click', function() {
 					$('#text').text('Scheduling Purging of All Unknowns');
 					pulsate('#text');
 					$.get('rrdcleaner.php?header=false&action=remall&raction=1&clear=1')

--- a/settings.php
+++ b/settings.php
@@ -489,14 +489,14 @@ default:
 	var permsMessage   = '<?php print __esc('After you change the Graph Permission Model you should audit your Users and User Groups Effective Graph permission to ensure that you still have adequate control of your Graphs.  NOTE: If you want to restrict all Graphs at the Device or Graph Template Graph Permission Model, the default Graph Policy should be set to \'Deny\'.');?>';
 
 	$(function() {
-		$('.subTab').find('a').click(function(event) {
+		$('.subTab').find('a').on('click', function(event) {
 			event.preventDefault();
 			strURL = $(this).attr('href');
 			strURL += (strURL.indexOf('?') > 0 ? '&':'?') + 'header=false';
 			loadPageNoHeader(strURL, true, false);
 		});
 
-		$('input[value="<?php print __esc('Save');?>"]').unbind().click(function(event) {
+		$('input[value="<?php print __esc('Save');?>"]').on('click', function(event) {
 			event.preventDefault();
 
 			if (parseInt($('#cron_interval').val()) < parseInt($('#poller_interval').val())) {
@@ -563,11 +563,11 @@ default:
 				width: '150'
 			});
 
-			$('#graph_auth_method').change(function() {
+			$('#graph_auth_method').on('change', function() {
 				permsChanger();
 			});
 
-			$('#i18n_default_language, #i18n_auto_detection, #i18n_language_support').change(function() {
+			$('#i18n_default_language, #i18n_auto_detection, #i18n_language_support').on('change', function() {
 				langDetectionChanger();
 			});
 		} else if (currentTab == 'spikes') {
@@ -622,7 +622,7 @@ default:
 				width: '150'
 			});
 		} else if (currentTab == 'data') {
-			$('#storage_location').change(function() {
+			$('#storage_location').on('change', function() {
 				if ($(this).val() == '0') {
 					$('#row_rrdp_header').hide();
 					$('#row_rrdp_server').hide();
@@ -646,7 +646,7 @@ default:
 				}
 			}).trigger('change');
 
-			$('#extended_paths').change(function() {
+			$('#extended_paths').on('change', function() {
 				if ($(this).is(':checked')) {
 					$('#row_extended_paths_type').show();
 				} else {
@@ -658,11 +658,11 @@ default:
 
 			initMail();
 
-			$('#settings_how').change(function() {
+			$('#settings_how').on('change', function() {
 				initMail();
 			});
 
-			$('#emailtest').click(function() {
+			$('#emailtest').on('click', function() {
 				$.get('settings.php?action=send_test')
 					.done(function(data) {
 						$('body').append('<div id="testmail" title="<?php print __esc('Test Email Results');?>"></div>');
@@ -696,15 +696,15 @@ default:
 			initFonts();
 			initRealtime();
 
-			$('#font_method').change(function() {
+			$('#font_method').on('change', function() {
 				initFonts();
 			});
 
-			$('#selected_theme').change(function() {
+			$('#selected_theme').on('change', function() {
 				themeChanger();
 			});
 
-			$('#realtime_enabled').change(function() {
+			$('#realtime_enabled').on('change', function() {
 				initRealtime();
 			});
 		} else if (currentTab == 'snmp') {
@@ -713,12 +713,12 @@ default:
 
 			setSNMP();
 
-			$('#snmp_version, #snmp_auth_protocol, #snmp_priv_protocol, #snmp_security_level').change(function() {
+			$('#snmp_version, #snmp_auth_protocol, #snmp_priv_protocol, #snmp_security_level').on('change', function() {
 				setSNMP();
 			});
 
 			initAvail();
-			$('#availability_method').change(function() {
+			$('#availability_method').on('change', function() {
 				initAvail();
 			});
 		} else if (currentTab == 'authentication') {
@@ -726,21 +726,21 @@ default:
 			initSearch();
 			initGroupMember();
 
-			$('#auth_method').change(function() {
+			$('#auth_method').on('change', function() {
 				initAuth();
 			});
 
-			$('#ldap_mode').change(function() {
+			$('#ldap_mode').on('change', function() {
 				initSearch();
 			});
 
-			$('#ldap_group_require').change(function() {
+			$('#ldap_group_require').on('change', function() {
 				initGroupMember();
 			});
 		} else if (currentTab == 'path') {
 			initRRDClean();
 
-			$('#rrd_autoclean').change(function() {
+			$('#rrd_autoclean').on('change', function() {
 				initRRDClean();
 			});
 
@@ -748,7 +748,7 @@ default:
 				$('#row_path_stderrlog').hide();
 			}
 
-			$('#rrd_autoclean_method').change(function() {
+			$('#rrd_autoclean_method').on('change', function() {
 				initRRDClean();
 			});
 		} else if (currentTab == 'boost') {
@@ -762,11 +762,11 @@ default:
 			initBoostOD();
 			initBoostCache();
 
-			$('#boost_rrd_update_enable').change(function() {
+			$('#boost_rrd_update_enable').on('change', function() {
 				initBoostOD();
 			});
 
-			$('#boost_png_cache_enable').change(function() {
+			$('#boost_png_cache_enable').on('change', function() {
 				initBoostCache();
 			});
 		}

--- a/sites.php
+++ b/sites.php
@@ -380,7 +380,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Site', 'Delete Sites', cacti_sizeof($site_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Site', 'Delete Sites', cacti_sizeof($site_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '2') { /* duplicate */
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -390,7 +390,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate Site', 'Duplicate Sites', cacti_sizeof($site_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Duplicate Site', 'Duplicate Sites', cacti_sizeof($site_array)) . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -515,7 +515,7 @@ function sites() {
 						<?php print __('Sites');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -550,15 +550,19 @@ function sites() {
 			}
 
 			$(function() {
-				$('#refresh').click(function() {
+				$('#refresh').on('click', function() {
 					applyFilter();
 				});
 
-				$('#clear').click(function() {
+				$('#rows').on('change', function() {
+					applyFilter();
+				});
+
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#form_site').submit(function(event) {
+				$('#form_site').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});

--- a/templates_export.php
+++ b/templates_export.php
@@ -185,12 +185,12 @@ function export() {
 	var stopTimer;
 
 	$(function() {
-		$('#export_type').change(function() {
+		$('#export_type').on('change', function() {
 			strURL = 'templates_export.php?header=false&export_type='+$('#export_type').val();
 			loadPageNoHeader(strURL);
 		});
 
-		$('form#export').submit(function(event) {
+		$('form#export').on('submit', function(event) {
 			stopTimer = setTimeout(function() { Pace.stop() }, 1000);
 		});
 	});

--- a/templates_import.php
+++ b/templates_import.php
@@ -478,7 +478,7 @@ function import() {
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	$(function() {
-		$('#import_file').change(function() {
+		$('#import_file').on('change', function() {
 			var form = $('#import')[0];
 			var data = new FormData(form);
 

--- a/tests/integration/ContentSecurityPolicyTest.php
+++ b/tests/integration/ContentSecurityPolicyTest.php
@@ -200,13 +200,13 @@ test('nonce mode replaces unsafe-inline with nonce in script-src and style-src',
 		$sStart = strpos($csp, 'script-src');
 		$sEnd   = strpos($csp, ';', $sStart);
 		$scriptSrc = substr($csp, $sStart, $sEnd - $sStart);
-		expect($scriptSrc)->toMatch("/'nonce-[A-Za-z0-9_-]+'/");
+		expect($scriptSrc)->toContain("/'nonce-[A-Za-z0-9_-]+'/");
 		expect($scriptSrc)->not->toContain("'unsafe-inline'");
 
 		$yStart = strpos($csp, 'style-src');
 		$yEnd   = strpos($csp, ';', $yStart);
 		$styleSrc = substr($csp, $yStart, $yEnd - $yStart);
-		expect($styleSrc)->toMatch("/'nonce-[A-Za-z0-9_-]+'/");
+		expect($styleSrc)->toContain("/'nonce-[A-Za-z0-9_-]+'/");
 		expect($styleSrc)->not->toContain("'unsafe-inline'");
 	} finally {
 		_csp_stop_server($server);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -98,7 +98,7 @@ cmd_exec	./snmpagent_persist.php:86			exec($php . ' ' . $extra_args . ' > /dev/n
 cmd_exec	./utilities.php:219					exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
 cmd_exec	./utilities.php:237				$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
 cmd_exec	./utilities.php:257				exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-dynamic_include	./automation_snmp.php:410		#include_once($config['base_path'].'/plugins/mactrack/lib/automation_functions.php');
+dynamic_include	./automation_snmp.php:414		#include_once($config['base_path'].'/plugins/mactrack/lib/automation_functions.php');
 dynamic_include	./automation_tree_rules.php:547		include_once($config['base_path'].'/lib/html_tree.php');
 dynamic_include	./cli/add_data_query.php:27	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./cli/add_data_query.php:28	require_once($config['base_path'] . '/lib/api_automation.php');
@@ -339,11 +339,11 @@ dynamic_include	./lib/aggregate.php:834		include_once($config['base_path'] . '/l
 dynamic_include	./lib/api_aggregate.php:1677		include($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/api_aggregate.php:203		include_once($config['base_path'] . '/lib/api_aggregate.php');
 dynamic_include	./lib/api_aggregate.php:671		include_once($config['base_path'] . '/lib/api_aggregate.php');
-dynamic_include	./lib/api_automation.php:2368		include_once($config['base_path'] . '/lib/template.php');
-dynamic_include	./lib/api_automation.php:2369		include_once($config['base_path'] . '/lib/api_automation_tools.php');
-dynamic_include	./lib/api_automation.php:2370		include_once($config['base_path'] . '/lib/utility.php');
-dynamic_include	./lib/api_automation.php:3058					include_once($config['base_path'] . '/plugins/thold/thold-functions.php');
-dynamic_include	./lib/api_automation.php:3061					include_once($config['base_path'] . '/plugins/thold/thold_functions.php');
+dynamic_include	./lib/api_automation.php:2376		include_once($config['base_path'] . '/lib/template.php');
+dynamic_include	./lib/api_automation.php:2377		include_once($config['base_path'] . '/lib/api_automation_tools.php');
+dynamic_include	./lib/api_automation.php:2378		include_once($config['base_path'] . '/lib/utility.php');
+dynamic_include	./lib/api_automation.php:3066					include_once($config['base_path'] . '/plugins/thold/thold-functions.php');
+dynamic_include	./lib/api_automation.php:3069					include_once($config['base_path'] . '/plugins/thold/thold_functions.php');
 dynamic_include	./lib/api_device.php:946		include_once($config['base_path'] . '/lib/utility.php');
 dynamic_include	./lib/api_device.php:947		include_once($config['base_path'] . '/lib/variables.php');
 dynamic_include	./lib/api_device.php:948		include_once($config['base_path'] . '/lib/data_query.php');
@@ -534,15 +534,15 @@ host_header	./include/global.php:421			if (!$is_https && isset($_SERVER['HTTP_HO
 host_header	./include/global.php:422				header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
 host_header	./lib/html_utility.php:988		} elseif (isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST'] != '') {
 host_header	./lib/html_utility.php:989			$srv_host = preg_replace('/:\d+$/', '', $_SERVER['HTTP_HOST']);
-sort_order_input	./automation_snmp.php:529				ORDER BY sequence', array(get_request_var('id')));
+sort_order_input	./automation_snmp.php:533				ORDER BY sequence', array(get_request_var('id')));
 sort_order_input	./data_queries.php:872						ORDER BY field_name, sequence', array(get_request_var('id'), $data_template['id']));
 sort_order_input	./graph_templates.php:504			ORDER BY name', array(get_request_var('id')));
 sort_order_input	./graph_templates_inputs.php:197			ORDER BY gti.sequence", array(get_request_var('id'), get_request_var('graph_template_id')));
 sort_order_input	./graphs.php:1363				ORDER BY gti.sequence", array(get_request_var('id')));
-sort_order_input	./host_templates.php:455				ORDER BY graph_templates.name', array(get_request_var('id')));
-sort_order_input	./host_templates.php:493									ORDER BY gt.name', array(get_request_var('id'))),'name','id','','','');?>
-sort_order_input	./host_templates.php:512				ORDER BY snmp_query.name', array(get_request_var('id')));
-sort_order_input	./host_templates.php:547									ORDER BY snmp_query.name', array(get_request_var('id'))),'name','id','','','');?>
-sort_order_input	./lib/api_automation.php:561			ORDER BY " . cacti_validate_sort_column(get_request_var('sort_column'),
-sort_order_input	./utilities.php:1138			ORDER BY " . cacti_validate_sort_column(get_request_var('sort_column'), array('username', 'time', 'result', 'ip'), 'time') . ' ' . (get_request_var('sort_direction') === 'ASC' ? 'ASC' : 'DESC') . '
-sort_order_input	./utilities.php:2179			ORDER BY " . cacti_validate_sort_column(get_request_var('sort_column'), array('action', 'hostname', 'rrd_path', 'arg1', 'arg2', 'arg3'), 'hostname') . ' ' . (get_request_var('sort_direction') === 'ASC' ? 'ASC' : 'DESC') . ', action ASC
+sort_order_input	./host_templates.php:467				ORDER BY graph_templates.name', array(get_request_var('id')));
+sort_order_input	./host_templates.php:505									ORDER BY gt.name', array(get_request_var('id'))),'name','id','','','');?>
+sort_order_input	./host_templates.php:524				ORDER BY snmp_query.name', array(get_request_var('id')));
+sort_order_input	./host_templates.php:559									ORDER BY snmp_query.name', array(get_request_var('id'))),'name','id','','','');?>
+sort_order_input	./lib/api_automation.php:565			ORDER BY " . cacti_validate_sort_column(get_request_var('sort_column'),
+sort_order_input	./utilities.php:1142			ORDER BY " . cacti_validate_sort_column(get_request_var('sort_column'), array('username', 'time', 'result', 'ip'), 'time') . ' ' . (get_request_var('sort_direction') === 'ASC' ? 'ASC' : 'DESC') . '
+sort_order_input	./utilities.php:2187			ORDER BY " . cacti_validate_sort_column(get_request_var('sort_column'), array('action', 'hostname', 'rrd_path', 'arg1', 'arg2', 'arg3'), 'hostname') . ' ' . (get_request_var('sort_direction') === 'ASC' ? 'ASC' : 'DESC') . ', action ASC

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -25,11 +25,11 @@ cmd_exec	./lib/functions.php:2249						$output = shell_exec($php . ' -q ' . $scr
 cmd_exec	./lib/functions.php:2516							$output = shell_exec($script_path);
 cmd_exec	./lib/functions.php:3017			return exec('whoami');
 cmd_exec	./lib/functions.php:3676		exec($command_line,$out,$err);
-cmd_exec	./lib/functions.php:6924				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v');
-cmd_exec	./lib/functions.php:6926				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v 2>&1');
-cmd_exec	./lib/functions.php:7125				exec('id -nu', $o, $r);
-cmd_exec	./lib/functions.php:7135				exec(sprintf('grep :%s: /etc/passwd | cut -d: -f1', (int) $uid), $o, $r);
-cmd_exec	./lib/functions.php:8257		exec($command, $out, $exit_code);
+cmd_exec	./lib/functions.php:6928				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v');
+cmd_exec	./lib/functions.php:6930				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v 2>&1');
+cmd_exec	./lib/functions.php:7129				exec('id -nu', $o, $r);
+cmd_exec	./lib/functions.php:7139				exec(sprintf('grep :%s: /etc/passwd | cut -d: -f1', (int) $uid), $o, $r);
+cmd_exec	./lib/functions.php:8261		exec($command, $out, $exit_code);
 cmd_exec	./lib/installer.php:3288				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
 cmd_exec	./lib/installer.php:3320						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
 cmd_exec	./lib/installer.php:3376						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
@@ -97,8 +97,8 @@ cmd_exec	./snmpagent_persist.php:86			exec($php . ' ' . $extra_args . ' > /dev/n
 cmd_exec	./utilities.php:219					exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
 cmd_exec	./utilities.php:237				$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
 cmd_exec	./utilities.php:257				exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-deserialize	./lib/functions.php:4680				$items = unserialize($unstripped, array('allowed_classes' => false));
-deserialize	./lib/functions.php:7821		return @unserialize($strobj, array('allowed_classes' => false));
+deserialize	./lib/functions.php:4684				$items = unserialize($unstripped, array('allowed_classes' => false));
+deserialize	./lib/functions.php:7825		return @unserialize($strobj, array('allowed_classes' => false));
 dynamic_include	./automation_tree_rules.php:547		include_once($config['base_path'].'/lib/html_tree.php');
 dynamic_include	./cli/add_data_query.php:27	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./cli/add_data_query.php:28	require_once($config['base_path'] . '/lib/api_automation.php');
@@ -339,9 +339,9 @@ dynamic_include	./lib/aggregate.php:834		include_once($config['base_path'] . '/l
 dynamic_include	./lib/api_aggregate.php:1677		include($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/api_aggregate.php:203		include_once($config['base_path'] . '/lib/api_aggregate.php');
 dynamic_include	./lib/api_aggregate.php:671		include_once($config['base_path'] . '/lib/api_aggregate.php');
-dynamic_include	./lib/api_automation.php:2368		include_once($config['base_path'] . '/lib/template.php');
-dynamic_include	./lib/api_automation.php:2369		include_once($config['base_path'] . '/lib/api_automation_tools.php');
-dynamic_include	./lib/api_automation.php:2370		include_once($config['base_path'] . '/lib/utility.php');
+dynamic_include	./lib/api_automation.php:2376		include_once($config['base_path'] . '/lib/template.php');
+dynamic_include	./lib/api_automation.php:2377		include_once($config['base_path'] . '/lib/api_automation_tools.php');
+dynamic_include	./lib/api_automation.php:2378		include_once($config['base_path'] . '/lib/utility.php');
 dynamic_include	./lib/api_device.php:946		include_once($config['base_path'] . '/lib/utility.php');
 dynamic_include	./lib/api_device.php:947		include_once($config['base_path'] . '/lib/variables.php');
 dynamic_include	./lib/api_device.php:948		include_once($config['base_path'] . '/lib/data_query.php');
@@ -362,17 +362,17 @@ dynamic_include	./lib/dsstats.php:1009			include_once($config['library_path'] . 
 dynamic_include	./lib/dsstats.php:967			include_once($config['base_path'] . '/lib/rrd.php');
 dynamic_include	./lib/export.php:465		include_once($config['library_path'] . '/vdef.php');
 dynamic_include	./lib/functions.php:421		include_once($config['base_path'] . '/lib/poller.php');
-dynamic_include	./lib/functions.php:4808		include_once($config['base_path'] . '/include/global_session.php');
-dynamic_include	./lib/functions.php:4811			include_once($config['base_path'] . '/include/bottom_footer.php');
-dynamic_include	./lib/functions.php:4836			include_once($config['base_path'] . '/include/top_header.php');
-dynamic_include	./lib/functions.php:4843			include_once($config['base_path'] . '/include/top_graph_header.php');
-dynamic_include	./lib/functions.php:4850			include_once($config['base_path'] . '/include/top_general_header.php');
-dynamic_include	./lib/functions.php:5012		require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
-dynamic_include	./lib/functions.php:5013		require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
-dynamic_include	./lib/functions.php:5014		require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
-dynamic_include	./lib/functions.php:5499	    require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
-dynamic_include	./lib/functions.php:5500	    require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
-dynamic_include	./lib/functions.php:5501	    require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
+dynamic_include	./lib/functions.php:4812		include_once($config['base_path'] . '/include/global_session.php');
+dynamic_include	./lib/functions.php:4815			include_once($config['base_path'] . '/include/bottom_footer.php');
+dynamic_include	./lib/functions.php:4840			include_once($config['base_path'] . '/include/top_header.php');
+dynamic_include	./lib/functions.php:4847			include_once($config['base_path'] . '/include/top_graph_header.php');
+dynamic_include	./lib/functions.php:4854			include_once($config['base_path'] . '/include/top_general_header.php');
+dynamic_include	./lib/functions.php:5016		require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
+dynamic_include	./lib/functions.php:5017		require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
+dynamic_include	./lib/functions.php:5018		require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
+dynamic_include	./lib/functions.php:5503	    require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
+dynamic_include	./lib/functions.php:5504	    require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
+dynamic_include	./lib/functions.php:5505	    require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
 dynamic_include	./lib/graph_variables.php:65		include_once($config['library_path'] . '/rrd.php');
 dynamic_include	./lib/html.php:1207		include($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/html_tree.php:479		include_once($config['base_path'] . '/lib/data_query.php');
@@ -553,6 +553,7 @@ fs_write	./lib/api_device.php:2637							file_put_contents($new_xmlfile, $data);
 fs_write	./lib/boost.php:449								if ($fileptr = fopen($cache_file, 'rb')) {
 fs_write	./lib/boost.php:572							if ($fileptr = fopen($cache_file, 'w')) {
 fs_write	./lib/clog_webapi.php:119					$log_fh = fopen($logfile, 'w');
+fs_write	./lib/csp_report_endpoint.php:176		$fh = @fopen($bucket, 'c+');
 fs_write	./lib/database.php:206					file_put_contents(sys_get_temp_dir() . '/cacti-option.log',
 fs_write	./lib/database.php:2130		file_put_contents(sys_get_temp_dir() . '/cacti-sql.log', get_debug_prefix() . $line, FILE_APPEND);
 fs_write	./lib/database.php:74					file_put_contents(sys_get_temp_dir() . '/cacti-option.log',
@@ -560,10 +561,10 @@ fs_write	./lib/functions.php:1353			$fp = @fopen($logfile, 'a');
 fs_write	./lib/functions.php:1428		$fp = fopen($file_name, 'r');
 fs_write	./lib/functions.php:483			file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() . cacti_debug_backtrace($config_name, false, false, 0, 1) . "\n", FILE_APPEND);
 fs_write	./lib/functions.php:698			file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() . cacti_debug_backtrace($config_name, false, false, 0, 1) . "\n", FILE_APPEND);
-fs_write	./lib/functions.php:7019			if (($f = @fopen($path, 'a'))) {
-fs_write	./lib/functions.php:7028		if (($f = @fopen($path, 'w'))) {
+fs_write	./lib/functions.php:7023			if (($f = @fopen($path, 'a'))) {
+fs_write	./lib/functions.php:7032		if (($f = @fopen($path, 'w'))) {
 fs_write	./lib/functions.php:710				file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() .
-fs_write	./lib/functions.php:7102				file_put_contents($tmp_file, 'cacti');
+fs_write	./lib/functions.php:7106				file_put_contents($tmp_file, 'cacti');
 fs_write	./lib/functions.php:719					file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() .
 fs_write	./lib/import.php:425		$f   = fopen($filename, 'r');
 fs_write	./lib/import.php:592							$file = fopen($filename, 'wb');
@@ -584,7 +585,7 @@ fs_write	./scripts/ss_net_snmp_disk_io.php:226			file_put_contents("$tmpdir/$tmp
 fs_write	./snmpagent_mibcachechild.php:90		$lock = fopen($path_mibcache_lock, 'w');
 fs_write	./snmpagent_mibcachechild.php:94			file_put_contents($path_mibcache, '<?php $cache = ' . var_export($cache, true) . ';', LOCK_EX);
 fs_write	./templates_import.php:67				$fp = fopen($_FILES['import_file']['tmp_name'],'r');
-fs_write	./utilities.php:1612				$log_fh = fopen($logfile, 'w');
+fs_write	./utilities.php:1620				$log_fh = fopen($logfile, 'w');
 header_redirect	./aggregate_graphs.php:102			header('Location: aggregate_graphs.php?header=false&action=edit&id=' . $local_graph_id);
 header_redirect	./aggregate_graphs.php:121			header('Location: aggregate_graphs.php?header=false&action=edit&id=' . $local_graph_id);
 header_redirect	./aggregate_graphs.php:248		header('Location: aggregate_graphs.php?header=false&action=edit&id=' . $local_graph_id);
@@ -606,7 +607,7 @@ header_redirect	./auth_changepassword.php:325			header('Location:index.php');
 header_redirect	./auth_login.php:230						header('Location: auth_login.php');
 header_redirect	./automation_devices.php:144			header('Location: automation_devices.php?header=false');
 header_redirect	./automation_devices.php:236			header('Location: automation_devices.php?header=false');
-header_redirect	./automation_devices.php:678		header('Location: automation_devices.php?header=false');
+header_redirect	./automation_devices.php:682		header('Location: automation_devices.php?header=false');
 header_redirect	./automation_graph_rules.php:114			header('Location: automation_graph_rules.php?header=false&action=edit&id=' . (empty($rule_id) ? get_nfilter_request_var('id') : $rule_id));
 header_redirect	./automation_graph_rules.php:147						header('Location: automation_graph_rules.php?header=false&action=edit&id=' . get_request_var('id'));
 header_redirect	./automation_graph_rules.php:165				header('Location: automation_graph_rules.php?header=false&action=item_edit&id=' . get_request_var('id') . '&item_id=' . (empty($item_id) ? get_request_var('item_id') : $item_id) . '&rule_type=' . AUTOMATION_RULE_TYPE_GRAPH_ACTION);
@@ -864,9 +865,9 @@ header_redirect	./lib/auth.php:4764					header('Location: ' . $config['url_path'
 header_redirect	./lib/auth.php:4769				header('Location: ' . $config['url_path'] . 'graph_view.php' . ($newtheme ? '?newtheme=1':''));
 header_redirect	./lib/auth.php:4964			header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'index.php')));
 header_redirect	./lib/clog_webapi.php:99			header('Location: ' . get_current_page());
-header_redirect	./lib/functions.php:7926		header('Location: ' . $save_url);
-header_redirect	./lib/functions.php:7949		header('Location: ' . $safe_url, true, $status);
-header_redirect	./lib/html_graph.php:471			header('Location: ' . $page . '?host_id=' . $host_id . '&header=false');
+header_redirect	./lib/functions.php:7930		header('Location: ' . $save_url);
+header_redirect	./lib/functions.php:7953		header('Location: ' . $safe_url, true, $status);
+header_redirect	./lib/html_graph.php:498			header('Location: ' . $page . '?host_id=' . $host_id . '&header=false');
 header_redirect	./lib/html_reports.php:1507				header('Location: reports.php');
 header_redirect	./lib/html_reports.php:274					header('Location: reports.php');
 header_redirect	./lib/html_reports.php:355			header('Location: ' . get_reports_page() . '?action=edit&header=false&id=' . (empty($id) ? get_nfilter_request_var('id') : $id));
@@ -887,11 +888,11 @@ header_redirect	./links.php:61		header('Location: links.php?header=false');
 header_redirect	./locales/index.php:25	header("Location:../index.php");
 header_redirect	./log/index.php:25	header("Location:../index.php");
 header_redirect	./logout.php:102		header('Location: index.php');
-header_redirect	./managers.php:1021					header('Location: managers.php?header=false');
-header_redirect	./managers.php:867				header('Location: managers.php?action=edit&tab=notifications&id=' . get_request_var('id'));
-header_redirect	./managers.php:916		header('Location: managers.php?action=edit&header=false&id=' . (empty($manager_id) ? get_nfilter_request_var('id') : $manager_id) );
-header_redirect	./managers.php:943				header('Location: managers.php');
-header_redirect	./managers.php:977				header('Location: managers.php?action=edit&id=' . get_nfilter_request_var('id') . '&tab=notifications&header=false');
+header_redirect	./managers.php:1039					header('Location: managers.php?header=false');
+header_redirect	./managers.php:885				header('Location: managers.php?action=edit&tab=notifications&id=' . get_request_var('id'));
+header_redirect	./managers.php:934		header('Location: managers.php?action=edit&header=false&id=' . (empty($manager_id) ? get_nfilter_request_var('id') : $manager_id) );
+header_redirect	./managers.php:961				header('Location: managers.php');
+header_redirect	./managers.php:995				header('Location: managers.php?action=edit&id=' . get_nfilter_request_var('id') . '&tab=notifications&header=false');
 header_redirect	./mibs/index.php:25	header("Location:../index.php");
 header_redirect	./package_import.php:128					header('Location: package_import.php');
 header_redirect	./package_import.php:134				header('Location: package_import.php');
@@ -978,7 +979,7 @@ header_redirect	./user_group_admin.php:574			header('Location: user_group_admin.
 header_redirect	./user_group_admin.php:595			header('Location: user_group_admin.php?action=edit&header=false&tab=settings&id=' . get_nfilter_request_var('id'));
 header_redirect	./user_group_admin.php:602		header('Location: user_group_admin.php?action=edit&header=false&tab=general&id=' .  get_nfilter_request_var('id'));
 header_redirect	./user_group_admin.php:625		header('Location: user_group_admin.php?action=edit&header=false&tab=gperms&id=' . get_request_var('group_id'));
-header_redirect	./utilities.php:1278			header('Location: utilities.php?action=view_logfile&filename=' . $logbase);
+header_redirect	./utilities.php:1282			header('Location: utilities.php?action=view_logfile&filename=' . $logbase);
 header_redirect	./utilities.php:43			header('Location: utilities.php?action=view_poller_cache');exit;
 header_redirect	./utilities.php:47			header('Location: utilities.php?header=false');exit;
 header_redirect	./utilities.php:95			header('Location: utilities.php');

--- a/tree.php
+++ b/tree.php
@@ -708,7 +708,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Tree', 'Delete Trees', cacti_sizeof($tree_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete Tree', 'Delete Trees', cacti_sizeof($tree_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '2') { // publish
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -717,7 +717,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Publish Tree', 'Publish Trees', cacti_sizeof($tree_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Publish Tree', 'Publish Trees', cacti_sizeof($tree_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '3') { // un-publish
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -726,7 +726,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Un-publish Tree', 'Un-publish Trees', cacti_sizeof($tree_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Un-publish Tree', 'Un-publish Trees', cacti_sizeof($tree_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') == '4') { // un-lock
 			print "<tr>
 				<td class='textArea' class='odd'>
@@ -735,7 +735,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Un-lock Tree', 'Un-lock Trees', cacti_sizeof($tree_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Un-lock Tree', 'Un-lock Trees', cacti_sizeof($tree_array)) . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -1127,7 +1127,7 @@ function tree_edit($partial = false) {
 		}
 
 		function initializeTreeEdit() {
-			$('#lock').click(function() {
+			$('#lock').on('click', function() {
 				strURL = 'tree.php?action=lock&id=<?php print $tree['id'];?>';
 
 				loadTreeEdit(strURL);
@@ -1152,7 +1152,7 @@ function tree_edit($partial = false) {
 				enableKeyups();
 			});
 
-			$('#unlock').click(function() {
+			$('#unlock').on('click', function() {
 				strURL = 'tree.php?action=unlock&id=<?php print $tree['id'];?>';
 
 				loadTreeEdit(strURL);
@@ -1345,17 +1345,17 @@ function tree_edit($partial = false) {
 		}
 
 		function enableKeyups() {
-			$('#gfilter').keyup(function(data) {
+			$('#gfilter').on('keyup', function(data) {
 				graphMeTimer && clearTimeout(graphMeTimer);
 				graphMeTimer = setTimeout(getGraphData, 300);
 			});
 
-			$('#hfilter').keyup(function(data) {
+			$('#hfilter').on('keyup', function(data) {
 				hostMeTimer && clearTimeout(hostMeTimer);
 				hostMeTimer = setTimeout(getHostData, 300);
 			});
 
-			$('#sfilter').keyup(function(data) {
+			$('#sfilter').on('keyup', function(data) {
 				siteMeTimer && clearTimeout(siteMeTimer);
 				siteMeTimer = setTimeout(getSiteData, 300);
 			});
@@ -1441,7 +1441,7 @@ function tree_edit($partial = false) {
 				});
 			}
 
-			$('form').unbind().submit(function(event) {
+			$('form').on('submit', function(event) {
 				event.preventDefault();
 
 				if ($(this).attr('id') == 'tree_edit') {
@@ -1468,11 +1468,11 @@ function tree_edit($partial = false) {
 			var hheight = parseInt($(window).height()-$('#hosts').offset().top-10)+'px';
 			var gheight = parseInt($(window).height()-$('#graphs').offset().top-10)+'px';
 
-			$('#element').change(function() {
+			$('#element').on('change', function() {
 				resizer();
 			});
 
-			$(window).resize(function() {
+			$(window).on('resize', function() {
 				resizer();
 			});
 
@@ -2094,23 +2094,27 @@ function tree() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#rows').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#sorta').click(function() {
+		$('#sorta').on('click', function() {
 			loadPageNoHeader('tree.php?action=sortasc');
 		});
 
-		$('#sortd').click(function() {
+		$('#sortd').on('click', function() {
 			loadPageNoHeader('tree.php?action=sortdesc');
 		});
 
-		$('#form_tree').submit(function(event) {
+		$('#form_tree').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2158,7 +2162,7 @@ function tree() {
 						<?php print __('Trees'); ?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {

--- a/user_admin.php
+++ b/user_admin.php
@@ -340,7 +340,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'><input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete User(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'><input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Delete User(s)') . "'>";
 		}
 		$user_id = '';
 
@@ -380,7 +380,7 @@ function form_actions() {
 			print "</p></td>
 				</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Copy User') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Copy User') . "'>";
 		}
 
 		if ((get_nfilter_request_var('drp_action') == '3') && (cacti_sizeof($user_array))) { // enable
@@ -391,7 +391,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Enable User(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Enable User(s)') . "'>";
 		}
 
 		if ((get_nfilter_request_var('drp_action') == '4') && (cacti_sizeof($user_array))) { // disable
@@ -402,7 +402,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Disable User(s)') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Disable User(s)') . "'>";
 		}
 
 		if ((get_nfilter_request_var('drp_action') == '5') && (cacti_sizeof($user_array))) { // batch copy
@@ -425,7 +425,7 @@ function form_actions() {
 					</td>
 				</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Reset User(s) Settings') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Reset User(s) Settings') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -1495,7 +1495,7 @@ function user_realms_edit($header_label) {
 	print "<div class='cactiTable' style='width:100%;text-align:left;'>
 		<div>
 			<div class='cactiTableTitle'><span style='padding:3px;'>" . __('User Permissions') . " " . html_escape($header_label) . "</span></div>
-			<div class='cactiTableButton'><span style='padding:3px;'><input class='checkbox' type='checkbox' id='all' name='all' title='" . __esc('Select All') . "' onClick='selectAllRealms(this.checked)'></a><label class='formCheckboxLabel' title='" . __esc('Select All') . "' for='all'></label></span></div>
+			<div class='cactiTableButton'><span style='padding:3px;'><input class='checkbox selectAllRealms' type='checkbox' id='all' name='all' title='" . __esc('Select All') . "'></a><label class='formCheckboxLabel' title='" . __esc('Select All') . "' for='all'></label></span></div>
 		</div>
 	</div>";
 
@@ -1968,11 +1968,11 @@ function user_edit() {
 				checkPasswordConfirm();
 			});
 
-			$('#realm').change(function() {
+			$('#realm').on('change', function() {
 				changeRealm();
 			});
 
-			$('#password_change').click(function() {
+			$('#password_change').on('click', function() {
 				password_change = $('#password_change').is(':checked');
 
 				if (!password_change && $('#must_change_password').is(':checked')) {
@@ -1985,7 +1985,7 @@ function user_edit() {
 				}
 			});
 
-			$('#must_change_password').click(function() {
+			$('#must_change_password').on('click', function() {
 				if ($(this).is(':checked')) {
 					button = ($('#must_change_password').button('instance') !== undefined);
 					if (button) {
@@ -2120,19 +2120,19 @@ function user() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#realm, #rows, #group, #login').change(function() {
+		$('#realm, #rows, #group, #login').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2575,19 +2575,19 @@ function graph_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows, #graph_template_id').change(function() {
+		$('#rows, #graph_template_id').on('change', function() {
 			applyFilter();
 		})
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2694,19 +2694,19 @@ function group_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows').change(function() {
+		$('#rows').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2792,19 +2792,19 @@ function device_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows, #host_template_id').change(function() {
+		$('#rows, #host_template_id').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2907,19 +2907,19 @@ function template_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows').change(function() {
+		$('#rows').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -3004,19 +3004,19 @@ function tree_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows').change(function() {
+		$('#rows').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -3101,19 +3101,19 @@ function member_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows').change(function() {
+		$('#rows').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});

--- a/user_admin.php
+++ b/user_admin.php
@@ -1960,11 +1960,11 @@ function user_edit() {
 			$('#password').val('');
 			$('#password_confirm').val('');
 
-			$('#password').keyup(function() {
+			$('#password').on('keyup', function() {
 				checkPassword();
 			});
 
-			$('#password_confirm').keyup(function() {
+			$('#password_confirm').on('keyup', function() {
 				checkPasswordConfirm();
 			});
 

--- a/user_domains.php
+++ b/user_domains.php
@@ -232,7 +232,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete User Domain', 'Delete User Domains', cacti_sizeof($d_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete User Domain', 'Delete User Domains', cacti_sizeof($d_array)) . "'>";
 		}else if (get_nfilter_request_var('drp_action') == '2') { // disable
 			print "<tr>
 				<td class='textArea'>
@@ -241,7 +241,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Disable User Domain', 'Disable User Domains', cacti_sizeof($d_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Disable User Domain', 'Disable User Domains', cacti_sizeof($d_array)) . "'>";
 		}else if (get_nfilter_request_var('drp_action') == '3') { // enable
 			print "<tr>
 				<td class='textArea'>
@@ -250,7 +250,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enabled User Domain', 'Enable User Domains', cacti_sizeof($d_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enabled User Domain', 'Enable User Domains', cacti_sizeof($d_array)) . "'>";
 		}else if (get_nfilter_request_var('drp_action') == '4') { // default
 			print "<tr>
 				<td class='textArea'>
@@ -259,7 +259,7 @@ function form_actions() {
 				</td>
 			</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Make Selected Domain Default') . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc('Make Selected Domain Default') . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -592,11 +592,11 @@ function domain_edit() {
 		initSearch();
 		initGroupMember();
 
-		$('#mode').change(function() {
+		$('#mode').on('change', function() {
 			initSearch();
 		});
 
-		$('#group_require').change(function() {
+		$('#group_require').on('change', function() {
 			initGroupMember();
 		});
 	});
@@ -664,7 +664,7 @@ function domains() {
 						<?php print __('Domains');?>
 					</td>
 					<td>
-						<select id='rows' onChange="applyFilter()">
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -698,15 +698,19 @@ function domains() {
 		}
 
 		$(function() {
-			$('#refresh').click(function() {
+			$('#refresh').on('click', function() {
 				applyFilter();
 			});
 
-			$('#clear').click(function() {
+			$('#rows').on('change', function() {
+				applyFilter();
+			});
+
+			$('#clear').on('click', function() {
 				clearFilter();
 			});
 
-			$('#form_domains').submit(function(event) {
+			$('#form_domains').on('submit', function(event) {
 				event.preventDefault();
 				applyFilter();
 			});

--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -446,7 +446,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete User Group', 'Delete User Groups', cacti_sizeof($group_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Delete User Group', 'Delete User Groups', cacti_sizeof($group_array)) . "'>";
 		}
 
 		$group_id = '';
@@ -465,7 +465,7 @@ function form_actions() {
 			print "</p></td>
 				</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Copy User Group', 'Copy User Groups', cacti_sizeof($group_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Copy User Group', 'Copy User Groups', cacti_sizeof($group_array)) . "'>";
 		}
 
 		if ((get_nfilter_request_var('drp_action') == '3') && (cacti_sizeof($group_array))) { /* enable */
@@ -476,7 +476,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enable User Group', 'Enable User Groups', cacti_sizeof($group_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Enable User Group', 'Enable User Groups', cacti_sizeof($group_array)) . "'>";
 		}
 
 		if ((get_nfilter_request_var('drp_action') == '4') && (cacti_sizeof($group_array))) { /* disable */
@@ -487,7 +487,7 @@ function form_actions() {
 				</td>
 			</tr>";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Disable User Group', 'Disable User Groups', cacti_sizeof($group_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __n('Disable User Group', 'Disable User Groups', cacti_sizeof($group_array)) . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -1379,7 +1379,7 @@ function user_group_realms_edit($header_label) {
 	print "<div class='cactiTable' style='width:100%;text-align:left;'>
 		<div>
 			<div class='cactiTableTitle'><span style='padding:3px;'>" . __('User Permissions') . ' ' . html_escape($header_label) . "</span></div>
-			<div class='cactiTableButton'><span style='padding:3px;'><input class='checkbox' type='checkbox' id='all' name='all' title='" . __esc('Select All') . "' onClick='selectAllRealms(this.checked)'><label class='formCheckboxLabel' title='" . __esc('Select All') . "' for='all'></label></a></span></div>
+			<div class='cactiTableButton'><span style='padding:3px;'><input class='checkbox selectAllRealms' type='checkbox' id='all' name='all' title='" . __esc('Select All') . "'><label class='formCheckboxLabel' title='" . __esc('Select All') . "' for='all'></label></a></span></div>
 		</div>
 	</div>";
 
@@ -1899,19 +1899,19 @@ function user_group() {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows').change(function() {
+		$('#rows').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2246,19 +2246,19 @@ function graph_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows, #graph_template_id').change(function() {
+		$('#rows, #graph_template_id').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2366,19 +2366,19 @@ function device_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows, #host_template_id').change(function() {
+		$('#rows, #host_template_id').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2481,19 +2481,19 @@ function template_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows').change(function() {
+		$('#rows').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2578,19 +2578,19 @@ function tree_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows').change(function() {
+		$('#rows').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2675,19 +2675,19 @@ function member_filter($header_label) {
 	}
 
 	$(function() {
-		$('#associated').click(function() {
+		$('#associated').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#rows').change(function() {
+		$('#rows').on('change', function() {
 			applyFilter();
 		});
 
-		$('#forms').submit(function(event) {
+		$('#forms').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});

--- a/utilities.php
+++ b/utilities.php
@@ -989,19 +989,23 @@ function utilities_view_user_log() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#username, #result, #rows').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#purge').click(function() {
+		$('#purge').on('click', function() {
 			purgeLog();
 		});
 
-		$('#form_userlog').submit(function(event) {
+		$('#form_userlog').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -1031,7 +1035,7 @@ function utilities_view_user_log() {
 						<?php print __('User');?>
 					</td>
 					<td>
-						<select id='username' onChange='applyFilter()'>
+						<select id='username'>
 							<option value='-1'<?php if (get_request_var('username') == '-1') {?> selected<?php }?>><?php print __('All');?></option>
 							<option value='-2'<?php if (get_request_var('username') == '-2') {?> selected<?php }?>><?php print __('Deleted/Invalid');?></option>
 							<?php
@@ -1049,7 +1053,7 @@ function utilities_view_user_log() {
 						<?php print __('Result');?>
 					</td>
 					<td>
-						<select id='result' onChange='applyFilter()'>
+						<select id='result'>
 							<option value='-1'<?php if (get_request_var('result') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 							<option value='1'<?php if (get_request_var('result') == '1') {?> selected<?php }?>><?php print __('Success - Password');?></option>
 							<option value='2'<?php if (get_request_var('result') == '2') {?> selected<?php }?>><?php print __('Success - Token');?></option>
@@ -1061,7 +1065,7 @@ function utilities_view_user_log() {
 						<?php print __('Attempts');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -1074,7 +1078,7 @@ function utilities_view_user_log() {
 					</td>
 					<td>
 						<span>
-							<input type='button' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __esc_x('Button: use filter settings', 'Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
+							<input type='submit' class='ui-button ui-corner-all ui-widget' id='refresh' value='<?php print __esc_x('Button: use filter settings', 'Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
 							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __esc_x('Button: reset filter settings', 'Clear');?>' title='<?php print __esc('Clear Filters');?>'>
 							<input type='button' class='ui-button ui-corner-all ui-widget' id='purge' value='<?php print __esc_x('Button: delete all table entries', 'Purge');?>' title='<?php print __esc('Purge User Log');?>'>
 						</span>
@@ -1339,19 +1343,23 @@ function utilities_view_logfile() {
 	}
 
 	$(function() {
-		$('#refreshme').click(function() {
+		$('#refreshme').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#filename, #tail_lines, #message_type, #reverse, #refresh').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#purge').click(function() {
+		$('#purge').on('click', function() {
 			purgeLog();
 		});
 
-		$('#form_logfile').submit(function(event) {
+		$('#form_logfile').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -1392,7 +1400,7 @@ function utilities_view_logfile() {
 						<?php print __('File');?>
 					</td>
 					<td>
-						<select id='filename' onChange='applyFilter()'>
+						<select id='filename'>
 							<?php
 							$logFileArray = clog_get_logfiles();
 
@@ -1419,7 +1427,7 @@ function utilities_view_logfile() {
 						<?php print __('Tail Lines');?>
 					</td>
 					<td>
-						<select id='tail_lines' onChange='applyFilter()'>
+						<select id='tail_lines'>
 							<?php
 							foreach($log_tail_lines AS $tail_lines => $display_text) {
 								print "<option value='" . $tail_lines . "'"; if (get_request_var('tail_lines') == $tail_lines) { print ' selected'; } print '>' . $display_text . '</option>';
@@ -1429,7 +1437,7 @@ function utilities_view_logfile() {
 					</td>
 					<td>
 						<span>
-							<input type='button' class='ui-button ui-corner-all ui-widget' id='refreshme' value='<?php print __esc_x('Button: use filter settings', 'Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
+							<input type='submit' class='ui-button ui-corner-all ui-widget' id='refreshme' value='<?php print __esc_x('Button: use filter settings', 'Go');?>' title='<?php print __esc('Set/Refresh Filters');?>'>
 							<input type='button' class='ui-button ui-corner-all ui-widget' id='clear' value='<?php print __esc_x('Button: reset filter settings', 'Clear');?>' title='<?php print __esc('Clear Filters');?>'>
 							<input type='button' class='ui-button ui-corner-all ui-widget' id='purge' value='<?php print __esc_x('Button: delete all table entries', 'Purge');?>' title='<?php print __esc('Purge Log');?>'>
 						</span>
@@ -1442,7 +1450,7 @@ function utilities_view_logfile() {
 						<?php print __('Type');?>
 					</td>
 					<td>
-						<select id='message_type' onChange='applyFilter()'>
+						<select id='message_type'>
 							<option value='-1'<?php if (get_request_var('message_type') == '-1') {?> selected<?php }?>><?php print __('All');?></option>
 							<option value='1'<?php if (get_request_var('message_type') == '1') {?> selected<?php }?>><?php print __('Stats');?></option>
 							<option value='2'<?php if (get_request_var('message_type') == '2') {?> selected<?php }?>><?php print __('Warnings');?></option>
@@ -1455,7 +1463,7 @@ function utilities_view_logfile() {
 						<?php print __('Display Order');?>
 					</td>
 					<td>
-						<select id='reverse' onChange='applyFilter()'>
+						<select id='reverse'>
 							<option value='1'<?php if (get_request_var('reverse') == '1') {?> selected<?php }?>><?php print __('Newest First');?></option>
 							<option value='2'<?php if (get_request_var('reverse') == '2') {?> selected<?php }?>><?php print __('Oldest First');?></option>
 						</select>
@@ -1464,7 +1472,7 @@ function utilities_view_logfile() {
 						<?php print __('Refresh');?>
 					</td>
 					<td>
-						<select id='refresh' onChange='applyFilter()'>
+						<select id='refresh'>
 							<?php
 							foreach($page_refresh_interval AS $seconds => $display_text) {
 								print "<option value='" . $seconds . "'"; if (get_request_var('refresh') == $seconds) { print ' selected'; } print '>' . $display_text . '</option>';
@@ -1517,7 +1525,7 @@ function utilities_view_logfile() {
 
 	$nav = html_nav_bar($base_url, MAX_DISPLAY_PAGES, $page_nr, $number_of_lines, $total_rows, 13, __('Entries'), 'page', 'main');
 
-	echo $nav;
+	print $nav;
 
 	html_start_box($start_string, '100%', '', '3', 'center', '');
 
@@ -1576,7 +1584,7 @@ function utilities_view_logfile() {
 	html_end_box();
 
 	if ($total_rows) {
-		echo $nav;
+		print $nav;
 	}
 
 	bottom_footer();
@@ -1701,15 +1709,15 @@ function utilities_view_snmp_cache() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_snmpcache').submit(function(event) {
+		$('#form_snmpcache').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -1994,15 +2002,15 @@ function utilities_view_poller_cache() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_pollercache').submit(function(event) {
+		$('#form_pollercache').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -2948,15 +2956,15 @@ function snmpagent_utilities_run_cache() {
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#form_snmpagent_cache').submit(function(event) {
+		$('#form_snmpagent_cache').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -3198,19 +3206,23 @@ function snmpagent_utilities_run_eventlog(){
 	}
 
 	$(function() {
-		$('#refresh').click(function() {
+		$('#refresh').on('click', function() {
 			applyFilter();
 		});
 
-		$('#clear').click(function() {
+		$('#severity, #receiver, #rows').on('change', function() {
+			applyFilter();
+		});
+
+		$('#clear').on('click', function() {
 			clearFilter();
 		});
 
-		$('#purge').click(function() {
+		$('#purge').on('click', function() {
 			purgeFilter();
 		});
 
-		$('#form_snmpagent_notifications').submit(function(event) {
+		$('#form_snmpagent_notifications').on('submit', function(event) {
 			event.preventDefault();
 			applyFilter();
 		});
@@ -3236,7 +3248,7 @@ function snmpagent_utilities_run_eventlog(){
 							<?php print __('Severity');?>
 						</td>
 						<td>
-							<select id='severity' onChange='applyFilter()'>
+							<select id='severity'>
 								<option value='-1'<?php if (get_request_var('severity') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 								<?php
 								foreach ($severity_levels as $level => $name) {
@@ -3249,7 +3261,7 @@ function snmpagent_utilities_run_eventlog(){
 							<?php print __('Receiver');?>
 						</td>
 						<td>
-							<select id='receiver' onChange='applyFilter()'>
+							<select id='receiver'>
 								<option value='-1'<?php if (get_request_var('receiver') == '-1') {?> selected<?php }?>><?php print __('Any');?></option>
 								<?php
 								foreach ($receivers as $receiver) {
@@ -3262,7 +3274,7 @@ function snmpagent_utilities_run_eventlog(){
 							<?php print __('Entries');?>
 						</td>
 						<td>
-							<select id='rows' onChange='applyFilter()'>
+							<select id='rows'>
 								<option value='-1'<?php if (get_request_var('rows') == '-1') {?> selected<?php }?>><?php print __('Default');?></option>
 								<?php
 								if (cacti_sizeof($item_rows)) {

--- a/vdef.php
+++ b/vdef.php
@@ -276,7 +276,7 @@ function vdef_form_actions() {
 					</td>
 				</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc_n('Delete VDEF', 'Delete VDEFs', cacti_sizeof($vdef_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc_n('Delete VDEF', 'Delete VDEFs', cacti_sizeof($vdef_array)) . "'>";
 		} elseif (get_nfilter_request_var('drp_action') === '2') { // duplicate
 			print "	<tr>
 					<td class='topBoxAlt'>
@@ -286,7 +286,7 @@ function vdef_form_actions() {
 					</td>
 				</tr>\n";
 
-			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget' value='" . __esc('Cancel') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc_n('Duplicate VDEF', 'Duplicate VDEFs', cacti_sizeof($vdef_array)) . "'>";
+			$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Cancel') . "'>&nbsp;<input type='submit' class='ui-button ui-corner-all ui-widget' value='" . __esc('Continue') . "' title='" . __esc_n('Duplicate VDEF', 'Duplicate VDEFs', cacti_sizeof($vdef_array)) . "'>";
 		}
 	} else {
 		raise_message(40);
@@ -485,7 +485,7 @@ function vdef_item_edit() {
 	?>
 	<script type='text/javascript' <?php print CactiSecureHeaders::getNonceAttribute();?>>
 	$(function() {
-		$('#type_select').unbind().change(function() {
+		$('#type_select').on('change', function() {
 			strURL  = 'vdef.php?action=item_edit';
 			strURL += '&id=' + $('#id').val();
 			strURL += '&vdef_id=' + $('#vdef_id').val();
@@ -669,14 +669,14 @@ function vdef_edit() {
 		$('#main').append("<div class='cdialog' id='cdialog'></div>");
 
 		<?php if (read_config_option('drag_and_drop') == 'on') { ?>
-		$('#vdef_item').unbind().tableDnD({
+		$('#vdef_item').tableDnD({
 			onDrop: function(table, row) {
 				loadPageNoHeader('vdef.php?action=ajax_dnd&id=<?php isset_request_var('id') ? print get_request_var('id') : print 0;?>&'+$.tableDnD.serialize());
 			}
 		});
 		<?php } ?>
 
-		$('.delete').unbind().click(function (event) {
+		$('.delete').on('click', function (event) {
 			event.preventDefault();
 
 			id = $(this).attr('id').split('_');
@@ -735,7 +735,7 @@ function vdef_filter() {
 						<?php print __('VDEFs');?>
 					</td>
 					<td>
-						<select id='rows' onChange='applyFilter()'>
+						<select id='rows'>
 							<option value='-1'<?php print (get_request_var('rows') == '-1' ? ' selected>':'>') . __('Default');?></option>
 							<?php
 							if (cacti_sizeof($item_rows)) {
@@ -754,7 +754,7 @@ function vdef_filter() {
                     </td>
 					<td>
 						<span>
-							<input type='button' class='ui-button ui-corner-all ui-widget' value='<?php print __esc_x('Button: use filter settings', 'Go');?>' id='refresh'>
+							<input type='submit' class='ui-button ui-corner-all ui-widget' value='<?php print __esc_x('Button: use filter settings', 'Go');?>' id='refresh'>
 							<input type='button' class='ui-button ui-corner-all ui-widget' value='<?php print __esc_x('Button: reset filter settings', 'Clear');?>' id='clear'>
 						</span>
 					</td>
@@ -777,19 +777,19 @@ function vdef_filter() {
 			}
 
 			$(function() {
-				$('#refresh').click(function() {
+				$('#refresh, #has_graphs').on('click', function() {
 					applyFilter();
 				});
 
-				$('#has_graphs').click(function() {
+				$('#rows').on('change', function() {
 					applyFilter();
 				});
 
-				$('#clear').click(function() {
+				$('#clear').on('click', function() {
 					clearFilter();
 				});
 
-				$('#form_vdef').submit(function(event) {
+				$('#form_vdef').on('submit', function(event) {
 					event.preventDefault();
 					applyFilter();
 				});


### PR DESCRIPTION
This change removes most of the remaining CSP warnings from the base Cacti.  There remain some CSP warnings in the following pages that needs to be remediated before the release of 1.2.32.  They include:

* User and User Group Permissions
* Graph Tree Rendering

The Graph Tree Rendering may be the version of jstree.js that is 5 minor versions out of date.

This change is not a show stopper for the 1.2.31 release.  Just getting things done.