### PR TITLE
fix(snmpagent): drop redundant snmp_priv_passphrase check in authNoPriv branch

### DIFF
--- a/lib/snmpagent.php
+++ b/lib/snmpagent.php
@@ -932,7 +932,7 @@ function snmpagent_notification(string $notification, string $mib, array $varbin
 
 					if ($notification_manager['snmp_password'] && $notification_manager['snmp_priv_passphrase']) {
 						$snmp_security_level = 'authPriv';
-					} elseif ($notification_manager['snmp_password'] && !$notification_manager['snmp_priv_passphrase']) {
+					} elseif ($notification_manager['snmp_password']) {
 						$snmp_security_level = 'authNoPriv';
 					} else {
 						$snmp_security_level = 'noAuthNoPriv';


### PR DESCRIPTION
PHPStan level 6 (the `PHP x Test` job in `syntax.yml`) currently fails on `develop` HEAD:

```
lib/snmpagent.php  Negated boolean expression is always true.  (booleanNot.alwaysTrue)
```

In both SNMPv3 trap blocks the `elseif` is reached only when the preceding `if (snmp_password && snmp_priv_passphrase)` is false. With `snmp_password` true at the `elseif`, `snmp_priv_passphrase` is necessarily empty, so `&& !snmp_priv_passphrase` is dead. Dropping it is behavior-identical and clears the gate. Per the repo's PHPStan policy this fixes the underlying cause rather than baselining.

Verified locally: `composer run-script phpstan` reports `[OK] No errors`. Unblocks the develop PHP test job for open develop PRs.