### PR TITLE
fix: dqselect dropdown change leaves rows permanently disabled after first graph creation

### DIFF
--- a/graphs_new.php
+++ b/graphs_new.php
@@ -989,7 +989,7 @@ function graphs() {
 			$('tr.notemplate').tooltip();
 
 			$('.dqselect').on('change', function() {
-				var prefix = $(this).data('prefix');
+				var prefix = $(this).data('prefix').split(',')[0];
 				dqUpdateDeps(prefix);
 			});
 		</script>";


### PR DESCRIPTION
**Do not merge until #7116 lands.**

## What

After creating graphs for one graph type (e.g. IN/OUT bits), switching the data query dropdown to a second type (e.g. IN/OUT Errors/Discards) left all interface rows locked in their disabled state, making it impossible to create additional graphs without a full page reload.

## Root cause

`data-prefix` on the `.dqselect` element is set to `"snmp_query_id,column_counter"` (e.g. `"7,5"`). The `change` handler passed this full string to `dqUpdateDeps()`. Inside that function the first thing it does is re-enable all rows via:

```js
$('tr[id^="dqline' + snmp_query_id + '_"]').addClass('selectable')...
```

With `snmp_query_id = "7,5"` that selector never matches anything, so no rows are re-enabled and the previously disabled rows stay locked.

## Fix

Split on `','` in the change handler and pass only the numeric snmp_query_id:

```js
var prefix = $(this).data('prefix').split(',')[0];
```

`dqUpdateDeps()` only uses the snmp_query_id; the column_counter portion of `data-prefix` is unused by that function.

Reported by @Macan in the project channel (2026-05-04).