### PR TITLE
fix: logic and security bugs in 1.3.0 upgrade scripts

### DIFF
--- a/cli/upgrade_database.php
+++ b/cli/upgrade_database.php
@@ -175,7 +175,7 @@ foreach ($cacti_version_codes as $cacti_upgrade_version => $hash_code) {
 	db_execute_prepared('UPDATE version SET cacti = ?', [$cacti_upgrade_version]);
 
 	if (cacti_version_compare(CACTI_VERSION, $cacti_upgrade_version, '=')) {
-		db_execute("UPDATE version SET cacti = '" . CACTI_VERSION_FULL . "'");
+		db_execute_prepared('UPDATE version SET cacti = ?', [CACTI_VERSION_FULL]);
 
 		break;
 	}

--- a/install/functions.php
+++ b/install/functions.php
@@ -305,6 +305,8 @@ function install_unlink(string $file) : void {
 
 	if (!str_contains($full_file, CACTI_PATH_BASE)) {
 		log_install_high('file', "Not Unlinking file: $full_file due to it not being in the Cacti base path.");
+
+		return;
 	}
 
 	if (file_exists($full_file) && is_writable($full_file)) {
@@ -323,6 +325,8 @@ function install_rmdir(string $directory) : void {
 
 	if (!str_contains($directory, CACTI_PATH_BASE)) {
 		log_install_high('file', "Not Unlinking directory: $directory due to it not being in the Cacti base path.");
+
+		return;
 	}
 
 	if (file_exists($directory) && is_writable($directory)) {
@@ -350,6 +354,8 @@ function install_rmdir_recursive(string $directory, bool $del_parent = false) : 
 
 	if (!str_contains($directory, CACTI_PATH_BASE)) {
 		log_install_high('file', "Not Unlinking directory: $directory due to it not being in the Cacti base path.");
+
+		return;
 	}
 
 	$files = glob($directory . '/{,.}[!.,!..]*',GLOB_MARK | GLOB_BRACE);
@@ -1384,12 +1390,16 @@ function import_colors() : bool {
 			$hex     = $parts[1];
 			$name    = $parts[2];
 
-			$id = db_fetch_cell("SELECT hex FROM colors WHERE hex='$hex'");
+			if (!preg_match('/^[0-9a-fA-F]{6}$/', $hex)) {
+				continue;
+			}
+
+			$id = db_fetch_cell_prepared('SELECT hex FROM colors WHERE hex = ?', [$hex]);
 
 			if (!empty($id)) {
-				db_execute("UPDATE colors SET name='$name', read_only='on' WHERE hex='$hex'");
+				db_execute_prepared('UPDATE colors SET name = ?, read_only = \'on\' WHERE hex = ?', [$name, $hex]);
 			} else {
-				db_execute("INSERT IGNORE INTO colors (name, hex, read_only) VALUES ('$name', '$hex', 'on')");
+				db_execute_prepared('INSERT IGNORE INTO colors (name, hex, read_only) VALUES (?, ?, \'on\')', [$name, $hex]);
 			}
 		}
 	}

--- a/install/functions.php
+++ b/install/functions.php
@@ -303,7 +303,10 @@ function install_unlink(string $file) : void {
 		$full_file = $file;
 	}
 
-	if (!str_contains($full_file, CACTI_PATH_BASE)) {
+	$real_base = realpath(CACTI_PATH_BASE);
+	$real_file = realpath($full_file);
+
+	if ($real_base === false || $real_file === false || !str_starts_with($real_file, $real_base . DIRECTORY_SEPARATOR)) {
 		log_install_high('file', "Not Unlinking file: $full_file due to it not being in the Cacti base path.");
 
 		return;
@@ -323,7 +326,10 @@ function install_rmdir(string $directory) : void {
 		$directory = CACTI_PATH_BASE . '/' . $directory;
 	}
 
-	if (!str_contains($directory, CACTI_PATH_BASE)) {
+	$real_base = realpath(CACTI_PATH_BASE);
+	$real_dir  = realpath($directory);
+
+	if ($real_base === false || $real_dir === false || !str_starts_with($real_dir, $real_base . DIRECTORY_SEPARATOR)) {
 		log_install_high('file', "Not Unlinking directory: $directory due to it not being in the Cacti base path.");
 
 		return;
@@ -352,7 +358,10 @@ function install_rmdir_recursive(string $directory, bool $del_parent = false) : 
 		$directory = CACTI_PATH_BASE . '/' . $directory;
 	}
 
-	if (!str_contains($directory, CACTI_PATH_BASE)) {
+	$real_base = realpath(CACTI_PATH_BASE);
+	$real_dir  = realpath($directory);
+
+	if ($real_base === false || $real_dir === false || !str_starts_with($real_dir, $real_base . DIRECTORY_SEPARATOR)) {
 		log_install_high('file', "Not Unlinking directory: $directory due to it not being in the Cacti base path.");
 
 		return;

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -41,7 +41,7 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_column('host', ['name' => 'snmp_retries', 'type' => 'tinyint(3) unsigned', 'NULL' => false, 'default' => '3', 'after' => 'snmp_timeout']);
 	db_install_add_column('host', ['name' => 'current_errors', 'type' => 'int(10)', 'unsigned' => true, 'default' => '0', 'after' => 'polling_time']);
 
-	db_add_index('host', 'INDEX', 'current_errors', ['current_errors']);
+	db_install_add_key('host', 'INDEX', 'current_errors', ['current_errors']);
 
 	db_install_add_column('poller_item', ['name' => 'snmp_retries', 'type' => 'tinyint(3) unsigned', 'NULL' => false, 'default' => '3', 'after' => 'snmp_timeout']);
 
@@ -82,11 +82,11 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_column('data_template', ['name' => 'last_updated', 'type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP']);
 	db_install_add_column('snmp_query', ['name' => 'last_updated', 'type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP']);
 
-	db_add_index('data_input_data', 'INDEX', 'data_template_id', ['data_template_id']);
-	db_add_index('data_input_data', 'INDEX', 'local_data_id', ['local_data_id']);
-	db_add_index('data_input_data', 'INDEX', 'host_id', ['host_id']);
+	db_install_add_key('data_input_data', 'INDEX', 'data_template_id', ['data_template_id']);
+	db_install_add_key('data_input_data', 'INDEX', 'local_data_id', ['local_data_id']);
+	db_install_add_key('data_input_data', 'INDEX', 'host_id', ['host_id']);
 
-	db_add_index('poller_output_boost', 'INDEX', 'time', ['time']);
+	db_install_add_key('poller_output_boost', 'INDEX', 'time', ['time']);
 
 	db_install_add_column('host_snmp_query', ['name' => 'reindex_last_runtime', 'type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP']);
 	db_install_add_column('host_snmp_query', ['name' => 'reindex_last_duration', 'type' => 'double', 'unsigned' => true, 'null' => false, 'default' => '0']);
@@ -288,8 +288,8 @@ function upgrade_to_1_3_0() : void {
 			ADD INDEX last_updated(last_updated)');
 	}
 
-	db_install_execute("ALTER TABLE `settings` MODIFY `name` varchar(75) not null default ''");
-	db_install_execute("ALTER TABLE `settings_user` MODIFY `name` varchar(75) not null default ''");
+	db_install_execute("ALTER TABLE `settings` MODIFY `name` varchar(255) not null default ''");
+	db_install_execute("ALTER TABLE `settings_user` MODIFY `name` varchar(255) not null default ''");
 
 	$tables = [
 		'aggregate_graph_templates' => [
@@ -687,10 +687,10 @@ function upgrade_reports() : void {
 						);
 
 						break;
-					case 10: // Hours
+					case 11: // Hours
 						db_execute_prepared('UPDATE reports
 							SET sched_type = ?,
-							enabled = ?
+							enabled = ?,
 							recur_every = ?,
 							next_start = ?,
 							last_started = ?


### PR DESCRIPTION
## Summary

Audit of `install/upgrades/1_3_0.php`, `install/functions.php`, and `cli/upgrade_database.php` found the following issues, all fixed here:

**Critical — `install/upgrades/1_3_0.php`**
- `case 10: // Hours` was a duplicate of `case 10: // Minutes`, making the Hours migration branch unreachable. Per the comment block at line 650, `intrvl=11` is Hours; changed to `case 11:`. Every site with hourly reports was silently skipping migration.
- The Hours `UPDATE` was also missing a comma between `enabled = ?` and `recur_every = ?`, which would cause a PDO syntax error if the case were reached.
- `settings.name` and `settings_user.name` were narrowed to `varchar(75)` — but `1_2_31` widened them to `varchar(255)` and the final `cacti.sql` schema defines `varchar(255)`. Restored to 255 to prevent silent truncation or hard errors on sites with longer setting names.
- Five `db_add_index()` calls replaced with `db_install_add_key()` so index-creation failures are captured in the upgrade status tracker instead of silently discarded.

**High — `install/functions.php`**
- `install_unlink()`, `install_rmdir()`, and `install_rmdir_recursive()` logged a warning when a path escaped `CACTI_PATH_BASE` but then fell through to the destructive operation anyway. Added `return` after each guard log.
- `import_colors()` interpolated `$hex` and `$name` directly from `colors.csv` into SQL strings. Replaced all three statements with `db_fetch_cell_prepared`/`db_execute_prepared` and added `/^[0-9a-fA-F]{6}$/` validation on `$hex`.

**Medium — `cli/upgrade_database.php`**
- Line 178 used string concatenation (`"... '" . CACTI_VERSION_FULL . "'"`) while adjacent lines on 167 and 175 use `db_execute_prepared`. Converted to prepared statement for consistency.

## Test plan

- [ ] Fresh install from 1.2.x with hourly reports: verify hourly reports migrate to `sched_type=6`
- [ ] Upgrade on a site with `settings.name` rows >= 76 chars: verify no truncation/error
- [ ] `php -l` passes on all three files; `composer run-script phpcsfixer` passes
- [ ] Run Cacti's upgrade path in CI against MariaDB and MySQL