### PR TITLE
fix: warn when MariaDB 11.8 innodb_snapshot_isolation=ON is detected

### DIFF
--- a/lib/utility.php
+++ b/lib/utility.php
@@ -1362,6 +1362,20 @@ function utilities_get_mysql_recommendations() : int {
 		];
 	}
 
+	if ($database == 'MariaDB' && version_compare($version, '11.8', '>=')) {
+		// MariaDB 11.8 enabled innodb_snapshot_isolation=ON by default (MDEV-39628).
+		// Under this mode, concurrent UPDATE statements on any InnoDB table can block
+		// for tens of thousands of seconds even when the table has only a handful of
+		// rows. Cacti's poller cycle issues many rapid UPDATEs; this setting makes
+		// those updates contend in ways that can freeze the entire poller.
+		$recommendations['innodb_snapshot_isolation'] = [
+			'value'   => 'OFF',
+			'measure' => 'equalint',
+			'class'   => 'error',
+			'comment' => __('MariaDB 11.8 enabled innodb_snapshot_isolation=ON by default. This causes severe lock contention: UPDATE statements can block for tens of thousands of seconds on small tables under concurrent load, which stalls the Cacti poller. Set innodb_snapshot_isolation=OFF in your [mysqld] configuration. See MDEV-39628.')
+		];
+	}
+
 	if (file_exists('/etc/my.cnf.d/server.cnf')) {
 		$location = '/etc/my.cnf.d/server.cnf';
 	} else {


### PR DESCRIPTION
## Summary

MariaDB 11.8 enabled `innodb_snapshot_isolation=ON` by default (MDEV-39628). Under this mode concurrent UPDATE statements on InnoDB tables can block for tens of thousands of seconds — observed in production on a 6-row table blocking the entire poller cycle. The workaround is `innodb_snapshot_isolation=OFF`.

- Adds an `error`-class entry to `utilities_get_mysql_recommendations()` for MariaDB >= 11.8
- The check only fires when the variable exists in `SHOW GLOBAL VARIABLES` (i.e., MariaDB 11.8+; older versions are unaffected)
- Directs admins to set `innodb_snapshot_isolation=OFF` in their `[mysqld]` configuration

## Test plan

- [ ] Verify the warning appears on the Utilities > System Diagnostics page against a MariaDB 11.8 instance with default settings
- [ ] Verify no new entry appears against MariaDB < 11.8 (variable absent from `SHOW GLOBAL VARIABLES`)
- [ ] `php -l lib/utility.php` passes; `composer run-script phpcsfixer` passes