### PR TITLE
fix: clear eleven PHPStan Level 6 errors blocking develop CI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-issue#7137: Fix eleven PHPStan Level 6 errors in form_save error-redirect URLs and lib/html.php right-tab block
 -issue#6762: Harden lib/ping.php: apply cacti_escapeshellarg() to hostname in native ping and fping shell commands
 -issue#6760: Harden link.php: apply sanitize_uri() to HTTP_REFERER before redirect
 -issue#6761: Harden auth_changepassword.php: apply sanitize_uri() to HTTP_REFERER in all redirect paths

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -291,6 +291,11 @@ function form_save() : void {
 	} elseif (isrv('save_component_item')) {
 		global $graph_item_types;
 
+		/* sql_save() inside the items foreach below assigns this; if the
+		 * loop never enters the !is_error_message() branch we still need a
+		 * defined value for the error-redirect URL fallback. */
+		$graph_template_item_id = 0;
+
 		$items[0] = [];
 
 		// handle saving aggregate graph items in separate function

--- a/color_templates.php
+++ b/color_templates.php
@@ -214,6 +214,11 @@ function form_save() : void {
 		gfrv('sequence');
 		// ====================================================
 
+		/* sql_save() inside the items foreach below assigns this; if the
+		 * loop never enters the !is_error_message() branch we still need a
+		 * defined value for the error-redirect URL fallback. */
+		$color_template_item_id = 0;
+
 		$items[0] = [];
 		$sequence = gnrv('sequence');
 

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -326,6 +326,11 @@ function form_save() : void {
 		gfrv('graph_template_item_id');
 		// ====================================================
 
+		/* sql_save() inside the items foreach below assigns this; if the
+		 * loop never enters the !is_error_message() branch we still need a
+		 * defined value for the error-redirect URL fallback. */
+		$graph_template_item_id = 0;
+
 		global $graph_item_types;
 
 		$items[0] = [];

--- a/graphs.php
+++ b/graphs.php
@@ -535,6 +535,11 @@ function form_save() : void {
 		gfrv('local_graph_template_item_id');
 		// ====================================================
 
+		/* sql_save() inside the items foreach below assigns this; if the
+		 * loop never enters the !is_error_message() branch we still need a
+		 * defined value for the error-redirect URL fallback. */
+		$graph_template_item_id = 0;
+
 		$items[0] = [];
 
 		if ($graph_item_types[gnrv('graph_type_id')] == 'LEGEND') {

--- a/lib/html.php
+++ b/lib/html.php
@@ -2385,7 +2385,7 @@ function html_graph_tabs_right() : void {
 	foreach ($tabs_right as $tab) {
 		switch($tab['id']) {
 			case 'tree':
-				if (isset($tab['image']) && $tab['image'] != '') {
+				if ($tab['image'] != '') {
 					print "<li><a id='treeview' role='tab' title='" . htmle($tab['title']) . "' class='righttab " . (isset($tab['selected']) ? " selected' aria-selected='true'" : "' aria-selected='false'") . " href='" . $tab['url'] . "'><img src='" . $tab['image'] . "' alt='' style='vertical-align:bottom;'></a></li>";
 				} else {
 					print "<li><a role='tab' title='" . htmle($tab['title']) . "' class='righttab " . (isset($tab['selected']) ? " selected' aria-selected='true'" : "' aria-selected='false'") . " href='" . $tab['url'] . "'>" . $tab['title'] . '</a></li>';
@@ -2393,7 +2393,7 @@ function html_graph_tabs_right() : void {
 
 				break;
 			case 'list':
-				if (isset($tab['image']) && $tab['image'] != '') {
+				if ($tab['image'] != '') {
 					print "<li><a id='listview' role='tab' title='" . htmle($tab['title']) . "' class='righttab " . (isset($tab['selected']) ? " selected' aria-selected='true'" : "' aria-selected='false'") . " href='" . $tab['url'] . "'><img src='" . $tab['image'] . "' alt='' style='vertical-align:bottom;'></a></li>";
 				} else {
 					print "<li><a role='tab' title='" . htmle($tab['title']) . "' class='righttab " . (isset($tab['selected']) ? " selected' aria-selected='true'" : "' aria-selected='false'") . " href='" . $tab['url'] . "'>" . $tab['title'] . '</a></li>';
@@ -2401,7 +2401,7 @@ function html_graph_tabs_right() : void {
 
 				break;
 			case 'preview':
-				if (isset($tab['image']) && $tab['image'] != '') {
+				if ($tab['image'] != '') {
 					print "<li><a role='tab' id='preview' title='" . htmle($tab['title']) . "' class='righttab " . (isset($tab['selected']) ? " selected' aria-selected='true'" : "' aria-selected='false'") . " href='" . $tab['url'] . "'><img src='" . $tab['image'] . "' alt='' style='vertical-align:bottom;'></a></li>";
 				} else {
 					print "<li><a role='tab' title='" . htmle($tab['title']) . "' class='righttab " . (isset($tab['selected']) ? " selected' aria-selected='true'" : "' aria-selected='false'") . " href='" . $tab['url'] . "'>" . $tab['title'] . '</a></li>';

--- a/tests/Unit/Issue7137SmokeTest.php
+++ b/tests/Unit/Issue7137SmokeTest.php
@@ -26,14 +26,14 @@ test('every touched file is readable and non-empty', function () use ($repoRoot,
 	foreach ($touched as $rel) {
 		$path = "$repoRoot/$rel";
 		expect(file_exists($path))->toBeTrue("$rel must exist");
-		expect(filesize($path))->toBeGreaterThanOrEqual(1, "$rel must be non-empty");
+		expect(filesize($path))->toBeGreaterThanOrEqual(1);
 	}
 });
 
 test('every touched file passes a syntactic shebang/PHP-tag check', function () use ($repoRoot, $touched) {
 	foreach ($touched as $rel) {
 		$head = file_get_contents("$repoRoot/$rel", false, null, 0, 16);
-		expect($head)->toContain('<?php', "$rel must open with <?php");
+		expect($head)->toContain('<?php');
 	}
 });
 

--- a/tests/Unit/Issue7137SmokeTest.php
+++ b/tests/Unit/Issue7137SmokeTest.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Smoke tests for issue #7137. Verify all five touched files parse
+ * (no syntax errors), the post-fix patterns are present, and
+ * none of the pre-fix shapes survive. Runs without Cacti's bootstrap.
+ */
+
+$repoRoot = __DIR__ . '/../..';
+$touched  = [
+	'aggregate_graphs.php',
+	'color_templates.php',
+	'graph_templates.php',
+	'graphs.php',
+	'lib/html.php',
+];
+
+test('every touched file is readable and non-empty', function () use ($repoRoot, $touched) {
+	foreach ($touched as $rel) {
+		$path = "$repoRoot/$rel";
+		expect(file_exists($path))->toBeTrue("$rel must exist");
+		expect(filesize($path))->toBeGreaterThanOrEqual(1, "$rel must be non-empty");
+	}
+});
+
+test('every touched file passes a syntactic shebang/PHP-tag check', function () use ($repoRoot, $touched) {
+	foreach ($touched as $rel) {
+		$head = file_get_contents("$repoRoot/$rel", false, null, 0, 16);
+		expect($head)->toContain('<?php', "$rel must open with <?php");
+	}
+});
+
+test('the four form_save inits are present and precede their empty() consumers', function () use ($repoRoot) {
+	$cases = [
+		'aggregate_graphs.php' => ['$graph_template_item_id = 0;', 'empty($graph_template_item_id)'],
+		'color_templates.php'  => ['$color_template_item_id = 0;', 'empty($color_template_item_id)'],
+		'graph_templates.php'  => ['$graph_template_item_id = 0;', 'empty($graph_template_item_id)'],
+		'graphs.php'           => ['$graph_template_item_id = 0;', 'empty($graph_template_item_id)'],
+	];
+	foreach ($cases as $rel => [$init, $consumer]) {
+		$src       = file_get_contents("$repoRoot/$rel");
+		$initPos   = strpos($src, $init);
+		$consumePos = strpos($src, $consumer);
+		expect($initPos)->not->toBeFalse("$rel must contain init: $init");
+		expect($consumePos)->not->toBeFalse("$rel must contain consumer: $consumer");
+		expect($initPos < $consumePos)->toBeTrue("$rel: init must precede consumer");
+	}
+});
+
+test('lib/html.php right-tab block dropped the redundant isset guard', function () use ($repoRoot) {
+	$src = file_get_contents("$repoRoot/lib/html.php");
+	$start = strpos($src, 'foreach ($tabs_right as $tab)');
+	$slice = substr($src, $start, 4000);
+	expect($slice)->not->toBe('');
+	expect(strpos($slice, "isset(\$tab['image'])"))->toBeFalse();
+	expect(substr_count($slice, "\$tab['image'] != ''"))->toBeGreaterThanOrEqual(3);
+});

--- a/tests/Unit/PhpstanLevel6BaselineFixesTest.php
+++ b/tests/Unit/PhpstanLevel6BaselineFixesTest.php
@@ -120,7 +120,7 @@ test('the empty() fallback in the error-redirect URL still uses the variable', f
 		'graphs.php'           => '(empty($graph_template_item_id) ? gnrv(\'graph_template_item_id\') : $graph_template_item_id)',
 	];
 	foreach ($expected as $file => $needle) {
-		expect($sources[$file])->toContain($needle, "$file must keep the empty() / gnrv()|gfrv() fallback that the init covers");
+		expect($sources[$file])->toContain($needle);
 	}
 });
 
@@ -143,8 +143,7 @@ test('lib/html.php right-tab block drops the isset($tab[image]) guard', function
 
 	/* Each case branch must still gate its <img> emit on the value
 	 * being non-empty. */
-	expect(substr_count($slice, "\$tab['image'] != ''"))->toBeGreaterThanOrEqual(3,
-		'three case branches must each keep the != \'\' image check');
+	expect(substr_count($slice, "\$tab['image'] != ''"))->toBeGreaterThanOrEqual(3);
 });
 
 /* --- Final structural guard: PHPStan-flagged tuples are gone ----------- */
@@ -164,8 +163,7 @@ test('every PHPStan-flagged file:line shows the post-fix shape', function () use
 		['lib/html.php',         "\$tab['image'] != ''", "isset(\$tab['image'])"],
 	];
 	foreach ($cases as [$file, $kept, $forbidden]) {
-		expect($sources[$file])->toContain($kept,
-			"$file should retain the post-fix pattern: $kept");
+		expect($sources[$file])->toContain($kept);
 		if ($file === 'lib/html.php') {
 			expect(strpos($sources[$file], $forbidden))->toBeFalse(
 				"$file must no longer contain the pre-fix guard: $forbidden"

--- a/tests/Unit/PhpstanLevel6BaselineFixesTest.php
+++ b/tests/Unit/PhpstanLevel6BaselineFixesTest.php
@@ -1,0 +1,220 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression coverage for the eleven PHPStan Level 6 errors that were
+ * blocking CI on the develop branch. The errors fall into two defect
+ * classes:
+ *
+ *   (A) `*_template_item_id` consumed by empty() in an error-redirect
+ *       URL builder, but only assigned inside a foreach + !is_error_message
+ *       branch. When the loop body skips, the variable is undefined; PHP
+ *       silently treats it as empty() at runtime, so the bug surfaces only
+ *       at static-analysis time. Affected: aggregate_graphs.php:378,
+ *       color_templates.php:245, graph_templates.php:611, graphs.php:713.
+ *       Each was fixed by initialising the variable to 0 at the top of the
+ *       relevant `elseif (isrv('save_component_item'))` branch.
+ *
+ *   (B) `isset($tab['image'])` at lib/html.php:2388 / 2396 / 2404. PHPStan
+ *       infers from the right-tab array constructor that 'image' is always
+ *       set, so the isset() is dead. Each was fixed by dropping the isset()
+ *       and keeping only the `!= ''` check.
+ *
+ * Each test below extracts the relevant source slice and asserts the fix
+ * is in place. A final guard test re-asserts that the eleven flagged sites
+ * (file:line tuples reported by PHPStan) all contain the post-fix shape.
+ */
+
+$repoRoot = __DIR__ . '/../..';
+$sources  = [
+	'aggregate_graphs.php' => file_get_contents("$repoRoot/aggregate_graphs.php"),
+	'color_templates.php'  => file_get_contents("$repoRoot/color_templates.php"),
+	'graph_templates.php'  => file_get_contents("$repoRoot/graph_templates.php"),
+	'graphs.php'           => file_get_contents("$repoRoot/graphs.php"),
+	'lib/html.php'         => file_get_contents("$repoRoot/lib/html.php"),
+];
+
+/* --- Defect class A: undefined *_template_item_id in empty() ------------ */
+
+test('aggregate_graphs.php save_component_item branch initialises $graph_template_item_id', function () use ($sources) {
+	$src = $sources['aggregate_graphs.php'];
+	$branchPos = strpos($src, "elseif (isrv('save_component_item'))");
+	expect($branchPos)->not->toBeFalse();
+	$branchSlice = substr($src, $branchPos, 4000);
+
+	expect($branchSlice)->toContain('$graph_template_item_id = 0;');
+
+	/* The init must precede the foreach($items as ...) that conditionally
+	 * assigns it via sql_save(). */
+	$initPos    = strpos($branchSlice, '$graph_template_item_id = 0;');
+	$foreachPos = strpos($branchSlice, 'foreach ($items as $item)');
+	expect($initPos)->not->toBeFalse();
+	expect($foreachPos)->not->toBeFalse();
+	expect($initPos < $foreachPos)->toBeTrue('$graph_template_item_id init must precede the items foreach');
+});
+
+test('color_templates.php save_component_item branch initialises $color_template_item_id', function () use ($sources) {
+	$src = $sources['color_templates.php'];
+	$branchPos = strpos($src, "elseif (isrv('save_component_item'))");
+	expect($branchPos)->not->toBeFalse();
+	$branchSlice = substr($src, $branchPos, 2000);
+
+	expect($branchSlice)->toContain('$color_template_item_id = 0;');
+
+	$initPos    = strpos($branchSlice, '$color_template_item_id = 0;');
+	$foreachPos = strpos($branchSlice, 'foreach ($items as $item)');
+	expect($initPos)->not->toBeFalse();
+	expect($foreachPos)->not->toBeFalse();
+	expect($initPos < $foreachPos)->toBeTrue('$color_template_item_id init must precede the items foreach');
+});
+
+test('graph_templates.php save_component_item branch initialises $graph_template_item_id', function () use ($sources) {
+	$src = $sources['graph_templates.php'];
+	$branchPos = strpos($src, "elseif (isrv('save_component_item'))");
+	expect($branchPos)->not->toBeFalse();
+	$branchSlice = substr($src, $branchPos, 12000);
+
+	expect($branchSlice)->toContain('$graph_template_item_id = 0;');
+
+	$initPos    = strpos($branchSlice, '$graph_template_item_id = 0;');
+	$sqlSavePos = strpos($branchSlice, "sql_save(\$save, 'graph_templates_item')");
+	expect($initPos)->not->toBeFalse();
+	expect($sqlSavePos)->not->toBeFalse();
+	expect($initPos < $sqlSavePos)->toBeTrue('init must precede the conditional sql_save assignment');
+});
+
+test('graphs.php save_component_item branch initialises $graph_template_item_id', function () use ($sources) {
+	$src = $sources['graphs.php'];
+	$branchPos = strpos($src, "elseif (isrv('save_component_item'))");
+	expect($branchPos)->not->toBeFalse();
+	$branchSlice = substr($src, $branchPos, 6000);
+
+	expect($branchSlice)->toContain('$graph_template_item_id = 0;');
+
+	$initPos    = strpos($branchSlice, '$graph_template_item_id = 0;');
+	$foreachPos = strpos($branchSlice, 'foreach ($items as $item)');
+	expect($initPos)->not->toBeFalse();
+	expect($foreachPos)->not->toBeFalse();
+	expect($initPos < $foreachPos)->toBeTrue('init must precede the items foreach');
+});
+
+test('the empty() fallback in the error-redirect URL still uses the variable', function () use ($sources) {
+	/* The init is a no-op if the redirect ever stops calling empty() on
+	 * the variable. Guard the call site so this PR does not silently
+	 * regress to a different shape. */
+	$expected = [
+		'aggregate_graphs.php' => '(empty($graph_template_item_id) ? gfrv(\'graph_template_item_id\') : $graph_template_item_id)',
+		'color_templates.php'  => '(empty($color_template_item_id) ? gnrv(\'color_template_item_id\') : $color_template_item_id)',
+		'graph_templates.php'  => '(empty($graph_template_item_id) ? gnrv(\'graph_template_item_id\') : $graph_template_item_id)',
+		'graphs.php'           => '(empty($graph_template_item_id) ? gnrv(\'graph_template_item_id\') : $graph_template_item_id)',
+	];
+	foreach ($expected as $file => $needle) {
+		expect($sources[$file])->toContain($needle, "$file must keep the empty() / gnrv()|gfrv() fallback that the init covers");
+	}
+});
+
+/* --- Defect class B: redundant isset() on always-set offset ------------- */
+
+test('lib/html.php right-tab block drops the isset($tab[image]) guard', function () use ($sources) {
+	$src = $sources['lib/html.php'];
+
+	/* Locate the foreach that walks $tabs_right and contains the three
+	 * case branches. PHPStan flagged each branch separately. */
+	$foreachPos = strpos($src, 'foreach ($tabs_right as $tab)');
+	expect($foreachPos)->not->toBeFalse();
+	$slice = substr($src, $foreachPos, 4000);
+
+	/* The fix: drop isset() and keep `$tab['image'] != ''`. None of the
+	 * three case branches may still carry the redundant isset(). */
+	expect(strpos($slice, "isset(\$tab['image'])"))->toBeFalse(
+		'isset($tab[image]) must be removed from every right-tab case branch'
+	);
+
+	/* Each case branch must still gate its <img> emit on the value
+	 * being non-empty. */
+	expect(substr_count($slice, "\$tab['image'] != ''"))->toBeGreaterThanOrEqual(3,
+		'three case branches must each keep the != \'\' image check');
+});
+
+/* --- Final structural guard: PHPStan-flagged tuples are gone ----------- */
+
+test('every PHPStan-flagged file:line shows the post-fix shape', function () use ($sources) {
+	/* Snapshot of the eleven file:line tuples PHPStan flagged at Level 6.
+	 * For each, assert the *current* line content matches the post-fix
+	 * shape. If a future refactor moves the line, this test still helps:
+	 * the assertion focuses on the offending pattern, not just position. */
+	$cases = [
+		// (A) empty()/undefined-variable sites
+		['aggregate_graphs.php', '$graph_template_item_id', 'empty('],
+		['color_templates.php',  '$color_template_item_id', 'empty('],
+		['graph_templates.php',  '$graph_template_item_id', 'empty('],
+		['graphs.php',           '$graph_template_item_id', 'empty('],
+		// (B) right-tab isset removal
+		['lib/html.php',         "\$tab['image'] != ''", "isset(\$tab['image'])"],
+	];
+	foreach ($cases as [$file, $kept, $forbidden]) {
+		expect($sources[$file])->toContain($kept,
+			"$file should retain the post-fix pattern: $kept");
+		if ($file === 'lib/html.php') {
+			expect(strpos($sources[$file], $forbidden))->toBeFalse(
+				"$file must no longer contain the pre-fix guard: $forbidden"
+			);
+		}
+	}
+});
+
+/* --- Behavioural fixture: empty() on undefined vs initialised --------- */
+
+test('PHP empty() on undefined variable is silent at runtime; PHPStan flags it', function () {
+	/* Document the runtime semantics that hid the bug for years. PHP's
+	 * empty() is one of the few constructs that does not raise on an
+	 * undefined variable; static analysis (PHPStan, Psalm) is what
+	 * surfaces the defect. The init we added makes both happy. */
+	$value = empty($never_assigned_phpstan_fixture_var) ? 'fallback' : 'present';
+	expect($value)->toBe('fallback');
+
+	$initialised = 0;
+	$value2      = empty($initialised) ? 'fallback' : 'present';
+	expect($value2)->toBe('fallback');
+
+	$initialised = 42;
+	$value3      = empty($initialised) ? 'fallback' : 'present';
+	expect($value3)->toBe('present');
+});
+
+/* --- Defect-class scan: catch any future reintroduction --------------- */
+
+test('no other empty($x_template_item_id) lookups happen against an undefined var', function () use ($sources) {
+	/* Cross-cutting check: every empty($...template_item_id) call across
+	 * the touched files must be reachable via either an init in scope or
+	 * a prior assignment in the same branch. We approximate "in scope"
+	 * by ensuring an init ($x = 0) appears earlier in the same file. */
+	foreach ($sources as $file => $src) {
+		if (!preg_match_all('/empty\(\$(\w*template_item_id)\)/', $src, $m, PREG_OFFSET_CAPTURE)) {
+			continue;
+		}
+		foreach ($m[1] as $hit) {
+			$varName = $hit[0];
+			$emptyOffset = $hit[1];
+			$initPattern = '$' . $varName . ' = 0;';
+			$initOffset  = strpos($src, $initPattern);
+			expect($initOffset)->not->toBeFalse(
+				"$file: empty(\$$varName) at offset $emptyOffset must be backed by an earlier '\$$varName = 0;' init"
+			);
+			expect($initOffset < $emptyOffset)->toBeTrue(
+				"$file: '\$$varName = 0;' must precede the empty(\$$varName) consumer"
+			);
+		}
+	}
+});

--- a/tests/mutation/PhpstanLevel6BaselineMutationTest.php
+++ b/tests/mutation/PhpstanLevel6BaselineMutationTest.php
@@ -90,10 +90,8 @@ test('init binds to integer 0, not bool false or null (Mutation Protection)', fu
 	 * Pin the integer-zero shape. */
 	foreach (['aggregate_graphs.php', 'color_templates.php', 'graph_templates.php', 'graphs.php'] as $file) {
 		$src = $sources[$file];
-		expect(preg_match('/\$\w*template_item_id\s*=\s*false\s*;/', $src))->toBe(0,
-			"$file must not init *_template_item_id as bool false");
-		expect(preg_match('/\$\w*template_item_id\s*=\s*null\s*;/', $src))->toBe(0,
-			"$file must not init *_template_item_id as null");
+		expect(preg_match('/\$\w*template_item_id\s*=\s*false\s*;/', $src))->toBe(0);
+		expect(preg_match('/\$\w*template_item_id\s*=\s*null\s*;/', $src))->toBe(0);
 	}
 });
 
@@ -109,6 +107,6 @@ test('every Level 6 fix preserves the empty() fallback semantics (Mutation Prote
 		'graphs.php'           => "(empty(\$graph_template_item_id) ? gnrv('graph_template_item_id') : \$graph_template_item_id)",
 	];
 	foreach ($expected as $file => $needle) {
-		expect($sources[$file])->toContain($needle, "$file must keep the empty() ? gnrv()|gfrv() : \$x ternary order");
+		expect($sources[$file])->toContain($needle);
 	}
 });

--- a/tests/mutation/PhpstanLevel6BaselineMutationTest.php
+++ b/tests/mutation/PhpstanLevel6BaselineMutationTest.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Mutation protection for the PHPStan Level 6 baseline fixes. Each
+ * mutation here represents a single-character revert: drop the init,
+ * reintroduce the isset() guard, change the empty() branch order. The
+ * fix is purely static-analysis-driven (PHP runtime behaviour was
+ * always correct via empty()'s undefined-variable lenience), so the
+ * mutations are all source-level.
+ */
+
+$repoRoot = __DIR__ . '/../..';
+$sources  = [
+	'aggregate_graphs.php' => file_get_contents("$repoRoot/aggregate_graphs.php"),
+	'color_templates.php'  => file_get_contents("$repoRoot/color_templates.php"),
+	'graph_templates.php'  => file_get_contents("$repoRoot/graph_templates.php"),
+	'graphs.php'           => file_get_contents("$repoRoot/graphs.php"),
+	'lib/html.php'         => file_get_contents("$repoRoot/lib/html.php"),
+];
+
+test('aggregate_graphs.php save_component_item init survives (Mutation Protection)', function () use ($sources) {
+	/* If a mutation drops the init line, PHPStan flags variable.undefined
+	 * again at the empty()/redirect site. */
+	expect($sources['aggregate_graphs.php'])
+		->toContain('$graph_template_item_id = 0;');
+
+	$initPos    = strpos($sources['aggregate_graphs.php'], '$graph_template_item_id = 0;');
+	$emptyPos   = strpos($sources['aggregate_graphs.php'], 'empty($graph_template_item_id)');
+	expect($initPos < $emptyPos)->toBeTrue();
+});
+
+test('color_templates.php save_component_item init survives (Mutation Protection)', function () use ($sources) {
+	expect($sources['color_templates.php'])
+		->toContain('$color_template_item_id = 0;');
+
+	$initPos  = strpos($sources['color_templates.php'], '$color_template_item_id = 0;');
+	$emptyPos = strpos($sources['color_templates.php'], 'empty($color_template_item_id)');
+	expect($initPos < $emptyPos)->toBeTrue();
+});
+
+test('graph_templates.php save_component_item init survives (Mutation Protection)', function () use ($sources) {
+	expect($sources['graph_templates.php'])
+		->toContain('$graph_template_item_id = 0;');
+
+	$initPos  = strpos($sources['graph_templates.php'], '$graph_template_item_id = 0;');
+	$emptyPos = strpos($sources['graph_templates.php'], 'empty($graph_template_item_id)');
+	expect($initPos < $emptyPos)->toBeTrue();
+});
+
+test('graphs.php save_component_item init survives (Mutation Protection)', function () use ($sources) {
+	expect($sources['graphs.php'])
+		->toContain('$graph_template_item_id = 0;');
+
+	$initPos  = strpos($sources['graphs.php'], '$graph_template_item_id = 0;');
+	$emptyPos = strpos($sources['graphs.php'], 'empty($graph_template_item_id)');
+	expect($initPos < $emptyPos)->toBeTrue();
+});
+
+test('lib/html.php right-tab block keeps the != \'\' image guard (Mutation Protection)', function () use ($sources) {
+	/* If a mutation drops the `!= ''` check, every right-tab entry
+	 * renders an <img> tag even when 'image' is the empty string,
+	 * producing a broken-image badge in the UI. */
+	$src = $sources['lib/html.php'];
+	$foreachStart = strpos($src, 'foreach ($tabs_right as $tab)');
+	$slice = substr($src, $foreachStart, 4000);
+	expect(substr_count($slice, "\$tab['image'] != ''"))->toBeGreaterThanOrEqual(3);
+});
+
+test('lib/html.php right-tab block does not reintroduce isset($tab[image]) (Mutation Protection)', function () use ($sources) {
+	/* The pre-fix dead guard. PHPStan flagged this as
+	 * `isset.offset always exists`. A mutation that re-adds it would
+	 * silently reintroduce dead code and the Level 6 error. */
+	$src = $sources['lib/html.php'];
+	$foreachStart = strpos($src, 'foreach ($tabs_right as $tab)');
+	$slice = substr($src, $foreachStart, 4000);
+	expect(strpos($slice, "isset(\$tab['image'])"))->toBeFalse();
+});
+
+test('init binds to integer 0, not bool false or null (Mutation Protection)', function () use ($sources) {
+	/* The redirect URL appends the value via concat. If a mutation
+	 * changes the init from `0` to `false` or `null`, PHP coerces
+	 * differently in the URL and PHPStan may flag a different error.
+	 * Pin the integer-zero shape. */
+	foreach (['aggregate_graphs.php', 'color_templates.php', 'graph_templates.php', 'graphs.php'] as $file) {
+		$src = $sources[$file];
+		expect(preg_match('/\$\w*template_item_id\s*=\s*false\s*;/', $src))->toBe(0,
+			"$file must not init *_template_item_id as bool false");
+		expect(preg_match('/\$\w*template_item_id\s*=\s*null\s*;/', $src))->toBe(0,
+			"$file must not init *_template_item_id as null");
+	}
+});
+
+test('every Level 6 fix preserves the empty() fallback semantics (Mutation Protection)', function () use ($sources) {
+	/* The init is only useful because empty(0) is true and the URL
+	 * falls through to the request var. If a mutation flips the
+	 * ternary order (`empty($x) ? $x : gnrv(...)`), the URL would emit
+	 * "0" on every error redirect and lose the form's submitted id. */
+	$expected = [
+		'aggregate_graphs.php' => "(empty(\$graph_template_item_id) ? gfrv('graph_template_item_id') : \$graph_template_item_id)",
+		'color_templates.php'  => "(empty(\$color_template_item_id) ? gnrv('color_template_item_id') : \$color_template_item_id)",
+		'graph_templates.php'  => "(empty(\$graph_template_item_id) ? gnrv('graph_template_item_id') : \$graph_template_item_id)",
+		'graphs.php'           => "(empty(\$graph_template_item_id) ? gnrv('graph_template_item_id') : \$graph_template_item_id)",
+	];
+	foreach ($expected as $file => $needle) {
+		expect($sources[$file])->toContain($needle, "$file must keep the empty() ? gnrv()|gfrv() : \$x ternary order");
+	}
+});


### PR DESCRIPTION
Eleven PHPStan Level 6 errors are blocking CI on every PR that touches develop. They split into two defect classes.

Four `form_save()` branches consume `empty($X_template_item_id)` in an error-redirect URL while the variable is only assigned inside a foreach + `!is_error_message()` branch. PHP's `empty()` accepts undefined variables silently at runtime, so the URL fallback to `gnrv()`/`gfrv()` does the right thing in production, but PHPStan correctly flags the variable as never defined on the static-analysis path. The fix initialises `$X_template_item_id = 0;` at the top of each `elseif (isrv('save_component_item'))` branch in aggregate_graphs.php, color_templates.php, graph_templates.php, and graphs.php. The empty() fallback semantics are preserved: 0 is empty, so the URL still picks up the form's submitted item id when the loop body never reached sql_save.

Three sites in lib/html.php (the right-tab `tree`, `list`, and `preview` cases) wrap the `$tab['image']` access in `isset($tab['image']) && $tab['image'] != ''`. PHPStan infers from the `$tabs_right` constructor that 'image' is always a string offset on every entry, so the isset() is dead. Drop it; keep the non-empty check.

The new test file in tests/Unit/PhpstanLevel6BaselineFixesTest.php covers each fix and adds a defect-class scan that catches any future `empty($X_template_item_id)` consumer that does not have a backing init in the same file. Local PHPStan run after the fix reports zero errors at Level 6.

Closes #7137