### PR TITLE
fix(security): anchor thumbnails filter and parameterize header-node query

### DIFF
--- a/graph_view.php
+++ b/graph_view.php
@@ -198,7 +198,7 @@ case 'save':
 		get_filter_request_var('predefined_timespan');
 		get_filter_request_var('predefined_timeshift');
 		get_filter_request_var('graphs');
-		get_filter_request_var('thumbnails', FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '(true|false)')));
+		get_filter_request_var('thumbnails', FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '^(true|false)$')));
 
 		if (isset_request_var('predefined_timespan')) {
 			set_graph_config_option('default_timespan', get_request_var('predefined_timespan'));

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -2764,7 +2764,7 @@ function create_all_header_nodes($item_id, $rule) {
 				LEFT JOIN host_template AS ht
 				ON h.host_template_id=ht.id ';
 
-			$sql_where = 'WHERE h.id='. $item_id . ' AND h.deleted = "" ';
+			$sql_where = 'WHERE h.id=? AND h.deleted = "" ';
 		} elseif ($rule['leaf_type'] == TREE_ITEM_TYPE_GRAPH) {
 			/* graphs require a different set of tables to be joined */
 			$sql_tables = 'FROM host AS h
@@ -2777,7 +2777,7 @@ function create_all_header_nodes($item_id, $rule) {
 				LEFT JOIN graph_templates_graph AS gtg
 				ON gl.id=gtg.local_graph_id ';
 
-			$sql_where = 'WHERE gl.id=' . $item_id . ' AND h.deleted = "" ';
+			$sql_where = 'WHERE gl.id=? AND h.deleted = "" ';
 		}
 
 		/* get the WHERE clause for matching hosts */


### PR DESCRIPTION
Two small hardening fixes for 1.2.x:

- `graph_view.php`: anchor the `thumbnails` FILTER_VALIDATE_REGEXP to `^(true|false)$` (previously unanchored).
- `lib/api_automation.php`: `create_all_header_nodes()` uses a `?` placeholder for the item id it already binds via `db_fetch_cell_prepared()` (was string-concatenated).

Base: 1.2.x. Rebased onto the current 1.2.x tip so the diff is limited to these two files.
