### PR TITLE
fix: [Security] SQL Injection in cacti endpoint

### DIFF
--- a/data_debug.php
+++ b/data_debug.php
@@ -109,8 +109,8 @@ switch (grv('action')) {
 	case 'ajax_hosts':
 		$sql_where = '';
 
-		if (grv('site_id') > 0) {
-			$sql_where = 'site_id = ' . grv('site_id');
+		if (gfrv('site_id') > 0) {
+			$sql_where = 'site_id = ' . gfrv('site_id');
 		}
 
 		get_allowed_ajax_hosts(true, true, $sql_where);
@@ -119,8 +119,8 @@ switch (grv('action')) {
 	case 'ajax_hosts_noany':
 		$sql_where = '';
 
-		if (grv('site_id') > 0) {
-			$sql_where = 'site_id = ' . grv('site_id');
+		if (gfrv('site_id') > 0) {
+			$sql_where = 'site_id = ' . gfrv('site_id');
 		}
 
 		get_allowed_ajax_hosts(false, true, $sql_where);

--- a/data_sources.php
+++ b/data_sources.php
@@ -87,8 +87,8 @@ switch (grv('action')) {
 	case 'ajax_hosts':
 		$sql_where = '';
 
-		if (grv('site_id') > 0) {
-			$sql_where = 'site_id = ' . grv('site_id');
+		if (gfrv('site_id') > 0) {
+			$sql_where = 'site_id = ' . gfrv('site_id');
 		}
 
 		get_allowed_ajax_hosts(true, true, $sql_where);
@@ -97,8 +97,8 @@ switch (grv('action')) {
 	case 'ajax_hosts_noany':
 		$sql_where = '';
 
-		if (grv('site_id') > 0) {
-			$sql_where = 'site_id = ' . grv('site_id');
+		if (gfrv('site_id') > 0) {
+			$sql_where = 'site_id = ' . gfrv('site_id');
 		}
 
 		get_allowed_ajax_hosts(false, true, $sql_where);

--- a/reports.php
+++ b/reports.php
@@ -96,12 +96,12 @@ switch (grv('action')) {
 
 		$sql_where = '';
 
-		if (grv('site_id') > 0) {
-			$sql_where .= ($sql_where != '' ? ' AND ' : '') . 'h.site_id = ' . grv('site_id');
+		if (gfrv('site_id') > 0) {
+			$sql_where .= ($sql_where != '' ? ' AND ' : '') . 'h.site_id = ' . gfrv('site_id');
 		}
 
-		if (grv('host_template_id') > 0) {
-			$sql_where .= ($sql_where != '' ? ' AND ' : '') . 'h.host_template_id = ' . grv('host_template_id');
+		if (gfrv('host_template_id') > 0) {
+			$sql_where .= ($sql_where != '' ? ' AND ' : '') . 'h.host_template_id = ' . gfrv('host_template_id');
 		}
 
 		get_allowed_ajax_hosts(true, true, $sql_where);


### PR DESCRIPTION
# Vulnerability Report — Cacti

## Summary
- **Product**        : Cacti — https://github.com/Cacti/cacti
- **Version**        : v1.2.30 (and likely earlier versions)
- **Vulnerability**  : Authenticated SQL Injection via `site_id` parameter in AJAX host endpoints
- **Severity**       : High
- **CVSS Score**     : 8.8 — CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
- **CWE**            : CWE-89 — Improper Neutralization of Special Elements used in an SQL Command
- **Discovered by**  : Nguyen Cong Tu (iaohkut)
- **Disclosure date**: 07/05/2026

---

## Vulnerability Details

### Description

Three AJAX endpoints in Cacti — `data_sources.php`, `data_debug.php`, and `reports.php` — accept a `site_id` GET parameter that is concatenated directly into a SQL query without sanitization. An authenticated attacker with Realm 3 (Sites/Devices/Data) access can inject arbitrary SQL through the `site_id` parameter when triggering the `ajax_hosts` action, allowing them to extract any data from the database including administrator password hashes, SNMP community strings, and API keys.

The root cause is the use of `grv()` (raw input function) instead of `gfrv()` (integer-validated function) for numeric input handling. PHP's loose type coercion allows the string `"1 AND payload"` to pass the guard check `grv('site_id') > 0` because PHP evaluates `"1 AND payload"` as the integer `1`. The injected string is then concatenated verbatim into SQL.

The vulnerability is confirmed exploitable via boolean-based blind injection: the number of JSON records returned by the endpoint differs depending on whether the injected SQL condition is TRUE or FALSE, allowing bit-by-bit data extraction.

### Affected Code

**File**: `data_sources.php`  
**Lines**: 87–92

**File**: `data_debug.php`  
**Lines**: 109–114 (identical pattern, requires Realm 15)

**File**: `reports.php`  
**Lines**: ~94–103 (also vulnerable on `host_template_id`, requires Realm 22)

**SQL Sink** — `lib/auth.php:get_allowed_devices()`, line 2758.

### Root Cause

`grv()` is an alias for `get_request_var()` which returns the raw `$_REQUEST` value without integer validation when the `CactiTableFilter` sanitization pipeline has not been invoked. For AJAX actions like `ajax_hosts`, the request is handled by a direct switch-case that skips `CactiTableFilter::sanitize_filter_variables()`. PHP's loose comparison (`grv('site_id') > 0`) allows strings like `"1 AND SLEEP(5)"` to pass the guard check because PHP coerces the string to the integer `1`.

---

## Proof of Concept

### Verification Summary (Confirmed Against Live Instance)

Tested against Cacti running at `http://localhost:8082/cacti/` (Cacti v1.3.0).

```
Using the method Blind Injection to exploit this vulnerability.
```

### Attack Scenario

1. Attacker has a Cacti account with Realm 3 (Sites/Devices/Data) — the lowest privilege level.
2. Attacker sends a crafted GET request to `data_sources.php?action=ajax_hosts` with condition query.
3. If the response contains devices, the condition is TRUE (character matches). If no devices, condition is FALSE.
4. Repeat for each character of the target value (password hash, SNMP strings, etc.).
5. With enough requests, attacker reconstructs the full admin bcrypt hash and may attempt offline cracking.

### Steps to Reproduce

1. Log in to Cacti with any account that has Realm 3 access.
2. Send the request (adjust session cookie) with True condition query.
3. Observe that validate data appears in the JSON response.
4. Now change to True condition query — validate data disappears. This confirms injection.
5. Use the subquery payload above to extract data character by character.

### Impact

- Any data in the Cacti database can be read, including:
  - `user_auth.password` — admin and all user bcrypt hashes (offline cracking target)
  - `host.snmp_community` — SNMP v1/v2 community strings for all monitored devices
  - `host.snmp_auth_pass` / `host.snmp_priv_pass` — SNMPv3 credentials
  - `user_auth.remember_me` — session tokens for persistent login bypass
- The lowest-privileged authenticated user (Realm 3) can exploit this.
- The vulnerability requires no user interaction beyond making HTTP requests.

---

## CVSS Vector Breakdown

| Metric | Value | Reason |
|---|---|---|
| Attack Vector | Network | Exploitable over HTTP |
| Attack Complexity | Low | Reliable exploitation, no race conditions |
| Privileges Required | Low | Requires Realm 3 (lowest level) account |
| User Interaction | None | No admin action required |
| Scope | Unchanged | Only database is affected |
| Confidentiality | High | Full database read access |
| Integrity | High | Potential data modification via stacked queries (if enabled) |
| Availability | High | SLEEP() can be used for DoS |

---

## Remediation

### Recommended Fix

Replace `grv('site_id')` with `gfrv('site_id')` in all three affected files. `gfrv()` uses PHP's `FILTER_VALIDATE_INT` which rejects any non-integer input.

### Affected Files

| File | Lines | Realm Required | Parameters |
|---|---|---|---|
| `data_sources.php` | 87–92 | Realm 3 (lowest) | `site_id` |
| `data_debug.php` | 109–114 | Realm 15 | `site_id` |
| `reports.php` | ~94–103 | Realm 22 | `site_id`, `host_template_id` |

### References

- CWE-89: https://cwe.mitre.org/data/definitions/89.html
- OWASP SQL Injection: https://owasp.org/www-community/attacks/SQL_Injection
- Fixed pattern reference: `graphs.php:118` in the same codebase
- PHP type juggling: https://www.php.net/manual/en/language.types.type-juggling.php

---

## Disclosure Timeline

| Date | Action |
|---|---|
| 2026-05-07 | Vulnerability discovered via static analysis + dynamic verification |
| 2026-05-13 | Vendor contacted via GitHub Security Advisory |
| TBD | Vendor acknowledged |
| TBD | Fix released |
| TBD | Public disclosure (90 days from report) |
