### PR TITLE
security: fix sort_column SQL injection in reports list (GHSA-72vr-jr4v-55vf)

### DIFF
--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -1965,8 +1965,10 @@ function reports() {
 		$sql_join
 		$sql_where
 		ORDER BY " .
-		get_request_var('sort_column') . ' ' .
-		get_request_var('sort_direction') .
+		cacti_validate_sort_column(get_request_var('sort_column'),
+			array('name', 'cint', 'lastsent', 'mailtime', 'full_name', 'username', 'from_name', 'attachment_type', 'enabled'),
+			'name') . ' ' .
+		(get_request_var('sort_direction') === 'DESC' ? 'DESC' : 'ASC') .
 		' LIMIT ' . ($rows*(get_request_var('page')-1)) . ',' . $rows);
 
 	form_start(get_reports_page(), 'chk');


### PR DESCRIPTION
## Summary

- `lib/html_reports.php`: replace raw `get_request_var('sort_column')` concatenation in `ORDER BY` with `cacti_validate_sort_column()` using an explicit column allowlist

## Details

The reports list query concatenated `sort_column` and `sort_direction` directly into SQL without validation. An authenticated user could inject arbitrary SQL via the `sort_column` parameter.

The fix uses `cacti_validate_sort_column()` — already present in `lib/functions.php` via #7054 — with an explicit allowlist of the columns defined in `$display_text`. `sort_direction` is reduced to a binary `DESC`/`ASC` check, matching the pattern used by `utilities.php` and `user_domains.php`.

Advisory: GHSA-72vr-jr4v-55vf

## Files changed

- `lib/html_reports.php` — 1 file, 4 insertions, 2 deletions

## Test plan

- [ ] Reports list sorts correctly by each column (name, frequency, last run, next run, from, type, enabled)
- [ ] Passing `sort_column=name)UNION SELECT...` in the URL produces no SQL error and defaults to `name`
- [ ] `sort_direction` accepts only `ASC`/`DESC`; anything else defaults to `ASC`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)