### PR TITLE
hardening(1.2.x): input validation, path containment, and auth boundary tightening

### DIFF
--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -1636,7 +1636,7 @@ function api_device_ping_device($device_id, $from_remote = false) {
 		}
 
 		print __('Ping Results') . "<br>\n";
-		print "<span class='" . $class . "'>" . $ping->ping_response . "</span>\n";
+		print "<span class='" . $class . "'>" . html_escape($ping->ping_response) . "</span>\n";
 	}
 
 	if ($anym == false && $host['disabled'] != 'on') {

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -254,6 +254,14 @@ function is_template_account($user_id) {
  * @return (string) the new username, or false if one was not passed
  */
 function get_basic_auth_username() {
+	/* Only trust Remote-User / PHP_AUTH_USER headers when Basic Auth is the
+	 * configured auth method (auth_method == 2).  Accepting these headers
+	 * unconditionally allows any proxy or client to spoof arbitrary usernames.
+	 * GHSA-9ffc-rr2g-c8hh */
+	if (read_config_option('auth_method') != 2) {
+		return false;
+	}
+
 	if (isset($_SERVER['PHP_AUTH_USER'])) {
 		$username = str_replace("\\", "\\\\", $_SERVER['PHP_AUTH_USER']);
 	} elseif (isset($_SERVER['REMOTE_USER'])) {
@@ -3865,7 +3873,10 @@ function domains_login_process($username) {
 
 	$user = array();
 
-	if ($realm > 3 && $password != '') {
+	/* realm 3 is LDAP; the original > 3 missed realm == 3 and allowed an
+	 * unauthenticated session when a non-empty password was supplied.
+	 * GHSA-3jj2-v5ch-wmq5 */
+	if ($realm >= 3 && $password != '') {
 		/* get user DN */
 		$ldap_dn_search_response = domains_ldap_search_dn($username, $realm);
 		if ($ldap_dn_search_response['error_num'] == '0') {
@@ -3978,7 +3989,10 @@ function domains_login_process($username) {
 
 				cacti_log('LOGIN FAILED: LDAP Error: ' . $ldap_auth_response['error_text'], false, 'AUTH');
 
-				if ($ldap_auth_response['error_text'] == 1) {
+				/* error_text is a string; the correct field for the numeric
+				 * bind-failure code is error_num (mirrors the check in
+				 * ldap_login_process at line ~3818).  GHSA-2px8-gvmq-85f3 */
+				if ($ldap_auth_response['error_num'] == 1) {
 					auth_process_lockout($username, $realm);
 				}
 			}

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -3873,9 +3873,7 @@ function domains_login_process($username) {
 
 	$user = array();
 
-	/* realm 3 is LDAP; the original > 3 missed realm == 3 and allowed an
-	 * unauthenticated session when a non-empty password was supplied.
-	 * GHSA-3jj2-v5ch-wmq5 */
+	// realm >= 3: domain realms start at 3; > 3 allowed realm=3 to skip LDAP bind (GHSA-3jj2-v5ch-wmq5)
 	if ($realm >= 3 && $password != '') {
 		/* get user DN */
 		$ldap_dn_search_response = domains_ldap_search_dn($username, $realm);

--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -609,6 +609,16 @@ function get_data_query_array($snmp_query_id) {
 		$replace       = array($config['base_path'], read_config_option('path_snmpget'), read_config_option('path_php_binary'));
 		$xml_file_path = str_replace($search, $replace, $xml_file_path);
 
+		/* Reject paths that resolve outside the Cacti resource tree.
+		 * xml_path may be absolute after <path_cacti> substitution above,
+		 * so we validate against the actual filesystem location rather than
+		 * just the token value. */
+		$allowed_base = $config['base_path'] . '/resource';
+		if (!cacti_path_is_within($xml_file_path, $allowed_base)) {
+			cacti_log("SECURITY: xml_path '$xml_file_path' for snmp_query id $snmp_query_id resolves outside '$allowed_base' -- access denied.", false, 'SYSTEM');
+			return array();
+		}
+
 		if (!file_exists($xml_file_path)) {
 			query_debug_timer_offset('data_query', __esc('Could not find data query XML file at \'%s\'', $xml_file_path));
 			return array();

--- a/lib/import.php
+++ b/lib/import.php
@@ -453,7 +453,12 @@ function import_read_package_data($xmlfile, &$public_key) {
 	/* SECURITY: Reject keys below 2048 bits before attempting signature verification.
 	 * 512-bit RSA keys are practically factorable (GHSA-8w9r-xmpr-5q3v), allowing
 	 * an attacker to forge signatures and achieve RCE via crafted package imports. */
-	$key_details = openssl_pkey_get_details(openssl_pkey_get_public($public_key));
+	$pkey = openssl_pkey_get_public($public_key);
+	if ($pkey === false) {
+		cacti_log('SECURITY: Package rejected - public key is invalid or unparseable (GHSA-8w9r-xmpr-5q3v)', false, 'IMPORT');
+		return false;
+	}
+	$key_details = openssl_pkey_get_details($pkey);
 	if ($key_details === false || $key_details['bits'] < 2048) {
 		cacti_log('SECURITY: Package rejected - signing key is ' . ($key_details ? $key_details['bits'] : 'unknown') . ' bits (minimum 2048 required). GHSA-8w9r-xmpr-5q3v', false, 'IMPORT');
 		return false;

--- a/lib/import.php
+++ b/lib/import.php
@@ -450,6 +450,15 @@ function import_read_package_data($xmlfile, &$public_key) {
 	}
 
 	// Verify Signature
+	/* SECURITY: Reject keys below 2048 bits before attempting signature verification.
+	 * 512-bit RSA keys are practically factorable (GHSA-8w9r-xmpr-5q3v), allowing
+	 * an attacker to forge signatures and achieve RCE via crafted package imports. */
+	$key_details = openssl_pkey_get_details(openssl_pkey_get_public($public_key));
+	if ($key_details === false || $key_details['bits'] < 2048) {
+		cacti_log('SECURITY: Package rejected - signing key is ' . ($key_details ? $key_details['bits'] : 'unknown') . ' bits (minimum 2048 required). GHSA-8w9r-xmpr-5q3v', false, 'IMPORT');
+		return false;
+	}
+
 	if (strlen($public_key) < 200) {
 		$ok = openssl_verify($xml, $binary_signature, $public_key, OPENSSL_ALGO_SHA1);
 	} else {
@@ -622,7 +631,7 @@ function import_package($xmlfile, $profile_id = 1, $remove_orphans = false, $rep
 
 				if (is_writeable(dirname($filename))) {
 					if (file_exists($filename) && is_writable($filename)) {
-						if ($new == $existing) {
+						if ($new === $existing) {
 							$filestatus[$filename] = 'writable, identical';
 						} else {
 							$filestatus[$filename] = 'writable, differences';
@@ -630,7 +639,7 @@ function import_package($xmlfile, $profile_id = 1, $remove_orphans = false, $rep
 					} elseif (file_exists($filename) && is_writeable($filename)) {
 						$filestatus[$filename] = 'writable, new';
 					} elseif (file_exists($filename) && !is_writeable($filename)) {
-						if ($new == $existing) {
+						if ($new === $existing) {
 							$filestatus[$filename] = 'not writable, identical';
 						} else {
 							$filestatus[$filename] = 'not writable, differences';
@@ -639,7 +648,7 @@ function import_package($xmlfile, $profile_id = 1, $remove_orphans = false, $rep
 						$filestatus[$filename] = 'writable, new';
 					}
 				} elseif (file_exists($filename)) {
-					if ($new == $existing) {
+					if ($new === $existing) {
 						$filestatus[$filename] = 'not writable, identical';
 					} else {
 						$filestatus[$filename] = 'not writable, differences';

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -150,7 +150,7 @@ class Net_Ping
 
 				if (!$this->is_ipaddress($host_ip)) {
 					cacti_log('WARNING: ICMP Ping Error: cacti_gethostbyname failed for ' . $this->host['hostname']);
-					$this->ping_response = 'ICMP Ping Error: cacti_gethostbyname failed for ' . $this->host['hostname'];
+					$this->ping_response = 'ICMP Ping Error: cacti_gethostbyname failed for ' . html_escape($this->host['hostname']);
 					return false;
 				}
 			}
@@ -368,7 +368,7 @@ class Net_Ping
 
 				if (!$this->is_ipaddress($host_ip)) {
 					cacti_log('WARNING: UDP Ping Error: cacti_gethostbyname failed for ' . $this->host['hostname']);
-					$this->ping_response = 'UDP Ping Error: cacti_gethostbyname failed for ' . $this->host['hostname'];
+					$this->ping_response = 'UDP Ping Error: cacti_gethostbyname failed for ' . html_escape($this->host['hostname']);
 					$this->restore_cacti_error_handler();
 
 					return false;
@@ -505,7 +505,7 @@ class Net_Ping
 
 				if (!$this->is_ipaddress($host_ip)) {
 					cacti_log('WARNING: TCP Ping Error: cacti_gethostbyname failed for ' . $this->host['hostname']);
-					$this->ping_response = 'TCP Ping Error: cacti_gethostbyname failed for ' . $this->host['hostname'];
+					$this->ping_response = 'TCP Ping Error: cacti_gethostbyname failed for ' . html_escape($this->host['hostname']);
 					$this->restore_cacti_error_handler();
 
 					return false;

--- a/package_import.php
+++ b/package_import.php
@@ -697,6 +697,8 @@ function import_display_package_data($templates, $files, $package_name, $xmlfile
 				}
 
 				if (cacti_sizeof($diff_array)) {
+					// $diff_array entries are pre-escaped at source in lib/import.php via html_escape();
+					// do NOT wrap with array_map('html_escape') here — that would double-encode color spans.
 					$diff_details .= __('Differences') . '<br>' . implode('<br>', $diff_array);
 				}
 

--- a/package_import.php
+++ b/package_import.php
@@ -697,7 +697,7 @@ function import_display_package_data($templates, $files, $package_name, $xmlfile
 				}
 
 				if (cacti_sizeof($diff_array)) {
-					$diff_details .= __('Differences') . '<br>' . implode('<br>', array_map('html_escape', $diff_array));
+					$diff_details .= __('Differences') . '<br>' . implode('<br>', $diff_array);
 				}
 
 				if (cacti_sizeof($orphan_array)) {

--- a/package_import.php
+++ b/package_import.php
@@ -581,8 +581,8 @@ function import_display_package_data($templates, $files, $package_name, $xmlfile
 					);
 
 					form_alternate_row('line_' . $id);
-					form_selectable_cell($file_package_name, $id);
-					form_selectable_cell($pfile, $id);
+					form_selectable_ecell($file_package_name, $id);
+					form_selectable_ecell($pfile, $id);
 
 					$status  = explode(',', $status);
 					$nstatus = '';
@@ -673,8 +673,8 @@ function import_display_package_data($templates, $files, $package_name, $xmlfile
 
 			form_alternate_row('line_import_' . $detail['status'] . '_' . $id);
 
-			form_selectable_cell($detail['type_name'], $id);
-			form_selectable_cell($detail['name'], $id);
+			form_selectable_ecell($detail['type_name'], $id);
+			form_selectable_ecell($detail['name'], $id);
 			form_selectable_cell($status, $id);
 
 			if (isset($detail['vals'])) {
@@ -697,11 +697,11 @@ function import_display_package_data($templates, $files, $package_name, $xmlfile
 				}
 
 				if (cacti_sizeof($diff_array)) {
-					$diff_details .= __('Differences') . '<br>' . implode('<br>', $diff_array);
+					$diff_details .= __('Differences') . '<br>' . implode('<br>', array_map('html_escape', $diff_array));
 				}
 
 				if (cacti_sizeof($orphan_array)) {
-					$diff_details .= ($diff_details != '' ? '<br>':'') . __('Orphans') . '<br>' . implode('<br>', $orphan_array);
+					$diff_details .= ($diff_details != '' ? '<br>':'') . __('Orphans') . '<br>' . implode('<br>', array_map('html_escape', $orphan_array));
 				}
 
 				form_selectable_cell($diff_details, $id, '', 'white-space:pre-wrap');

--- a/tests/Unit/HardeningAuth2026RegressionTest.php
+++ b/tests/Unit/HardeningAuth2026RegressionTest.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$authSource = file_get_contents(dirname(__DIR__, 2) . '/lib/auth.php');
+
+// --- GHSA-9ffc-rr2g-c8hh: Remote-User header gate ---
+
+test('GHSA-9ffc-rr2g-c8hh: get_basic_auth_username checks auth_method before reading headers', function () use ($authSource) {
+    // The fix gates all header reads behind a read_config_option('auth_method') == 2
+    // check; without it any proxy can spoof arbitrary usernames.
+    $start = strpos($authSource, 'function get_basic_auth_username(');
+    expect($start)->not->toBeFalse();
+
+    $body = substr($authSource, $start, 600);
+    expect($body)->toContain("read_config_option('auth_method')");
+});
+
+test('GHSA-9ffc-rr2g-c8hh: auth_method guard compares against 2', function () use ($authSource) {
+    $start = strpos($authSource, 'function get_basic_auth_username(');
+    expect($start)->not->toBeFalse();
+
+    $body = substr($authSource, $start, 600);
+    // Must use != 2 (or == 2) to gate the Basic-Auth method specifically.
+    expect($body)->toContain("read_config_option('auth_method') != 2");
+});
+
+test('GHSA-9ffc-rr2g-c8hh: function returns false when auth_method is not 2', function () use ($authSource) {
+    $start = strpos($authSource, 'function get_basic_auth_username(');
+    expect($start)->not->toBeFalse();
+
+    // The guard block: if (read_config_option('auth_method') != 2) { return false; }
+    // returnfalse is at ~336 chars into the function; use 400 to be safe.
+    $body = substr($authSource, $start, 400);
+    expect($body)->toContain('return false;');
+});
+
+test('GHSA-9ffc-rr2g-c8hh: header reads only appear after the auth_method gate', function () use ($authSource) {
+    $start = strpos($authSource, 'function get_basic_auth_username(');
+    expect($start)->not->toBeFalse();
+
+    $body = substr($authSource, $start, 1200);
+
+    $guardPos = strpos($body, "read_config_option('auth_method') != 2");
+
+    // Use $_SERVER['...'] forms to skip the mention in the docblock comment.
+    $remoteUserPos = strpos($body, "\$_SERVER['REMOTE_USER']");
+    $httpRemotePos = strpos($body, "\$_SERVER['HTTP_REMOTE_USER']");
+    $phpAuthPos    = strpos($body, "\$_SERVER['PHP_AUTH_USER']");
+
+    // Guard must exist and must come before every actual server-variable access.
+    expect($guardPos)->not->toBeFalse();
+    expect($remoteUserPos)->toBeGreaterThan($guardPos);
+    expect($httpRemotePos)->toBeGreaterThan($guardPos);
+    expect($phpAuthPos)->toBeGreaterThan($guardPos);
+});
+
+// --- GHSA-3jj2-v5ch-wmq5: LDAP realm boundary ---
+
+test('GHSA-3jj2-v5ch-wmq5: domains_login_process uses >= 3 realm boundary', function () use ($authSource) {
+    // realm=3 is a valid domain realm; > 3 would allow it to bypass the LDAP bind.
+    // The guard and comment sit ~605-640 chars into the function body.
+    $start = strpos($authSource, 'function domains_login_process(');
+    expect($start)->not->toBeFalse();
+
+    $body = substr($authSource, $start, 800);
+    expect($body)->toContain('$realm >= 3');
+});
+
+test('GHSA-3jj2-v5ch-wmq5: realm boundary comment cites the advisory', function () use ($authSource) {
+    $start = strpos($authSource, 'function domains_login_process(');
+    expect($start)->not->toBeFalse();
+
+    $body = substr($authSource, $start, 800);
+    expect($body)->toContain('GHSA-3jj2-v5ch-wmq5');
+});
+
+// --- GHSA-2px8-gvmq-85f3: LDAP lockout call-site ---
+
+test('GHSA-2px8-gvmq-85f3: lockout condition uses error_num not error_text', function () use ($authSource) {
+    // error_text is a human-readable string; using it in a numeric comparison
+    // always evaluates to zero (false), silently skipping the lockout call.
+    // The condition sits ~4865 chars into the function; use 5200 to be safe.
+    $start = strpos($authSource, 'function domains_login_process(');
+    expect($start)->not->toBeFalse();
+
+    $body = substr($authSource, $start, 5200);
+    expect($body)->toContain('$ldap_auth_response[\'error_num\'] == 1');
+});
+
+test('GHSA-2px8-gvmq-85f3: error_num == 1 appears adjacent to auth_process_lockout', function () use ($authSource) {
+    $start = strpos($authSource, 'function domains_login_process(');
+    expect($start)->not->toBeFalse();
+
+    $body = substr($authSource, $start, 5200);
+
+    $errorNumPos = strpos($body, "'error_num'] == 1");
+    $lockoutPos  = strpos($body, 'auth_process_lockout(');
+
+    expect($errorNumPos)->not->toBeFalse();
+    expect($lockoutPos)->not->toBeFalse();
+    // The lockout call must follow closely (within 150 chars) after the condition.
+    expect($lockoutPos - $errorNumPos)->toBeLessThan(150);
+});
+
+test('GHSA-2px8-gvmq-85f3: error_text is not used in a numeric comparison inside domains_login_process', function () use ($authSource) {
+    $start = strpos($authSource, 'function domains_login_process(');
+    expect($start)->not->toBeFalse();
+
+    $body = substr($authSource, $start, 5200);
+    // The pre-fix bug was 'error_text' == 1; that pattern must not exist.
+    expect($body)->not->toContain("'error_text'] == 1");
+});

--- a/tests/Unit/HardeningDataQueryPathRegressionTest.php
+++ b/tests/Unit/HardeningDataQueryPathRegressionTest.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$dqSource = file_get_contents(__DIR__ . '/../../lib/data_query.php');
+
+test('GHSA-gx62-3v55-846j: get_data_query_array calls cacti_path_is_within before file read', function () use ($dqSource) {
+	$start = strpos($dqSource, 'function get_data_query_array(');
+	expect($start)->not->toBeFalse();
+
+	$end  = strpos($dqSource, "\nfunction ", $start + 1);
+	$body = substr($dqSource, $start, $end - $start);
+
+	expect($body)->toContain('cacti_path_is_within(');
+
+	// Both must appear; ordering is tested separately.
+	$hasFile = strpos($body, 'file(') !== false || strpos($body, 'file_get_contents(') !== false;
+	expect($hasFile)->toBeTrue();
+});
+
+test('GHSA-gx62-3v55-846j: allowed base includes /resource directory', function () use ($dqSource) {
+	$start = strpos($dqSource, 'function get_data_query_array(');
+	$end   = strpos($dqSource, "\nfunction ", $start + 1);
+	$body  = substr($dqSource, $start, $end - $start);
+
+	// The guard must anchor paths to the Cacti resource subtree.
+	$guardPos = strpos($body, 'cacti_path_is_within(');
+	expect($guardPos)->not->toBeFalse();
+
+	// Look for '/resource' within a reasonable window around the guard.
+	$window = substr($body, max(0, $guardPos - 200), 400);
+	expect($window)->toContain('/resource');
+});
+
+test('GHSA-gx62-3v55-846j: traversal is rejected before file() call', function () use ($dqSource) {
+	$start = strpos($dqSource, 'function get_data_query_array(');
+	$end   = strpos($dqSource, "\nfunction ", $start + 1);
+	$body  = substr($dqSource, $start, $end - $start);
+
+	$guardPos = strpos($body, 'cacti_path_is_within(');
+	expect($guardPos)->not->toBeFalse();
+
+	// file() is the actual read call; it must appear after the guard.
+	$filePos = strpos($body, 'file(', $guardPos);
+	expect($filePos)->not->toBeFalse();
+	expect($guardPos)->toBeLessThan($filePos);
+});
+
+test('GHSA-gx62-3v55-846j: rejected path logs a security warning', function () use ($dqSource) {
+	$start = strpos($dqSource, 'function get_data_query_array(');
+	$end   = strpos($dqSource, "\nfunction ", $start + 1);
+	$body  = substr($dqSource, $start, $end - $start);
+
+	// Find the rejection branch — the block that runs when the path check fails.
+	$guardPos = strpos($body, 'cacti_path_is_within(');
+	$window   = substr($body, $guardPos, 300);
+
+	expect($window)->toContain('cacti_log(');
+	expect($window)->toContain('SECURITY');
+});

--- a/tests/Unit/HardeningImportKeyStrengthRegressionTest.php
+++ b/tests/Unit/HardeningImportKeyStrengthRegressionTest.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression tests for GHSA-8w9r-xmpr-5q3v.
+ *
+ * Fix: reject RSA signing keys below 2048 bits in import_read_package_data()
+ *      before calling openssl_verify(), preventing signature forgery via a
+ *      practically factorable 512-bit key.
+ *
+ * Source-scan invariants — each assertion targets a pattern introduced by the
+ * fix; reverting the patch causes at least one test to fail.
+ */
+
+$importSource = file_get_contents(__DIR__ . '/../../lib/import.php');
+
+$start = strpos($importSource, 'function import_read_package_data(');
+$end   = strpos($importSource, "\nfunction ", $start + 1);
+$body  = substr($importSource, $start, $end - $start);
+
+test('GHSA-8w9r-xmpr-5q3v: key strength check uses 2048-bit threshold', function () use ($body) {
+	expect($body)->toContain('2048');
+});
+
+test('GHSA-8w9r-xmpr-5q3v: openssl_pkey_get_public result is checked before use', function () use ($body) {
+	// The fix adds a strict false-check on the resource returned by
+	// openssl_pkey_get_public() so an unparseable key is rejected early.
+	expect($body)->toContain('=== false');
+});
+
+test('GHSA-8w9r-xmpr-5q3v: key strength check appears before openssl_verify call', function () use ($body) {
+	$bitsCheckOffset   = strpos($body, '< 2048');
+	$opensslVerifyOffset = strpos($body, 'openssl_verify(');
+
+	expect($bitsCheckOffset)->not->toBeFalse();
+	expect($opensslVerifyOffset)->not->toBeFalse();
+	expect($bitsCheckOffset)->toBeLessThan($opensslVerifyOffset);
+});
+
+test('GHSA-8w9r-xmpr-5q3v: weak key rejection returns false', function () use ($body) {
+	// The check and the early return must be in close proximity; find the
+	// bits-check block and confirm `return false` follows it.
+	$bitsCheckOffset = strpos($body, '< 2048');
+	$returnOffset    = strpos($body, 'return false', $bitsCheckOffset);
+
+	expect($bitsCheckOffset)->not->toBeFalse();
+	// return false must appear within 200 bytes of the bits check
+	expect($returnOffset - $bitsCheckOffset)->toBeLessThan(200);
+});
+
+test('GHSA-8w9r-xmpr-5q3v: key strength check logs a SECURITY message', function () use ($body) {
+	// The rejection block must log both the severity marker and the key size
+	// so operators can diagnose which package triggered the guard.
+	$bitsCheckOffset = strpos($body, '< 2048');
+	$logWindow       = substr($body, $bitsCheckOffset, 300);
+
+	expect($logWindow)->toContain('SECURITY');
+	expect($logWindow)->toContain('bits');
+});

--- a/tests/Unit/HardeningPackageImportXssRegressionTest.php
+++ b/tests/Unit/HardeningPackageImportXssRegressionTest.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$pkgSource = file_get_contents(__DIR__ . '/../../package_import.php');
+
+test('GHSA-wqqv-4rrg-mrrc: template name column uses form_selectable_ecell', function () use ($pkgSource) {
+	// form_selectable_ecell HTML-encodes before output; the plain variant does not.
+	// Locate the detail-row rendering block and confirm $detail['name'] goes
+	// through the escaping variant.
+	$pos = strpos($pkgSource, "form_selectable_ecell(\$detail['name']");
+	expect($pos)->not->toBeFalse();
+});
+
+test('GHSA-wqqv-4rrg-mrrc: type_name column uses form_selectable_ecell', function () use ($pkgSource) {
+	$pos = strpos($pkgSource, "form_selectable_ecell(\$detail['type_name']");
+	expect($pos)->not->toBeFalse();
+});
+
+test('GHSA-wqqv-4rrg-mrrc: package name column uses form_selectable_ecell', function () use ($pkgSource) {
+	$pos = strpos($pkgSource, 'form_selectable_ecell($file_package_name,');
+	expect($pos)->not->toBeFalse();
+});
+
+test('GHSA-wqqv-4rrg-mrrc: diff_array is not double-escaped', function () use ($pkgSource) {
+	// Entries in $diff_array are pre-escaped at source in lib/import.php.
+	// Wrapping them again with array_map('html_escape') would double-encode
+	// the color spans used to highlight differences, breaking the UI.
+	$doubleEscape = strpos($pkgSource, "array_map('html_escape', \$diff_array)");
+	expect($doubleEscape)->toBeFalse();
+});
+
+test('GHSA-wqqv-4rrg-mrrc: orphan_array is escaped at sink', function () use ($pkgSource) {
+	// $orphan_array entries are NOT pre-escaped, so they must be escaped at
+	// the output site to prevent stored XSS from attacker-controlled names.
+	$pos = strpos($pkgSource, "array_map('html_escape', \$orphan_array)");
+	expect($pos)->not->toBeFalse();
+});
+
+test('GHSA-wqqv-4rrg-mrrc: pre-escape comment present for diff_array', function () use ($pkgSource) {
+	// A code comment must explain why double-escaping is intentionally omitted
+	// near the implode($diff_array) call, so future reviewers do not "fix" it.
+
+	// Find the implode call that renders diff_array.
+	$implodePos = strpos($pkgSource, 'implode(\'<br>\', $diff_array)');
+	if ($implodePos === false) {
+		$implodePos = strpos($pkgSource, 'implode("<br>", $diff_array)');
+	}
+	expect($implodePos)->not->toBeFalse();
+
+	// The explanatory comment must appear within 300 bytes before the call.
+	$window = substr($pkgSource, max(0, $implodePos - 300), 350);
+	$hasComment = strpos($window, 'pre-escaped') !== false
+		|| strpos($window, 'pre_escaped') !== false
+		|| strpos($window, 'double') !== false;
+	expect($hasComment)->toBeTrue();
+});

--- a/tests/Unit/HardeningPingXssRegressionTest.php
+++ b/tests/Unit/HardeningPingXssRegressionTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$pingSource = file_get_contents(__DIR__ . '/../../lib/ping.php');
+
+test('GHSA-43gj-mcpx-24m9: ICMP DNS failure ping_response wraps hostname in html_escape', function () use ($pingSource) {
+	// When cacti_gethostbyname returns a non-IP (DNS failure), the caller-
+	// visible ping_response must HTML-escape the hostname before embedding
+	// it in the string, so a crafted hostname like <script>... cannot
+	// reach the browser unescaped.
+	expect($pingSource)->toContain(
+		"'ICMP Ping Error: cacti_gethostbyname failed for ' . html_escape(\$this->host['hostname'])"
+	);
+});
+
+test('GHSA-43gj-mcpx-24m9: UDP DNS failure ping_response wraps hostname in html_escape', function () use ($pingSource) {
+	expect($pingSource)->toContain(
+		"'UDP Ping Error: cacti_gethostbyname failed for ' . html_escape(\$this->host['hostname'])"
+	);
+});
+
+test('GHSA-43gj-mcpx-24m9: TCP DNS failure ping_response wraps hostname in html_escape', function () use ($pingSource) {
+	expect($pingSource)->toContain(
+		"'TCP Ping Error: cacti_gethostbyname failed for ' . html_escape(\$this->host['hostname'])"
+	);
+});
+
+test('GHSA-43gj-mcpx-24m9: cacti_log calls use raw hostname (not html_escape)', function () use ($pingSource) {
+	// Log sinks consume plain text; HTML entities in log output would
+	// corrupt syslog/file readers.  The log lines must pass the raw
+	// hostname through, not the escaped variant.
+	expect($pingSource)->toContain(
+		"cacti_log('WARNING: ICMP Ping Error: cacti_gethostbyname failed for ' . \$this->host['hostname'])"
+	);
+	expect($pingSource)->toContain(
+		"cacti_log('WARNING: UDP Ping Error: cacti_gethostbyname failed for ' . \$this->host['hostname'])"
+	);
+	expect($pingSource)->toContain(
+		"cacti_log('WARNING: TCP Ping Error: cacti_gethostbyname failed for ' . \$this->host['hostname'])"
+	);
+});
+
+test('GHSA-43gj-mcpx-24m9: shell command invocations do not use html_escape on hostname', function () use ($pingSource) {
+	// Shell execution paths must use cacti_escapeshellarg (shell-safe),
+	// never html_escape (HTML-safe only).  Mixing the two would either
+	// double-encode or leave the shell boundary unprotected.
+	$shellLines = preg_grep('/shell_exec\(/', explode("\n", $pingSource));
+	foreach ($shellLines as $line) {
+		expect($line)->not->toContain('html_escape');
+		expect($line)->toContain('cacti_escapeshellarg');
+	}
+});

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * Minimal bootstrap for source-scan unit tests.
+ * These tests only call file_get_contents() on PHP source files and
+ * never touch the database, so we skip global.php entirely.
+ */
+require_once __DIR__ . '/vendor/autoload.php';

--- a/tests/integration/HardeningImportKeyStrengthIntegrationTest.php
+++ b/tests/integration/HardeningImportKeyStrengthIntegrationTest.php
@@ -1,0 +1,150 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Integration test for GHSA-8w9r-xmpr-5q3v: RSA key strength gate.
+ *
+ * Generates real RSA keypairs at 512 bits and 2048 bits, then exercises the
+ * key-strength guard extracted from import_read_package_data() directly.
+ *
+ * Run:
+ *   docker exec cacti12_web php /var/www/html/cacti/tests/integration/HardeningImportKeyStrengthIntegrationTest.php
+ *
+ * Exit codes: 0 = all pass, 1 = one or more failures.
+ */
+
+$failures = 0;
+
+function pass(string $name): void {
+	echo "PASS: $name\n";
+}
+
+function fail(string $name, string $reason): void {
+	global $failures;
+	$failures++;
+	echo "FAIL: $name -- $reason\n";
+}
+
+/*
+ * Inline the key-strength guard from import_read_package_data().
+ * Returns false when the key is absent, unparseable, or below 2048 bits.
+ * Returns the key details array when the size gate passes.
+ */
+function check_key_strength(string $public_key_pem): bool|array {
+	$pkey = openssl_pkey_get_public($public_key_pem);
+	if ($pkey === false) {
+		return false;
+	}
+	$details = openssl_pkey_get_details($pkey);
+	if ($details === false || $details['bits'] < 2048) {
+		return false;
+	}
+	return $details;
+}
+
+// -------------------------------------------------------------------------
+// Generate a 512-bit RSA keypair
+// -------------------------------------------------------------------------
+$weak_res = openssl_pkey_new([
+	'private_key_bits' => 512,
+	'private_key_type' => OPENSSL_KEYTYPE_RSA,
+]);
+
+if ($weak_res === false) {
+	fail('512-bit key generation', 'openssl_pkey_new failed: ' . openssl_error_string());
+	exit(1);
+}
+
+$weak_pub_details = openssl_pkey_get_details($weak_res);
+$weak_pub_pem     = $weak_pub_details['key'];
+
+// -------------------------------------------------------------------------
+// Generate a 2048-bit RSA keypair
+// -------------------------------------------------------------------------
+$strong_res = openssl_pkey_new([
+	'private_key_bits' => 2048,
+	'private_key_type' => OPENSSL_KEYTYPE_RSA,
+]);
+
+if ($strong_res === false) {
+	fail('2048-bit key generation', 'openssl_pkey_new failed: ' . openssl_error_string());
+	exit(1);
+}
+
+$strong_pub_details = openssl_pkey_get_details($strong_res);
+$strong_pub_pem     = $strong_pub_details['key'];
+
+// -------------------------------------------------------------------------
+// Test 1: 512-bit key must be rejected by the size gate
+// -------------------------------------------------------------------------
+$result = check_key_strength($weak_pub_pem);
+if ($result === false) {
+	pass('512-bit RSA key is rejected by the key strength gate');
+} else {
+	fail('512-bit RSA key is rejected by the key strength gate', "expected false, got bits={$result['bits']}");
+}
+
+// -------------------------------------------------------------------------
+// Test 2: 2048-bit key must pass the size gate (returns details, not false)
+// -------------------------------------------------------------------------
+$result = check_key_strength($strong_pub_pem);
+if ($result !== false && isset($result['bits']) && $result['bits'] >= 2048) {
+	pass('2048-bit RSA key passes the key strength gate');
+} else {
+	$got = ($result === false) ? 'false' : (string)($result['bits'] ?? 'unknown');
+	fail('2048-bit RSA key passes the key strength gate', "expected details with bits>=2048, got $got");
+}
+
+// -------------------------------------------------------------------------
+// Test 3: unparseable / empty key must be rejected
+// -------------------------------------------------------------------------
+$result = check_key_strength('not-a-pem-key');
+if ($result === false) {
+	pass('Garbage PEM is rejected before key-size check');
+} else {
+	fail('Garbage PEM is rejected before key-size check', 'expected false for unparseable input');
+}
+
+// -------------------------------------------------------------------------
+// Test 4: confirm the guard position in lib/import.php source
+//         (sanity check that the file on disk matches what we tested above)
+// -------------------------------------------------------------------------
+$src_path = dirname(__DIR__, 2) . '/lib/import.php';
+if (!file_exists($src_path)) {
+	fail('import.php source guard position', "file not found at $src_path");
+} else {
+	$src   = file_get_contents($src_path);
+	$start = strpos($src, 'function import_read_package_data(');
+	$end   = strpos($src, "\nfunction ", $start + 1);
+	$body  = substr($src, $start, $end - $start);
+
+	$bits_pos   = strpos($body, '< 2048');
+	$verify_pos = strpos($body, 'openssl_verify(');
+
+	if ($bits_pos !== false && $verify_pos !== false && $bits_pos < $verify_pos) {
+		pass('Key strength guard precedes openssl_verify in import_read_package_data source');
+	} else {
+		fail(
+			'Key strength guard precedes openssl_verify in import_read_package_data source',
+			sprintf('bits_pos=%s verify_pos=%s', var_export($bits_pos, true), var_export($verify_pos, true))
+		);
+	}
+}
+
+// -------------------------------------------------------------------------
+// Summary
+// -------------------------------------------------------------------------
+echo "\n";
+if ($failures === 0) {
+	echo "All tests passed.\n";
+	exit(0);
+} else {
+	echo "$failures test(s) failed.\n";
+	exit(1);
+}

--- a/tests/integration/HardeningPingXssIntegrationTest.php
+++ b/tests/integration/HardeningPingXssIntegrationTest.php
@@ -1,0 +1,121 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ |
+ | Integration test: hostname XSS hardening in lib/ping.php (GHSA-43gj-mcpx-24m9).
+ |
+ | Run inside the container where lib/ and include/ are available:
+ |   docker exec cacti12_web php /var/www/html/cacti/tests/integration/HardeningPingXssIntegrationTest.php
+ |
+ | Exit 0 on all assertions passing; exit 1 on first failure.
+ +-------------------------------------------------------------------------+
+*/
+
+define('CACTI_CLI_ONLY', true);
+chdir('/var/www/html/cacti');
+require_once 'include/global.php';
+require_once 'lib/ping.php';
+
+/* ---- harness ---- */
+
+$failures = 0;
+
+function ping_xss_pass($label) {
+	echo "PASS: {$label}" . PHP_EOL;
+}
+
+function ping_xss_fail($label, $detail = '') {
+	global $failures;
+	$failures++;
+	echo "FAIL: {$label}" . ($detail !== '' ? " -- {$detail}" : '') . PHP_EOL;
+}
+
+/* ---- test: UDP DNS-fail path escapes the XSS payload ---- */
+
+// A hostname that is not an IP address will go through cacti_gethostbyname(),
+// which returns the original string on DNS failure.  is_ipaddress() then
+// returns false and the code takes the DNS-fail branch, which must call
+// html_escape() before embedding the hostname in ping_response.
+
+$xss = '<script>alert(1)</script>';
+
+$ping          = new Net_Ping();
+$ping->host    = ['hostname' => $xss];
+$ping->timeout = 500;
+$ping->retries = 1;
+
+$ping->ping_udp();
+
+$response = $ping->ping_response;
+
+// The raw tag must not appear in the response string that callers display.
+if (strpos($response, '<script>') !== false) {
+	ping_xss_fail('ping_response must not contain raw <script> tag', "got: {$response}");
+} else {
+	ping_xss_pass('ping_response does not contain raw <script> tag');
+}
+
+// The HTML-escaped form must be present, confirming html_escape() was called.
+if (strpos($response, '&lt;script&gt;') === false) {
+	ping_xss_fail('ping_response must contain &lt;script&gt; (escaped form)', "got: {$response}");
+} else {
+	ping_xss_pass('ping_response contains &lt;script&gt; (escaped form)');
+}
+
+/* ---- test: ICMP DNS-fail path ---- */
+
+$ping2          = new Net_Ping();
+$ping2->host    = ['hostname' => $xss];
+$ping2->timeout = 500;
+$ping2->retries = 1;
+
+$ping2->ping_icmp();
+
+$resp2 = $ping2->ping_response;
+
+if (strpos($resp2, '<script>') !== false) {
+	ping_xss_fail('ICMP ping_response must not contain raw <script> tag', "got: {$resp2}");
+} else {
+	ping_xss_pass('ICMP ping_response does not contain raw <script> tag');
+}
+
+if (strpos($resp2, '&lt;script&gt;') === false) {
+	ping_xss_fail('ICMP ping_response must contain &lt;script&gt; (escaped form)', "got: {$resp2}");
+} else {
+	ping_xss_pass('ICMP ping_response contains &lt;script&gt; (escaped form)');
+}
+
+/* ---- test: TCP DNS-fail path ---- */
+
+$ping3          = new Net_Ping();
+$ping3->host    = ['hostname' => $xss];
+$ping3->timeout = 500;
+$ping3->retries = 1;
+
+$ping3->ping_tcp();
+
+$resp3 = $ping3->ping_response;
+
+if (strpos($resp3, '<script>') !== false) {
+	ping_xss_fail('TCP ping_response must not contain raw <script> tag', "got: {$resp3}");
+} else {
+	ping_xss_pass('TCP ping_response does not contain raw <script> tag');
+}
+
+if (strpos($resp3, '&lt;script&gt;') === false) {
+	ping_xss_fail('TCP ping_response must contain &lt;script&gt; (escaped form)', "got: {$resp3}");
+} else {
+	ping_xss_pass('TCP ping_response contains &lt;script&gt; (escaped form)');
+}
+
+/* ---- summary ---- */
+
+$total = 6;
+$passed = $total - $failures;
+echo PHP_EOL . "Tests: {$total}, Passed: {$passed}, Failed: {$failures}" . PHP_EOL;
+
+exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

General hardening pass across auth, input handling, and file I/O for 1.2.x.

- `lib/auth.php` — tighten `get_basic_auth_username()` to respect the configured `auth_method` before reading identity headers; align `domains_login_process()` realm boundary with the domain realm range; ensure the LDAP lockout counter uses the correct response field
- `lib/ping.php` — output-escape device hostnames in ping status strings
- `lib/data_query.php` — add path containment check on the snmp_query XML file path before reading
- `lib/import.php` — enforce a minimum RSA key strength on package signatures; add a null guard on the key-parse step
- `package_import.php` — use the escaping cell variant for user-supplied template and package name columns in the import list

## Test plan

- [ ] LDAP/Domain login flow works normally with valid credentials
- [ ] Ping status output renders correctly for devices with special characters in hostname
- [ ] Data query XML loads correctly from the resource directory
- [ ] Package import accepts normally-signed packages; rejects packages with weak keys
- [ ] Template names display correctly in the import review table