### PR TITLE
revert: Restore rrdtool hack to compensate for missing CFs in RRDfiles

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -230,7 +230,8 @@ jobs:
     - name: Add Device for Moc Test, Check CLI scripts for Errors
       run: |
         cd ${{ github.workspace }}
-        sudo php cli/add_device.php --description=test_device --ip=127.0.0.1 --template=24
+        template=$(php -q add_device.php --list-host-templates | grep "Net-SNMP Device" | awk '{print $1}')
+        sudo php cli/add_device.php --description=test_device --ip=127.0.0.1 --template=$template
         sudo php cli/rebuild_poller_cache.php --debug
         sudo php cli/poller_reindex_hosts.php --id=all --debug
 

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -3179,7 +3179,7 @@ function get_total_row_data($user_id, $sql, $sql_params = array(), $class = '', 
 	}
 
 	if (cacti_sizeof($sql_params)) {
-		$rows = db_fetch_cell($sql, $sql_params);
+		$rows = db_fetch_cell_prepared($sql, $sql_params);
 	} else {
 		$rows = db_fetch_cell($sql);
 	}

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1837,6 +1837,19 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 
 	if (cacti_sizeof($graph_items)) {
 		foreach ($graph_items as $graph_item) {
+			// ToDO: The code blcok appears to not be required as at the end of the block
+			// we simply discard the $cf_id for the computed 'cf_reference' that was already
+			// computed previously.
+
+			// Relative to the ToDo.  I believe that this was a hack put in where a user created a
+			// Data Template that did not include the CF required to generate the graph.  The
+			// cf_reference picks the CF of the first graph item and uses it as the CF.  So,
+			// instead of breaking these graphs, we use the cf_reference to ensure that RRDtool
+			// get's a legit CF.  In many cases, the Data Template, or in Cacti 1.2, the Data Source Profile
+			// misses the LAST consolidatin function.  So, we have to use either Average or Max depending
+			// on what showed up.  So, this code block can be discarded.  We will do this in the near
+			// future when we have more testers available.
+
 			/* hack around RRDtool behavior in first RRA */
 			$graph_cf = generate_graph_best_cf($graph_item['local_data_id'], $graph_item['consolidation_function_id'], $rra_seconds);
 
@@ -1845,8 +1858,8 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 			if (isset($cf_ds_cache[$graph_item['data_template_rrd_id']][$graph_cf])) {
 				$cf_id = $graph_item['consolidation_function_id'];
 			} else {
-			/* if there is not a DEF defined for the current data source/cf combination, then we will have to
-			improvise. choose the first available cf in the following order: AVERAGE, MAX, MIN, LAST */
+				/* if there is not a DEF defined for the current data source/cf combination, then we will have to
+				improvise. choose the first available cf in the following order: AVERAGE, MAX, MIN, LAST */
 				if (isset($cf_ds_cache[$graph_item['data_template_rrd_id']][1])) {
 					$cf_id = 1; /* CF: AVERAGE */
 				} elseif (isset($cf_ds_cache[$graph_item['data_template_rrd_id']][3])) {
@@ -1859,6 +1872,9 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					$cf_id = 1; /* CF: AVERAGE */
 				}
 			}
+
+			/* Compensate for RRDfiles that are missing CF's required for the Graph Template */
+			$cf_id = $graph_item['cf_reference'];
 
 			/* +++++++++++++++++++++++ GRAPH ITEMS: CDEF START +++++++++++++++++++++++ */
 

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1595,10 +1595,12 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 				case GRAPH_ITEM_TYPE_AREA:
 				case GRAPH_ITEM_TYPE_STACK:
 					$graph_cf = generate_graph_best_cf($graph_item['local_data_id'], $graph_item['consolidation_function_id'], $rra_seconds);
+
 					/* remember the last CF for this data source for use with GPRINT
 					 * if e.g. an AREA/AVERAGE and a LINE/MAX is used
 					 * we will have AVERAGE first and then MAX, depending on GPRINT sequence */
 					$last_graph_cf['data_source_name']['local_data_template_rrd_id'] = $graph_cf;
+
 					/* remember this for second foreach loop */
 					$graph_items[$key]['cf_reference'] = $graph_cf;
 
@@ -1619,28 +1621,35 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 						/* remember this for second foreach loop */
 						$graph_items[$key]['cf_reference'] = $graph_cf;
 					}
+
 					break;
 				case GRAPH_ITEM_TYPE_GPRINT_AVERAGE:
 					$graph_cf = $graph_item['consolidation_function_id'];
 					$graph_items[$key]['cf_reference'] = $graph_cf;
+
 					break;
 				case GRAPH_ITEM_TYPE_GPRINT_LAST:
 					$graph_cf = $graph_item['consolidation_function_id'];
 					$graph_items[$key]['cf_reference'] = $graph_cf;
+
 					break;
 				case GRAPH_ITEM_TYPE_GPRINT_MAX:
 					$graph_cf = $graph_item['consolidation_function_id'];
 					$graph_items[$key]['cf_reference'] = $graph_cf;
+
 					break;
 				case GRAPH_ITEM_TYPE_GPRINT_MIN:
 					$graph_cf = $graph_item['consolidation_function_id'];
 					$graph_items[$key]['cf_reference'] = $graph_cf;
+
 					break;
 				default:
 					/* all other types are based on the best matching CF */
 					$graph_cf = generate_graph_best_cf($graph_item['local_data_id'], $graph_item['consolidation_function_id'], $rra_seconds);
+
 					/* remember this for second foreach loop */
 					$graph_items[$key]['cf_reference'] = $graph_cf;
+
 					break;
 			}
 
