### PR TITLE
fix(cli): repair dead PHP-binary dash-prefix guard in push_out_hosts.php

### DIFF
--- a/cli/push_out_hosts.php
+++ b/cli/push_out_hosts.php
@@ -47,14 +47,15 @@ if (in_array('-v', $parms) || in_array('-V', $parms) || in_array('--version', $p
 	print 'WARNING: Deprecated script push_out_hosts.php. Please use rebuild_poller_cache.php.' . PHP_EOL;
 
 	if (!is_string($php_binary) || trim($php_binary) === '') {
-		cacti_log('ERROR: Rejected en empty PHP binary.', false, 'SYSTEM');
+		cacti_log('ERROR: Rejected an empty PHP binary.', false, 'SYSTEM');
 
 		exit(1);
 	}
 
-	if (strpos(trim($binary), '-') === 0) {
-		cacti_log('ERROR: Rejected PHP binary starting with dash: ' . $binary, false, 'SYSTEM');
-		return 1;
+	if (strpos(trim($php_binary), '-') === 0) {
+		cacti_log('ERROR: Rejected PHP binary starting with dash: ' . $php_binary, false, 'SYSTEM');
+
+		exit(1);
 	}
 
 	$args = array_merge(array($config['base_path'] . '/cli/rebuild_poller_cache.php'), $parms);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -7,7 +7,7 @@ cmd_exec	./cli/audit_database.php:989				exec($db_shell .
 cmd_exec	./cli/batchgapfix.php:388			exec($command, $output, $return_var);
 cmd_exec	./cli/float_rrdfiles.php:335				$response = exec($command, $output, $return);
 cmd_exec	./cli/float_rrdfiles.php:443					$response = exec($command, $output, $return);
-cmd_exec	./cli/push_out_hosts.php:66		passthru($command, $exit_code);
+cmd_exec	./cli/push_out_hosts.php:67		passthru($command, $exit_code);
 cmd_exec	./cli/remove_broken_graphs.php:47		$stty = shell_exec('stty size');
 cmd_exec	./cli/splice_rrd.php:237	$response = shell_exec($rrdtool);
 cmd_exec	./cli/splice_rrd.php:269	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($oldrrd) . ' > ' . cacti_escapeshellarg($oldxmlfile));

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -6,7 +6,7 @@ cmd_exec	./cli/audit_database.php:989				exec($db_shell .
 cmd_exec	./cli/batchgapfix.php:388			exec($command, $output, $return_var);
 cmd_exec	./cli/float_rrdfiles.php:335				$response = exec($command, $output, $return);
 cmd_exec	./cli/float_rrdfiles.php:443					$response = exec($command, $output, $return);
-cmd_exec	./cli/push_out_hosts.php:66		passthru($command, $exit_code);
+cmd_exec	./cli/push_out_hosts.php:67		passthru($command, $exit_code);
 cmd_exec	./cli/remove_broken_graphs.php:47		$stty = shell_exec('stty size');
 cmd_exec	./cli/splice_rrd.php:237	$response = shell_exec($rrdtool);
 cmd_exec	./cli/splice_rrd.php:269	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($oldrrd) . ' > ' . cacti_escapeshellarg($oldxmlfile));


### PR DESCRIPTION
The dash-prefix safety check at `cli/push_out_hosts.php:55` references an undefined `$binary` instead of the local `$php_binary` set on line 39. Under PHP 8 `strpos(null, '-')` returns false, so the guard never fires and a `path_php_binary` value starting with `-` slips through to `passthru()` on line 67.

The same branch used `return 1;` from top-level script context, where it does not propagate the failure to the shell. Switched to `exit(1);` to match the empty-binary branch above.

Also fixed the "Rejected en empty" log typo.

## Test plan
- `php -l cli/push_out_hosts.php` clean
- No remaining `$binary` references in the file