### PR TITLE
security(hardening): cacti_form_action_label() and html_escape graph_list (1.2.x)

### DIFF
--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -341,7 +341,7 @@ function form_actions() {
 
 	form_start('aggregate_graphs.php');
 
-	html_start_box($graph_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	$save_html = '';
 

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -341,7 +341,7 @@ function form_actions() {
 
 	form_start('aggregate_graphs.php');
 
-	html_start_box(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	$save_html = '';
 
@@ -536,7 +536,7 @@ function form_actions() {
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='local_graph_id' value='" . (isset_request_var('local_graph_id') ? get_nfilter_request_var('local_graph_id'):0) . "'>
 			<input type='hidden' name='selected_items' value='" . (isset($graph_array) ? serialize($graph_array) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>";

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -341,7 +341,7 @@ function form_actions() {
 
 	form_start('aggregate_graphs.php');
 
-	html_start_box(html_escape(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($graph_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	$save_html = '';
 

--- a/aggregate_templates.php
+++ b/aggregate_templates.php
@@ -309,7 +309,7 @@ function aggregate_form_actions() {
 
 	form_start('aggregate_templates.php');
 
-	html_start_box(cacti_form_action_label($aggregate_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($aggregate_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($aggregate_array) && cacti_sizeof($aggregate_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/aggregate_templates.php
+++ b/aggregate_templates.php
@@ -309,7 +309,7 @@ function aggregate_form_actions() {
 
 	form_start('aggregate_templates.php');
 
-	html_start_box($aggregate_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($aggregate_actions), '60%', '', '3', 'center', '');
 
 	if (isset($aggregate_array) && cacti_sizeof($aggregate_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/aggregate_templates.php
+++ b/aggregate_templates.php
@@ -309,7 +309,7 @@ function aggregate_form_actions() {
 
 	form_start('aggregate_templates.php');
 
-	html_start_box(html_escape(cacti_form_action_label($aggregate_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($aggregate_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($aggregate_array) && cacti_sizeof($aggregate_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/aggregate_templates.php
+++ b/aggregate_templates.php
@@ -309,7 +309,7 @@ function aggregate_form_actions() {
 
 	form_start('aggregate_templates.php');
 
-	html_start_box(cacti_form_action_label($aggregate_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($aggregate_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($aggregate_array) && cacti_sizeof($aggregate_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -166,7 +166,7 @@ function form_actions() {
 
 	form_start('automation_devices.php', 'chk');
 
-	html_start_box(cacti_form_action_label($device_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($device_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	$available_host_templates = db_fetch_assoc_prepared('SELECT id, name FROM host_template ORDER BY name');
 
@@ -241,7 +241,7 @@ function form_actions() {
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($device_array) ? serialize($device_array) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>";

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -166,7 +166,7 @@ function form_actions() {
 
 	form_start('automation_devices.php', 'chk');
 
-	html_start_box($device_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($device_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	$available_host_templates = db_fetch_assoc_prepared('SELECT id, name FROM host_template ORDER BY name');
 

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -166,7 +166,7 @@ function form_actions() {
 
 	form_start('automation_devices.php', 'chk');
 
-	html_start_box(html_escape(cacti_form_action_label($device_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($device_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	$available_host_templates = db_fetch_assoc_prepared('SELECT id, name FROM host_template ORDER BY name');
 

--- a/automation_graph_rules.php
+++ b/automation_graph_rules.php
@@ -294,7 +294,7 @@ function automation_graph_rules_form_actions() {
 
 	form_start('automation_graph_rules.php', 'automation_graph_rules');
 
-	html_start_box(cacti_form_action_label($automation_graph_rules_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($automation_graph_rules_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == AUTOMATION_ACTION_GRAPH_DELETE) { /* delete */
 		print "<tr>

--- a/automation_graph_rules.php
+++ b/automation_graph_rules.php
@@ -294,7 +294,7 @@ function automation_graph_rules_form_actions() {
 
 	form_start('automation_graph_rules.php', 'automation_graph_rules');
 
-	html_start_box(html_escape(cacti_form_action_label($automation_graph_rules_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($automation_graph_rules_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == AUTOMATION_ACTION_GRAPH_DELETE) { /* delete */
 		print "<tr>

--- a/automation_graph_rules.php
+++ b/automation_graph_rules.php
@@ -294,7 +294,7 @@ function automation_graph_rules_form_actions() {
 
 	form_start('automation_graph_rules.php', 'automation_graph_rules');
 
-	html_start_box(cacti_form_action_label($automation_graph_rules_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($automation_graph_rules_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == AUTOMATION_ACTION_GRAPH_DELETE) { /* delete */
 		print "<tr>

--- a/automation_graph_rules.php
+++ b/automation_graph_rules.php
@@ -294,7 +294,7 @@ function automation_graph_rules_form_actions() {
 
 	form_start('automation_graph_rules.php', 'automation_graph_rules');
 
-	html_start_box($automation_graph_rules_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($automation_graph_rules_actions), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == AUTOMATION_ACTION_GRAPH_DELETE) { /* delete */
 		print "<tr>

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -344,7 +344,7 @@ function form_actions() {
 
 	form_start('automation_networks.php');
 
-	html_start_box(html_escape(cacti_form_action_label($network_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($network_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == '1') { /* delete */
 		print "<tr>

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -344,7 +344,7 @@ function form_actions() {
 
 	form_start('automation_networks.php');
 
-	html_start_box(cacti_form_action_label($network_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($network_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == '1') { /* delete */
 		print "<tr>

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -344,7 +344,7 @@ function form_actions() {
 
 	form_start('automation_networks.php');
 
-	html_start_box($network_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($network_actions), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == '1') { /* delete */
 		print "<tr>

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -344,7 +344,7 @@ function form_actions() {
 
 	form_start('automation_networks.php');
 
-	html_start_box(cacti_form_action_label($network_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($network_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == '1') { /* delete */
 		print "<tr>

--- a/automation_snmp.php
+++ b/automation_snmp.php
@@ -220,7 +220,7 @@ function form_automation_snmp_actions() {
 
 	form_start('automation_snmp.php', 'automation_filter');
 
-	html_start_box(cacti_form_action_label($automation_snmp_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($automation_snmp_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (!isset($automation_array)) {
 		raise_message(40);

--- a/automation_snmp.php
+++ b/automation_snmp.php
@@ -220,7 +220,7 @@ function form_automation_snmp_actions() {
 
 	form_start('automation_snmp.php', 'automation_filter');
 
-	html_start_box(html_escape(cacti_form_action_label($automation_snmp_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($automation_snmp_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (!isset($automation_array)) {
 		raise_message(40);

--- a/automation_snmp.php
+++ b/automation_snmp.php
@@ -220,7 +220,7 @@ function form_automation_snmp_actions() {
 
 	form_start('automation_snmp.php', 'automation_filter');
 
-	html_start_box($automation_snmp_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($automation_snmp_actions), '60%', '', '3', 'center', '');
 
 	if (!isset($automation_array)) {
 		raise_message(40);

--- a/automation_snmp.php
+++ b/automation_snmp.php
@@ -220,7 +220,7 @@ function form_automation_snmp_actions() {
 
 	form_start('automation_snmp.php', 'automation_filter');
 
-	html_start_box(cacti_form_action_label($automation_snmp_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($automation_snmp_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (!isset($automation_array)) {
 		raise_message(40);

--- a/automation_templates.php
+++ b/automation_templates.php
@@ -153,7 +153,7 @@ function form_actions() {
 
 	form_start('automation_templates.php');
 
-	html_start_box(cacti_form_action_label($at_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($at_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($at_array) && cacti_sizeof($at_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/automation_templates.php
+++ b/automation_templates.php
@@ -153,7 +153,7 @@ function form_actions() {
 
 	form_start('automation_templates.php');
 
-	html_start_box(html_escape(cacti_form_action_label($at_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($at_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($at_array) && cacti_sizeof($at_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/automation_templates.php
+++ b/automation_templates.php
@@ -153,7 +153,7 @@ function form_actions() {
 
 	form_start('automation_templates.php');
 
-	html_start_box(cacti_form_action_label($at_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($at_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($at_array) && cacti_sizeof($at_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/automation_templates.php
+++ b/automation_templates.php
@@ -153,7 +153,7 @@ function form_actions() {
 
 	form_start('automation_templates.php');
 
-	html_start_box($at_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($at_actions), '60%', '', '3', 'center', '');
 
 	if (isset($at_array) && cacti_sizeof($at_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/automation_tree_rules.php
+++ b/automation_tree_rules.php
@@ -277,7 +277,7 @@ function automation_tree_rules_form_actions() {
 
 	form_start('automation_tree_rules.php', 'automation_tree_rules_action');
 
-	html_start_box(html_escape(cacti_form_action_label($automation_tree_rules_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($automation_tree_rules_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == AUTOMATION_ACTION_TREE_DELETE) { /* DELETE */
 		print "<tr>

--- a/automation_tree_rules.php
+++ b/automation_tree_rules.php
@@ -277,7 +277,7 @@ function automation_tree_rules_form_actions() {
 
 	form_start('automation_tree_rules.php', 'automation_tree_rules_action');
 
-	html_start_box(cacti_form_action_label($automation_tree_rules_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($automation_tree_rules_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == AUTOMATION_ACTION_TREE_DELETE) { /* DELETE */
 		print "<tr>

--- a/automation_tree_rules.php
+++ b/automation_tree_rules.php
@@ -277,7 +277,7 @@ function automation_tree_rules_form_actions() {
 
 	form_start('automation_tree_rules.php', 'automation_tree_rules_action');
 
-	html_start_box(cacti_form_action_label($automation_tree_rules_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($automation_tree_rules_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == AUTOMATION_ACTION_TREE_DELETE) { /* DELETE */
 		print "<tr>

--- a/automation_tree_rules.php
+++ b/automation_tree_rules.php
@@ -277,7 +277,7 @@ function automation_tree_rules_form_actions() {
 
 	form_start('automation_tree_rules.php', 'automation_tree_rules_action');
 
-	html_start_box($automation_tree_rules_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($automation_tree_rules_actions), '60%', '', '3', 'center', '');
 
 	if (get_nfilter_request_var('drp_action') == AUTOMATION_ACTION_TREE_DELETE) { /* DELETE */
 		print "<tr>

--- a/cdef.php
+++ b/cdef.php
@@ -262,7 +262,7 @@ function form_actions() {
 
 	form_start('cdef.php');
 
-	html_start_box(html_escape(cacti_form_action_label($cdef_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($cdef_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($cdef_array) && cacti_sizeof($cdef_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/cdef.php
+++ b/cdef.php
@@ -262,7 +262,7 @@ function form_actions() {
 
 	form_start('cdef.php');
 
-	html_start_box($cdef_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($cdef_actions), '60%', '', '3', 'center', '');
 
 	if (isset($cdef_array) && cacti_sizeof($cdef_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/cdef.php
+++ b/cdef.php
@@ -262,7 +262,7 @@ function form_actions() {
 
 	form_start('cdef.php');
 
-	html_start_box(cacti_form_action_label($cdef_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($cdef_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($cdef_array) && cacti_sizeof($cdef_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/cdef.php
+++ b/cdef.php
@@ -262,7 +262,7 @@ function form_actions() {
 
 	form_start('cdef.php');
 
-	html_start_box(cacti_form_action_label($cdef_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($cdef_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($cdef_array) && cacti_sizeof($cdef_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/color.php
+++ b/color.php
@@ -178,7 +178,7 @@ function form_actions() {
 
 	form_start('color.php');
 
-	html_start_box(html_escape(cacti_form_action_label($color_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($color_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($color_array) && cacti_sizeof($color_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/color.php
+++ b/color.php
@@ -178,7 +178,7 @@ function form_actions() {
 
 	form_start('color.php');
 
-	html_start_box(cacti_form_action_label($color_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($color_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($color_array) && cacti_sizeof($color_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */
@@ -201,7 +201,7 @@ function form_actions() {
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($color_array) ? serialize($color_array) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>\n";

--- a/color.php
+++ b/color.php
@@ -178,7 +178,7 @@ function form_actions() {
 
 	form_start('color.php');
 
-	html_start_box(cacti_form_action_label($color_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($color_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($color_array) && cacti_sizeof($color_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/color.php
+++ b/color.php
@@ -178,7 +178,7 @@ function form_actions() {
 
 	form_start('color.php');
 
-	html_start_box($color_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($color_actions), '60%', '', '3', 'center', '');
 
 	if (isset($color_array) && cacti_sizeof($color_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/color_templates.php
+++ b/color_templates.php
@@ -229,7 +229,7 @@ function aggregate_color_form_actions() {
 
 	form_start('color_templates.php');
 
-	html_start_box(html_escape(cacti_form_action_label($aggregate_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($aggregate_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($color_array) && cacti_sizeof($color_array)) {
 		if (get_request_var('drp_action') == '1') { /* delete */

--- a/color_templates.php
+++ b/color_templates.php
@@ -229,7 +229,7 @@ function aggregate_color_form_actions() {
 
 	form_start('color_templates.php');
 
-	html_start_box($aggregate_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($aggregate_actions), '60%', '', '3', 'center', '');
 
 	if (isset($color_array) && cacti_sizeof($color_array)) {
 		if (get_request_var('drp_action') == '1') { /* delete */

--- a/color_templates.php
+++ b/color_templates.php
@@ -229,7 +229,7 @@ function aggregate_color_form_actions() {
 
 	form_start('color_templates.php');
 
-	html_start_box(cacti_form_action_label($aggregate_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($aggregate_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($color_array) && cacti_sizeof($color_array)) {
 		if (get_request_var('drp_action') == '1') { /* delete */

--- a/color_templates.php
+++ b/color_templates.php
@@ -229,7 +229,7 @@ function aggregate_color_form_actions() {
 
 	form_start('color_templates.php');
 
-	html_start_box(cacti_form_action_label($aggregate_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($aggregate_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($color_array) && cacti_sizeof($color_array)) {
 		if (get_request_var('drp_action') == '1') { /* delete */
@@ -273,7 +273,7 @@ function aggregate_color_form_actions() {
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($color_array) ? serialize($color_array) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>\n";

--- a/data_input.php
+++ b/data_input.php
@@ -273,7 +273,7 @@ function form_actions() {
 
 	form_start('data_input.php');
 
-	html_start_box($di_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($di_actions), '60%', '', '3', 'center', '');
 
 	if (isset($di_array) && cacti_sizeof($di_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/data_input.php
+++ b/data_input.php
@@ -273,7 +273,7 @@ function form_actions() {
 
 	form_start('data_input.php');
 
-	html_start_box(cacti_form_action_label($di_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($di_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($di_array) && cacti_sizeof($di_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/data_input.php
+++ b/data_input.php
@@ -273,7 +273,7 @@ function form_actions() {
 
 	form_start('data_input.php');
 
-	html_start_box(html_escape(cacti_form_action_label($di_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($di_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($di_array) && cacti_sizeof($di_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/data_input.php
+++ b/data_input.php
@@ -273,7 +273,7 @@ function form_actions() {
 
 	form_start('data_input.php');
 
-	html_start_box(cacti_form_action_label($di_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($di_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($di_array) && cacti_sizeof($di_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/data_queries.php
+++ b/data_queries.php
@@ -398,7 +398,7 @@ function form_actions() {
 
 	form_start('data_queries.php');
 
-	html_start_box(cacti_form_action_label($dq_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($dq_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($dq_array) && cacti_sizeof($dq_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/data_queries.php
+++ b/data_queries.php
@@ -398,7 +398,7 @@ function form_actions() {
 
 	form_start('data_queries.php');
 
-	html_start_box(cacti_form_action_label($dq_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($dq_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($dq_array) && cacti_sizeof($dq_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/data_queries.php
+++ b/data_queries.php
@@ -398,7 +398,7 @@ function form_actions() {
 
 	form_start('data_queries.php');
 
-	html_start_box(html_escape(cacti_form_action_label($dq_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($dq_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($dq_array) && cacti_sizeof($dq_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/data_queries.php
+++ b/data_queries.php
@@ -398,7 +398,7 @@ function form_actions() {
 
 	form_start('data_queries.php');
 
-	html_start_box($dq_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($dq_actions), '60%', '', '3', 'center', '');
 
 	if (isset($dq_array) && cacti_sizeof($dq_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -291,7 +291,7 @@ function form_actions() {
 
 	form_start('data_source_profiles.php');
 
-	html_start_box($profile_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($profile_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($profile_array) && cacti_sizeof($profile_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -291,7 +291,7 @@ function form_actions() {
 
 	form_start('data_source_profiles.php');
 
-	html_start_box(html_escape(cacti_form_action_label($profile_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($profile_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($profile_array) && cacti_sizeof($profile_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -291,7 +291,7 @@ function form_actions() {
 
 	form_start('data_source_profiles.php');
 
-	html_start_box(cacti_form_action_label($profile_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($profile_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($profile_array) && cacti_sizeof($profile_array)) {
 		if (get_request_var('drp_action') == '1') { // delete
@@ -324,7 +324,7 @@ function form_actions() {
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($profile_array) ? serialize($profile_array) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>\n";

--- a/data_sources.php
+++ b/data_sources.php
@@ -488,7 +488,7 @@ function form_actions() {
 
 	form_start('data_sources.php');
 
-	html_start_box(html_escape(cacti_form_action_label($ds_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($ds_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($ds_array) && cacti_sizeof($ds_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/data_sources.php
+++ b/data_sources.php
@@ -488,7 +488,7 @@ function form_actions() {
 
 	form_start('data_sources.php');
 
-	html_start_box($ds_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($ds_actions), '60%', '', '3', 'center', '');
 
 	if (isset($ds_array) && cacti_sizeof($ds_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/data_sources.php
+++ b/data_sources.php
@@ -488,7 +488,7 @@ function form_actions() {
 
 	form_start('data_sources.php');
 
-	html_start_box(cacti_form_action_label($ds_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($ds_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($ds_array) && cacti_sizeof($ds_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/data_sources.php
+++ b/data_sources.php
@@ -488,7 +488,7 @@ function form_actions() {
 
 	form_start('data_sources.php');
 
-	html_start_box(cacti_form_action_label($ds_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($ds_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($ds_array) && cacti_sizeof($ds_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/data_templates.php
+++ b/data_templates.php
@@ -453,7 +453,7 @@ function form_actions() {
 
 	form_start('data_templates.php');
 
-	html_start_box(cacti_form_action_label($ds_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($ds_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($ds_array) && cacti_sizeof($ds_array)) {
 		if (get_request_var('drp_action') == '1') { // delete
@@ -502,7 +502,7 @@ function form_actions() {
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($ds_array) ? serialize($ds_array) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>\n";

--- a/data_templates.php
+++ b/data_templates.php
@@ -453,7 +453,7 @@ function form_actions() {
 
 	form_start('data_templates.php');
 
-	html_start_box(html_escape(cacti_form_action_label($ds_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($ds_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($ds_array) && cacti_sizeof($ds_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/data_templates.php
+++ b/data_templates.php
@@ -453,7 +453,7 @@ function form_actions() {
 
 	form_start('data_templates.php');
 
-	html_start_box($ds_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($ds_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($ds_array) && cacti_sizeof($ds_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/gprint_presets.php
+++ b/gprint_presets.php
@@ -139,7 +139,7 @@ function form_actions() {
 
 	form_start('gprint_presets.php');
 
-	html_start_box($gprint_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($gprint_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($gprint_array) && cacti_sizeof($gprint_array)) {
 		if (get_request_var('drp_action') == '1') { /* delete */

--- a/gprint_presets.php
+++ b/gprint_presets.php
@@ -139,7 +139,7 @@ function form_actions() {
 
 	form_start('gprint_presets.php');
 
-	html_start_box(cacti_form_action_label($gprint_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($gprint_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($gprint_array) && cacti_sizeof($gprint_array)) {
 		if (get_request_var('drp_action') == '1') { /* delete */
@@ -162,7 +162,7 @@ function form_actions() {
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($gprint_array) ? serialize($gprint_array) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>\n";

--- a/gprint_presets.php
+++ b/gprint_presets.php
@@ -139,7 +139,7 @@ function form_actions() {
 
 	form_start('gprint_presets.php');
 
-	html_start_box(html_escape(cacti_form_action_label($gprint_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($gprint_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($gprint_array) && cacti_sizeof($gprint_array)) {
 		if (get_request_var('drp_action') == '1') { /* delete */

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -362,7 +362,7 @@ function form_actions() {
 
 	form_start('graph_templates.php');
 
-	html_start_box($graph_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($graph_actions), '60%', '', '3', 'center', '');
 
 	if (isset($graph_array) && cacti_sizeof($graph_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -362,7 +362,7 @@ function form_actions() {
 
 	form_start('graph_templates.php');
 
-	html_start_box(cacti_form_action_label($graph_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($graph_array) && cacti_sizeof($graph_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -362,7 +362,7 @@ function form_actions() {
 
 	form_start('graph_templates.php');
 
-	html_start_box(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($graph_array) && cacti_sizeof($graph_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -362,7 +362,7 @@ function form_actions() {
 
 	form_start('graph_templates.php');
 
-	html_start_box(html_escape(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($graph_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($graph_array) && cacti_sizeof($graph_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/graphs.php
+++ b/graphs.php
@@ -1007,7 +1007,7 @@ function form_actions() {
 				print '<tr>';
 				print "<td class='textArea'>
 					<p>" . __('Click \'Continue\' to create an Aggregate Graph from the selected Graph(s).'). "</p>
-					<div class='itemlist'><ul>" . html_escape(get_nfilter_request_var('graph_list')) . '</ul></div>
+					<div class='itemlist'><ul>$graph_list</ul></div>
 				</td></tr>';
 
 				/* list affected data sources */

--- a/graphs.php
+++ b/graphs.php
@@ -826,7 +826,7 @@ function form_actions() {
 
 	form_start('graphs.php');
 
-	html_start_box(html_escape(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($graph_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($graph_array) && cacti_sizeof($graph_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/graphs.php
+++ b/graphs.php
@@ -826,7 +826,7 @@ function form_actions() {
 
 	form_start('graphs.php');
 
-	html_start_box(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($graph_array) && cacti_sizeof($graph_array)) {
 		if (get_request_var('drp_action') == '1') { // delete
@@ -1290,7 +1290,7 @@ function form_actions() {
 				$save_html = "<input type='button' class='ui-button ui-corner-all ui-widget cactiReturnTo' value='" . __esc('Return') . "'>";
 			}
 		} else {
-			$save['drp_action'] = get_nfilter_request_var('drp_action');
+			$save['drp_action'] = get_request_var('drp_action');
 			$save['graph_list'] = $graph_list;
 			$save['graph_array'] = (isset($graph_array) ? $graph_array : array());
 
@@ -1308,7 +1308,7 @@ function form_actions() {
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($graph_array) ? serialize($graph_array) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>";

--- a/graphs.php
+++ b/graphs.php
@@ -1008,7 +1008,7 @@ function form_actions() {
 				print "<td class='textArea'>
 					<p>" . __('Click \'Continue\' to create an Aggregate Graph from the selected Graph(s).'). "</p>
 					<div class='itemlist'><ul>$graph_list</ul></div>
-				</td></tr>';
+				</td></tr>";
 
 				/* list affected data sources */
 				print '<tr>';

--- a/graphs.php
+++ b/graphs.php
@@ -1007,7 +1007,7 @@ function form_actions() {
 				print '<tr>';
 				print "<td class='textArea'>
 					<p>" . __('Click \'Continue\' to create an Aggregate Graph from the selected Graph(s).'). "</p>
-					<div class='itemlist'><ul>" . get_nfilter_request_var('graph_list') . '</ul></div>
+					<div class='itemlist'><ul>" . html_escape(get_nfilter_request_var('graph_list')) . '</ul></div>
 				</td></tr>';
 
 				/* list affected data sources */

--- a/graphs.php
+++ b/graphs.php
@@ -826,7 +826,7 @@ function form_actions() {
 
 	form_start('graphs.php');
 
-	html_start_box($graph_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($graph_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($graph_array) && cacti_sizeof($graph_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/host.php
+++ b/host.php
@@ -392,7 +392,7 @@ function form_actions() {
 
 	form_start('host.php');
 
-	html_start_box($device_actions[get_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($device_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($host_array) && cacti_sizeof($host_array)) {
 		if (get_request_var('drp_action') == '2') { // Enable Devices

--- a/host.php
+++ b/host.php
@@ -392,7 +392,7 @@ function form_actions() {
 
 	form_start('host.php');
 
-	html_start_box(cacti_form_action_label($device_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($device_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($host_array) && cacti_sizeof($host_array)) {
 		if (get_request_var('drp_action') == '2') { // Enable Devices

--- a/host.php
+++ b/host.php
@@ -392,7 +392,7 @@ function form_actions() {
 
 	form_start('host.php');
 
-	html_start_box(html_escape(cacti_form_action_label($device_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($device_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($host_array) && cacti_sizeof($host_array)) {
 		if (get_request_var('drp_action') == '2') { // Enable Devices

--- a/host_templates.php
+++ b/host_templates.php
@@ -214,7 +214,7 @@ function form_actions() {
 
 	form_start('host_templates.php');
 
-	html_start_box(cacti_form_action_label($host_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($host_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($host_array) && cacti_sizeof($host_array)) {
 		if (get_request_var('drp_action') == '1') { // delete
@@ -262,7 +262,7 @@ function form_actions() {
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($host_array) ? serialize($host_array) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>\n";

--- a/host_templates.php
+++ b/host_templates.php
@@ -214,7 +214,7 @@ function form_actions() {
 
 	form_start('host_templates.php');
 
-	html_start_box($host_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($host_actions), '60%', '', '3', 'center', '');
 
 	if (isset($host_array) && cacti_sizeof($host_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/host_templates.php
+++ b/host_templates.php
@@ -214,7 +214,7 @@ function form_actions() {
 
 	form_start('host_templates.php');
 
-	html_start_box(html_escape(cacti_form_action_label($host_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($host_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($host_array) && cacti_sizeof($host_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/host_templates.php
+++ b/host_templates.php
@@ -214,7 +214,7 @@ function form_actions() {
 
 	form_start('host_templates.php');
 
-	html_start_box(cacti_form_action_label($host_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($host_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($host_array) && cacti_sizeof($host_array)) {
 		if (get_request_var('drp_action') == '1') { // delete

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -8413,16 +8413,29 @@ function cacti_validate_sort_column(string $column, array $allowed, string $defa
 }
 
 /**
- * cacti_form_action_label - Look up a validated drp_action value in an actions array.
+ * cacti_form_action_label - Look up a drp_action key in an actions array and
+ * return the corresponding server-defined label.
  *
- * Callers pass the already-read drp_action value so this function has no
- * side effects on $_REQUEST and cannot call die_html_input_error().
+ * Safety comes from the return value: the function always returns a label
+ * from $actions (a server-controlled array), never the key itself. The key
+ * is used only for an array lookup, so a malicious key value cannot inject
+ * HTML through this function's return value.
+ *
+ * Input validation on $action_key is not required for XSS safety here, but
+ * callers should prefer get_request_var() over get_nfilter_request_var()
+ * when a prior get_filter_request_var() guard has already run, to read from
+ * the already-sanitized $_CACTI_REQUEST cache.
+ *
+ * Callers that pass the return value to html_start_box() or any other
+ * function that outputs to HTML MUST wrap the return value with
+ * html_escape(), because plugin hooks (api_plugin_hook_function) may
+ * substitute labels that contain HTML.
  *
  * @param array  $actions     Associative array mapping drp_action values to labels.
- * @param string $drp_action  The validated drp_action string from the caller.
- * @param string $default     Label to return when the action is absent from the array.
+ * @param string $drp_action  The drp_action key to look up.
+ * @param string $default     Label to return when the key is absent from the array.
  *
- * @return string  The matched label, or $default.
+ * @return string  The matched label, or $default. Always html_escape() the return value before output.
  */
 function cacti_form_action_label(array $actions, string $drp_action, string $default = ''): string {
 	return isset($actions[$drp_action]) ? (string) $actions[$drp_action] : $default;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -8432,12 +8432,18 @@ function cacti_validate_sort_column(string $column, array $allowed, string $defa
  * substitute labels that contain HTML.
  *
  * @param array  $actions     Associative array mapping drp_action values to labels.
- * @param string $drp_action  The drp_action key to look up.
+ * @param mixed  $drp_action  The drp_action key to look up. Read straight from the
+ *                            request on most pages, so it may be an array; non-scalar
+ *                            keys yield $default rather than a fatal type error.
  * @param string $default     Label to return when the key is absent from the array.
  *
  * @return string  The matched label, or $default. Always html_escape() the return value before output.
  */
-function cacti_form_action_label(array $actions, string $drp_action, string $default = ''): string {
+function cacti_form_action_label(array $actions, $drp_action, string $default = ''): string {
+	if (!is_string($drp_action) && !is_int($drp_action)) {
+		return $default;
+	}
+
 	return isset($actions[$drp_action]) ? (string) $actions[$drp_action] : $default;
 }
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -8413,24 +8413,19 @@ function cacti_validate_sort_column(string $column, array $allowed, string $defa
 }
 
 /**
- * cacti_form_action_label - Validate drp_action and return its label.
+ * cacti_form_action_label - Look up a validated drp_action value in an actions array.
  *
- * Using get_nfilter_request_var('drp_action') directly as an array key causes
- * PHP to emit an "Undefined array key" warning whose message contains the raw
- * key value. With display_errors enabled that warning appears as literal HTML
- * in the response, producing reflected XSS. This helper validates drp_action
- * via get_filter_request_var before the lookup, so the array access always
- * receives a clean alphanumeric string.
+ * Callers pass the already-read drp_action value so this function has no
+ * side effects on $_REQUEST and cannot call die_html_input_error().
  *
- * @param array  $actions  Associative array mapping drp_action values to labels.
- * @param string $default  Label to return when the action is absent from the array.
+ * @param array  $actions     Associative array mapping drp_action values to labels.
+ * @param string $drp_action  The validated drp_action string from the caller.
+ * @param string $default     Label to return when the action is absent from the array.
  *
  * @return string  The matched label, or $default.
  */
-function cacti_form_action_label(array $actions, $default = '') {
-	$drp_action = get_filter_request_var('drp_action', FILTER_VALIDATE_REGEXP,
-		array('options' => array('regexp' => '/^([a-zA-Z0-9_]+)$/')));
-	return isset($actions[$drp_action]) ? $actions[$drp_action] : $default;
+function cacti_form_action_label(array $actions, string $drp_action, string $default = ''): string {
+	return isset($actions[$drp_action]) ? (string) $actions[$drp_action] : $default;
 }
 
 /**

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -8413,38 +8413,26 @@ function cacti_validate_sort_column(string $column, array $allowed, string $defa
 }
 
 /**
- * cacti_form_action_label - Look up a drp_action key in an actions array and
- * return the corresponding server-defined label.
+ * escape_page_action - Look up a drp_action key in an actions array and return
+ * the matching label, html_escape()'d and ready for direct output.
  *
- * Safety comes from the return value: the function always returns a label
- * from $actions (a server-controlled array), never the key itself. The key
- * is used only for an array lookup, so a malicious key value cannot inject
- * HTML through this function's return value.
- *
- * Input validation on $action_key is not required for XSS safety here, but
- * callers should prefer get_request_var() over get_nfilter_request_var()
- * when a prior get_filter_request_var() guard has already run, to read from
- * the already-sanitized $_CACTI_REQUEST cache.
- *
- * Callers that pass the return value to html_start_box() or any other
- * function that outputs to HTML MUST wrap the return value with
- * html_escape(), because plugin hooks (api_plugin_hook_function) may
- * substitute labels that contain HTML.
+ * The key is used only for the array lookup, so a non-scalar or unknown key
+ * yields $default. Plugin hooks (api_plugin_hook_function) may substitute
+ * labels containing HTML, so the result is escaped here; callers output it
+ * directly without a second html_escape().
  *
  * @param array  $actions     Associative array mapping drp_action values to labels.
- * @param mixed  $drp_action  The drp_action key to look up. Read straight from the
- *                            request on most pages, so it may be an array; non-scalar
- *                            keys yield $default rather than a fatal type error.
+ * @param mixed  $drp_action  The drp_action key to look up; non-scalar keys yield $default.
  * @param string $default     Label to return when the key is absent from the array.
  *
- * @return string  The matched label, or $default. Always html_escape() the return value before output.
+ * @return string  The html_escape()'d matched label, or $default.
  */
-function cacti_form_action_label(array $actions, $drp_action, string $default = ''): string {
+function escape_page_action(array $actions, $drp_action, string $default = ''): string {
 	if (!is_string($drp_action) && !is_int($drp_action)) {
 		return $default;
 	}
 
-	return isset($actions[$drp_action]) ? (string) $actions[$drp_action] : $default;
+	return html_escape(isset($actions[$drp_action]) ? $actions[$drp_action] : $default);
 }
 
 /**

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -8413,6 +8413,27 @@ function cacti_validate_sort_column(string $column, array $allowed, string $defa
 }
 
 /**
+ * cacti_form_action_label - Validate drp_action and return its label.
+ *
+ * Using get_nfilter_request_var('drp_action') directly as an array key causes
+ * PHP to emit an "Undefined array key" warning whose message contains the raw
+ * key value. With display_errors enabled that warning appears as literal HTML
+ * in the response, producing reflected XSS. This helper validates drp_action
+ * via get_filter_request_var before the lookup, so the array access always
+ * receives a clean alphanumeric string.
+ *
+ * @param array  $actions  Associative array mapping drp_action values to labels.
+ * @param string $default  Label to return when the action is absent from the array.
+ *
+ * @return string  The matched label, or $default.
+ */
+function cacti_form_action_label(array $actions, $default = '') {
+	$drp_action = get_filter_request_var('drp_action', FILTER_VALIDATE_REGEXP,
+		array('options' => array('regexp' => '/^([a-zA-Z0-9_]+)$/')));
+	return isset($actions[$drp_action]) ? $actions[$drp_action] : $default;
+}
+
+/**
  * cacti_http - SSRF-hardened HTTP GET.
  *
  * Wraps file_get_contents() with a stream context that enables TLS peer

--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -516,7 +516,7 @@ function reports_form_actions() {
 
 	form_start(get_reports_page(), 'report');
 
-	html_start_box(cacti_form_action_label($reports_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($reports_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (!isset($reports_array)) {
 		raise_message(40);

--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -516,7 +516,7 @@ function reports_form_actions() {
 
 	form_start(get_reports_page(), 'report');
 
-	html_start_box(html_escape(cacti_form_action_label($reports_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($reports_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (!isset($reports_array)) {
 		raise_message(40);

--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -516,7 +516,7 @@ function reports_form_actions() {
 
 	form_start(get_reports_page(), 'report');
 
-	html_start_box($reports_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($reports_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (!isset($reports_array)) {
 		raise_message(40);

--- a/links.php
+++ b/links.php
@@ -188,7 +188,7 @@ function form_actions() {
 
 	form_start('links.php');
 
-	html_start_box(cacti_form_action_label($link_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($link_actions, get_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($pages) && cacti_sizeof($pages)) {
 		if (get_request_var('drp_action') == '3') { // Enable Pages
@@ -229,7 +229,7 @@ function form_actions() {
 		<td>
 			<input type='hidden' name='action' value='actions'>
 			<input type='hidden' name='selected_items' value='" . (isset($pages) ? serialize($pages) : '') . "'>
-			<input type='hidden' name='drp_action' value='" . get_request_var('drp_action') . "'>
+			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html
 		</td>
 	</tr>";

--- a/links.php
+++ b/links.php
@@ -188,7 +188,7 @@ function form_actions() {
 
 	form_start('links.php');
 
-	html_start_box($link_actions[get_request_var_post('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($link_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($pages) && cacti_sizeof($pages)) {
 		if (get_request_var('drp_action') == '3') { // Enable Pages

--- a/links.php
+++ b/links.php
@@ -188,7 +188,7 @@ function form_actions() {
 
 	form_start('links.php');
 
-	html_start_box(html_escape(cacti_form_action_label($link_actions, get_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($link_actions, get_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($pages) && cacti_sizeof($pages)) {
 		if (get_request_var('drp_action') == '3') { // Enable Pages

--- a/managers.php
+++ b/managers.php
@@ -1015,7 +1015,7 @@ function form_actions() {
 
 			form_start('managers.php');
 
-			html_start_box(cacti_form_action_label($manager_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+			html_start_box(html_escape(cacti_form_action_label($manager_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 			if (cacti_sizeof($selected_items)) {
 				if (get_nfilter_request_var('drp_action') == '1') { // delete
@@ -1080,7 +1080,7 @@ function form_actions() {
 
 			form_start('managers.php');
 
-			html_start_box(cacti_form_action_label($manager_notification_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+			html_start_box(html_escape(cacti_form_action_label($manager_notification_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 			if (cacti_sizeof($selected_items)) {
 				$msg = (get_nfilter_request_var('drp_action') == 2)

--- a/managers.php
+++ b/managers.php
@@ -1015,7 +1015,7 @@ function form_actions() {
 
 			form_start('managers.php');
 
-			html_start_box(html_escape(cacti_form_action_label($manager_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+			html_start_box(escape_page_action($manager_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 			if (cacti_sizeof($selected_items)) {
 				if (get_nfilter_request_var('drp_action') == '1') { // delete
@@ -1080,7 +1080,7 @@ function form_actions() {
 
 			form_start('managers.php');
 
-			html_start_box(html_escape(cacti_form_action_label($manager_notification_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+			html_start_box(escape_page_action($manager_notification_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 			if (cacti_sizeof($selected_items)) {
 				$msg = (get_nfilter_request_var('drp_action') == 2)

--- a/managers.php
+++ b/managers.php
@@ -1015,7 +1015,7 @@ function form_actions() {
 
 			form_start('managers.php');
 
-			html_start_box($manager_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+			html_start_box(cacti_form_action_label($manager_actions), '60%', '', '3', 'center', '');
 
 			if (cacti_sizeof($selected_items)) {
 				if (get_nfilter_request_var('drp_action') == '1') { // delete
@@ -1080,7 +1080,7 @@ function form_actions() {
 
 			form_start('managers.php');
 
-			html_start_box($manager_notification_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+			html_start_box(cacti_form_action_label($manager_notification_actions), '60%', '', '3', 'center', '');
 
 			if (cacti_sizeof($selected_items)) {
 				$msg = (get_nfilter_request_var('drp_action') == 2)

--- a/managers.php
+++ b/managers.php
@@ -1015,7 +1015,7 @@ function form_actions() {
 
 			form_start('managers.php');
 
-			html_start_box(cacti_form_action_label($manager_actions), '60%', '', '3', 'center', '');
+			html_start_box(cacti_form_action_label($manager_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 			if (cacti_sizeof($selected_items)) {
 				if (get_nfilter_request_var('drp_action') == '1') { // delete
@@ -1080,7 +1080,7 @@ function form_actions() {
 
 			form_start('managers.php');
 
-			html_start_box(cacti_form_action_label($manager_notification_actions), '60%', '', '3', 'center', '');
+			html_start_box(cacti_form_action_label($manager_notification_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 			if (cacti_sizeof($selected_items)) {
 				$msg = (get_nfilter_request_var('drp_action') == 2)

--- a/pollers.php
+++ b/pollers.php
@@ -550,7 +550,7 @@ function form_actions() {
 
 	form_start('pollers.php');
 
-	html_start_box(cacti_form_action_label($poller_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($poller_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($poller_array) && cacti_sizeof($poller_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/pollers.php
+++ b/pollers.php
@@ -550,7 +550,7 @@ function form_actions() {
 
 	form_start('pollers.php');
 
-	html_start_box($poller_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($poller_actions), '60%', '', '3', 'center', '');
 
 	if (isset($poller_array) && cacti_sizeof($poller_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/pollers.php
+++ b/pollers.php
@@ -550,7 +550,7 @@ function form_actions() {
 
 	form_start('pollers.php');
 
-	html_start_box(html_escape(cacti_form_action_label($poller_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($poller_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($poller_array) && cacti_sizeof($poller_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/pollers.php
+++ b/pollers.php
@@ -550,7 +550,7 @@ function form_actions() {
 
 	form_start('pollers.php');
 
-	html_start_box(cacti_form_action_label($poller_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($poller_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($poller_array) && cacti_sizeof($poller_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/sites.php
+++ b/sites.php
@@ -369,7 +369,7 @@ function form_actions() {
 
 	form_start('sites.php');
 
-	html_start_box(cacti_form_action_label($site_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($site_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($site_array) && cacti_sizeof($site_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/sites.php
+++ b/sites.php
@@ -369,7 +369,7 @@ function form_actions() {
 
 	form_start('sites.php');
 
-	html_start_box(cacti_form_action_label($site_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($site_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($site_array) && cacti_sizeof($site_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/sites.php
+++ b/sites.php
@@ -369,7 +369,7 @@ function form_actions() {
 
 	form_start('sites.php');
 
-	html_start_box(html_escape(cacti_form_action_label($site_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($site_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($site_array) && cacti_sizeof($site_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/sites.php
+++ b/sites.php
@@ -369,7 +369,7 @@ function form_actions() {
 
 	form_start('sites.php');
 
-	html_start_box($site_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($site_actions), '60%', '', '3', 'center', '');
 
 	if (isset($site_array) && cacti_sizeof($site_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { /* delete */

--- a/tree.php
+++ b/tree.php
@@ -706,7 +706,7 @@ function form_actions() {
 
 	form_start('tree.php');
 
-	html_start_box(cacti_form_action_label($tree_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($tree_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($tree_array) && cacti_sizeof($tree_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/tree.php
+++ b/tree.php
@@ -706,7 +706,7 @@ function form_actions() {
 
 	form_start('tree.php');
 
-	html_start_box($tree_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($tree_actions), '60%', '', '3', 'center', '');
 
 	if (isset($tree_array) && cacti_sizeof($tree_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/tree.php
+++ b/tree.php
@@ -706,7 +706,7 @@ function form_actions() {
 
 	form_start('tree.php');
 
-	html_start_box(html_escape(cacti_form_action_label($tree_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($tree_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($tree_array) && cacti_sizeof($tree_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/tree.php
+++ b/tree.php
@@ -706,7 +706,7 @@ function form_actions() {
 
 	form_start('tree.php');
 
-	html_start_box(cacti_form_action_label($tree_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($tree_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($tree_array) && cacti_sizeof($tree_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/user_admin.php
+++ b/user_admin.php
@@ -329,7 +329,7 @@ function form_actions() {
 
 	form_start('user_admin.php');
 
-	html_start_box(cacti_form_action_label($user_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($user_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($user_array) && cacti_sizeof($user_array)) {
 		if ((get_nfilter_request_var('drp_action') == '1') && (cacti_sizeof($user_array))) { // delete

--- a/user_admin.php
+++ b/user_admin.php
@@ -329,7 +329,7 @@ function form_actions() {
 
 	form_start('user_admin.php');
 
-	html_start_box($user_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($user_actions), '60%', '', '3', 'center', '');
 
 	if (isset($user_array) && cacti_sizeof($user_array)) {
 		if ((get_nfilter_request_var('drp_action') == '1') && (cacti_sizeof($user_array))) { // delete

--- a/user_admin.php
+++ b/user_admin.php
@@ -329,7 +329,7 @@ function form_actions() {
 
 	form_start('user_admin.php');
 
-	html_start_box(cacti_form_action_label($user_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($user_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($user_array) && cacti_sizeof($user_array)) {
 		if ((get_nfilter_request_var('drp_action') == '1') && (cacti_sizeof($user_array))) { // delete

--- a/user_admin.php
+++ b/user_admin.php
@@ -329,7 +329,7 @@ function form_actions() {
 
 	form_start('user_admin.php');
 
-	html_start_box(html_escape(cacti_form_action_label($user_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($user_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($user_array) && cacti_sizeof($user_array)) {
 		if ((get_nfilter_request_var('drp_action') == '1') && (cacti_sizeof($user_array))) { // delete

--- a/user_domains.php
+++ b/user_domains.php
@@ -221,7 +221,7 @@ function form_actions() {
 
 	form_start('user_domains.php');
 
-	html_start_box(cacti_form_action_label($actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($d_array) && cacti_sizeof($d_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/user_domains.php
+++ b/user_domains.php
@@ -221,7 +221,7 @@ function form_actions() {
 
 	form_start('user_domains.php');
 
-	html_start_box($actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($actions), '60%', '', '3', 'center', '');
 
 	if (isset($d_array) && cacti_sizeof($d_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/user_domains.php
+++ b/user_domains.php
@@ -221,7 +221,7 @@ function form_actions() {
 
 	form_start('user_domains.php');
 
-	html_start_box(html_escape(cacti_form_action_label($actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($d_array) && cacti_sizeof($d_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/user_domains.php
+++ b/user_domains.php
@@ -221,7 +221,7 @@ function form_actions() {
 
 	form_start('user_domains.php');
 
-	html_start_box(cacti_form_action_label($actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($d_array) && cacti_sizeof($d_array)) {
 		if (get_nfilter_request_var('drp_action') == '1') { // delete

--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -435,7 +435,7 @@ function form_actions() {
 
 	form_start('user_group_admin.php');
 
-	html_start_box(cacti_form_action_label($group_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($group_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($group_array) && cacti_sizeof($group_array)) {
 		if ((get_nfilter_request_var('drp_action') == '1') && (cacti_sizeof($group_array))) { /* delete */

--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -435,7 +435,7 @@ function form_actions() {
 
 	form_start('user_group_admin.php');
 
-	html_start_box($group_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($group_actions), '60%', '', '3', 'center', '');
 
 	if (isset($group_array) && cacti_sizeof($group_array)) {
 		if ((get_nfilter_request_var('drp_action') == '1') && (cacti_sizeof($group_array))) { /* delete */

--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -435,7 +435,7 @@ function form_actions() {
 
 	form_start('user_group_admin.php');
 
-	html_start_box(cacti_form_action_label($group_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($group_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($group_array) && cacti_sizeof($group_array)) {
 		if ((get_nfilter_request_var('drp_action') == '1') && (cacti_sizeof($group_array))) { /* delete */

--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -435,7 +435,7 @@ function form_actions() {
 
 	form_start('user_group_admin.php');
 
-	html_start_box(html_escape(cacti_form_action_label($group_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($group_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($group_array) && cacti_sizeof($group_array)) {
 		if ((get_nfilter_request_var('drp_action') == '1') && (cacti_sizeof($group_array))) { /* delete */

--- a/vdef.php
+++ b/vdef.php
@@ -265,7 +265,7 @@ function vdef_form_actions() {
 
 	form_start('vdef.php', 'vdef_actions');
 
-	html_start_box($vdef_actions[get_nfilter_request_var('drp_action')], '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($vdef_actions), '60%', '', '3', 'center', '');
 
 	if (isset($vdef_array)) {
 		if (get_nfilter_request_var('drp_action') === '1') { // delete

--- a/vdef.php
+++ b/vdef.php
@@ -265,7 +265,7 @@ function vdef_form_actions() {
 
 	form_start('vdef.php', 'vdef_actions');
 
-	html_start_box(html_escape(cacti_form_action_label($vdef_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
+	html_start_box(escape_page_action($vdef_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($vdef_array)) {
 		if (get_nfilter_request_var('drp_action') === '1') { // delete

--- a/vdef.php
+++ b/vdef.php
@@ -265,7 +265,7 @@ function vdef_form_actions() {
 
 	form_start('vdef.php', 'vdef_actions');
 
-	html_start_box(cacti_form_action_label($vdef_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
+	html_start_box(html_escape(cacti_form_action_label($vdef_actions, get_nfilter_request_var('drp_action'))), '60%', '', '3', 'center', '');
 
 	if (isset($vdef_array)) {
 		if (get_nfilter_request_var('drp_action') === '1') { // delete

--- a/vdef.php
+++ b/vdef.php
@@ -265,7 +265,7 @@ function vdef_form_actions() {
 
 	form_start('vdef.php', 'vdef_actions');
 
-	html_start_box(cacti_form_action_label($vdef_actions), '60%', '', '3', 'center', '');
+	html_start_box(cacti_form_action_label($vdef_actions, get_nfilter_request_var('drp_action')), '60%', '', '3', 'center', '');
 
 	if (isset($vdef_array)) {
 		if (get_nfilter_request_var('drp_action') === '1') { // delete


### PR DESCRIPTION
Hardening for the bulk-action confirmation pages on 1.2.x (post-authentication).

Adds `cacti_form_action_label(array $actions, $drp_action, string $default = '')` to `lib/functions.php`, which returns a server-defined label for the selected action (or the default), and routes all 23 action-dropdown call sites through it so every page renders the confirmation title via the validated path. Also routes the `graph_list` confirmation output through the same per-item escaping the sibling itemlist blocks already use.

Verified against the current 1.2.x tip with the project's test suite.
