### PR TITLE
fix(mailer): prevent null from_name reaching PHPMailer preg_replace()

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5119,10 +5119,12 @@ function mailer($from, $to, $cc, $bcc, $replyto, $subject, $body, $body_text = '
 		} else {
 			$from['email'] = 'Cacti@cacti.net';
 		}
+	}
 
-		if (empty($from['name'])) {
-			$from['name'] = 'Cacti';
-		}
+	// Ensure name is never null — PHPMailer passes it to preg_replace()
+	// which is deprecated for null in PHP 8.x.
+	if (empty($from['name'])) {
+		$from['name'] = 'Cacti';
 	}
 
 	$result = null;
@@ -5355,7 +5357,7 @@ function add_email_details($emails, &$result, callable $addFunc) {
 		if (!empty($e['email'])) {
 			//if (is_callable($addFunc)) {
 			if (!empty($addFunc)) {
-				$result = $addFunc($e['email'], $e['name']);
+				$result = $addFunc($e['email'], (string) $e['name']);
 				if (!$result) {
 					return '';
 				}

--- a/tests/Unit/MailerNullNameRegressionTest.php
+++ b/tests/Unit/MailerNullNameRegressionTest.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$functionsSource = file_get_contents(__DIR__ . '/../../lib/functions.php');
+
+// Locate the mailer() body once; all tests below slice from it.
+$mailerStart = strpos($functionsSource, 'function mailer(');
+$mailerEnd   = strpos($functionsSource, "\nfunction ", $mailerStart + 1);
+$mailerBody  = substr($functionsSource, $mailerStart, $mailerEnd - $mailerStart);
+
+// Locate the add_email_details() body once.
+$addEmailStart = strpos($functionsSource, 'function add_email_details(');
+$addEmailEnd   = strpos($functionsSource, "\nfunction ", $addEmailStart + 1);
+$addEmailBody  = substr($functionsSource, $addEmailStart, $addEmailEnd - $addEmailStart);
+
+test('mailer-null-name: null from_name falls back to Cacti literal before PHPMailer call', function () use ($mailerBody) {
+	// The fallback guard must appear after the settings lookup so that a null
+	// settings_from_name value never reaches PHPMailer as null.
+	$settingsPos  = strpos($mailerBody, "read_config_option('settings_from_name')");
+	$fallbackPos  = strpos($mailerBody, "\$from['name'] = 'Cacti'");
+
+	expect($settingsPos)->not->toBeFalse();
+	expect($fallbackPos)->not->toBeFalse();
+	// Guard comes after the settings read, not before.
+	expect($fallbackPos)->toBeGreaterThan($settingsPos);
+});
+
+test('mailer-null-name: from name fallback is inside an empty() guard, not an unconditional assignment', function () use ($mailerBody) {
+	// An unconditional assignment would overwrite a valid configured name.
+	// Confirm the 'Cacti' literal only appears inside a conditional block.
+	$pos = strpos($mailerBody, "\$from['name'] = 'Cacti'");
+	expect($pos)->not->toBeFalse();
+
+	// The nearest preceding control keyword must be 'if' (via empty()).
+	$preceding = substr($mailerBody, 0, $pos);
+	$lastIf    = strrpos($preceding, 'if (empty($from[\'name\'])');
+	expect($lastIf)->not->toBeFalse();
+});
+
+test('mailer-null-name: add_email_details casts name to string before the PHPMailer call', function () use ($addEmailBody) {
+	// PHPMailer passes the name argument to preg_replace(); passing null is a
+	// deprecated TypeError in PHP 8.x.  The cast must be present at the call site.
+	expect($addEmailBody)->toContain('(string) $e[\'name\']');
+});
+
+test('mailer-null-name: add_email_details does not pass $e[name] uncast to the address method', function () use ($addEmailBody) {
+	// Ensure no second call site passes the name without the cast.
+	// Count occurrences of the cast vs. bare references passed as arguments.
+	$castCount = substr_count($addEmailBody, "(string) \$e['name']");
+	$bareCount  = substr_count($addEmailBody, "\$addFunc(\$e['email'], \$e['name']");
+
+	expect($castCount)->toBeGreaterThanOrEqual(1);
+	expect($bareCount)->toBe(0);
+});


### PR DESCRIPTION
## Summary

Fixes the CMDPHP backtrace reported by bmfmancini:
```
PHP DEPRECATED: preg_replace(): Passing null to parameter #3 ($subject) ...
/include/vendor/phpmailer/src/PHPMailer.php on line: 1338
```

Two fixes in `lib/functions.php`:

**Fix 1 — `add_email_details()` line 5358**

Cast `$e['name']` to string before passing to the PHPMailer callable. `setFrom()` passes the name directly to `preg_replace()`, which deprecates null in PHP 8.x.

```diff
- $result = $addFunc($e['email'], $e['name']);
+ $result = $addFunc($e['email'], (string) $e['name']);
```

**Fix 2 — `mailer()` name fallback**

The `empty($from['name']) => 'Cacti'` guard was nested inside the `empty($from['email'])` block. When `settings_from_email` IS configured but `settings_from_name` is null/unconfigured, the name stayed null through to `setFrom()`. Moved the name fallback outside so it applies unconditionally.

## Root cause

`parse_email_details()` returns `null` for name when the report's `from_name` is null. `read_config_option('settings_from_name')` also returns null when the setting is unconfigured. The only existing null-guard was inside the email-empty block, so a configured email + unconfigured name bypassed it.

## Files changed

- `lib/functions.php` — 1 file, 6 insertions, 4 deletions

## Test plan

- [ ] Send a report with `from_name` empty in report settings — no PHP deprecated error in logs
- [ ] Send a report with `settings_from_name` unconfigured in Cacti settings — no PHP deprecated error
- [ ] Reports with fully configured from_name still send correctly
- [ ] Confirm report error handling still works when SMTP is misconfigured

🤖 Generated with [Claude Code](https://claude.ai/claude-code)