@@ -1838,17 +1847,19 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 	if (cacti_sizeof($graph_items)) {
 		foreach ($graph_items as $graph_item) {
 			// ToDO: The code blcok appears to not be required as at the end of the block
-			// we simply discard the $cf_id for the computed 'cf_reference' that was already
+			// we simply discard the $cf_id for the computed 'cf_reference' that was
 			// computed previously.
 
 			// Relative to the ToDo.  I believe that this was a hack put in where a user created a
 			// Data Template that did not include the CF required to generate the graph.  The
-			// cf_reference picks the CF of the first graph item and uses it as the CF.  So,
+			// cf_reference picks the CF of the previously visible graph item and uses it as the CF.  So,
 			// instead of breaking these graphs, we use the cf_reference to ensure that RRDtool
-			// get's a legit CF.  In many cases, the Data Template, or in Cacti 1.2, the Data Source Profile
-			// misses the LAST consolidatin function.  So, we have to use either Average or Max depending
-			// on what showed up.  So, this code block can be discarded.  We will do this in the near
-			// future when we have more testers available.
+			// get's a legit DEF that includes the CF.  In many cases, the Data Template, or in Cacti 1.2,
+			// the Data Source Profile misses the LAST consolidatin function.  So, we have to use
+			// either Average or Max depending on what showed up.  So, this code block can be discarded.
+			// We will do this in the near future when we have more testers available.
+			//
+			// There are obvious logic flaws when I review ho the 'cf_reference' is calculated above.
 
 			/* hack around RRDtool behavior in first RRA */
 			$graph_cf = generate_graph_best_cf($graph_item['local_data_id'], $graph_item['consolidation_function_id'], $rra_seconds);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -419,9 +419,9 @@ dynamic_include	./lib/rrd.php:1346		include_once($config['library_path'] . '/gra
 dynamic_include	./lib/rrd.php:1347		include_once($config['library_path'] . '/boost.php');
 dynamic_include	./lib/rrd.php:1348		include_once($config['library_path'] . '/xml.php');
 dynamic_include	./lib/rrd.php:1349		include($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/rrd.php:2603			include($rrdtheme);
-dynamic_include	./lib/rrd.php:3208		include_once($config['library_path'] . '/time.php');
-dynamic_include	./lib/rrd.php:3979			include($themefile);
+dynamic_include	./lib/rrd.php:2630			include($rrdtheme);
+dynamic_include	./lib/rrd.php:3235		include_once($config['library_path'] . '/time.php');
+dynamic_include	./lib/rrd.php:4006			include($themefile);
 dynamic_include	./lib/rrd.php:590		include ($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/rrd.php:909		include($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/rrd.php:983		include_once($config['library_path'] . '/boost.php');

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -417,9 +417,9 @@ dynamic_include	./lib/rrd.php:1346		include_once($config['library_path'] . '/gra
 dynamic_include	./lib/rrd.php:1347		include_once($config['library_path'] . '/boost.php');
 dynamic_include	./lib/rrd.php:1348		include_once($config['library_path'] . '/xml.php');
 dynamic_include	./lib/rrd.php:1349		include($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/rrd.php:2603			include($rrdtheme);
-dynamic_include	./lib/rrd.php:3208		include_once($config['library_path'] . '/time.php');
-dynamic_include	./lib/rrd.php:3979			include($themefile);
+dynamic_include	./lib/rrd.php:2630			include($rrdtheme);
+dynamic_include	./lib/rrd.php:3235		include_once($config['library_path'] . '/time.php');
+dynamic_include	./lib/rrd.php:4006			include($themefile);
 dynamic_include	./lib/rrd.php:590		include ($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/rrd.php:909		include($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/rrd.php:983		include_once($config['library_path'] . '/boost.php');
@@ -574,7 +574,7 @@ fs_write	./lib/poller.php:1306												file_put_contents($mypath, $contents);
 fs_write	./lib/poller.php:1335								file_put_contents($mypath, $contents);
 fs_write	./lib/reports.php:1704			$f = fopen($fn, 'wb');
 fs_write	./lib/reports.php:1745			$f = fopen($fn, 'wb');
-fs_write	./lib/rrd.php:2490					if ($fp = fopen($graph_data_array['export_realtime'], 'w')) {
+fs_write	./lib/rrd.php:2517					if ($fp = fopen($graph_data_array['export_realtime'], 'w')) {
 fs_write	./lib/spikekill.php:780			return file_put_contents($xmlfile, $output);
 fs_write	./package_import.php:385					file_put_contents($xmlfile, $data);
 fs_write	./package_import.php:96		if (file_put_contents($xmlfile, $_SESSION['sess_import_package']) === false) {

--- a/tests/tools/check_all_pages.sh
+++ b/tests/tools/check_all_pages.sh
@@ -372,7 +372,7 @@ shutdown_handler() {
 
   save_log_files
 
-  exit 0
+  exit 1
 }
 
 normal_exit() {
@@ -385,13 +385,13 @@ normal_exit() {
     rm -f /tmp/vmstat.out
   fi
 
-  exit 0
+  exit $exit
 }
 
 # ------------------------------------------------------------------------------
 # To make sure that the autopkgtest/CI sites store the information
 # ------------------------------------------------------------------------------
-trap 'shutdown_handler' 1 2 3 6 9 14 15
+trap 'shutdown_handler' 1 2 3 6 14 15
 trap 'normal_exit' 0
 
 echo "NOTE: Current Directory is $(pwd)"
@@ -642,8 +642,8 @@ error=0
 if [ -n "${FILTERED_LOG}" ] ; then
   echo "ERROR: Fail Unexpected output in ${CACTI_LOG}:"
   echo "${FILTERED_LOG}"
-  exit 179
+  error=179
 else
   echo "NOTE: Success No unexpected output in ${CACTI_LOG}"
-  exit 0
+  error=0
 fi

--- a/tests/tools/check_all_pages.sh
+++ b/tests/tools/check_all_pages.sh
@@ -376,8 +376,6 @@ shutdown_handler() {
 }
 
 normal_exit() {
-  echo "NOTE: Process exiting normally.  Killing any background jobs"
-
   # Get rid of any jobs
   kill -SIGINT $(jobs -p) 2> /dev/null
 
@@ -385,7 +383,7 @@ normal_exit() {
     rm -f /tmp/vmstat.out
   fi
 
-  exit $exit
+  exit $error
 }
 
 # ------------------------------------------------------------------------------

--- a/utilities.php
+++ b/utilities.php
@@ -2156,6 +2156,7 @@ function utilities_view_poller_cache() {
 				dtd.name_cache LIKE ?
 				OR pi.arg1 LIKE ?
 				OR pi.rrd_path  LIKE ?)';
+
 			$params[] = '%' . get_request_var('filter') . '%';
 			$params[] = '%' . get_request_var('filter') . '%';
 			$params[] = '%' . get_request_var('filter') . '%';
@@ -2166,6 +2167,7 @@ function utilities_view_poller_cache() {
 				OR pi.arg1 LIKE ?
 				OR pi.hostname LIKE ?
 				OR pi.rrd_path  LIKE ?)';
+
 			$params[] = '%' . get_request_var('filter') . '%';
 			$params[] = '%' . get_request_var('filter') . '%';
 			$params[] = '%' . get_request_var('filter') . '%';


### PR DESCRIPTION
This change restores a hack that was placed back in the code some years ago where users were able to have a Data Source that did not include all the required Consolidation Functions and was therefore missing the DEF for that consolidation function in the RRDtool syntax.  This generally happened Pre Cacti 1.x where an RRA might have been accidentally dropped from the RRDfile.  The most common was "LAST" as it made no sense to keep this.

Without the hack, you get broken Cacti Graphs with out this hack.

I'm not 100% certain if the hack is even required in the modern RRDfile.  It's something we have to discuss in the context of architecture support moving forward.  For example, you can always get LAST of the Average DEF RRA.  It's complicated.