### PR TITLE
fix: [Security] Cross-Site Scripting (XSS) stored

### DIFF
--- a/support.php
+++ b/support.php
@@ -923,7 +923,7 @@ function show_cacti_poller() : void {
 
 		foreach ($problematic as $host) {
 			form_alternate_row();
-			print '<td>' . $host['description'] . '</td>';
+			print '<td>' . htmle($host['description']) . '</td>';
 			print '<td class="right">' . $host['id'] . '</td>';
 			print '<td class="right">' . number_format_i18n($host['ratio'],3) . '</td>';
 			form_end_row();


### PR DESCRIPTION
# Vulnerability Report — Cacti

## Summary
- **Product**        : Cacti — https://github.com/Cacti/cacti
- **Version**        : v1.2.30 (and likely earlier versions)
- **Vulnerability**  : Stored Cross-Site Scripting via device description in support.php
- **Severity**       : Medium
- **CVSS Score**     : 8.0 — CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:N
- **CWE**            : CWE-79 — Improper Neutralization of Input During Web Page Generation
- **Discovered by**  : Nguyen Cong Tu (iaohkut)
- **Disclosure date**: 07/05/2026

---

## Vulnerability Details

### Description

The "Worst 20 failed/total polls ratio" section in `support.php` outputs the device `description` field directly into HTML without calling `htmle()` (Cacti's HTML escaping wrapper around `htmlspecialchars()`). An attacker with Realm 3 (Sites/Devices/Data) access — the lowest Cacti privilege level — can create a device with a malicious JavaScript payload in the description field. When an administrator with Realm 15 (Settings/Utilities) visits the Technical Support page (`support.php`), their browser executes the injected JavaScript, enabling session hijacking and full privilege escalation.

The bug is a single missing `htmle()` call. Notably, the immediately preceding code block in the same file ("Worst 20 polling times") does use `htmle()` correctly — making this a clear copy-paste inconsistency introduced at some point during development.

### Affected Code

**File**: `support.php`  
**Line**: ~926

```php
// VULNERABLE — "Worst 20 failed/total polls ratio" block
foreach ($problematic as $host) {
    form_alternate_row();
    print '<td>' . $host['description'] . '</td>';   // ← MISSING htmle()
    print '<td class="right">' . $host['id'] . '</td>';
    print '<td class="right">' . number_format_i18n($host['ratio'],3) . '</td>';
    form_end_row();
}
```

**Compare with the CORRECT block directly above (line ~884):**

```php
// CORRECT — "Worst 20 polling times" block
foreach ($problematic as $host) {
    form_alternate_row();
    print '<td>' . htmle($host['description']) . '</td>';   // ← htmle() present
```

**Source query** (line ~900):

```sql
SELECT h.id, h.description, h.failed_polls/h.total_polls AS ratio
FROM host h
LEFT JOIN sites s ON h.site_id = s.id
WHERE IFNULL(h.disabled,"") != "on"
AND IFNULL(s.disabled,"") != "on"
ORDER BY ratio DESC
LIMIT 20
```

### Root Cause

The `description` column is stored raw (no HTML encoding applied at write time). At read time, `htmle()` must be called on output to prevent XSS. Every other `description` output in the same file applies `htmle()`, but the "Worst 20 failed/total polls ratio" block was written without it.

The `support.php` page requires Realm 15 to view (Settings/Utilities). However, the `description` field can be written by any user with Realm 3 (via `host.php`). This privilege gap is the enabler: a low-privileged user writes the payload, and a high-privileged user triggers it.

---

## Proof of Concept

### Attack Scenario

1. **Attacker** has a Cacti account with Realm 3.
2. Attacker creates a new device via `host.php` (or edits an existing one) with hostname/IP unreachable - ensures 100% poll failure rate.
3. The device begins failing all polls and rises to the top of the "Worst 20 failed/total polls ratio" list.
4. An administrator visits `support.php` → Technical Info tab.
5. The page renders the unescaped description, executing the JavaScript in the admin's browser.
6. Admin's `Cacti` session cookie is exfiltrated to attacker's server.
7. Attacker uses the stolen session cookie to gain full admin access.

### Steps to Reproduce

1. Log in as any user with Realm 3 (Sites/Devices/Data).
2. Navigate to `Console → Management → Devices → Add Device`.
3. Attacker creates a new device (or edits an existing one) with hostname/IP unreachable - ensures 100% poll failure rate.
4. Save the device. Wait for polling to record failed polls (or set `failed_polls` directly in DB to simulate failures).
5. Log in as an administrator and visit:
   `http://<cacti-host>/cacti/support.php?tab=poller`
6. Scroll to the **"Worst 20 failed/total polls ratio"** section.
7. Observe the alert dialog executing with the admin's session cookie.

### Impact

- **Session Hijacking**: Admin's `Cacti` session cookie stolen → attacker gains full admin panel access.
- **Privilege Escalation**: Realm 3 user escalates to full administrator.
- **Further Actions**: Attacker can create new admin accounts, run CLI scripts via poller, modify monitoring configuration, or pivot to monitored infrastructure via SNMP credentials stored in the database.

---

## CVSS Vector Breakdown

| Metric | Value | Reason |
|---|---|---|
| Attack Vector | Network | Attacker injects via web interface; victim triggers via web browser |
| Attack Complexity | Low | No race condition; payload persists in database |
| Privileges Required | Low | Requires Realm 3 account only |
| User Interaction | Required | Administrator must visit support.php |
| Scope | Changed | Admin browser context is exploited (different from attacker's session) |
| Confidentiality | High | Full session token exfiltration |
| Integrity | High | Attacker can perform any admin action |
| Availability | None | No direct availability impact from XSS itself |

---

### References

- CWE-79: https://cwe.mitre.org/data/definitions/79.html
- OWASP XSS Prevention Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
- Correct usage reference: `support.php:884` in the same file

---

## Disclosure Timeline

| Date | Action |
|---|---|
| 2026-05-07 | Vulnerability discovered via static analysis + dynamic verification |
| 2026-05-13 | Vendor contacted via GitHub Pull Request |
| TBD | Vendor acknowledged |
| TBD | Fix released |
| TBD | Public disclosure (90 days from report) |
