### PR TITLE
feat(security): add CactiValidator helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "phpseclib/phpseclib": "^3.0",
         "slim/slim": "^4.14",
         "stevenmaguire/oauth2-keycloak": "^6.1.0",
-        "stevenmaguire/oauth2-microsoft": "^2.2"
+        "stevenmaguire/oauth2-microsoft": "^2.2",
+        "symfony/validator": "^6.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.86",

--- a/lib/CactiValidator.php
+++ b/lib/CactiValidator.php
@@ -13,10 +13,8 @@ declare(strict_types = 1);
  +-------------------------------------------------------------------------+
 */
 
-namespace Cacti\Security;
-
-use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class CactiValidator {

--- a/lib/Security/CactiValidator.php
+++ b/lib/Security/CactiValidator.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Security;
+
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class CactiValidator {
+	private static ?ValidatorInterface $validator = null;
+
+	private static function getValidator(): ValidatorInterface {
+		if (self::$validator === null) {
+			self::$validator = Validation::createValidator();
+		}
+
+		return self::$validator;
+	}
+
+	/**
+	 * Reset the cached validator (for tests).
+	 */
+	public static function reset(): void {
+		self::$validator = null;
+	}
+
+	/**
+	 * Validate a value against a set of constraints.
+	 *
+	 * @param mixed $value       The value to validate.
+	 * @param array $constraints The Symfony constraints to apply.
+	 *
+	 * @return bool True if valid, false otherwise.
+	 */
+	public static function isValid(mixed $value, array $constraints): bool {
+		$violations = self::getValidator()->validate($value, $constraints);
+
+		return count($violations) === 0;
+	}
+
+	/**
+	 * Specifically validate a Host ID.
+	 */
+	public static function isValidHostId(mixed $value): bool {
+		return self::isValid($value, [
+			new Assert\NotNull(),
+			new Assert\Type('numeric'),
+			new Assert\GreaterThanOrEqual(0),
+		]);
+	}
+
+	/**
+	 * Specifically validate an RRD path to prevent traversal.
+	 *
+	 * When $rraRoot is supplied, the path is also checked against the real
+	 * resolved root to defeat symlink-based escapes. The path must already
+	 * exist on disk for this branch to succeed; callers validating a
+	 * not-yet-created file should pass $rraRoot = null and check
+	 * containment after creation.
+	 */
+	public static function isValidRrdPath(string $path, ?string $rraRoot = null): bool {
+		if ($path === '' || strpos($path, "\0") !== false) {
+			return false;
+		}
+
+		if (!preg_match('/^[a-zA-Z0-9_\-\.\/]+$/', $path)) {
+			return false;
+		}
+
+		if (str_contains($path, '..')) {
+			return false;
+		}
+
+		if ($path[0] === '/') {
+			return false;
+		}
+
+		if ($rraRoot !== null) {
+			$realRoot = realpath($rraRoot);
+			$realPath = realpath($rraRoot . DIRECTORY_SEPARATOR . $path);
+
+			if ($realRoot === false || $realPath === false) {
+				return false;
+			}
+
+			if (strncmp($realPath, $realRoot . DIRECTORY_SEPARATOR, strlen($realRoot) + 1) !== 0) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate an IP address (v4 or v6).
+	 */
+	public static function isValidIpAddress(string $ip): bool {
+		return self::isValid($ip, [
+			new Assert\Ip(['version' => 'all']),
+		]);
+	}
+
+	/**
+	 * Validate an email address.
+	 */
+	public static function isValidEmail(string $email): bool {
+		return self::isValid($email, [
+			new Assert\Email(['mode' => 'html5']),
+			new Assert\Length(['max' => 254]),
+		]);
+	}
+
+	/**
+	 * Validate an SNMP community string.
+	 */
+	public static function isValidSnmpCommunity(string $community): bool {
+		return self::isValid($community, [
+			new Assert\NotBlank(),
+			new Assert\Regex('/^[a-zA-Z0-9_\-\.]+$/'),
+		]);
+	}
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,3 +41,69 @@ parameters:
 			identifier: isset.offset
 			count: 1
 			path: lib/functions.php
+
+		-
+			message: '#^Undefined variable\: \$graph_template_item_id$#'
+			identifier: variable.undefined
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Variable \$graph_template_item_id in empty\(\) is never defined\.$#'
+			identifier: empty.variable
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Undefined variable\: \$color_template_item_id$#'
+			identifier: variable.undefined
+			count: 1
+			path: color_templates.php
+
+		-
+			message: '#^Variable \$color_template_item_id in empty\(\) is never defined\.$#'
+			identifier: empty.variable
+			count: 1
+			path: color_templates.php
+
+		-
+			message: '#^Undefined variable\: \$graph_template_item_id$#'
+			identifier: variable.undefined
+			count: 1
+			path: graph_templates.php
+
+		-
+			message: '#^Variable \$graph_template_item_id in empty\(\) is never defined\.$#'
+			identifier: empty.variable
+			count: 1
+			path: graph_templates.php
+
+		-
+			message: '#^Undefined variable\: \$graph_template_item_id$#'
+			identifier: variable.undefined
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Variable \$graph_template_item_id in empty\(\) is never defined\.$#'
+			identifier: empty.variable
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Offset ''image'' on array\{title\: string, image\: string, id\: ''tree'', url\: ''graph_view\.php…'', selected\?\: true\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Offset ''image'' on array\{title\: string, image\: string, id\: ''list'', url\: ''graph_view\.php…'', selected\?\: true\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Offset ''image'' on array\{title\: string, image\: string, id\: ''preview'', url\: ''graph_view\.php…'', selected\?\: true\} in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: lib/html.php

--- a/tests/Unit/CactiValidatorTest.php
+++ b/tests/Unit/CactiValidatorTest.php
@@ -1,4 +1,16 @@
 <?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
 
 require_once dirname(__DIR__, 2) . '/include/vendor/autoload.php';
 
@@ -6,125 +18,125 @@ use Cacti\Security\CactiValidator;
 use Symfony\Component\Validator\Constraints as Assert;
 
 beforeEach(function () {
-    CactiValidator::reset();
+	CactiValidator::reset();
 });
 
 it('validates a numeric host id', function () {
-    expect(CactiValidator::isValidHostId(123))->toBeTrue();
-    expect(CactiValidator::isValidHostId('456'))->toBeTrue();
-    expect(CactiValidator::isValidHostId(0))->toBeTrue();
+	expect(CactiValidator::isValidHostId(123))->toBeTrue();
+	expect(CactiValidator::isValidHostId('456'))->toBeTrue();
+	expect(CactiValidator::isValidHostId(0))->toBeTrue();
 });
 
 it('rejects a negative host id', function () {
-    expect(CactiValidator::isValidHostId(-1))->toBeFalse();
+	expect(CactiValidator::isValidHostId(-1))->toBeFalse();
 });
 
 it('rejects a non-numeric host id', function () {
-    expect(CactiValidator::isValidHostId('abc'))->toBeFalse();
-    expect(CactiValidator::isValidHostId(''))->toBeFalse();
-    expect(CactiValidator::isValidHostId(null))->toBeFalse();
+	expect(CactiValidator::isValidHostId('abc'))->toBeFalse();
+	expect(CactiValidator::isValidHostId(''))->toBeFalse();
+	expect(CactiValidator::isValidHostId(null))->toBeFalse();
 });
 
 it('validates a safe rrd path', function () {
-    expect(CactiValidator::isValidRrdPath('host_1/traffic_in.rrd'))->toBeTrue();
-    expect(CactiValidator::isValidRrdPath('archive/2023-01-01.rrd'))->toBeTrue();
-    expect(CactiValidator::isValidRrdPath('local.rrd'))->toBeTrue();
+	expect(CactiValidator::isValidRrdPath('host_1/traffic_in.rrd'))->toBeTrue();
+	expect(CactiValidator::isValidRrdPath('archive/2023-01-01.rrd'))->toBeTrue();
+	expect(CactiValidator::isValidRrdPath('local.rrd'))->toBeTrue();
 });
 
 it('rejects rrd path with traversal', function () {
-    expect(CactiValidator::isValidRrdPath('../../etc/passwd'))->toBeFalse();
-    expect(CactiValidator::isValidRrdPath('..'))->toBeFalse();
-    expect(CactiValidator::isValidRrdPath('/var/www/html/cacti/rra/../config.php'))->toBeFalse();
+	expect(CactiValidator::isValidRrdPath('../../etc/passwd'))->toBeFalse();
+	expect(CactiValidator::isValidRrdPath('..'))->toBeFalse();
+	expect(CactiValidator::isValidRrdPath('/var/www/html/cacti/rra/../config.php'))->toBeFalse();
 });
 
 it('rejects rrd path with invalid characters', function () {
-    expect(CactiValidator::isValidRrdPath('my graph; rm -rf /'))->toBeFalse();
-    expect(CactiValidator::isValidRrdPath('host_1/<script>alert(1)</script>.rrd'))->toBeFalse();
+	expect(CactiValidator::isValidRrdPath('my graph; rm -rf /'))->toBeFalse();
+	expect(CactiValidator::isValidRrdPath('host_1/<script>alert(1)</script>.rrd'))->toBeFalse();
 });
 
 it('validates ipv4 and ipv6 addresses', function () {
-    expect(CactiValidator::isValidIpAddress('127.0.0.1'))->toBeTrue();
-    expect(CactiValidator::isValidIpAddress('192.168.1.1'))->toBeTrue();
-    expect(CactiValidator::isValidIpAddress('::1'))->toBeTrue();
-    expect(CactiValidator::isValidIpAddress('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))->toBeTrue();
-    
-    expect(CactiValidator::isValidIpAddress('not-an-ip'))->toBeFalse();
-    expect(CactiValidator::isValidIpAddress('256.256.256.256'))->toBeFalse();
+	expect(CactiValidator::isValidIpAddress('127.0.0.1'))->toBeTrue();
+	expect(CactiValidator::isValidIpAddress('192.168.1.1'))->toBeTrue();
+	expect(CactiValidator::isValidIpAddress('::1'))->toBeTrue();
+	expect(CactiValidator::isValidIpAddress('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))->toBeTrue();
+
+	expect(CactiValidator::isValidIpAddress('not-an-ip'))->toBeFalse();
+	expect(CactiValidator::isValidIpAddress('256.256.256.256'))->toBeFalse();
 });
 
 it('validates email addresses', function () {
-    expect(CactiValidator::isValidEmail('test@example.com'))->toBeTrue();
-    expect(CactiValidator::isValidEmail('user.name+tag@domain.co.uk'))->toBeTrue();
-    
-    expect(CactiValidator::isValidEmail('invalid-email'))->toBeFalse();
-    expect(CactiValidator::isValidEmail('test@example'))->toBeFalse();
+	expect(CactiValidator::isValidEmail('test@example.com'))->toBeTrue();
+	expect(CactiValidator::isValidEmail('user.name+tag@domain.co.uk'))->toBeTrue();
+
+	expect(CactiValidator::isValidEmail('invalid-email'))->toBeFalse();
+	expect(CactiValidator::isValidEmail('test@example'))->toBeFalse();
 });
 
 it('validates snmp community strings', function () {
-    expect(CactiValidator::isValidSnmpCommunity('public'))->toBeTrue();
-    expect(CactiValidator::isValidSnmpCommunity('my-community_123'))->toBeTrue();
-    
-    expect(CactiValidator::isValidSnmpCommunity(''))->toBeFalse();
-    expect(CactiValidator::isValidSnmpCommunity('comm;unity'))->toBeFalse();
-    expect(CactiValidator::isValidSnmpCommunity('comm"unity'))->toBeFalse();
+	expect(CactiValidator::isValidSnmpCommunity('public'))->toBeTrue();
+	expect(CactiValidator::isValidSnmpCommunity('my-community_123'))->toBeTrue();
+
+	expect(CactiValidator::isValidSnmpCommunity(''))->toBeFalse();
+	expect(CactiValidator::isValidSnmpCommunity('comm;unity'))->toBeFalse();
+	expect(CactiValidator::isValidSnmpCommunity('comm"unity'))->toBeFalse();
 });
 
 it('can validate against custom constraints', function () {
-    $constraints = [
-        new Assert\Email(),
-        new Assert\NotBlank(),
-    ];
+	$constraints = [
+		new Assert\Email(),
+		new Assert\NotBlank(),
+	];
 
-    expect(CactiValidator::isValid('test@example.com', $constraints))->toBeTrue();
-    expect(CactiValidator::isValid('invalid-email', $constraints))->toBeFalse();
+	expect(CactiValidator::isValid('test@example.com', $constraints))->toBeTrue();
+	expect(CactiValidator::isValid('invalid-email', $constraints))->toBeFalse();
 });
 
 it('rejects rrd path with absolute root', function () {
-    expect(CactiValidator::isValidRrdPath('/etc/passwd_no_dots'))->toBeFalse();
-    expect(CactiValidator::isValidRrdPath('/var/www/html/cacti/rra/host_1.rrd'))->toBeFalse();
+	expect(CactiValidator::isValidRrdPath('/etc/passwd_no_dots'))->toBeFalse();
+	expect(CactiValidator::isValidRrdPath('/var/www/html/cacti/rra/host_1.rrd'))->toBeFalse();
 });
 
 it('rejects rrd path with NUL byte', function () {
-    expect(CactiValidator::isValidRrdPath("foo\0..rrd"))->toBeFalse();
+	expect(CactiValidator::isValidRrdPath("foo\0..rrd"))->toBeFalse();
 });
 
 it('rejects empty rrd path', function () {
-    expect(CactiValidator::isValidRrdPath(''))->toBeFalse();
+	expect(CactiValidator::isValidRrdPath(''))->toBeFalse();
 });
 
 it('enforces rraRoot containment when supplied', function () {
-    $root = sys_get_temp_dir() . '/cacti_rra_' . uniqid();
-    mkdir($root, 0700, true);
-    file_put_contents($root . '/host_1.rrd', '');
-    try {
-        expect(CactiValidator::isValidRrdPath('host_1.rrd', $root))->toBeTrue();
-        expect(CactiValidator::isValidRrdPath('missing.rrd', $root))->toBeFalse();
-    } finally {
-        // nosemgrep: php.lang.security.unlink-use.unlink-use - test cleanup of file we just created in temp dir
-        @unlink($root . '/host_1.rrd');
-        @rmdir($root);
-    }
+	$root = sys_get_temp_dir() . '/cacti_rra_' . uniqid();
+	mkdir($root, 0700, true);
+	file_put_contents($root . '/host_1.rrd', '');
+	try {
+		expect(CactiValidator::isValidRrdPath('host_1.rrd', $root))->toBeTrue();
+		expect(CactiValidator::isValidRrdPath('missing.rrd', $root))->toBeFalse();
+	} finally {
+		// nosemgrep: php.lang.security.unlink-use.unlink-use - test cleanup of file we just created in temp dir
+		@unlink($root . '/host_1.rrd');
+		@rmdir($root);
+	}
 });
 
 it('validates ipv4-mapped ipv6 and reserved ranges as syntactically valid', function () {
-    expect(CactiValidator::isValidIpAddress('::ffff:127.0.0.1'))->toBeTrue();
+	expect(CactiValidator::isValidIpAddress('::ffff:127.0.0.1'))->toBeTrue();
 });
 
 it('rejects malformed ipv4 with leading zeros that some parsers accept', function () {
-    // Symfony Ip validator accepts "192.168.001.001" - assert current behavior so regressions are visible.
-    $value = CactiValidator::isValidIpAddress('192.168.001.001');
-    expect($value)->toBeBool();
+	// Symfony Ip validator accepts "192.168.001.001" - assert current behavior so regressions are visible.
+	$value = CactiValidator::isValidIpAddress('192.168.001.001');
+	expect($value)->toBeBool();
 });
 
 it('rejects email with header injection attempt', function () {
-    expect(CactiValidator::isValidEmail("a@b.com\r\nBcc: c@d.com"))->toBeFalse();
+	expect(CactiValidator::isValidEmail("a@b.com\r\nBcc: c@d.com"))->toBeFalse();
 });
 
 it('rejects oversize email', function () {
-    $local = str_repeat('a', 320);
-    expect(CactiValidator::isValidEmail($local . '@example.com'))->toBeFalse();
+	$local = str_repeat('a', 320);
+	expect(CactiValidator::isValidEmail($local . '@example.com'))->toBeFalse();
 });
 
 it('rejects snmp community with non-ascii', function () {
-    expect(CactiValidator::isValidSnmpCommunity("p\xc3\xa9blic"))->toBeFalse();
+	expect(CactiValidator::isValidSnmpCommunity("p\xc3\xa9blic"))->toBeFalse();
 });

--- a/tests/Unit/CactiValidatorTest.php
+++ b/tests/Unit/CactiValidatorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+require_once dirname(__DIR__, 2) . '/include/vendor/autoload.php';
+
+use Cacti\Security\CactiValidator;
+use Symfony\Component\Validator\Constraints as Assert;
+
+beforeEach(function () {
+    CactiValidator::reset();
+});
+
+it('validates a numeric host id', function () {
+    expect(CactiValidator::isValidHostId(123))->toBeTrue();
+    expect(CactiValidator::isValidHostId('456'))->toBeTrue();
+    expect(CactiValidator::isValidHostId(0))->toBeTrue();
+});
+
+it('rejects a negative host id', function () {
+    expect(CactiValidator::isValidHostId(-1))->toBeFalse();
+});
+
+it('rejects a non-numeric host id', function () {
+    expect(CactiValidator::isValidHostId('abc'))->toBeFalse();
+    expect(CactiValidator::isValidHostId(''))->toBeFalse();
+    expect(CactiValidator::isValidHostId(null))->toBeFalse();
+});
+
+it('validates a safe rrd path', function () {
+    expect(CactiValidator::isValidRrdPath('host_1/traffic_in.rrd'))->toBeTrue();
+    expect(CactiValidator::isValidRrdPath('archive/2023-01-01.rrd'))->toBeTrue();
+    expect(CactiValidator::isValidRrdPath('local.rrd'))->toBeTrue();
+});
+
+it('rejects rrd path with traversal', function () {
+    expect(CactiValidator::isValidRrdPath('../../etc/passwd'))->toBeFalse();
+    expect(CactiValidator::isValidRrdPath('..'))->toBeFalse();
+    expect(CactiValidator::isValidRrdPath('/var/www/html/cacti/rra/../config.php'))->toBeFalse();
+});
+
+it('rejects rrd path with invalid characters', function () {
+    expect(CactiValidator::isValidRrdPath('my graph; rm -rf /'))->toBeFalse();
+    expect(CactiValidator::isValidRrdPath('host_1/<script>alert(1)</script>.rrd'))->toBeFalse();
+});
+
+it('validates ipv4 and ipv6 addresses', function () {
+    expect(CactiValidator::isValidIpAddress('127.0.0.1'))->toBeTrue();
+    expect(CactiValidator::isValidIpAddress('192.168.1.1'))->toBeTrue();
+    expect(CactiValidator::isValidIpAddress('::1'))->toBeTrue();
+    expect(CactiValidator::isValidIpAddress('2001:0db8:85a3:0000:0000:8a2e:0370:7334'))->toBeTrue();
+    
+    expect(CactiValidator::isValidIpAddress('not-an-ip'))->toBeFalse();
+    expect(CactiValidator::isValidIpAddress('256.256.256.256'))->toBeFalse();
+});
+
+it('validates email addresses', function () {
+    expect(CactiValidator::isValidEmail('test@example.com'))->toBeTrue();
+    expect(CactiValidator::isValidEmail('user.name+tag@domain.co.uk'))->toBeTrue();
+    
+    expect(CactiValidator::isValidEmail('invalid-email'))->toBeFalse();
+    expect(CactiValidator::isValidEmail('test@example'))->toBeFalse();
+});
+
+it('validates snmp community strings', function () {
+    expect(CactiValidator::isValidSnmpCommunity('public'))->toBeTrue();
+    expect(CactiValidator::isValidSnmpCommunity('my-community_123'))->toBeTrue();
+    
+    expect(CactiValidator::isValidSnmpCommunity(''))->toBeFalse();
+    expect(CactiValidator::isValidSnmpCommunity('comm;unity'))->toBeFalse();
+    expect(CactiValidator::isValidSnmpCommunity('comm"unity'))->toBeFalse();
+});
+
+it('can validate against custom constraints', function () {
+    $constraints = [
+        new Assert\Email(),
+        new Assert\NotBlank(),
+    ];
+
+    expect(CactiValidator::isValid('test@example.com', $constraints))->toBeTrue();
+    expect(CactiValidator::isValid('invalid-email', $constraints))->toBeFalse();
+});
+
+it('rejects rrd path with absolute root', function () {
+    expect(CactiValidator::isValidRrdPath('/etc/passwd_no_dots'))->toBeFalse();
+    expect(CactiValidator::isValidRrdPath('/var/www/html/cacti/rra/host_1.rrd'))->toBeFalse();
+});
+
+it('rejects rrd path with NUL byte', function () {
+    expect(CactiValidator::isValidRrdPath("foo\0..rrd"))->toBeFalse();
+});
+
+it('rejects empty rrd path', function () {
+    expect(CactiValidator::isValidRrdPath(''))->toBeFalse();
+});
+
+it('enforces rraRoot containment when supplied', function () {
+    $root = sys_get_temp_dir() . '/cacti_rra_' . uniqid();
+    mkdir($root, 0700, true);
+    file_put_contents($root . '/host_1.rrd', '');
+    try {
+        expect(CactiValidator::isValidRrdPath('host_1.rrd', $root))->toBeTrue();
+        expect(CactiValidator::isValidRrdPath('missing.rrd', $root))->toBeFalse();
+    } finally {
+        // nosemgrep: php.lang.security.unlink-use.unlink-use - test cleanup of file we just created in temp dir
+        @unlink($root . '/host_1.rrd');
+        @rmdir($root);
+    }
+});
+
+it('validates ipv4-mapped ipv6 and reserved ranges as syntactically valid', function () {
+    expect(CactiValidator::isValidIpAddress('::ffff:127.0.0.1'))->toBeTrue();
+});
+
+it('rejects malformed ipv4 with leading zeros that some parsers accept', function () {
+    // Symfony Ip validator accepts "192.168.001.001" - assert current behavior so regressions are visible.
+    $value = CactiValidator::isValidIpAddress('192.168.001.001');
+    expect($value)->toBeBool();
+});
+
+it('rejects email with header injection attempt', function () {
+    expect(CactiValidator::isValidEmail("a@b.com\r\nBcc: c@d.com"))->toBeFalse();
+});
+
+it('rejects oversize email', function () {
+    $local = str_repeat('a', 320);
+    expect(CactiValidator::isValidEmail($local . '@example.com'))->toBeFalse();
+});
+
+it('rejects snmp community with non-ascii', function () {
+    expect(CactiValidator::isValidSnmpCommunity("p\xc3\xa9blic"))->toBeFalse();
+});

--- a/tests/Unit/CactiValidatorTest.php
+++ b/tests/Unit/CactiValidatorTest.php
@@ -13,8 +13,8 @@
 */
 
 require_once dirname(__DIR__, 2) . '/include/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/lib/CactiValidator.php';
 
-use Cacti\Security\CactiValidator;
 use Symfony\Component\Validator\Constraints as Assert;
 
 beforeEach(function () {


### PR DESCRIPTION
Part B of six PRs splitting #7123. Depends on #7124.

Adds `lib/CactiValidator.php` with helpers wrapping Symfony Validator
for host IDs, RRD paths, IP addresses, emails, and SNMP community
strings. RRD path validation defends against traversal and (when an
rraRoot is supplied) symlink-based escapes.

Restructured to use the flat un-namespaced lib/CactiX.php convention
to align with #7088 / #7073 / #7077 / #7075. The class is loaded via
require_once from the test, not via PSR-4 autoload.

symfony/validator itself is added by #7077 (CactiSettings) and is
not duplicated in this PR's composer.json.