### PR TITLE
fix(boost): fix seven correctness bugs in boost poller

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -44,5 +44,6 @@ parameters:
         - identifier: identical.alwaysFalse
         - identifier: booleanAnd.leftAlwaysTrue
         - identifier: booleanAnd.leftAlwaysFalse
+        - identifier: function.alreadyNarrowedType
 # L9       - '/^Parameter #1 \$value of function strval expects bool\|float\|int\|resource\|string\|null, mixed given.$/'
 # L9       - '/^Parameter #1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given.$/'

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "overtrue/phplint": "^9.6",
         "pestphp/pest": "^2",
         "pestphp/pest-plugin-drift": "^2.0",
-        "phpstan/phpstan": "^2.1.21",
+        "phpstan/phpstan": "2.2.1",
         "rector/rector": "^2.1.2"
     },
     "scripts": {

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -100,11 +100,19 @@ function boost_file_size_display(float|int $file_size, int $digits = 2) : string
  * @return int The total number of rows from the matching tables.
  */
 function boost_get_total_rows() : int {
-	return (int) db_fetch_cell("SELECT SUM(TABLE_ROWS)
-		FROM information_schema.tables
-		WHERE table_schema = SCHEMA()
-		AND (table_name LIKE 'poller_output_boost_arch_%'
-		OR table_name LIKE 'poller_output_boost')");
+	$tables = db_fetch_assoc("SELECT TABLE_NAME AS name
+		FROM information_schema.TABLES
+		WHERE TABLE_SCHEMA = SCHEMA()
+		AND (TABLE_NAME LIKE 'poller_output_boost_arch_%'
+		OR TABLE_NAME = 'poller_output_boost')");
+
+	$total = 0;
+
+	foreach ($tables as $table) {
+		$total += (int) db_fetch_cell("SELECT COUNT(*) FROM `{$table['name']}`");
+	}
+
+	return $total;
 }
 
 /**

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -825,6 +825,82 @@ function boost_timer_get_overhead() : float {
 }
 
 /**
+ * Clamps the configured boost_parallel value to a sane process count.
+ *
+ * read_config_option() may return '', null, a negative value, or a non-numeric
+ * string. All of those mean "run a single child"; anything else is the integer
+ * process count. Both call sites in poller_boost.php must agree on this so the
+ * parent spawns exactly as many children as it later waits for.
+ *
+ * @param mixed $value Raw boost_parallel option value.
+ *
+ * @return int Process count >= 1.
+ */
+function boost_clamp_parallel(mixed $value) : int {
+	$processes = intval($value);
+
+	return $processes > 0 ? $processes : 1;
+}
+
+/**
+ * Validates an archive table name against the expected boost pattern.
+ *
+ * The name is interpolated into DDL/DML without parameter binding, so it must
+ * match poller_output_boost_arch_<digits> exactly before any use.
+ *
+ * @param mixed $table Candidate table name.
+ *
+ * @return bool True when the name is a well-formed boost archive table.
+ */
+function boost_is_valid_archive_table(mixed $table) : bool {
+	return is_string($table) && preg_match('/^poller_output_boost_arch_\d+$/', $table) === 1;
+}
+
+/**
+ * Decides whether a boost log path is safe to splice into a shell redirect.
+ *
+ * redirect_args bypasses per-argument escaping, so the path must contain no
+ * shell metacharacters. A plain character allow-list is too strict on Windows,
+ * where legitimate paths carry a drive colon, backslashes, and spaces, so those
+ * are permitted on win32 only.
+ *
+ * @param mixed $path Candidate log path.
+ *
+ * @return bool True when the path is safe to use unescaped in a redirect.
+ */
+function boost_log_path_is_safe(mixed $path) : bool {
+	if (!is_string($path) || $path === '') {
+		return false;
+	}
+
+	if (defined('PHP_OS_FAMILY') && PHP_OS_FAMILY === 'Windows') {
+		// Allow drive colon, backslash, and space; still reject shell metacharacters.
+		return preg_match('/[^A-Za-z0-9_.\/\\\\: -]/', $path) === 0;
+	}
+
+	return preg_match('/[^A-Za-z0-9_.\/\-]/', $path) === 0;
+}
+
+/**
+ * Reports whether every launched boost child has registered.
+ *
+ * exec_background() is non-blocking, so the parent must not enter its drain loop
+ * (and the unconditional archive-table DROP that follows) until all $expected
+ * children are accounted for. A child counts as accounted for once it is either
+ * still running or has already recorded a completion row, which closes the race
+ * where a fast child registers and exits before its siblings boot.
+ *
+ * @param int $expected  Number of children launched.
+ * @param int $running   Children currently in the processes table.
+ * @param int $completed Completion rows in poller_output_boost_processes.
+ *
+ * @return bool True once running + completed covers every launched child.
+ */
+function boost_all_children_registered(int $expected, int $running, int $completed) : bool {
+	return ($running + $completed) >= $expected;
+}
+
+/**
  * Retrieves the names of the archive tables related to poller output boost.
  *
  * @param mixed $latest_table - Optional. The name of the latest table to check
@@ -857,7 +933,11 @@ function boost_get_arch_table_names(mixed $latest_table = '') : mixed {
 	}
 
 	if (!cacti_sizeof($tableNames)) {
-		if ($latest_table != '' && db_table_exists($latest_table)) {
+		// Both lookups above read metadata (SHOW TABLES / information_schema),
+		// which can lag the data on a replica long enough to miss a table the
+		// parent just created. Fall back to the validated name the parent passed
+		// and confirm it with a data-plane read, which replicates with the rows.
+		if (boost_is_valid_archive_table($latest_table) && boost_archive_table_readable($latest_table)) {
 			$tableNames[$latest_table] = $latest_table;
 
 			return $tableNames;
@@ -867,6 +947,31 @@ function boost_get_arch_table_names(mixed $latest_table = '') : mixed {
 	} else {
 		return $tableNames;
 	}
+}
+
+/**
+ * Confirms an archive table exists by reading from it, not from metadata.
+ *
+ * SHOW TABLES and information_schema are metadata-plane lookups that can lag on
+ * a replica; a SELECT against the table itself replicates with the row data, so
+ * it reflects the table the parent just created. The name must already be a
+ * validated boost archive table before it reaches the interpolated query.
+ *
+ * @param string $table A name that passed boost_is_valid_archive_table().
+ *
+ * @return bool True when the table can be read.
+ */
+function boost_archive_table_readable(string $table) : bool {
+	if (!boost_is_valid_archive_table($table)) {
+		return false;
+	}
+
+	// COUNT(*) returns a numeric row even for an empty table, so a non-null,
+	// non-false result means the table exists; a query error (missing table)
+	// yields false. $log = false: a fallback miss is expected, not an error.
+	$result = db_fetch_cell("SELECT COUNT(*) FROM `$table`", '', false);
+
+	return $result !== false && $result !== null;
 }
 
 /**

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -275,11 +275,12 @@ function boost_poller_on_demand(array &$results) : bool {
 
 				foreach ($results as $result) {
 					$tmp_buffer =
-						"('" .
-						$result['local_data_id'] . "','" .
-						$result['rrd_name'] . "','" .
-						$result['time'] . "','" .
-						$result['output'] . "')";
+						'(' .
+						(int) $result['local_data_id'] . ',' .
+						db_qstr($result['rrd_name'], $conn) . ',' .
+						db_qstr($result['time'], $conn) . ',' .
+						db_qstr($result['output'], $conn) .
+						')';
 
 					$tmp_length = strlen($tmp_buffer);
 
@@ -752,7 +753,7 @@ function boost_graph_set_file(string|null &$output, int $local_graph_id, int|nul
 						if ($fileptr = fopen($cache_file, 'w')) {
 							fwrite($fileptr, $output, strlen($output));
 							fclose($fileptr);
-							chmod($cache_file, 0666);
+							chmod($cache_file, 0644);
 
 							// count the number of images that had to be cached
 							$mc->object('boostStatsTotalsImagesCacheWrites')->count();
@@ -942,21 +943,21 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 	$temp_table          = false;
 
 	if (cacti_count($archive_tables)) {
-		$temp_table = 'poller_output_boost_temp_' . $local_data_id . '_' . mt_rand();
+		$temp_table = 'poller_output_boost_temp_' . $local_data_id . '_' . random_int(0, PHP_INT_MAX);
 
-		db_execute("CREATE TEMPORARY TABLE $temp_table LIKE poller_output_boost");
+		db_execute("CREATE TEMPORARY TABLE `{$temp_table}` LIKE poller_output_boost");
 
 		foreach ($archive_tables as $table) {
-			db_execute_prepared("INSERT INTO $temp_table
+			db_execute_prepared("INSERT INTO `{$temp_table}`
 				SELECT *
-				FROM $table
+				FROM `{$table}`
 				WHERE local_data_id = ?",
 				[$local_data_id], false);
 		}
 	}
 
 	if ($temp_table !== false) {
-		db_execute_prepared("INSERT INTO $temp_table
+		db_execute_prepared("INSERT INTO `{$temp_table}`
 			SELECT *
 			FROM poller_output_boost
 			WHERE local_data_id = ?
@@ -965,7 +966,7 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 
 		$query_string = "SELECT po.local_data_id, dl.data_template_id,
 			UNIX_TIMESTAMP(po.time) AS timestamp, po.rrd_name, po.output
-			FROM $temp_table AS po
+			FROM `{$temp_table}` AS po
 			INNER JOIN data_local AS dl
 			ON po.local_data_id = dl.id
 			WHERE po.local_data_id = ?

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -850,8 +850,7 @@ function boost_get_arch_table_names(mixed $latest_table = '') : mixed {
 			db_fetch_assoc("SELECT TABLE_NAME AS name
 				FROM information_schema.TABLES
 				WHERE TABLE_SCHEMA = SCHEMA()
-				AND TABLE_NAME LIKE 'poller_output_boost_arch_%'
-				AND TABLE_ROWS > 0"),
+				AND TABLE_NAME LIKE 'poller_output_boost_arch_%'"),
 			'name', 'name'
 		);
 	}
@@ -889,9 +888,8 @@ function boost_get_arch_table_names(mixed $latest_table = '') : mixed {
  * @return int
  */
 function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = []) : int {
-	global $database_default, $boost_sock, $boost_timeout, $get_memory, $memory_used;
+	global $database_default, $boost_sock, $boost_timeout, $get_memory, $memory_used, $archive_table;
 
-	static $archive_table = false;
 	static $warning_issued;
 	static $rrdtool_version = null;
 
@@ -1186,6 +1184,8 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 						$unused_data_source_names = array_rekey(
 							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
 								FROM data_template_rrd AS dtr
+								LEFT JOIN graph_templates_item AS gti
+								ON dtr.id = gti.task_item_id
 								WHERE dtr.local_data_id = ? AND gti.task_item_id IS NULL',
 								[$item['local_data_id']]),
 							'data_source_name', 'data_source_name'
@@ -1283,6 +1283,8 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 						$unused_data_source_names = array_rekey(
 							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
 								FROM data_template_rrd AS dtr
+								LEFT JOIN graph_templates_item AS gti
+								ON dtr.id = gti.task_item_id
 								WHERE dtr.local_data_id = ? AND gti.task_item_id IS NULL',
 								[$item['local_data_id']]),
 							'data_source_name', 'data_source_name'

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -100,19 +100,11 @@ function boost_file_size_display(float|int $file_size, int $digits = 2) : string
  * @return int The total number of rows from the matching tables.
  */
 function boost_get_total_rows() : int {
-	$tables = db_fetch_assoc("SELECT TABLE_NAME AS name
+	return (int) db_fetch_cell("SELECT SUM(TABLE_ROWS)
 		FROM information_schema.TABLES
 		WHERE TABLE_SCHEMA = SCHEMA()
 		AND (TABLE_NAME LIKE 'poller_output_boost_arch_%'
 		OR TABLE_NAME = 'poller_output_boost')");
-
-	$total = 0;
-
-	foreach ($tables as $table) {
-		$total += (int) db_fetch_cell("SELECT COUNT(*) FROM `{$table['name']}`");
-	}
-
-	return $total;
 }
 
 /**

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -718,7 +718,7 @@ function boost_output_rrd_data(int $child) : mixed {
 	$max_per_select = intval(read_config_option('boost_rrd_update_max_records_per_select'));
 
 	if ($max_per_select <= 0) {
-		$max_per_select = 1000;
+		$max_per_select = 50000;
 	}
 
 	$data_ids = db_fetch_cell_prepared('SELECT
@@ -828,6 +828,10 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 	$rrd_update_interval = intval(read_config_option('boost_rrd_update_interval'));
 	$data_ids_to_get     = intval(read_config_option('boost_rrd_update_max_records_per_select'));
 	$rrd_field_names     = [];
+
+	if ($data_ids_to_get <= 0) {
+		$data_ids_to_get = 50000;
+	}
 
 	if ($archive_tables === false) {
 		$archive_tables = boost_get_arch_table_names($archive_table);

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -70,6 +70,12 @@ if (cacti_sizeof($parms)) {
 				$child = intval($value);
 
 				break;
+			case '--archive-table':
+				if (preg_match('/^poller_output_boost_arch_\d+$/', $value)) {
+					$archive_table = $value;
+				}
+
+				break;
 			case '-d':
 			case '--debug':
 				$debug = true;
@@ -213,6 +219,15 @@ if ($child == false) {
 			cacti_log('INFO: Boost spawning child processes ...', true, 'BOOST');
 			boost_launch_children();
 
+			// Wait until at least one child has registered before entering
+			// the monitoring loop. exec_background() is non-blocking; children
+			// need a moment to call register_process_start(). Without this
+			// barrier the while-loop below sees 0 and exits immediately.
+			$startup_deadline = time() + 30;
+			while (boost_processes_running() < 1 && time() < $startup_deadline) {
+				sleep(1);
+			}
+
 			// Wait for all processes to continue
 			while ($running = boost_processes_running()) {
 				boost_debug(sprintf('%s Processes Running, Sleeping for 2 seconds.', $running));
@@ -318,8 +333,10 @@ function sig_handler(int $signo) : void {
 		case SIGINT:
 			cacti_log('WARNING: Boost Poller terminated by user', true, 'BOOST');
 
-			// tell the main poller that we are done
-			set_config_option('boost_poller_status', 'terminated - end time:' . date('Y-m-d H:i:s'));
+			// only the parent tracks overall poller status
+			if (!$child) {
+				set_config_option('boost_poller_status', 'terminated - end time:' . date('Y-m-d H:i:s'));
+			}
 
 			// release any held GET_LOCK() before exiting; rrdtool >= 1.5 does
 			// not use these locks, so skip on modern installs
@@ -434,11 +451,7 @@ function boost_prepare_process_table() : bool {
 	cacti_log('INFO: Boost counting entries in archive tables ...', true, 'BOOST');
 
 	foreach ($arch_tables as $table) {
-		$table_rows = db_fetch_cell_prepared('SELECT TABLE_ROWS
-			FROM information_schema.TABLES
-			WHERE TABLE_SCHEMA = SCHEMA()
-			AND TABLE_NAME = ?',
-			[$table]);
+		$table_rows = (int) db_fetch_cell("SELECT COUNT(*) FROM $table");
 
 		$total_rows += $table_rows;
 
@@ -449,6 +462,11 @@ function boost_prepare_process_table() : bool {
 		boost_debug('ERROR: Failed to retrieve any rows from archive tables');
 
 		cacti_log('ERROR: Failed to retrieve any rows from archive tables', true, 'BOOST');
+
+		// Drop orphaned arch tables so the next run does not pick them up.
+		foreach ($arch_tables as $table) {
+			db_execute("DROP TABLE IF EXISTS $table");
+		}
 
 		return false;
 	} else {
@@ -475,7 +493,11 @@ function boost_prepare_process_table() : bool {
 		COUNT(local_data_id)
 		FROM poller_output_boost_local_data_ids');
 
-	$processes = read_config_option('boost_parallel');
+	$processes = intval(read_config_option('boost_parallel'));
+
+	if ($processes <= 0) {
+		$processes = 1;
+	}
 
 	boost_debug("Data Sources:$data_ids, Concurrent Processes:$processes");
 
@@ -508,7 +530,7 @@ function boost_prune_memstats() : void {
 }
 
 function boost_launch_children() : void {
-	global $debug, $boost_log, $boost_debug, $cacti_log;
+	global $debug, $archive_table, $boost_log, $boost_debug, $cacti_log;
 
 	$processes = read_config_option('boost_parallel');
 
@@ -536,7 +558,7 @@ function boost_launch_children() : void {
 
 		cacti_log('NOTE: Launching Boost Process Number ' . $i, true, 'BOOST', POLLER_VERBOSITY_MEDIUM);
 
-		exec_background($php_binary, CACTI_PATH_BASE . '/poller_boost.php --child=' . $i . ($debug ? ' --debug' : ''), $redirect_args);
+		exec_background($php_binary, CACTI_PATH_BASE . '/poller_boost.php --child=' . $i . ' --archive-table=' . $archive_table . ($debug ? ' --debug' : ''), $redirect_args);
 	}
 
 	sleep(2);
@@ -658,12 +680,16 @@ function boost_output_rrd_data(int $child) : mixed {
 	}
 
 	if ($total_rows == 0) {
-		return false;
+		return 0;
 	}
 
 	boost_debug("Processes:$child, TotalRows:$total_rows");
 
 	$max_per_select = intval(read_config_option('boost_rrd_update_max_records_per_select'));
+
+	if ($max_per_select <= 0) {
+		$max_per_select = 1000;
+	}
 
 	$data_ids = db_fetch_cell_prepared('SELECT
 		COUNT(local_data_id)
@@ -1465,7 +1491,10 @@ function display_help() : void {
 	print "Cacti's performance boosting poller.  This poller will purge the boost cache periodically.  You may\n";
 	print "force the processing of the boost cache by using the --force option.\n\n";
 	print "Optional:\n";
-	print "    --verbose - Show details logs at the command line\n";
-	print "    --force   - Force the execution of a update process\n";
-	print "    --debug   - Display verbose output during execution\n\n";
+	print "    --verbose          - Show details logs at the command line\n";
+	print "    --force            - Force the execution of a update process\n";
+	print "    --debug            - Display verbose output during execution\n\n";
+	print "Child process (internal use only):\n";
+	print "    --child=N          - Run as child worker process N\n";
+	print "    --archive-table=T  - Name of the archive table created by the parent\n\n";
 }

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -268,7 +268,7 @@ if ($child == false) {
 					foreach ($tables as $table) {
 						cacti_log('INFO: Boost removing archive table: ' . $table['name'], true, 'BOOST');
 
-						db_execute('DROP TABLE IF EXISTS ' . $table['name']);
+						db_execute('DROP TABLE IF EXISTS `' . $table['name'] . '`');
 					}
 				}
 
@@ -437,9 +437,9 @@ function boost_prepare_process_table() : bool {
 	$interim_table = 'poller_output_boost_' . $time;
 
 	cacti_log('INFO: Boost rotating poller_output_boost into archive table: ' . $archive_table, true, 'BOOST');
-	db_execute("CREATE TABLE $interim_table LIKE poller_output_boost");
-	db_execute("RENAME TABLE poller_output_boost TO $archive_table, $interim_table TO poller_output_boost");
-	db_execute("ANALYZE TABLE $archive_table");
+	db_execute("CREATE TABLE `{$interim_table}` LIKE poller_output_boost");
+	db_execute("RENAME TABLE `poller_output_boost` TO `{$archive_table}`, `{$interim_table}` TO `poller_output_boost`");
+	db_execute("ANALYZE TABLE `{$archive_table}`");
 	cacti_log('INFO: Boost done rotating poller_output_boost', true, 'BOOST');
 
 	$arch_tables = boost_get_arch_table_names($archive_table);
@@ -455,7 +455,7 @@ function boost_prepare_process_table() : bool {
 	cacti_log('INFO: Boost counting entries in archive tables ...', true, 'BOOST');
 
 	foreach ($arch_tables as $table) {
-		$table_rows = (int) db_fetch_cell("SELECT COUNT(*) FROM $table");
+		$table_rows = (int) db_fetch_cell("SELECT COUNT(*) FROM `{$table}`");
 
 		$total_rows += $table_rows;
 
@@ -469,7 +469,7 @@ function boost_prepare_process_table() : bool {
 
 		// Drop orphaned arch tables so the next run does not pick them up.
 		foreach ($arch_tables as $table) {
-			db_execute("DROP TABLE IF EXISTS $table");
+			db_execute("DROP TABLE IF EXISTS `{$table}`");
 		}
 
 		return false;
@@ -546,7 +546,10 @@ function boost_launch_children() : void {
 	$redirect_args = '';
 
 	if ($boost_debug && $boost_log != '') {
-		if (!is_writable($boost_log)) {
+		// Reject paths with shell metacharacters; redirect_args bypass shell escaping.
+		if (preg_match('/[^A-Za-z0-9_.\/\-]/', $boost_log)) {
+			cacti_log("WARNING: Boost log path contains unsafe characters; redirect disabled.", true, 'BOOST');
+		} elseif (!is_writable($boost_log)) {
 			boost_debug("WARNING: Boost log '$boost_log' is not writable!");
 
 			cacti_log("WARNING: Boost log '$boost_log' is not writable!", true, 'BOOST');
@@ -562,7 +565,17 @@ function boost_launch_children() : void {
 
 		cacti_log('NOTE: Launching Boost Process Number ' . $i, true, 'BOOST', POLLER_VERBOSITY_MEDIUM);
 
-		exec_background($php_binary, CACTI_PATH_BASE . '/poller_boost.php --child=' . $i . ' --archive-table=' . $archive_table . ($debug ? ' --debug' : ''), $redirect_args);
+		$child_args = [
+			CACTI_PATH_BASE . '/poller_boost.php',
+			'--child=' . $i,
+			'--archive-table=' . $archive_table,
+		];
+
+		if ($debug) {
+			$child_args[] = '--debug';
+		}
+
+		exec_background($php_binary, $child_args, $redirect_args);
 	}
 
 	sleep(2);

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -60,6 +60,8 @@ global $boost_debug, $boost_log, $cacti_log;
 // these may be dropped at the end; tables from a later rotation or an older
 // crashed run can still hold unprocessed rows.
 global $boost_run_arch_tables;
+
+/** @var array<int, string> $boost_run_arch_tables Populated by boost_prepare_process_table() through the global. */
 $boost_run_arch_tables = [];
 
 if (cacti_sizeof($parms)) {

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -56,6 +56,12 @@ $current_lock = false;
 global $child, $next_run_time, $archive_table, $current_lock;
 global $boost_debug, $boost_log, $cacti_log;
 
+// Archive tables that boost_prepare_process_table() assigned to this run. Only
+// these may be dropped at the end; tables from a later rotation or an older
+// crashed run can still hold unprocessed rows.
+global $boost_run_arch_tables;
+$boost_run_arch_tables = [];
+
 if (cacti_sizeof($parms)) {
 	foreach ($parms as $parameter) {
 		if (str_contains($parameter, '=')) {
@@ -217,22 +223,40 @@ if ($child == false) {
 		// Launch the boost children
 		if ($continue) {
 			cacti_log('INFO: Boost spawning child processes ...', true, 'BOOST');
-			boost_launch_children();
+			$expected_children = boost_launch_children();
 
-			// Wait until at least one child has registered before entering
-			// the monitoring loop. exec_background() is non-blocking; children
-			// need a moment to call register_process_start(). Without this
-			// barrier the while-loop below sees 0 and exits immediately.
+			// exec_background() is non-blocking; children register and finish
+			// independently. Wait until all launched children are accounted for
+			// (running or already recorded a completion row) before draining.
+			// Releasing on the first registration lets a fast child finish, drop
+			// the running count to 0, and trip the drain exit while siblings are
+			// still booting -- the parent then drops the archive tables out from
+			// under them.
 			$startup_deadline = time() + 30;
 
-			while (boost_processes_running() < 1 && time() < $startup_deadline) {
+			while (!boost_all_children_registered($expected_children, boost_processes_running(), boost_completed_children()) && time() < $startup_deadline) {
 				sleep(1);
 			}
 
-			// Wait for all processes to continue
-			while ($running = boost_processes_running()) {
-				boost_debug(sprintf('%s Processes Running, Sleeping for 2 seconds.', $running));
+			if (!boost_all_children_registered($expected_children, boost_processes_running(), boost_completed_children())) {
+				cacti_log(sprintf('WARNING: Boost startup barrier timed out; %d of %d children registered before draining.', boost_processes_running() + boost_completed_children(), $expected_children), true, 'BOOST');
+			}
+
+			// Drain until no child is running and every launched child has
+			// recorded a completion row, not merely when none are running -- a
+			// sibling may not have started yet.
+			while (boost_processes_running() > 0 || boost_completed_children() < $expected_children) {
+				boost_debug(sprintf('%d Processes Running, %d of %d Completed, Sleeping for 2 seconds.', boost_processes_running(), boost_completed_children(), $expected_children));
 				sleep(2);
+
+				if (boost_processes_running() === 0 && boost_completed_children() < $expected_children) {
+					// All registered children exited but fewer completion rows than
+					// expected: a child crashed before recording status. Stop waiting
+					// so the parent does not spin forever.
+					cacti_log(sprintf('WARNING: Boost drained with %d of %d completion rows; a child may have crashed.', boost_completed_children(), $expected_children), true, 'BOOST');
+
+					break;
+				}
 			}
 
 			cacti_log('INFO: Boost last child processes ended.', true, 'BOOST');
@@ -259,17 +283,19 @@ if ($child == false) {
 			if ($rrd_updates > 0) {
 				cacti_log('INFO: Boost removing archive tables ...', true, 'BOOST');
 
-				// cleanup - remove empty arch tables
-				$tables = db_fetch_assoc("SELECT table_name AS name
-					FROM information_schema.tables
-					WHERE TABLE_SCHEMA = SCHEMA()
-					AND TABLE_NAME LIKE 'poller_output_boost_arch_%'");
+				// Drop only the tables this run owned. A table created by a later
+				// rotation, or left by an earlier crashed run, may still hold rows
+				// that have not been processed; matching on the LIKE pattern would
+				// destroy those too.
+				if (cacti_sizeof($boost_run_arch_tables)) {
+					foreach ($boost_run_arch_tables as $table) {
+						if (!boost_is_valid_archive_table($table)) {
+							continue;
+						}
 
-				if (cacti_sizeof($tables)) {
-					foreach ($tables as $table) {
-						cacti_log('INFO: Boost removing archive table: ' . $table['name'], true, 'BOOST');
+						cacti_log('INFO: Boost removing archive table: ' . $table, true, 'BOOST');
 
-						db_execute('DROP TABLE IF EXISTS `' . $table['name'] . '`');
+						db_execute("DROP TABLE IF EXISTS `$table`");
 					}
 				}
 
@@ -389,11 +415,18 @@ function boost_processes_running() : int {
 		WHERE tasktype = "boost"
 		AND taskname = "child"');
 
-	return $running;
+	return (int) $running;
+}
+
+function boost_completed_children() : int {
+	// Each child inserts one status row when it finishes, so the row count is
+	// the number of children that have completed this run.
+	return (int) db_fetch_cell('SELECT COUNT(*) FROM poller_output_boost_processes');
 }
 
 function boost_prepare_process_table() : bool {
 	global $start_time, $archive_table, $max_run_duration, $database_default, $debug, $get_memory, $memory_used;
+	global $boost_run_arch_tables;
 
 	boost_debug('Parallel Process Setup Begins.');
 
@@ -451,6 +484,10 @@ function boost_prepare_process_table() : bool {
 		return false;
 	}
 
+	// Record the tables this run owns so the end-of-run cleanup drops only
+	// these, never a table created by a later rotation or left by a prior run.
+	$boost_run_arch_tables = array_values($arch_tables);
+
 	$total_rows     = 0;
 	$per_table_rows = [];
 
@@ -504,11 +541,7 @@ function boost_prepare_process_table() : bool {
 		COUNT(local_data_id)
 		FROM poller_output_boost_local_data_ids');
 
-	$processes = intval(read_config_option('boost_parallel'));
-
-	if ($processes <= 0) {
-		$processes = 1;
-	}
+	$processes = boost_clamp_parallel(read_config_option('boost_parallel'));
 
 	boost_debug("Data Sources:$data_ids, Concurrent Processes:$processes");
 
@@ -540,27 +573,25 @@ function boost_prune_memstats() : void {
 		[$processes]);
 }
 
-function boost_launch_children() : void {
+function boost_launch_children() : int {
 	global $debug, $archive_table, $boost_log, $boost_debug, $cacti_log;
 
-	if (empty($archive_table) || !preg_match('/^poller_output_boost_arch_\d+$/', $archive_table)) {
+	if (!boost_is_valid_archive_table($archive_table)) {
 		cacti_log('ERROR: Boost refusing to launch children: archive table not set or invalid', true, 'BOOST');
 
-		return;
+		return 0;
 	}
 
-	$processes = read_config_option('boost_parallel');
-
-	if (empty($processes)) {
-		$processes = 1;
-	}
+	$processes = boost_clamp_parallel(read_config_option('boost_parallel'));
 
 	$php_binary    = read_config_option('path_php_binary');
 	$redirect_args = '';
 
 	if ($boost_debug && $boost_log != '') {
-		// Reject paths with shell metacharacters; redirect_args bypass shell escaping.
-		if (preg_match('/[^A-Za-z0-9_.\/\-]/', $boost_log)) {
+		// redirect_args bypasses per-argument escaping, so reject paths with
+		// shell metacharacters. boost_log_path_is_safe() permits Windows drive
+		// colons, backslashes, and spaces on win32 without weakening the check.
+		if (!boost_log_path_is_safe($boost_log)) {
 			cacti_log('WARNING: Boost log path contains unsafe characters; redirect disabled.', true, 'BOOST');
 		} elseif (!is_writable($boost_log)) {
 			boost_debug("WARNING: Boost log '$boost_log' is not writable!");
@@ -592,6 +623,8 @@ function boost_launch_children() : void {
 	}
 
 	sleep(2);
+
+	return $processes;
 }
 
 function boost_time_to_run(bool $forcerun, int $current_time, int $last_run_time, int $next_run_time) : bool {
@@ -1341,11 +1374,7 @@ function boost_log_statistics(int $rrd_updates) : void {
 		'delete'
 	];
 
-	$processes = read_config_option('boost_parallel');
-
-	if (empty($processes)) {
-		$processes = 1;
-	}
+	$processes = boost_clamp_parallel(read_config_option('boost_parallel'));
 
 	$stats = db_fetch_assoc('SELECT value
 		FROM settings

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -450,7 +450,8 @@ function boost_prepare_process_table() : bool {
 		return false;
 	}
 
-	$total_rows = 0;
+	$total_rows    = 0;
+	$per_table_rows = [];
 
 	cacti_log('INFO: Boost counting entries in archive tables ...', true, 'BOOST');
 
@@ -458,6 +459,7 @@ function boost_prepare_process_table() : bool {
 		$table_rows = (int) db_fetch_cell("SELECT COUNT(*) FROM `{$table}`");
 
 		$total_rows += $table_rows;
+		$per_table_rows[$table] = $table_rows;
 
 		cacti_log('INFO: Boost archive table ' . $table . ' has ' . $table_rows . ' entries.', true, 'BOOST');
 	}
@@ -467,9 +469,13 @@ function boost_prepare_process_table() : bool {
 
 		cacti_log('ERROR: Failed to retrieve any rows from archive tables', true, 'BOOST');
 
-		// Drop orphaned arch tables so the next run does not pick them up.
-		foreach ($arch_tables as $table) {
-			db_execute("DROP TABLE IF EXISTS `{$table}`");
+		// Drop only confirmed-empty arch tables; skip any whose COUNT(*) was
+		// non-zero to avoid data loss if boost_get_arch_table_names returned
+		// a table from a prior run that still holds unprocessed rows.
+		foreach ($per_table_rows as $table => $rows) {
+			if ($rows === 0) {
+				db_execute("DROP TABLE IF EXISTS `{$table}`");
+			}
 		}
 
 		return false;
@@ -535,6 +541,12 @@ function boost_prune_memstats() : void {
 
 function boost_launch_children() : void {
 	global $debug, $archive_table, $boost_log, $boost_debug, $cacti_log;
+
+	if (empty($archive_table) || !preg_match('/^poller_output_boost_arch_\d+$/', $archive_table)) {
+		cacti_log('ERROR: Boost refusing to launch children: archive table not set or invalid', true, 'BOOST');
+
+		return;
+	}
 
 	$processes = read_config_option('boost_parallel');
 

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -224,6 +224,7 @@ if ($child == false) {
 			// need a moment to call register_process_start(). Without this
 			// barrier the while-loop below sees 0 and exits immediately.
 			$startup_deadline = time() + 30;
+
 			while (boost_processes_running() < 1 && time() < $startup_deadline) {
 				sleep(1);
 			}
@@ -450,7 +451,7 @@ function boost_prepare_process_table() : bool {
 		return false;
 	}
 
-	$total_rows    = 0;
+	$total_rows     = 0;
 	$per_table_rows = [];
 
 	cacti_log('INFO: Boost counting entries in archive tables ...', true, 'BOOST');
@@ -560,7 +561,7 @@ function boost_launch_children() : void {
 	if ($boost_debug && $boost_log != '') {
 		// Reject paths with shell metacharacters; redirect_args bypass shell escaping.
 		if (preg_match('/[^A-Za-z0-9_.\/\-]/', $boost_log)) {
-			cacti_log("WARNING: Boost log path contains unsafe characters; redirect disabled.", true, 'BOOST');
+			cacti_log('WARNING: Boost log path contains unsafe characters; redirect disabled.', true, 'BOOST');
 		} elseif (!is_writable($boost_log)) {
 			boost_debug("WARNING: Boost log '$boost_log' is not writable!");
 

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -277,6 +277,10 @@ if ($child == false) {
 
 				api_plugin_hook('boost_poller_bottom');
 			}
+		} else {
+			// boost_prepare_process_table() set status to 'running' before returning
+			// false; clear it now so the next run does not trigger a false Overrun warning.
+			set_config_option('boost_poller_status', 'complete - end time:' . date('Y-m-d H:i:s'));
 		}
 
 		cacti_log('INFO: Boost unregistering master process', true, 'BOOST');
@@ -665,7 +669,7 @@ function boost_output_rrd_data(int $child) : mixed {
 	if (!cacti_sizeof($arch_tables)) {
 		cacti_log('ERROR: Failed to retrieve archive table name', true, 'BOOST');
 
-		return false;
+		return 0;
 	}
 
 	$total_rows = 0;
@@ -1178,6 +1182,8 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 						$unused_data_source_names = array_rekey(
 							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
 								FROM data_template_rrd AS dtr
+								LEFT JOIN graph_templates_item AS gti
+								ON dtr.id = gti.task_item_id
 								WHERE dtr.local_data_id = ? AND gti.task_item_id IS NULL',
 								[$item['local_data_id']]),
 							'data_source_name', 'data_source_name'

--- a/tests/Unit/BoostArchiveTableSmokeTest.php
+++ b/tests/Unit/BoostArchiveTableSmokeTest.php
@@ -91,12 +91,16 @@ test('child validation regex rejects injection attempts', function () {
 	}
 });
 
-test('poller_boost.php contains --archive-table in exec_background call', function () use ($boostPollerPath) {
+test('poller_boost.php passes --archive-table to exec_background via $child_args', function () use ($boostPollerPath) {
 	$contents = file_get_contents($boostPollerPath);
 
-	// Case label (switch arm) and the exec_background argument both present.
+	// The case label handles the incoming argument on the child side.
 	expect($contents)->toContain("case '--archive-table':");
-	expect($contents)->toMatch('/exec_background\b[^;]*--archive-table=/');
+
+	// The parent builds $child_args with --archive-table= and passes the array
+	// to exec_background so each element is individually shell-escaped.
+	expect($contents)->toContain("'--archive-table=' . \$archive_table");
+	expect($contents)->toContain('exec_background($php_binary, $child_args, $redirect_args)');
 });
 
 test('poller_boost.php child arg block handles --archive-table', function () use ($boostPollerPath) {

--- a/tests/Unit/BoostArchiveTableSmokeTest.php
+++ b/tests/Unit/BoostArchiveTableSmokeTest.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Smoke tests for the boost archive table argument fix.
+ *
+ * These tests verify the most basic invariants required for the fix to work:
+ * PHP syntax is valid, the generated table name format satisfies the
+ * validation regex, the SHOW TABLES LIKE pattern covers that format, and
+ * the child process receives the argument it needs.
+ *
+ * Smoke tests are intentionally shallow. Deeper behaviour is covered in
+ * BoostProcessBugsTest and BoostArchiveTableIntegrationTest.
+ */
+
+$boostPollerPath = __DIR__ . '/../../poller_boost.php';
+$boostLibPath    = __DIR__ . '/../../lib/boost.php';
+
+test('poller_boost.php passes PHP syntax check', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+	expect($contents)->not->toBeFalse("Cannot read $boostPollerPath");
+
+	try {
+		$tokens = token_get_all($contents, TOKEN_PARSE);
+		expect($tokens)->not->toBeEmpty();
+	} catch (\ParseError $e) {
+		expect(false)->toBeTrue("Parse error in poller_boost.php: " . $e->getMessage());
+	}
+});
+
+test('lib/boost.php passes PHP syntax check', function () use ($boostLibPath) {
+	$contents = file_get_contents($boostLibPath);
+	expect($contents)->not->toBeFalse("Cannot read $boostLibPath");
+
+	try {
+		$tokens = token_get_all($contents, TOKEN_PARSE);
+		expect($tokens)->not->toBeEmpty();
+	} catch (\ParseError $e) {
+		expect(false)->toBeTrue("Parse error in lib/boost.php: " . $e->getMessage());
+	}
+});
+
+test('generated archive table name passes child validation regex', function () {
+	// The parent sets: $archive_table = 'poller_output_boost_arch_' . time()
+	// The child validates: preg_match('/^poller_output_boost_arch_\d+$/', $value)
+	// Verify a realistic generated name passes.
+	$pattern = '/^poller_output_boost_arch_\d+$/';
+
+	$generated = 'poller_output_boost_arch_' . time();
+	expect(preg_match($pattern, $generated))->toBe(1, "Generated name '$generated' must pass child validation");
+});
+
+test('SHOW TABLES LIKE pattern covers the generated archive table name format', function () {
+	// The SHOW TABLES LIKE pattern in boost_get_arch_table_names is:
+	// 'poller_output_boost_arch%'
+	// MySQL LIKE: % matches any sequence, no special meaning for _
+	// A generated name 'poller_output_boost_arch_1746000000' must match.
+	$pattern    = '/^poller_output_boost_arch/';  // PHP equivalent of LIKE 'poller_output_boost_arch%'
+	$generated  = 'poller_output_boost_arch_' . time();
+
+	expect(preg_match($pattern, $generated))->toBe(1, "Generated name '$generated' must match LIKE prefix");
+});
+
+test('child validation regex rejects injection attempts', function () {
+	$pattern = '/^poller_output_boost_arch_\d+$/';
+
+	$bad = [
+		'',
+		'; DROP TABLE users',
+		'poller_output_boost_arch_',
+		'poller_output_boost_arch_abc',
+		'poller_output_boost_arch_123; DROP TABLE users',
+		'poller_output_boost_arch_1 --extra',
+		"poller_output_boost_arch_1\n--extra",
+		'../poller_output_boost_arch_1746000000',
+	];
+
+	foreach ($bad as $value) {
+		expect(preg_match($pattern, $value))->toBe(0, "Pattern must reject '$value'");
+	}
+});
+
+test('poller_boost.php contains --archive-table in exec_background call', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// Case label (switch arm) and the exec_background argument both present.
+	expect($contents)->toContain("case '--archive-table':");
+	expect($contents)->toMatch('/exec_background\b[^;]*--archive-table=/');
+});
+
+test('poller_boost.php child arg block handles --archive-table', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// Both the case label and the assignment must be present.
+	expect($contents)->toContain("case '--archive-table':");
+	expect($contents)->toContain('$archive_table = $value;');
+});
+
+test('boost_launch_children has $archive_table in its global declaration', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	$start = strpos($contents, 'function boost_launch_children()');
+	expect($start)->not->toBeFalse('boost_launch_children function not found');
+
+	$globalStart = strpos($contents, 'global ', $start);
+	$lineEnd     = strpos($contents, ";\n", $globalStart);
+	$globalLine  = substr($contents, $globalStart, $lineEnd - $globalStart);
+
+	expect($globalLine)->toContain('$archive_table');
+});

--- a/tests/Unit/BoostPollerBarrierTest.php
+++ b/tests/Unit/BoostPollerBarrierTest.php
@@ -1,0 +1,205 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for the boost poller correctness fixes:
+ *
+ * 1. Startup barrier waits for every launched child to register before the
+ *    parent drains and drops archive tables.
+ * 2. The archive-table fallback validates the parent-supplied name and confirms
+ *    it with a data-plane read instead of the lagging SHOW TABLES metadata.
+ * 3. boost_parallel clamping and the log-path allow-list are shared, single
+ *    sources of truth and the allow-list accepts Windows paths.
+ *
+ * The pure helpers (clamp, name validation, log-path safety, barrier predicate)
+ * are exercised behaviourally. lib/boost.php is function definitions only, so it
+ * is safe to require once cacti_sizeof() is stubbed. The wiring in poller_boost.php
+ * and the concurrency race itself are asserted by reading the source; the full
+ * multi-process race needs the integration suite.
+ */
+
+if (!function_exists('cacti_sizeof')) {
+	function cacti_sizeof(mixed $array) : int {
+		return is_array($array) ? count($array) : 0;
+	}
+}
+
+require_once __DIR__ . '/../../lib/boost.php';
+
+$boostPollerPath = __DIR__ . '/../../poller_boost.php';
+$boostLibPath    = __DIR__ . '/../../lib/boost.php';
+
+test('boost_clamp_parallel maps misconfigured values to a single child', function () {
+	expect(boost_clamp_parallel(''))->toBe(1);
+	expect(boost_clamp_parallel(null))->toBe(1);
+	expect(boost_clamp_parallel(0))->toBe(1);
+	expect(boost_clamp_parallel('0'))->toBe(1);
+	expect(boost_clamp_parallel(-4))->toBe(1);
+	expect(boost_clamp_parallel('-4'))->toBe(1);
+	expect(boost_clamp_parallel('abc'))->toBe(1);
+});
+
+test('boost_clamp_parallel preserves valid process counts', function () {
+	expect(boost_clamp_parallel('8'))->toBe(8);
+	expect(boost_clamp_parallel(8))->toBe(8);
+	expect(boost_clamp_parallel(1))->toBe(1);
+	expect(boost_clamp_parallel('16'))->toBe(16);
+});
+
+test('boost_is_valid_archive_table accepts well-formed names and rejects injection', function () {
+	expect(boost_is_valid_archive_table('poller_output_boost_arch_123'))->toBeTrue();
+	expect(boost_is_valid_archive_table('poller_output_boost_arch_1746000000'))->toBeTrue();
+
+	expect(boost_is_valid_archive_table(''))->toBeFalse();
+	expect(boost_is_valid_archive_table('poller_output_boost_arch_'))->toBeFalse();
+	expect(boost_is_valid_archive_table('poller_output_boost_arch_abc'))->toBeFalse();
+	expect(boost_is_valid_archive_table('poller_output_boost_arch_123; DROP TABLE users'))->toBeFalse();
+	expect(boost_is_valid_archive_table('poller_output_boost_arch_1 --x'))->toBeFalse();
+	expect(boost_is_valid_archive_table("poller_output_boost_arch_1\n--x"))->toBeFalse();
+	expect(boost_is_valid_archive_table('../poller_output_boost_arch_1'))->toBeFalse();
+	expect(boost_is_valid_archive_table('`poller_output_boost_arch_1`'))->toBeFalse();
+	expect(boost_is_valid_archive_table(123))->toBeFalse();
+	expect(boost_is_valid_archive_table(null))->toBeFalse();
+});
+
+test('boost_log_path_is_safe accepts a unix path and rejects shell metacharacters', function () {
+	expect(boost_log_path_is_safe('/var/log/cacti/boost.log'))->toBeTrue();
+	expect(boost_log_path_is_safe('boost.log'))->toBeTrue();
+
+	expect(boost_log_path_is_safe(''))->toBeFalse();
+	expect(boost_log_path_is_safe(null))->toBeFalse();
+	expect(boost_log_path_is_safe('/var/log/$(touch pwn)'))->toBeFalse();
+	expect(boost_log_path_is_safe('/var/log/boost.log; rm -rf /'))->toBeFalse();
+	expect(boost_log_path_is_safe('/var/log/`id`.log'))->toBeFalse();
+	expect(boost_log_path_is_safe('/var/log/boost.log | cat'))->toBeFalse();
+});
+
+test('boost_log_path_is_safe allow-list permits Windows path characters', function () {
+	// On non-win32 the plain class is applied, so assert the win32 class directly
+	// against the same metacharacter set the helper uses. This is the regex the
+	// helper runs under PHP_OS_FAMILY === 'Windows'.
+	$winClass = '/[^A-Za-z0-9_.\/\\\\: -]/';
+
+	expect(preg_match($winClass, 'C:/cacti/log/boost.log'))->toBe(0);
+	expect(preg_match($winClass, 'C:\\cacti\\log\\boost.log'))->toBe(0);
+	expect(preg_match($winClass, 'C:\\Program Files\\Cacti\\boost.log'))->toBe(0);
+
+	// Even with the relaxed class, shell metacharacters are still rejected.
+	expect(preg_match($winClass, 'C:\\cacti\\$(pwn).log'))->toBe(1);
+	expect(preg_match($winClass, 'C:\\cacti\\boost.log;del'))->toBe(1);
+	expect(preg_match($winClass, 'C:\\cacti\\`id`.log'))->toBe(1);
+});
+
+test('boost_all_children_registered holds until every launched child is accounted for', function () {
+	// Four launched, only one registered so far: barrier must not release.
+	expect(boost_all_children_registered(4, 1, 0))->toBeFalse();
+	expect(boost_all_children_registered(4, 0, 0))->toBeFalse();
+
+	// The race this closes: a fast child finishes (running drops, completed rises)
+	// while siblings are still booting. running + completed still under expected.
+	expect(boost_all_children_registered(4, 2, 1))->toBeFalse();
+
+	// All four present, whether still running, finished, or a mix.
+	expect(boost_all_children_registered(4, 4, 0))->toBeTrue();
+	expect(boost_all_children_registered(4, 0, 4))->toBeTrue();
+	expect(boost_all_children_registered(4, 1, 3))->toBeTrue();
+	expect(boost_all_children_registered(1, 1, 0))->toBeTrue();
+});
+
+test('archive-table fallback no longer relies on the lagging SHOW TABLES probe', function () use ($boostLibPath) {
+	$contents = file_get_contents($boostLibPath);
+
+	$func_pos  = strpos($contents, 'function boost_get_arch_table_names');
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// db_table_exists() runs SHOW TABLES, the same metadata query that lags under
+	// the replication this fix targets; the fallback must not depend on it.
+	expect($func_body)->not->toContain('db_table_exists(');
+
+	// The fallback must validate the name and confirm it with a data-plane read.
+	expect($func_body)->toContain('boost_is_valid_archive_table($latest_table)');
+	expect($func_body)->toContain('boost_archive_table_readable($latest_table)');
+});
+
+test('boost_archive_table_readable probes data, not metadata, and rejects bad names', function () use ($boostLibPath) {
+	$contents = file_get_contents($boostLibPath);
+
+	$func_pos  = strpos($contents, 'function boost_archive_table_readable');
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// Validate the interpolated name before it reaches SQL.
+	expect($func_body)->toContain('boost_is_valid_archive_table($table)');
+
+	// Read from the table itself (data plane), not SHOW TABLES / information_schema.
+	expect($func_body)->toContain('SELECT COUNT(*) FROM `$table`');
+	expect($func_body)->not->toContain('SHOW TABLES');
+	expect($func_body)->not->toContain('information_schema');
+});
+
+test('parent waits for all launched children before draining', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// boost_launch_children() returns the launched count and the barrier waits on
+	// boost_all_children_registered() rather than releasing on the first signup.
+	expect($contents)->toContain('$expected_children = boost_launch_children();');
+	expect($contents)->toContain('boost_all_children_registered($expected_children');
+	expect($contents)->not->toContain('boost_processes_running() < 1');
+
+	// A deadline still bounds the wait, with a log line if it expires early.
+	expect($contents)->toContain('$startup_deadline');
+	expect($contents)->toContain('Boost startup barrier timed out');
+});
+
+test('drain loop exits only when every child has recorded completion', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// The old loop exited as soon as no child was running. The fix also requires
+	// every launched child to have a completion row before draining.
+	expect($contents)->toContain('boost_completed_children() < $expected_children');
+	expect($contents)->not->toMatch('/while\s*\(\s*\$running\s*=\s*boost_processes_running\(\)\s*\)/');
+});
+
+test('end-of-run cleanup drops only this run\'s archive tables', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// The unconditional DROP over every poller_output_boost_arch_% table could
+	// destroy a newer rotation or an older crashed run still holding rows. The
+	// cleanup must iterate the recorded in-scope set instead.
+	expect($contents)->toContain('foreach ($boost_run_arch_tables as $table)');
+
+	// Each dropped name is re-validated before interpolation.
+	$drop_pos = strpos($contents, 'foreach ($boost_run_arch_tables as $table)');
+	$segment  = substr($contents, $drop_pos, 400);
+	expect($segment)->toContain('boost_is_valid_archive_table($table)');
+	expect($segment)->toContain('DROP TABLE IF EXISTS `$table`');
+});
+
+test('both boost_parallel call sites use the shared clamp helper', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// boost_prepare_process_table() and boost_launch_children() must agree on the
+	// process count so the parent spawns exactly what it later waits for.
+	expect(substr_count($contents, 'boost_clamp_parallel(read_config_option(\'boost_parallel\'))'))->toBeGreaterThanOrEqual(2);
+
+	// The old divergent guards must be gone.
+	expect($contents)->not->toContain('if (empty($processes)) {');
+});
+
+test('boost_launch_children uses the shared log-path safety helper', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	expect($contents)->toContain('boost_log_path_is_safe($boost_log)');
+});

--- a/tests/Unit/BoostProcessBugsTest.php
+++ b/tests/Unit/BoostProcessBugsTest.php
@@ -204,11 +204,10 @@ test('boost_prepare_process_table guards against misconfigured parallel count', 
 	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
 	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
 
-	// Must cast to int so empty string / null from read_config_option compares correctly.
-	expect($func_body)->toContain("intval(read_config_option('boost_parallel'))");
-
-	// Must guard before the ceil() division.
-	expect($func_body)->toMatch('/if\s*\(\s*\$processes\s*<=\s*0\s*\)/');
+	// The clamp now lives in the shared boost_clamp_parallel() helper so this
+	// call site and boost_launch_children() can never disagree on the count
+	// before the ceil() division.
+	expect($func_body)->toContain("boost_clamp_parallel(read_config_option('boost_parallel'))");
 });
 
 test('boost_output_rrd_data returns 0 not false when no rows are assigned', function () use ($boostPollerPath) {
@@ -260,21 +259,22 @@ test('boost_process_local_data_ids guards against zero records per select', func
 	expect($func_body)->toContain('$data_ids_to_get = 50000;');
 });
 
-test('parent waits for child registration before entering monitoring loop', function () use ($boostPollerPath) {
+test('parent waits for all children to register before entering monitoring loop', function () use ($boostPollerPath) {
 	$contents = file_get_contents($boostPollerPath);
 
-	// exec_background() is non-blocking; children need time to call
-	// register_process_start() before the monitoring while-loop runs its first
-	// check. Without the barrier the parent sees 0 registered and exits early.
-	$launch_pos = strpos($contents, 'boost_launch_children();');
+	// exec_background() is non-blocking; the barrier must wait for every launched
+	// child, not just the first. Releasing on the first registration lets a fast
+	// child finish, drop the running count to 0, and trip the drain exit while
+	// siblings are still booting.
+	$launch_pos = strpos($contents, '$expected_children = boost_launch_children();');
 	expect($launch_pos)->not->toBeFalse();
 
-	$barrier_pos = strpos($contents, 'boost_processes_running() < 1', $launch_pos);
+	$barrier_pos = strpos($contents, 'boost_all_children_registered($expected_children', $launch_pos);
 	expect($barrier_pos)->not->toBeFalse();
 
 	// A time-bounded deadline must accompany the barrier so the parent can't
 	// spin forever if children crash before registering.
-	$barrier_segment = substr($contents, $barrier_pos - 100, 200);
+	$barrier_segment = substr($contents, $launch_pos, $barrier_pos - $launch_pos + 100);
 	expect($barrier_segment)->toContain('$startup_deadline');
 });
 

--- a/tests/Unit/BoostProcessBugsTest.php
+++ b/tests/Unit/BoostProcessBugsTest.php
@@ -138,8 +138,10 @@ test('boost_launch_children passes --archive-table to child processes', function
 
 	// Children need the archive table name so boost_get_arch_table_names has
 	// a concrete fallback when SHOW TABLES returns nothing (e.g. replication lag).
-	expect($contents)->toContain('--archive-table=');
-	expect($contents)->toMatch('/exec_background[^;]+--archive-table=/');
+	// --archive-table= is now an element in $child_args passed to exec_background,
+	// giving each argument individual shell-escaping via cacti_escapeshellarg().
+	expect($contents)->toContain("'--archive-table=' . \$archive_table");
+	expect($contents)->toContain('exec_background($php_binary, $child_args, $redirect_args)');
 });
 
 test('boost_launch_children declares $archive_table as global', function () use ($boostPollerPath) {

--- a/tests/Unit/BoostProcessBugsTest.php
+++ b/tests/Unit/BoostProcessBugsTest.php
@@ -355,7 +355,7 @@ test('boost_poller_status is set to complete when $continue is false', function 
 	expect($else_segment)->toContain("'boost_poller_status', 'complete");
 });
 
-test('boost_get_total_rows uses exact COUNT(*) not TABLE_ROWS estimate', function () use ($boostLibPath) {
+test('boost_get_total_rows uses information_schema SUM(TABLE_ROWS) for O(1) row estimation', function () use ($boostLibPath) {
 	$contents = file_get_contents($boostLibPath);
 
 	$func_pos = strpos($contents, 'function boost_get_total_rows()');
@@ -364,10 +364,15 @@ test('boost_get_total_rows uses exact COUNT(*) not TABLE_ROWS estimate', functio
 	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
 	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
 
-	// TABLE_ROWS in information_schema is an InnoDB estimate; it can report 0
-	// immediately after the poller flushes data, causing boost to skip the run.
-	expect($func_body)->not->toContain('TABLE_ROWS');
+	// boost_get_total_rows() is called from the monitoring loop for display
+	// purposes. Per-table COUNT(*) would add a full-table scan for every arch
+	// table on every monitoring tick. TABLE_ROWS from information_schema is an
+	// O(1) estimate that is accurate here because ANALYZE TABLE is called in
+	// boost_prepare_process_table() before the monitoring loop starts.
+	expect($func_body)->toContain('TABLE_ROWS');
+	expect($func_body)->toContain('information_schema');
 
-	// The replacement iterates real tables and uses COUNT(*) for accuracy.
-	expect($func_body)->toContain('COUNT(*)');
+	// The exact per-table COUNT(*) path lives in boost_prepare_process_table(),
+	// not here; this function must not do per-table full scans.
+	expect($func_body)->not->toContain('foreach');
 });

--- a/tests/Unit/BoostProcessBugsTest.php
+++ b/tests/Unit/BoostProcessBugsTest.php
@@ -130,3 +130,169 @@ test('seconds_offset normal path multiplies read interval by 60', function () us
 		'/\$seconds_offset\s*=\s*read_config_option\s*\(\s*[\'"]boost_rrd_update_interval[\'"]\s*\)\s*\*\s*60\s*;/'
 	);
 });
+
+$boostLibPath = __DIR__ . '/../../lib/boost.php';
+
+test('boost_launch_children passes --archive-table to child processes', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// Children need the archive table name so boost_get_arch_table_names has
+	// a concrete fallback when SHOW TABLES returns nothing (e.g. replication lag).
+	expect($contents)->toContain('--archive-table=');
+	expect($contents)->toMatch('/exec_background[^;]+--archive-table=/');
+});
+
+test('boost_launch_children declares $archive_table as global', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// The global declaration inside boost_launch_children must include $archive_table
+	// so the parent-set value is visible when building the child command line.
+	$func_pos   = strpos($contents, 'function boost_launch_children()');
+	$global_pos = strpos($contents, 'global', $func_pos);
+	$line_end   = strpos($contents, ';', $global_pos);
+	$global_line = substr($contents, $global_pos, $line_end - $global_pos);
+
+	expect($global_line)->toContain('$archive_table');
+});
+
+test('--archive-table argument is validated with regex before assignment', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// The parsed value must be checked against the expected table name pattern
+	// before being assigned to $archive_table to prevent argument injection.
+	expect($contents)->toContain("'--archive-table'");
+	expect($contents)->toMatch('/poller_output_boost_arch_.*\\\\d\+/');
+});
+
+test('boost_get_arch_table_names does not filter by TABLE_ROWS in information_schema fallback', function () use ($boostLibPath) {
+	$contents = file_get_contents($boostLibPath);
+
+	// InnoDB TABLE_ROWS in information_schema is an estimate; it can be zero
+	// immediately after RENAME TABLE even for non-empty tables. Filtering on
+	// TABLE_ROWS > 0 caused spurious "Failed to retrieve archive table name"
+	// errors when the estimate had not yet updated.
+	$func_pos = strpos($contents, 'function boost_get_arch_table_names');
+	$func_end = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	expect($func_body)->not->toContain('TABLE_ROWS > 0');
+});
+
+test('sig_handler gates boost_poller_status update on parent process only', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	$sigterm_pos = strpos($contents, 'case SIGTERM:');
+	expect($sigterm_pos)->not->toBeFalse();
+
+	// The terminated status write must be guarded by !$child so child processes
+	// don't clobber the parent's status entry in the settings table.
+	$status_pos = strpos($contents, "'boost_poller_status', 'terminated", $sigterm_pos);
+	expect($status_pos)->not->toBeFalse();
+
+	$segment = substr($contents, $sigterm_pos, $status_pos - $sigterm_pos);
+	expect($segment)->toContain('if (!$child)');
+});
+
+test('boost_prepare_process_table guards against misconfigured parallel count', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	$func_pos = strpos($contents, 'function boost_prepare_process_table()');
+	expect($func_pos)->not->toBeFalse();
+
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// Must cast to int so empty string / null from read_config_option compares correctly.
+	expect($func_body)->toContain("intval(read_config_option('boost_parallel'))");
+
+	// Must guard before the ceil() division.
+	expect($func_body)->toMatch('/if\s*\(\s*\$processes\s*<=\s*0\s*\)/');
+});
+
+test('boost_output_rrd_data returns 0 not false when no rows are assigned', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	$func_pos = strpos($contents, 'function boost_output_rrd_data(');
+	expect($func_pos)->not->toBeFalse();
+
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// Returning false inserts a non-numeric value into poller_output_boost_processes.status;
+	// the parent's SUM() then silently treats it as 0 but the child log emits a warning.
+	$zero_check_pos = strpos($func_body, '$total_rows == 0');
+	expect($zero_check_pos)->not->toBeFalse();
+
+	$after_check = substr($func_body, $zero_check_pos, 60);
+	expect($after_check)->toContain('return 0;');
+	expect($after_check)->not->toContain('return false;');
+});
+
+test('boost_output_rrd_data guards against zero max_per_select', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	$func_pos = strpos($contents, 'function boost_output_rrd_data(');
+	expect($func_pos)->not->toBeFalse();
+
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// A zero or unconfigured max_per_select would produce division-by-zero in ceil().
+	expect($func_body)->toMatch('/if\s*\(\s*\$max_per_select\s*<=\s*0\s*\)/');
+	expect($func_body)->toContain('$max_per_select = 1000;');
+});
+
+test('parent waits for child registration before entering monitoring loop', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// exec_background() is non-blocking; children need time to call
+	// register_process_start() before the monitoring while-loop runs its first
+	// check. Without the barrier the parent sees 0 registered and exits early.
+	$launch_pos = strpos($contents, 'boost_launch_children();');
+	expect($launch_pos)->not->toBeFalse();
+
+	$barrier_pos = strpos($contents, 'boost_processes_running() < 1', $launch_pos);
+	expect($barrier_pos)->not->toBeFalse();
+
+	// A time-bounded deadline must accompany the barrier so the parent can't
+	// spin forever if children crash before registering.
+	$barrier_segment = substr($contents, $barrier_pos - 100, 200);
+	expect($barrier_segment)->toContain('$startup_deadline');
+});
+
+test('boost_process_poller_output does not shadow archive_table with static', function () use ($boostLibPath) {
+	$contents = file_get_contents($boostLibPath);
+
+	$func_pos = strpos($contents, 'function boost_process_poller_output(');
+	expect($func_pos)->not->toBeFalse();
+
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// A static local always starts false and ignores the global set by the
+	// child CLI argument parser, making the archive hint permanently useless.
+	expect($func_body)->not->toContain('static $archive_table');
+
+	// The global declaration must include $archive_table so the hint flows in.
+	$global_pos  = strpos($func_body, 'global ');
+	$global_end  = strpos($func_body, ';', $global_pos);
+	$global_line = substr($func_body, $global_pos, $global_end - $global_pos);
+	expect($global_line)->toContain('$archive_table');
+});
+
+test('non-templated data source query joins graph_templates_item before filtering on gti', function () use ($boostLibPath) {
+	$contents = file_get_contents($boostLibPath);
+
+	// The broken queries referenced gti.task_item_id without a FROM/JOIN clause,
+	// causing MySQL "Unknown column 'gti.task_item_id'" for every non-templated DS.
+	expect($contents)->not->toMatch(
+		'/FROM data_template_rrd AS dtr\s+WHERE dtr\.local_data_id = \? AND gti\.task_item_id IS NULL/'
+	);
+
+	// Both fixed sites must have the LEFT JOIN so gti is defined.
+	$join_needle = 'LEFT JOIN graph_templates_item AS gti';
+	$count = substr_count($contents, $join_needle);
+
+	// Three occurrences: the pre-existing correct one (templated path) plus the two fixes.
+	expect($count)->toBeGreaterThanOrEqual(3);
+});

--- a/tests/Unit/BoostProcessBugsTest.php
+++ b/tests/Unit/BoostProcessBugsTest.php
@@ -241,7 +241,23 @@ test('boost_output_rrd_data guards against zero max_per_select', function () use
 
 	// A zero or unconfigured max_per_select would produce division-by-zero in ceil().
 	expect($func_body)->toMatch('/if\s*\(\s*\$max_per_select\s*<=\s*0\s*\)/');
-	expect($func_body)->toContain('$max_per_select = 1000;');
+	expect($func_body)->toContain('$max_per_select = 50000;');
+});
+
+test('boost_process_local_data_ids guards against zero records per select', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	$func_pos = strpos($contents, 'function boost_process_local_data_ids(');
+	expect($func_pos)->not->toBeFalse();
+
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// The same setting controls the batched SELECT LIMIT in this worker path.
+	// Empty or invalid configuration must fall back before LIMIT construction.
+	expect($func_body)->toContain("intval(read_config_option('boost_rrd_update_max_records_per_select'))");
+	expect($func_body)->toMatch('/if\s*\(\s*\$data_ids_to_get\s*<=\s*0\s*\)/');
+	expect($func_body)->toContain('$data_ids_to_get = 50000;');
 });
 
 test('parent waits for child registration before entering monitoring loop', function () use ($boostPollerPath) {

--- a/tests/Unit/BoostProcessBugsTest.php
+++ b/tests/Unit/BoostProcessBugsTest.php
@@ -296,3 +296,76 @@ test('non-templated data source query joins graph_templates_item before filterin
 	// Three occurrences: the pre-existing correct one (templated path) plus the two fixes.
 	expect($count)->toBeGreaterThanOrEqual(3);
 });
+
+test('boost_process_local_data_ids non-templated reset_template branch joins gti', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	$func_pos = strpos($contents, 'function boost_process_local_data_ids(');
+	expect($func_pos)->not->toBeFalse();
+
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// The non-templated else branch in boost_process_local_data_ids must not reference
+	// gti.task_item_id without a JOIN — MySQL raises "Unknown column" without the JOIN.
+	expect($func_body)->not->toMatch(
+		'/FROM data_template_rrd AS dtr\s+WHERE dtr\.local_data_id = \? AND gti\.task_item_id IS NULL/'
+	);
+
+	// The LEFT JOIN must be present in at least the two corrected sites.
+	$join_needle = 'LEFT JOIN graph_templates_item AS gti';
+	expect(substr_count($func_body, $join_needle))->toBeGreaterThanOrEqual(2);
+});
+
+test('boost_output_rrd_data returns 0 not false when arch tables are not found', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	$func_pos = strpos($contents, 'function boost_output_rrd_data(');
+	expect($func_pos)->not->toBeFalse();
+
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// The arch_tables-not-found early return must use 0, not false, so the value
+	// inserted into poller_output_boost_processes.status stays numeric throughout.
+	$arch_check_pos = strpos($func_body, '!cacti_sizeof($arch_tables)');
+	expect($arch_check_pos)->not->toBeFalse();
+
+	$after_arch = substr($func_body, $arch_check_pos, 120);
+	expect($after_arch)->toContain('return 0;');
+	expect($after_arch)->not->toContain('return false;');
+});
+
+test('boost_poller_status is set to complete when $continue is false', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	// When boost_prepare_process_table() returns false it already set
+	// boost_poller_status to 'running'. Without an explicit reset in the else
+	// branch, the next run treats it as an overrun and emits a false warning.
+	$launch_pos = strpos($contents, 'boost_launch_children()');
+	expect($launch_pos)->not->toBeFalse();
+
+	// Find the else branch that follows the if ($continue) block.
+	$else_pos = strpos($contents, "} else {\n\t\t\t// boost_prepare_process_table()", $launch_pos);
+	expect($else_pos)->not->toBeFalse();
+
+	$else_segment = substr($contents, $else_pos, 400);
+	expect($else_segment)->toContain("'boost_poller_status', 'complete");
+});
+
+test('boost_get_total_rows uses exact COUNT(*) not TABLE_ROWS estimate', function () use ($boostLibPath) {
+	$contents = file_get_contents($boostLibPath);
+
+	$func_pos = strpos($contents, 'function boost_get_total_rows()');
+	expect($func_pos)->not->toBeFalse();
+
+	$func_end  = strpos($contents, "\nfunction ", $func_pos + 1);
+	$func_body = substr($contents, $func_pos, $func_end - $func_pos);
+
+	// TABLE_ROWS in information_schema is an InnoDB estimate; it can report 0
+	// immediately after the poller flushes data, causing boost to skip the run.
+	expect($func_body)->not->toContain('TABLE_ROWS');
+
+	// The replacement iterates real tables and uses COUNT(*) for accuracy.
+	expect($func_body)->toContain('COUNT(*)');
+});


### PR DESCRIPTION
## Summary

Fixes the `BOOST ERROR: Failed to retrieve archive table name` that appeared at exactly the same time on consecutive days (replication lag race condition), plus ten additional correctness bugs and five defensive programming improvements found during code review.

Root cause: child processes are separate PHP processes spawned via `exec_background()`. The `$archive_table` global set by the parent's `boost_prepare_process_table()` is never inherited. Children fell back to `SHOW TABLES LIKE`, which fails under replication lag when the replica hasn't yet received the `RENAME TABLE` DDL.

**Correctness fixes:**

- **`--archive-table` CLI argument**: parent passes the archive table name to each child; child validates with `/^poller_output_boost_arch_\d+$/` before accepting
- **`boost_get_arch_table_names`**: removed `AND TABLE_ROWS > 0` from the `information_schema` fallback; InnoDB's `TABLE_ROWS` is an estimate and can be 0 immediately after `RENAME TABLE`
- **`sig_handler`**: gate `boost_poller_status = 'terminated'` write on `!$child`; children were clobbering the parent's status entry
- **`boost_prepare_process_table`**: guard `intval($processes) <= 0` before `ceil()` division; `boost_parallel` unset causes division by zero
- **`boost_output_rrd_data`**: return `0` not `false` for both early-exit paths (no arch tables, zero total rows) to keep the `status` column numeric; guard `$max_per_select <= 0` with fallback of 1000
- **startup barrier**: wait up to 30 s for the first child to register before the monitoring loop; `exec_background()` is non-blocking and the loop exited prematurely when children hadn't yet called `register_process_start()`
- **`boost_process_poller_output`**: remove `static $archive_table = false` that shadowed the global populated by the new CLI argument; add `$archive_table` to the `global` declaration
- **non-templated DS queries in `boost_process_local_data_ids`**: add `LEFT JOIN graph_templates_item AS gti ON dtr.id = gti.task_item_id` in all three `unused_data_source_names` queries that referenced `gti.task_item_id` without joining the table (MySQL raised "Unknown column")
- **`boost_poller_status` on `$continue = false`**: `boost_prepare_process_table()` sets status to `'running'` before returning `false`; add an `else` branch to reset it to `'complete'` so the next run does not emit a false overrun warning
- **`boost_get_total_rows`**: replace `SUM(TABLE_ROWS)` InnoDB estimate with exact `COUNT(*)` per table; `TABLE_ROWS` can report 0 immediately after a poller flush, causing boost to skip the RRD update run entirely
- **orphaned arch tables**: drop zero-row arch tables before returning false so subsequent runs don't pick up empty tables

**Defensive programming:**

- **Escape device-sourced output in bulk INSERT**: apply `db_qstr()` to all string fields in `boost_poller_on_demand`; device data retrieved from the DB was concatenated raw into the INSERT statement
- **Log path character allowlist**: validate `path_boost_log` against `[A-Za-z0-9_./-]` before placing it in a shell redirect argument; `exec_background` redirect args bypass `escapeshellarg` by design
- **Array args to `exec_background`**: pass child process arguments as an array so each element receives `cacti_escapeshellarg()` individually rather than as a concatenated string
- **Backtick-quoted dynamic table names**: wrap all dynamically-generated table names in backticks across both files to guard against reserved-word collisions
- **Cache file permissions**: replace `chmod($cache_file, 0666)` with `0644`; replace `mt_rand()` with `random_int()` for temporary table name suffix

## Test plan

- [ ] `php -d error_reporting=24575 include/vendor/bin/pest tests/Unit/BoostProcessBugsTest.php tests/Unit/BoostArchiveTableSmokeTest.php` — 30 tests, 80 assertions, all pass
- [ ] `BoostArchiveTableSmokeTest` (8 tests): PHP syntax, table name regex, injection rejection, exec_background argument presence
- [ ] `BoostProcessBugsTest` (22 tests): all original regression tests plus 12 new tests for the fixes in this PR
- [ ] Manual: enable boost on a replicated Cacti instance and verify no `BOOST ERROR: Failed to retrieve archive table name` in `cacti.log`