### PR TITLE
fix: repair broken FILTER_VALIDATE_REGEXP rules missing delimiters

### DIFF
--- a/lib/html_graph.php
+++ b/lib/html_graph.php
@@ -252,7 +252,7 @@ function create_graphs_preview_filter(string $session_var) : array {
 					'method'         => 'drop_multi',
 					'friendly_name'  => __('Template'),
 					'filter'         => FILTER_VALIDATE_REGEXP,
-					'filter_options' => ['options' => ['regexp' => '(cg_[0-9]|dq_[0-9]|[\-0-9])']],
+					'filter_options' => ['options' => ['regexp' => '/^(cg_[0-9]+|dq_[0-9]+|-?[0-9]+)$/']],
 					'default'        => '-1',
 					'dynamic'        => false,
 					'class'          => 'graph-multiselect',
@@ -284,7 +284,7 @@ function create_graphs_preview_filter(string $session_var) : array {
 					'method'         => 'filter_checkbox',
 					'friendly_name'  => __('Thumbnails'),
 					'filter'         => FILTER_VALIDATE_REGEXP,
-					'filter_options' => ['options' => ['regexp' => '(true|false)']],
+					'filter_options' => ['options' => ['regexp' => '/^(true|false)$/']],
 					'default'        => read_user_setting('thumbnail_section_preview') == 'on' ? 'true' : 'false',
 					'value'          => $thumbnails
 				],
@@ -292,7 +292,7 @@ function create_graphs_preview_filter(string $session_var) : array {
 					'method'         => 'filter_checkbox',
 					'friendly_name'  => __('Business Hours'),
 					'filter'         => FILTER_VALIDATE_REGEXP,
-					'filter_options' => ['options' => ['regexp' => '(true|false)']],
+					'filter_options' => ['options' => ['regexp' => '/^(true|false)$/']],
 					'default'        => read_user_setting('show_business_hours') == 'on' ? 'true' : 'false',
 					'value'          => $business_hours
 				]
@@ -726,8 +726,8 @@ function html_save_graph_settings() : void {
 		gfrv('predefined_timespan');
 		gfrv('predefined_timeshift');
 		gfrv('graphs');
-		gfrv('thumbnails', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => '(true|false)']]);
-		gfrv('business_hours', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => '(true|false)']]);
+		gfrv('thumbnails', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => '/^(true|false)$/']]);
+		gfrv('business_hours', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => '/^(true|false)$/']]);
 
 		if (isrv('predefined_timespan')) {
 			set_user_setting('default_timespan', grv('predefined_timespan'));
@@ -1049,7 +1049,7 @@ function create_listview_filter(string $session_var) : array {
 					'method'         => 'drop_multi',
 					'friendly_name'  => __('Template'),
 					'filter'         => FILTER_VALIDATE_REGEXP,
-					'filter_options' => ['options' => ['regexp' => '(cg_[0-9]|dq_[0-9]|[\-0-9])']],
+					'filter_options' => ['options' => ['regexp' => '/^(cg_[0-9]+|dq_[0-9]+|-?[0-9]+)$/']],
 					'default'        => '-1',
 					'dynamic'        => false,
 					'class'          => 'graph-multiselect',

--- a/tests/Unit/FilterValidateRegexTest.php
+++ b/tests/Unit/FilterValidateRegexTest.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+*/
+
+test('FILTER_VALIDATE_REGEXP requires delimiters and works for true/false parameters', function () {
+	// Without delimiters, filter_var returns false (and emits a warning in strict environments)
+	$broken_regex = '^(true|false)$';
+	
+	$warning_emitted = false;
+	set_error_handler(function ($errno, $errstr) use (&$warning_emitted) {
+		if ($errno === E_WARNING && strpos($errstr, 'No ending delimiter') !== false) {
+			$warning_emitted = true;
+			return true;
+		}
+		return false;
+	});
+	$broken_result = filter_var('true', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $broken_regex]]);
+	restore_error_handler();
+	
+	expect($broken_result)->toBeFalse()
+		->and($warning_emitted)->toBeTrue();
+
+	// With delimiters, it works correctly
+	$fixed_regex = '/^(true|false)$/';
+	$fixed_result = filter_var('true', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $fixed_regex]]);
+	expect($fixed_result)->toBe('true');
+
+	$fixed_result_false = filter_var('false', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $fixed_regex]]);
+	expect($fixed_result_false)->toBe('false');
+
+	$fixed_result_invalid = filter_var('not_true', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $fixed_regex]]);
+	expect($fixed_result_invalid)->toBeFalse();
+});
+
+test('FILTER_VALIDATE_REGEXP works for template parameters with delimiters', function () {
+	$regex = '/^(cg_[0-9]+|dq_[0-9]+|-?[0-9]+)$/';
+
+	expect(filter_var('cg_123', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regex]]))->toBe('cg_123')
+		->and(filter_var('dq_456', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regex]]))->toBe('dq_456')
+		->and(filter_var('123', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regex]]))->toBe('123')
+		->and(filter_var('-1', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regex]]))->toBe('-1')
+		->and(filter_var('invalid', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regex]]))->toBeFalse()
+		->and(filter_var('-', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regex]]))->toBeFalse()
+		->and(filter_var('--1', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regex]]))->toBeFalse()
+		->and(filter_var('1-2', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regex]]))->toBeFalse();
+});


### PR DESCRIPTION
This PR fixes a bug where `FILTER_VALIDATE_REGEXP` was missing required delimiters, causing valid parameters (like thumbnails or business_hours) to be rejected. Includes a new unit test for verification.