### PR TITLE
fix(poller): coerce invalid SCRIPT/SCRIPT_PHP output to U in cmd.php

### DIFF
--- a/cmd.php
+++ b/cmd.php
@@ -729,6 +729,8 @@ function collect_device_data(&$item, &$error_ds) {
 					if (read_config_option('spine_log_level') == 2) {
 						cacti_log("WARNING: Invalid Response, Device[$host_id] DS[$ds] SCRIPT: " . $item['arg1'] . ", output: $output", $print_data_to_stdout, 'POLLER');
 					}
+
+					$output = 'U';
 				}
 			}
 
@@ -753,6 +755,8 @@ function collect_device_data(&$item, &$error_ds) {
 					if (read_config_option('spine_log_level') == 2) {
 						cacti_log("WARNING: Invalid Response, Device[$host_id] DS[$ds] SERVER: " . $item['arg1'] . ", output: $output", $print_data_to_stdout, 'POLLER');
 					}
+
+					$output = 'U';
 				}
 			}
 


### PR DESCRIPTION
The SCRIPT and SCRIPT_PHP collection branches in `cmd.php` log an invalid (non-numeric, shape-invalid) script/script-server response but leave `$output` as the raw junk string, unlike the SNMP branch and `cmd_realtime.php`, which reset it to `'U'`. Downstream `process_poller_output`/boost coerce non-numeric values to U before the RRD update, so this is a consistency/robustness fix (a raw bad value is otherwise stored in `poller_output` before being discarded), not a security issue. Base: 1.2.x.