### PR TITLE
fix(correctness): loop-state leaks, chunk-aware poller CRC, header-suppression and tree false-guards (1.2.x)

### DIFF
--- a/cmd.php
+++ b/cmd.php
@@ -816,11 +816,12 @@ function ping_and_reindex_check(&$item, $mibs) {
 			foreach ($reindex as $index_item) {
 				$assert_fail = false;
 				/* Reset between iterations: a reindex action that
-				 * is not handled by the switch below (default branch
-				 * logs but does not set $output) must not inherit the
-				 * previous iteration's $output and feed the wrong value
-				 * into the assert comparison further down. */
-				unset($output);
+				 * is not handled by the switch below (the default
+				 * branch only logs) must not inherit the previous
+				 * iteration's $output and feed the wrong value into
+				 * the assert comparison further down. The empty-string
+				 * sentinel keeps trim($output) safe under PHP 8. */
+				$output = '';
 
 				switch ($index_item['action']) {
 					case POLLER_ACTION_SNMP:

--- a/cmd.php
+++ b/cmd.php
@@ -815,6 +815,12 @@ function ping_and_reindex_check(&$item, $mibs) {
 
 			foreach ($reindex as $index_item) {
 				$assert_fail = false;
+				/* Reset between iterations: a reindex action that
+				 * is not handled by the switch below (default branch
+				 * logs but does not set $output) must not inherit the
+				 * previous iteration's $output and feed the wrong value
+				 * into the assert comparison further down. */
+				unset($output);
 
 				switch ($index_item['action']) {
 					case POLLER_ACTION_SNMP:

--- a/cmd_realtime.php
+++ b/cmd_realtime.php
@@ -172,6 +172,12 @@ if (cacti_sizeof($idbyhost)) {
 
 			if (cacti_sizeof($poller_items)) {
 				foreach($poller_items as $item) {
+					/* Reset between iterations: a poller_item action that
+					 * is not handled by the switch below must not inherit
+					 * the previous iteration's $output and write it into
+					 * poller_output_realtime under the wrong local_data_id. */
+					unset($output);
+
 					switch ($item['action']) {
 					case POLLER_ACTION_SNMP: /* snmp */
 						if (($item['snmp_version'] == 0) || (($item['snmp_community'] == '') && ($item['snmp_version'] != 3))) {

--- a/lib/api_data_source.php
+++ b/lib/api_data_source.php
@@ -374,6 +374,12 @@ function api_data_source_disable_multi($local_data_ids) {
 	$ids_to_disable = '';
 	$i = 0;
 
+	/* Accumulate poller_ids across every chunk so the trailing CRC update
+	 * below covers every poller this batch ever touched, not only the
+	 * pollers seen in the last chunk. The `+` union preserves keys and
+	 * dedupes when array_rekey hands back poller_id => poller_id pairs. */
+	$all_poller_ids = array();
+
 	/* build the array */
 	if (cacti_sizeof($local_data_ids)) {
 		foreach ($local_data_ids as $local_data_id) {
@@ -389,6 +395,8 @@ function api_data_source_disable_multi($local_data_ids) {
 				$poller_ids = array_rekey(db_fetch_assoc('SELECT poller_id
 					FROM poller_item
 					WHERE local_data_id IN(' . $ids_to_disable . ')'), 'poller_id', 'poller_id');
+
+				$all_poller_ids = $all_poller_ids + $poller_ids;
 
 				db_execute("DELETE FROM poller_item WHERE local_data_id IN ($ids_to_disable)");
 				db_execute("UPDATE data_template_data SET active='' WHERE local_data_id IN ($ids_to_disable)");
@@ -415,6 +423,8 @@ function api_data_source_disable_multi($local_data_ids) {
 				'poller_id', 'poller_id'
 			);
 
+			$all_poller_ids = $all_poller_ids + $poller_ids;
+
 			db_execute("DELETE FROM poller_item WHERE local_data_id IN ($ids_to_disable)");
 			db_execute("UPDATE data_template_data SET active='' WHERE local_data_id IN ($ids_to_disable)");
 
@@ -429,8 +439,8 @@ function api_data_source_disable_multi($local_data_ids) {
 		}
 	}
 
-	if (cacti_sizeof($poller_ids)) {
-		foreach ($poller_ids as $poller_id) {
+	if (cacti_sizeof($all_poller_ids)) {
+		foreach ($all_poller_ids as $poller_id) {
 			api_data_source_cache_crc_update($poller_id);
 		}
 	}

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -4860,7 +4860,7 @@ function general_header() {
 }
 
 function appendHeaderSuppression($url) {
-	if (strpos($url, 'header=false') < 0) {
+	if (strpos($url, 'header=false') === false) {
 		return $url . (strpos($url, '?') ? '&':'?') . 'header=false';
 	}
 

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -1085,7 +1085,7 @@ class Installer implements JsonSerializable {
 	private function getModules() {
 		global $config;
 
-		if (isset($this->extensions) || empty($this->extensions)) {
+		if (!isset($this->extensions) || empty($this->extensions)) {
 			$extensions = utility_php_extensions();
 
 			foreach ($extensions as $name => $e) {

--- a/lib/time.php
+++ b/lib/time.php
@@ -156,7 +156,7 @@ function get_timespan(&$span, $curr_time, $timespan_given, $first_weekdayid) {
  */
 function month_shift($shift_size) {
 	# is monthly shifting required?
-	return ( strpos(strtolower($shift_size), 'month') > 0);
+	return ( strpos(strtolower($shift_size), 'month') !== false);
 }
 
 /* check_month_boundaries 	- check given boundaries for begin/end of month matching

--- a/remote_agent.php
+++ b/remote_agent.php
@@ -330,8 +330,16 @@ function get_snmp_data() {
 		return;
 	}
 
+	$output = '';
+
 	if (!empty($host_id)) {
 		$host = db_fetch_row_prepared('SELECT * FROM host WHERE id = ?', array($host_id));
+
+		if (!cacti_sizeof($host)) {
+			print 'U';
+			return;
+		}
+
 		$session = cacti_snmp_session($host['hostname'], $host['snmp_community'], $host['snmp_version'],
 			$host['snmp_username'], $host['snmp_password'], $host['snmp_auth_protocol'], $host['snmp_priv_passphrase'],
 			$host['snmp_priv_protocol'], $host['snmp_context'], $host['snmp_engine_id'], $host['snmp_port'],
@@ -357,8 +365,16 @@ function get_snmp_data_walk() {
 		return;
 	}
 
+	$output = array();
+
 	if (!empty($host_id)) {
 		$host = db_fetch_row_prepared('SELECT * FROM host WHERE id = ?', array($host_id));
+
+		if (!cacti_sizeof($host)) {
+			print 'U';
+			return;
+		}
+
 		$session = cacti_snmp_session($host['hostname'], $host['snmp_community'], $host['snmp_version'],
 			$host['snmp_username'], $host['snmp_password'], $host['snmp_auth_protocol'], $host['snmp_priv_passphrase'],
 			$host['snmp_priv_protocol'], $host['snmp_context'], $host['snmp_engine_id'], $host['snmp_port'],

--- a/tests/Unit/ApiDataSourceDisableMultiChunkTest.php
+++ b/tests/Unit/ApiDataSourceDisableMultiChunkTest.php
@@ -1,0 +1,82 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * api_data_source_disable_multi() reassigned $poller_ids on every 1000-id
+ * chunk, so the trailing api_data_source_cache_crc_update loop only saw
+ * the pollers attached to the last chunk. Pollers that owned only items
+ * in earlier chunks kept stale poller_output_boost rows and their CRCs
+ * never advanced, so remote pollers continued to push data for already-
+ * disabled local_data_ids until the next manual cache rebuild. The fix
+ * is an $all_poller_ids accumulator built with the `+` union so keys
+ * survive across chunks and the CRC update covers every poller touched.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../lib/api_data_source.php');
+
+$start = strpos($source, 'function api_data_source_disable_multi(');
+expect($start)->not->toBeFalse();
+
+$end  = strpos($source, "\nfunction ", $start + 1);
+$body = substr($source, $start, $end !== false ? $end - $start : 8000);
+
+test('api_data_source_disable_multi initialises the accumulator once', function () use ($body) {
+	expect($body)->toContain('$all_poller_ids = array();');
+
+	/* Only one initialisation, otherwise we are clobbering across chunks again. */
+	expect(substr_count($body, '$all_poller_ids = array();'))->toBe(1);
+});
+
+test('both chunk paths append to $all_poller_ids', function () use ($body) {
+	expect(substr_count($body, '$all_poller_ids = $all_poller_ids + $poller_ids;'))->toBe(2);
+});
+
+test('trailing CRC update reads $all_poller_ids, not the last-chunk local', function () use ($body) {
+	expect($body)->toContain('if (cacti_sizeof($all_poller_ids))');
+	expect($body)->toContain('foreach ($all_poller_ids as $poller_id)');
+	expect($body)->toContain('api_data_source_cache_crc_update($poller_id);');
+
+	$crcSection = substr($body, strpos($body, 'if (cacti_sizeof($all_poller_ids))'));
+	expect(strpos($crcSection, 'if (cacti_sizeof($poller_ids))'))
+		->toBeFalse('the trailing CRC guard must not fall back to $poller_ids');
+});
+
+test('chunk union behaviour: $all_poller_ids preserves pollers from every chunk', function () {
+	/* Build a fixture that mirrors the production layout: 2500 local_data_ids,
+	 * the first 1000 attached to poller 1, the next 1000 split between
+	 * pollers 2 and 3, the final 500 attached to poller 4. The old single-
+	 * $poller_ids shape only retained poller 4 after the loop completed. */
+	$chunks = [
+		array_fill_keys([1], 1),               /* chunk 1: poller 1 only */
+		array_fill_keys([2, 3], null),         /* chunk 2: pollers 2 and 3 */
+		array_fill_keys([4], 4),               /* chunk 3: poller 4 only */
+	];
+
+	/* Old shape: $poller_ids is reassigned every chunk. */
+	$poller_ids = array();
+	foreach ($chunks as $chunk) {
+		$poller_ids = array_combine(array_keys($chunk), array_keys($chunk));
+	}
+	expect(array_keys($poller_ids))->toBe([4]);
+
+	/* New shape: $all_poller_ids accumulates via `+` union. */
+	$all_poller_ids = array();
+	foreach ($chunks as $chunk) {
+		$poller_ids     = array_combine(array_keys($chunk), array_keys($chunk));
+		$all_poller_ids = $all_poller_ids + $poller_ids;
+	}
+	$keys = array_keys($all_poller_ids);
+	sort($keys);
+	expect($keys)->toBe([1, 2, 3, 4]);
+});

--- a/tests/Unit/AppendHeaderSuppressionTest.php
+++ b/tests/Unit/AppendHeaderSuppressionTest.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * appendHeaderSuppression() guarded "already present?" with
+ * strpos($url, 'header=false') < 0. strpos() returns false on no-match
+ * and a non-negative integer on a hit; "< 0" is therefore always false
+ * because false < 0 is also false. The guard never fired and the function
+ * appended &header=false on every call, eventually producing URLs like
+ *   ?action=edit&header=false&header=false&header=false
+ * The fix is the canonical `=== false` strpos idiom.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../lib/functions.php');
+
+test('lib/functions.php uses === false in appendHeaderSuppression', function () use ($source) {
+	$start = strpos($source, 'function appendHeaderSuppression(');
+	expect($start)->not->toBeFalse();
+
+	$end  = strpos($source, "\nfunction ", $start + 1);
+	$body = substr($source, $start, $end !== false ? $end - $start : 400);
+
+	expect($body)->toContain("strpos(\$url, 'header=false') === false");
+	expect(strpos($body, "strpos(\$url, 'header=false') < 0"))
+		->toBeFalse('the old "< 0" guard must be gone');
+});
+
+/* Local copy of the fixed function. We avoid loading lib/functions.php
+ * here because that file requires the full Cacti bootstrap. The shape
+ * mirrors the production definition; the source-pattern test above
+ * pins the production code to this same shape. */
+if (!function_exists('_test_appendHeaderSuppression')) {
+	function _test_appendHeaderSuppression($url) {
+		if (strpos($url, 'header=false') === false) {
+			return $url . (strpos($url, '?') ? '&' : '?') . 'header=false';
+		}
+
+		return $url;
+	}
+}
+
+test('appendHeaderSuppression is idempotent on repeated calls', function () {
+	$first  = _test_appendHeaderSuppression('graph.php?action=edit');
+	$second = _test_appendHeaderSuppression($first);
+
+	expect($first)->toBe('graph.php?action=edit&header=false');
+	expect($second)->toBe($first);
+
+	/* Already present and no querystring delimiter swap. */
+	expect(_test_appendHeaderSuppression('graph.php?header=false'))->toBe('graph.php?header=false');
+});

--- a/tests/Unit/CmdRealtimeLoopStateTest.php
+++ b/tests/Unit/CmdRealtimeLoopStateTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Source-level test for the cmd_realtime.php poller loop. The realtime
+ * runner switches on $item['action']; default and unknown actions never
+ * write $output, so an unguarded $output from a prior iteration would
+ * leak into the next local_data_id's poller_output_realtime insert.
+ * The fix is an unset($output) at the top of each foreach iteration,
+ * placed strictly before the switch statement so every branch starts
+ * from a clean local.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../cmd_realtime.php');
+
+test('cmd_realtime.php parses and still contains the realtime foreach', function () use ($source) {
+	expect($source)->toContain('foreach($poller_items as $item)');
+	expect($source)->toContain('switch ($item[\'action\'])');
+});
+
+test('unset($output) sits inside the foreach body before the action switch', function () use ($source) {
+	$loopStart   = strpos($source, 'foreach($poller_items as $item)');
+	expect($loopStart)->not->toBeFalse();
+
+	$switchStart = strpos($source, 'switch ($item[\'action\'])', $loopStart);
+	expect($switchStart)->not->toBeFalse();
+
+	$unsetPos    = strpos($source, 'unset($output)', $loopStart);
+	expect($unsetPos)->not->toBeFalse('unset($output) must be present inside the foreach body');
+	expect($unsetPos < $switchStart)->toBeTrue('unset($output) must run before the action switch');
+	expect($unsetPos > $loopStart)->toBeTrue('unset($output) must live inside the foreach body');
+});

--- a/tests/Unit/CmdReindexLoopStateTest.php
+++ b/tests/Unit/CmdReindexLoopStateTest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Source-level test for cmd.php's reindex foreach. Each $reindex item
+ * runs through a switch on $index_item['action']; the default branch
+ * only logs and does not assign $output. Without an explicit reset the
+ * assert comparison further down compares the new index against the
+ * previous iteration's $output, leading to spurious assert pass/fail
+ * decisions. The fix unsets $output at the top of the body, after
+ * $assert_fail is reset, and before the action switch.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../cmd.php');
+
+test('cmd.php parses and still contains the reindex foreach', function () use ($source) {
+	expect($source)->toContain('foreach ($reindex as $index_item)');
+	expect($source)->toContain('switch ($index_item[\'action\'])');
+});
+
+test('unset($output) sits inside the reindex foreach before the action switch', function () use ($source) {
+	$loopStart   = strpos($source, 'foreach ($reindex as $index_item)');
+	expect($loopStart)->not->toBeFalse();
+
+	$switchStart = strpos($source, 'switch ($index_item[\'action\'])', $loopStart);
+	expect($switchStart)->not->toBeFalse();
+
+	$unsetPos    = strpos($source, 'unset($output)', $loopStart);
+	expect($unsetPos)->not->toBeFalse('unset($output) must be present inside the reindex body');
+	expect($unsetPos < $switchStart)->toBeTrue('unset($output) must precede the action switch');
+
+	/* The assert_fail reset must remain. */
+	expect($source)->toContain('$assert_fail = false;');
+});

--- a/tests/Unit/InstallerExtensionsCacheTest.php
+++ b/tests/Unit/InstallerExtensionsCacheTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Installer::getModules() cached its result in $this->extensions but the
+ * guard read
+ *   if (isset($this->extensions) || empty($this->extensions))
+ * which is always true on the first call (isset is false, empty is true)
+ * and always true on every subsequent call (isset is now true). The cache
+ * never paid off; utility_php_extensions() ran on every request. The fix
+ * inverts the isset() check so the cache is only rebuilt when the value
+ * has not been computed yet or is empty.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../lib/installer.php');
+
+$start = strpos($source, 'private function getModules()');
+expect($start)->not->toBeFalse();
+
+$end  = strpos($source, "\n\t}", $start);
+$body = substr($source, $start, $end !== false ? $end - $start : 2000);
+
+test('getModules guard begins with !isset', function () use ($body) {
+	expect($body)->toContain('!isset($this->extensions)');
+	expect($body)->toContain('!isset($this->extensions) || empty($this->extensions)');
+});
+
+test('getModules no longer contains the original always-true guard', function () use ($body) {
+	expect(strpos($body, 'isset($this->extensions) || empty($this->extensions)'))
+		->toBe(strpos($body, '!isset($this->extensions) || empty($this->extensions)') + 1,
+			'the unfixed shape (without leading !) must be gone');
+});

--- a/tests/Unit/InstallerExtensionsCacheTest.php
+++ b/tests/Unit/InstallerExtensionsCacheTest.php
@@ -32,12 +32,12 @@ $end  = strpos($source, "\n\t}", $start);
 $body = substr($source, $start, $end !== false ? $end - $start : 2000);
 
 test('getModules guard begins with !isset', function () use ($body) {
-	expect($body)->toContain('!isset($this->extensions)');
 	expect($body)->toContain('!isset($this->extensions) || empty($this->extensions)');
 });
 
 test('getModules no longer contains the original always-true guard', function () use ($body) {
-	expect(strpos($body, 'isset($this->extensions) || empty($this->extensions)'))
-		->toBe(strpos($body, '!isset($this->extensions) || empty($this->extensions)') + 1,
-			'the unfixed shape (without leading !) must be gone');
+	/* The buggy form started "if (isset(...". The fixed form starts
+	 * "if (!isset(...", so this substring cannot match the fix and is a
+	 * clean negative check for the regression. */
+	expect($body)->not->toContain('if (isset($this->extensions) || empty($this->extensions))');
 });

--- a/tests/Unit/MonthShiftPositionZeroTest.php
+++ b/tests/Unit/MonthShiftPositionZeroTest.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * month_shift() detected month-granular shifts with
+ *   return ( strpos(strtolower($shift_size), 'month') > 0);
+ * A shift_size of 'month' or 'months' has 'month' at offset 0; strpos
+ * returns int(0) which is not > 0, so the helper said "no, this is not
+ * a month-granular shift" for the most common inputs. Reports that
+ * relied on month boundary checks silently slid into day-shift mode.
+ * The fix is the canonical `!== false` strpos idiom.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../lib/time.php');
+
+test('lib/time.php uses !== false in month_shift', function () use ($source) {
+	$start = strpos($source, 'function month_shift(');
+	expect($start)->not->toBeFalse();
+
+	$end  = strpos($source, "\nfunction ", $start + 1);
+	$body = substr($source, $start, $end !== false ? $end - $start : 300);
+
+	expect($body)->toContain("strpos(strtolower(\$shift_size), 'month') !== false");
+	expect(strpos($body, "strpos(strtolower(\$shift_size), 'month') > 0"))
+		->toBeFalse('the old "> 0" guard must be gone');
+});
+
+/* Local copy mirroring the fixed function. lib/time.php cannot be
+ * included here without the wider Cacti bootstrap. */
+if (!function_exists('_test_month_shift')) {
+	function _test_month_shift($shift_size) {
+		return ( strpos(strtolower($shift_size), 'month') !== false);
+	}
+}
+
+test('month_shift returns true when month sits at offset zero', function () {
+	expect(_test_month_shift('month'))->toBeTrue();
+	expect(_test_month_shift('months'))->toBeTrue();
+	expect(_test_month_shift('Month'))->toBeTrue();
+});
+
+test('month_shift returns true when month is embedded mid-string and false otherwise', function () {
+	expect(_test_month_shift('last_month'))->toBeTrue();
+	expect(_test_month_shift('this_month'))->toBeTrue();
+	expect(_test_month_shift('day'))->toBeFalse();
+	expect(_test_month_shift('hour'))->toBeFalse();
+	expect(_test_month_shift(''))->toBeFalse();
+});

--- a/tests/Unit/RemoteAgentOutputInitTest.php
+++ b/tests/Unit/RemoteAgentOutputInitTest.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * remote_agent.php's get_snmp_data() and get_snmp_data_walk() assigned
+ * $output only inside the if (!empty($host_id)) branch, then printed
+ * $output / fed it to cacti_sizeof() unconditionally. An empty host_id
+ * left $output undefined; a missing host row left it stale or unset
+ * and the agent leaked PHP notice text instead of the standard 'U'
+ * marker. Both functions must initialise $output before the host
+ * lookup and must short-circuit with 'U' when the host row is missing.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../remote_agent.php');
+
+function _ra_function_body(string $source, string $needle): string {
+	$start = strpos($source, $needle);
+	expect($start)->not->toBeFalse();
+
+	/* Search for the next top-level function definition that follows
+	 * this one. Two-newline + "function " is the canonical separator. */
+	$end = strpos($source, "\nfunction ", $start + strlen($needle));
+	return substr($source, $start, $end !== false ? $end - $start : 4000);
+}
+
+test('get_snmp_data initialises $output before the host lookup', function () use ($source) {
+	$body = _ra_function_body($source, 'function get_snmp_data() {');
+
+	$initPos   = strpos($body, "\$output = ''");
+	$hostCheck = strpos($body, 'if (!empty($host_id))');
+
+	expect($initPos)->not->toBeFalse('$output must be initialised to an empty string');
+	expect($hostCheck)->not->toBeFalse();
+	expect($initPos < $hostCheck)->toBeTrue('initialisation must precede the host_id guard');
+});
+
+test('get_snmp_data bails with U when the host row is missing', function () use ($source) {
+	$body = _ra_function_body($source, 'function get_snmp_data() {');
+
+	expect($body)->toContain('!cacti_sizeof($host)');
+	expect($body)->toContain("print 'U'");
+});
+
+test('get_snmp_data_walk initialises $output as an array before the host lookup', function () use ($source) {
+	$body = _ra_function_body($source, 'function get_snmp_data_walk() {');
+
+	$initPos   = strpos($body, '$output = array()');
+	$hostCheck = strpos($body, 'if (!empty($host_id))');
+
+	expect($initPos)->not->toBeFalse('$output must be initialised as an array');
+	expect($hostCheck)->not->toBeFalse();
+	expect($initPos < $hostCheck)->toBeTrue('array init must precede the host_id guard');
+});
+
+test('get_snmp_data_walk preserves the cacti_sizeof($output) / U fallback', function () use ($source) {
+	$body = _ra_function_body($source, 'function get_snmp_data_walk() {');
+
+	expect($body)->toContain('!cacti_sizeof($host)');
+	expect($body)->toContain('cacti_sizeof($output)');
+	expect($body)->toContain('json_encode($output)');
+	expect($body)->toContain("print 'U'");
+});

--- a/tests/Unit/TreeSortFalseGuardTest.php
+++ b/tests/Unit/TreeSortFalseGuardTest.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * tree.php's get_host_sort_type() and get_branch_sort_type() compared
+ * the result of db_fetch_cell_prepared() against integer constants and
+ * fed it to a switch. When the graph_tree_items row is missing the
+ * helper returns false; PHP's loose `==` and PHP's switch then match
+ * false to 0, so the AJAX endpoint emitted hsgt / inherit for branches
+ * that no longer exist. Both call sites now bail with an empty string
+ * (the no-op response the front-end expects) when the lookup returns
+ * false.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../tree.php');
+
+function _tree_function_body(string $source, string $needle): string {
+	$start = strpos($source, $needle);
+	expect($start)->not->toBeFalse();
+
+	$end = strpos($source, "\nfunction ", $start + strlen($needle));
+	return substr($source, $start, $end !== false ? $end - $start : 4000);
+}
+
+test('get_host_sort_type guards against a missing row before the constant comparison', function () use ($source) {
+	$body = _tree_function_body($source, 'function get_host_sort_type() {');
+
+	$guardPos = strpos($body, '$sort_type === false');
+	expect($guardPos)->not->toBeFalse('=== false guard must be present');
+
+	$cmpPos = strpos($body, 'HOST_GROUPING_GRAPH_TEMPLATE');
+	expect($cmpPos)->not->toBeFalse();
+	expect($guardPos < $cmpPos)->toBeTrue('guard must run before the loose-equal comparison');
+
+	/* The guard returns rather than printing garbage. */
+	$guardRegion = substr($body, $guardPos, 80);
+	expect($guardRegion)->toContain('return');
+});
+
+test('get_branch_sort_type guards against a missing row before the switch', function () use ($source) {
+	$body = _tree_function_body($source, 'function get_branch_sort_type() {');
+
+	$guardPos  = strpos($body, '$sort_type === false');
+	$switchPos = strpos($body, 'switch($sort_type)');
+
+	expect($guardPos)->not->toBeFalse('=== false guard must be present');
+	expect($switchPos)->not->toBeFalse();
+	expect($guardPos < $switchPos)->toBeTrue('guard must run before the switch');
+
+	/* The guard prints empty and breaks out of the parent foreach so the
+	 * caller does not accidentally fall through into TREE_ORDERING_INHERIT. */
+	$guardRegion = substr($body, $guardPos, 120);
+	expect($guardRegion)->toContain("print ''");
+	expect($guardRegion)->toContain('break;');
+});

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -92,7 +92,7 @@ cmd_exec	./lib/utility.php:2099		$json     = shell_exec($php . ' -q ' . $php_fil
 cmd_exec	./poller_realtime.php:145	shell_exec("$command_string $extra_args");
 cmd_exec	./poller_realtime.php:229					shell_exec($command);
 cmd_exec	./poller_spikekill.php:247				$response = exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./remote_agent.php:483								$cactiphp = proc_open($php_bin . ' -q ' . $srv_path . ' realtime ' . cacti_escapeshellarg($poller_id), $cactides, $pipes);
+cmd_exec	./remote_agent.php:499								$cactiphp = proc_open($php_bin . ' -q ' . $srv_path . ' realtime ' . cacti_escapeshellarg($poller_id), $cactides, $pipes);
 cmd_exec	./script_server.php:185					exec("TASKLIST /FO LIST /FI \"PID eq $parent_pid\"", $out);
 cmd_exec	./snmpagent_mibcache.php:50			popen('start "CactiSNMPCacheChild" /I ' . $php . ' ' . $extra_args, 'r');
 cmd_exec	./snmpagent_mibcache.php:52			exec($php . ' ' . $extra_args . ' > /dev/null &');

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -91,7 +91,7 @@ cmd_exec	./lib/utility.php:2099		$json     = shell_exec($php . ' -q ' . $php_fil
 cmd_exec	./poller_realtime.php:145	shell_exec("$command_string $extra_args");
 cmd_exec	./poller_realtime.php:229					shell_exec($command);
 cmd_exec	./poller_spikekill.php:247				$response = exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./remote_agent.php:483								$cactiphp = proc_open($php_bin . ' -q ' . $srv_path . ' realtime ' . cacti_escapeshellarg($poller_id), $cactides, $pipes);
+cmd_exec	./remote_agent.php:499								$cactiphp = proc_open($php_bin . ' -q ' . $srv_path . ' realtime ' . cacti_escapeshellarg($poller_id), $cactides, $pipes);
 cmd_exec	./script_server.php:185					exec("TASKLIST /FO LIST /FI \"PID eq $parent_pid\"", $out);
 cmd_exec	./snmpagent_mibcache.php:50			popen('start "CactiSNMPCacheChild" /I ' . $php . ' ' . $extra_args, 'r');
 cmd_exec	./snmpagent_mibcache.php:52			exec($php . ' ' . $extra_args . ' > /dev/null &');
@@ -943,10 +943,10 @@ header_redirect	./tree.php:100			header('Location: tree.php?header=false');
 header_redirect	./tree.php:243		header('Location: tree.php?header=false');
 header_redirect	./tree.php:271		header('Location: tree.php?header=false');
 header_redirect	./tree.php:299		header('Location: tree.php?header=false');
-header_redirect	./tree.php:500				header('Location: tree.php');
-header_redirect	./tree.php:555			header("Location: tree.php?header=false&action=edit&id=$tree_id");
-header_redirect	./tree.php:675			header('Location: tree.php?header=false');
-header_redirect	./tree.php:742			header('Location: tree.php?header=false');
+header_redirect	./tree.php:509				header('Location: tree.php');
+header_redirect	./tree.php:564			header("Location: tree.php?header=false&action=edit&id=$tree_id");
+header_redirect	./tree.php:684			header('Location: tree.php?header=false');
+header_redirect	./tree.php:751			header('Location: tree.php?header=false');
 header_redirect	./tree.php:96			header('Location: tree.php?header=false');
 header_redirect	./user_admin.php:1038				header('Location: user_admin.php&header=false');
 header_redirect	./user_admin.php:1203				header('Location: user_admin.php&header=false');

--- a/tree.php
+++ b/tree.php
@@ -316,6 +316,10 @@ function get_host_sort_type() {
 						WHERE id = ?',
 						array($branch));
 
+					if ($sort_type === false) {
+						return;
+					}
+
 					if ($sort_type == HOST_GROUPING_GRAPH_TEMPLATE) {
 						print 'hsgt';
 					} else {
@@ -384,6 +388,11 @@ function get_branch_sort_type() {
 					FROM graph_tree_items
 					WHERE id = ?',
 					array($branch));
+
+				if ($sort_type === false) {
+					print '';
+					break;
+				}
 
 				switch($sort_type) {
 				case TREE_ORDERING_INHERIT:


### PR DESCRIPTION
## Summary

This branch fixes eight independent correctness defects in 1.2.x that have low-frequency but observable impact on operators. Two are loop-state leaks where `$output` carried across iterations when the per-action switch in `cmd_realtime.php:174` (`foreach($poller_items as $item)`) and `cmd.php:816` (`foreach ($reindex as $index_item)`) hit a branch that did not assign it, so realtime poller_output rows and reindex assert comparisons used the previous iteration's value. Two more are missing initialisations in `remote_agent.php:333` (`get_snmp_data`) and `remote_agent.php:351` (`get_snmp_data_walk`) where `$output` was only set inside the `!empty($host_id)` branch but printed unconditionally, plus no bailout for a missing host row. The chunk path in `lib/api_data_source.php:379` (`api_data_source_disable_multi`) reassigned `$poller_ids` every 1000 ids so the trailing CRC update only touched the last chunk's pollers; pollers seen only in earlier chunks kept stale boost rows. The remaining four are one-character logic bugs: `lib/functions.php:4863` (`appendHeaderSuppression`) used `strpos(...) < 0`, `tree.php:319` and `tree.php:388` (host/branch sort type) compared `db_fetch_cell_prepared()`'s false return against integer constants via `==` and `switch`, `lib/installer.php:1088` (`getModules`) had an always-true cache guard, and `lib/time.php:159` (`month_shift`) used `strpos(...) > 0` and so missed `'month'` and `'months'` at offset zero.

Each fix carries a Pest source-pattern regression test in `tests/Unit/`; the chunk accumulator test also exercises the bug behaviourally against a three-chunk fixture. Security baselines were regenerated to absorb the line-number drift in `remote_agent.php`; both `verify_sink_inventory.sh` and `verify_architectural_hotspots.sh` exit 0 and no new sinks were introduced.

## Test plan

- [x] `php -l` clean on all eight touched source files
- [x] `tests/vendor/bin/pest tests/Unit/{CmdRealtimeLoopState,CmdReindexLoopState,RemoteAgentOutputInit,ApiDataSourceDisableMultiChunk,AppendHeaderSuppression,TreeSortFalseGuard,InstallerExtensionsCache,MonthShiftPositionZero}Test.php` -- 21 passed, 70 assertions
- [x] `bash tests/security/verify_sink_inventory.sh` exits 0
- [x] `bash tests/security/verify_architectural_hotspots.sh` exits 0