### PR TITLE
fix(test): align OrderBySessionHardeningTest with shipped get_order_string

### DIFF
--- a/tests/Unit/OrderBySessionHardeningTest.php
+++ b/tests/Unit/OrderBySessionHardeningTest.php
@@ -14,11 +14,12 @@ test('sort order uses normalized column helper before session sql generation', f
 	expect($htmlUtilitySource)->toContain('cacti_build_sort_fragment($column, $direction)');
 });
 
-test('get_order_string hardens the sort column via normalize and build_sort_fragment', function () use ($htmlUtilitySource) {
+test('get_order_string normalizes, validates and builds the sort fragment', function () use ($htmlUtilitySource) {
 	$start = strpos($htmlUtilitySource, 'function get_order_string()');
 	expect($start)->not->toBeFalse();
 
-	$body = substr($htmlUtilitySource, $start, 1800);
+	$next = strpos($htmlUtilitySource, "\nfunction ", $start + 1);
+	$body = $next === false ? substr($htmlUtilitySource, $start) : substr($htmlUtilitySource, $start, $next - $start);
 	expect($body)->toContain("cacti_normalize_sort_column(get_nfilter_request_var('sort_column'))");
 	expect($body)->toContain('cacti_build_sort_fragment($sort_column, $sort_dir)');
 	expect($body)->toContain('validate_sort_column($request_column, $page)');

--- a/tests/Unit/OrderBySessionHardeningTest.php
+++ b/tests/Unit/OrderBySessionHardeningTest.php
@@ -14,11 +14,12 @@ test('sort order uses normalized column helper before session sql generation', f
 	expect($htmlUtilitySource)->toContain('cacti_build_sort_fragment($column, $direction)');
 });
 
-test('get_order_string rebuilds ORDER BY from validated session sort_data', function () use ($htmlUtilitySource) {
+test('get_order_string hardens the sort column via normalize and build_sort_fragment', function () use ($htmlUtilitySource) {
 	$start = strpos($htmlUtilitySource, 'function get_order_string()');
 	expect($start)->not->toBeFalse();
 
 	$body = substr($htmlUtilitySource, $start, 1800);
-	expect($body)->toContain("if (isset(\$_SESSION['sort_data'][\$page]) && is_array(\$_SESSION['sort_data'][\$page]))");
-	expect($body)->toContain("\$_SESSION['sort_string'][\$page] = 'ORDER BY ' . implode(', ', \$order_parts);");
+	expect($body)->toContain("cacti_normalize_sort_column(get_nfilter_request_var('sort_column'))");
+	expect($body)->toContain('cacti_build_sort_fragment($sort_column, $sort_dir)');
+	expect($body)->toContain('validate_sort_column($request_column, $page)');
 });


### PR DESCRIPTION
`OrderBySessionHardeningTest` (added in #7054) asserts that `get_order_string()` rebuilds the ORDER BY via `implode(', ', $order_parts)` from `$_SESSION['sort_data']`. #7098 later reworked the function to the `cacti_normalize_sort_column` / `cacti_build_sort_fragment` design and the test was not updated, so it is red on the current 1.2.x tip.

This updates the source-inspection assertions to the helpers the shipped function actually uses (`cacti_normalize_sort_column`, `cacti_build_sort_fragment`, allowlist `validate_sort_column`). No production code change. Base: 1.2.x.