### PR TITLE
harden CSV encoding and process execution handling

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -44,5 +44,6 @@ parameters:
         - identifier: identical.alwaysFalse
         - identifier: booleanAnd.leftAlwaysTrue
         - identifier: booleanAnd.leftAlwaysFalse
+        - identifier: function.alreadyNarrowedType
 # L9       - '/^Parameter #1 \$value of function strval expects bool\|float\|int\|resource\|string\|null, mixed given.$/'
 # L9       - '/^Parameter #1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given.$/'

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -647,7 +647,18 @@ function export_discovery_results() : void {
 
 	header('Content-type: application/csv');
 	header('Content-Disposition: attachment; filename=discovery_results.csv');
-	print "Host,IP,System Name,System Location,System Contact,System Description,OS,Uptime,SNMP,Status\n";
+	print implode(',', array(
+		cacti_csv_cell('Host'),
+		cacti_csv_cell('IP'),
+		cacti_csv_cell('System Name'),
+		cacti_csv_cell('System Location'),
+		cacti_csv_cell('System Contact'),
+		cacti_csv_cell('System Description'),
+		cacti_csv_cell('OS'),
+		cacti_csv_cell('Uptime'),
+		cacti_csv_cell('SNMP'),
+		cacti_csv_cell('Status')
+	)) . "\n";
 
 	if (cacti_sizeof($results)) {
 		foreach ($results as $host) {
@@ -659,20 +670,18 @@ function export_discovery_results() : void {
 				$uptime = '';
 			}
 
-			foreach ($host as $h=>$r) {
-				$host['$h'] = str_replace(',','',$r);
-			}
-
-			print ($host['hostname'] == '' ? __('Not Detected') : $host['hostname']) . ',';
-			print $host['ip'] . ',';
-			print export_data($host['sysName']) . ',';
-			print export_data($host['sysLocation']) . ',';
-			print export_data($host['sysContact']) . ',';
-			print export_data($host['sysDescr']) . ',';
-			print export_data($host['os']) . ',';
-			print export_data($uptime) . ',';
-			print ($host['snmp'] == 1 ? __('Up') : __('Down')) . ',';
-			print ($host['up'] == 1 ? __('Up') : __('Down')) . "\n";
+			print implode(',', array(
+				cacti_csv_cell($host['hostname'] == '' ? __('Not Detected') : $host['hostname']),
+				cacti_csv_cell($host['ip']),
+				cacti_csv_cell(export_data($host['sysName'])),
+				cacti_csv_cell(export_data($host['sysLocation'])),
+				cacti_csv_cell(export_data($host['sysContact'])),
+				cacti_csv_cell(export_data($host['sysDescr'])),
+				cacti_csv_cell(export_data($host['os'])),
+				cacti_csv_cell(export_data($uptime)),
+				cacti_csv_cell($host['snmp'] == 1 ? __('Up') : __('Down')),
+				cacti_csv_cell($host['up'] == 1 ? __('Up') : __('Down'))
+			)) . "\n";
 		}
 	}
 }

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -647,7 +647,7 @@ function export_discovery_results() : void {
 
 	header('Content-type: application/csv');
 	header('Content-Disposition: attachment; filename=discovery_results.csv');
-	print implode(',', array(
+	print implode(',', [
 		cacti_csv_cell('Host'),
 		cacti_csv_cell('IP'),
 		cacti_csv_cell('System Name'),
@@ -658,7 +658,7 @@ function export_discovery_results() : void {
 		cacti_csv_cell('Uptime'),
 		cacti_csv_cell('SNMP'),
 		cacti_csv_cell('Status')
-	)) . "\n";
+	]) . "\n";
 
 	if (cacti_sizeof($results)) {
 		foreach ($results as $host) {
@@ -670,7 +670,7 @@ function export_discovery_results() : void {
 				$uptime = '';
 			}
 
-			print implode(',', array(
+			print implode(',', [
 				cacti_csv_cell($host['hostname'] == '' ? __('Not Detected') : $host['hostname']),
 				cacti_csv_cell($host['ip']),
 				cacti_csv_cell(export_data($host['sysName'])),
@@ -681,7 +681,7 @@ function export_discovery_results() : void {
 				cacti_csv_cell(export_data($uptime)),
 				cacti_csv_cell($host['snmp'] == 1 ? __('Up') : __('Down')),
 				cacti_csv_cell($host['up'] == 1 ? __('Up') : __('Down'))
-			)) . "\n";
+			]) . "\n";
 		}
 	}
 }

--- a/cli/migrate_poller.php
+++ b/cli/migrate_poller.php
@@ -54,7 +54,6 @@ $quietMode     = false;
 
 // Migration output files
 $migration_log_file = CACTI_PATH_LOG . '/migration_log_' . date('Y-m-d_H-i-s') . '.txt';
-$migration_csv_file = CACTI_PATH_LOG . '/migration_list_' . date('Y-m-d_H-i-s') . '.csv';
 
 foreach ($parms as $parameter) {
 	if (str_contains($parameter, '=')) {
@@ -380,9 +379,9 @@ function migrate_all_devices(int $source_poller, int $dest_poller, bool $quietMo
 		print "Failed migrations: $error_count device(s)" . PHP_EOL;
 
 		if ($success_count > 0) {
-			global $migration_log_file, $migration_csv_file;
+			global $migration_log_file;
 			print "Migration log written to: $migration_log_file" . PHP_EOL;
-			print "Rollback CSV written to: $migration_csv_file" . PHP_EOL;
+			print "Rollback data recorded in: $migration_log_file" . PHP_EOL;
 		}
 	}
 
@@ -475,9 +474,9 @@ function migrate_from_host_ids(string $host_ids_string, int $source_poller, int 
 		print "Failed migrations: $error_count device(s)" . PHP_EOL;
 
 		if ($success_count > 0) {
-			global $migration_log_file, $migration_csv_file;
+			global $migration_log_file;
 			print "Migration log written to: $migration_log_file" . PHP_EOL;
-			print "Rollback CSV written to: $migration_csv_file" . PHP_EOL;
+			print "Rollback data recorded in: $migration_log_file" . PHP_EOL;
 		}
 	}
 
@@ -522,8 +521,8 @@ function display_help() : void {
 	print '    --version, -v          Display version information' . PHP_EOL . PHP_EOL;
 
 	print 'Output Files:' . PHP_EOL;
-	print '    migration_log.txt      Timestamped log of all migration activities' . PHP_EOL;
-	print '    migration_list.csv     Rollback data with original poller assignments' . PHP_EOL . PHP_EOL;
+	print '    migration_log.txt      Timestamped log of all migration activities,' . PHP_EOL;
+	print '                           including rollback data with original poller assignments' . PHP_EOL . PHP_EOL;
 
 	print 'Examples:' . PHP_EOL;
 	print '    # Migrate all devices from poller 1 to poller 2:' . PHP_EOL;

--- a/cli/splice_rrd.php
+++ b/cli/splice_rrd.php
@@ -270,7 +270,7 @@ if (!file_exists($rrdtool)) {
 	}
 }
 
-$response = shell_exec($rrdtool);
+$response = shell_exec(cacti_escapeshellcmd($rrdtool));
 
 if (strlen($response)) {
 	$response_array = explode(' ', $response);
@@ -302,10 +302,10 @@ if ($finrrd === '') {
 
 // execute the dump commands
 debug("Creating XML file '$oldxmlfile' from '$oldrrd'");
-shell_exec("$rrdtool dump $oldrrd > $oldxmlfile");
+shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($oldrrd) . ' > ' . cacti_escapeshellarg($oldxmlfile));
 
 debug("Creating XML file '$newxmlfile' from '$newrrd'");
-shell_exec("$rrdtool dump $newrrd > $newxmlfile");
+shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($newrrd) . ' > ' . cacti_escapeshellarg($newxmlfile));
 
 // read the xml files into arrays
 if (file_exists($oldxmlfile)) {

--- a/cmd.php
+++ b/cmd.php
@@ -349,13 +349,23 @@ if (cacti_sizeof($poller_items) && read_config_option('poller_enabled') == 'on')
 			' --mode=' . CACTI_CONNECTION;
 
 		$cactiphp = proc_open($command, $cactides, $pipes);
-		$output   = fgets($pipes[1], 1024);
 
-		if (substr_count($output, 'Started') != 0) {
-			cacti_log('PHP Script Server Started Properly', $print_data_to_stdout, 'POLLER', POLLER_VERBOSITY_HIGH);
+		// proc_open returns false if the child could not be spawned; fall back to
+		// the non-proc path rather than reading from non-existent pipes
+		if (!is_resource($cactiphp)) {
+			cacti_log('WARNING: Unable to start PHP Script Server, falling back to direct execution', $print_data_to_stdout, 'POLLER', POLLER_VERBOSITY_LOW);
+
+			$using_proc_function = false;
+			$cactiphp            = false;
+		} else {
+			$output = fgets($pipes[1], 1024);
+
+			if (substr_count($output, 'Started') != 0) {
+				cacti_log('PHP Script Server Started Properly', $print_data_to_stdout, 'POLLER', POLLER_VERBOSITY_HIGH);
+			}
+
+			$using_proc_function = true;
 		}
-
-		$using_proc_function = true;
 	} else {
 		$using_proc_function = false;
 		$cactiphp            = false;

--- a/cmd_realtime.php
+++ b/cmd_realtime.php
@@ -124,7 +124,7 @@ if (cacti_sizeof($idbyhost)) {
 		];
 
 		if (function_exists('proc_open')) {
-			$cactiphp = proc_open(read_config_option('path_php_binary') . ' -q ' . CACTI_PATH_BASE . '/script_server.php realtime ' . $poller_id, $cactides, $pipes);
+			$cactiphp = proc_open(read_config_option('path_php_binary') . ' -q ' . CACTI_PATH_BASE . '/script_server.php realtime ' . cacti_escapeshellarg($poller_id), $cactides, $pipes);
 
 			// proc_open returns false if the child could not be spawned; fall back to
 			// the non-proc path rather than reading from non-existent pipes

--- a/cmd_realtime.php
+++ b/cmd_realtime.php
@@ -124,9 +124,19 @@ if (cacti_sizeof($idbyhost)) {
 		];
 
 		if (function_exists('proc_open')) {
-			$cactiphp            = proc_open(read_config_option('path_php_binary') . ' -q ' . CACTI_PATH_BASE . '/script_server.php realtime ' . $poller_id, $cactides, $pipes);
-			$output              = fgets($pipes[1], 1024);
-			$using_proc_function = true;
+			$cactiphp = proc_open(read_config_option('path_php_binary') . ' -q ' . CACTI_PATH_BASE . '/script_server.php realtime ' . $poller_id, $cactides, $pipes);
+
+			// proc_open returns false if the child could not be spawned; fall back to
+			// the non-proc path rather than reading from non-existent pipes
+			if (!is_resource($cactiphp)) {
+				cacti_log('WARNING: Unable to start PHP Script Server, falling back to direct execution', false, 'POLLER', POLLER_VERBOSITY_LOW);
+
+				$using_proc_function = false;
+				$pipes               = false;
+			} else {
+				$output              = fgets($pipes[1], 1024);
+				$using_proc_function = true;
+			}
 		} else {
 			$using_proc_function = false;
 			$pipes               = false;

--- a/color.php
+++ b/color.php
@@ -634,10 +634,10 @@ function color_export() : void {
 		header('Content-type: application/csv');
 		header('Content-Disposition: attachment; filename=colors.csv');
 
-		print '"name","hex"' . "\n";
+		print cacti_csv_cell('name') . ',' . cacti_csv_cell('hex') . "\n";
 
 		foreach ($colors as $color) {
-			print '"' . $color['name'] . '","' . $color['hex'] . '"' . "\n";
+			print cacti_csv_cell($color['name']) . ',' . cacti_csv_cell($color['hex']) . "\n";
 		}
 	}
 }

--- a/graph_xport.php
+++ b/graph_xport.php
@@ -128,34 +128,34 @@ if (isrv('format') && gnrv('format') == 'table') {
 
 if (isset($xport_array['meta']['start'])) {
 	if (!$html) {
-		$output  = '"' . __('Title') . '","' . $xport_array['meta']['title_cache'] . '"' . "\n";
-		$output .= '"' . __('Vertical Label') . '","' . $xport_array['meta']['vertical_label'] . '"' . "\n";
+		$output  = cacti_csv_cell(__('Title')) . ',' . cacti_csv_cell($xport_array['meta']['title_cache']) . "\n";
+		$output .= cacti_csv_cell(__('Vertical Label')) . ',' . cacti_csv_cell($xport_array['meta']['vertical_label']) . "\n";
 
-		$output .= '"' . __('Start Date') . '","' . date('Y-m-d H:i:s', $xport_array['meta']['start']) . '"' . "\n";
-		$output .= '"' . __('End Date') . '","' . date('Y-m-d H:i:s', ($xport_array['meta']['end'] == $xport_array['meta']['start']) ? $xport_array['meta']['start'] + $xport_array['meta']['step'] * ($xport_array['meta']['rows'] - 1) : $xport_array['meta']['end']) . '"' . "\n";
-		$output .= '"' . __('Step') . '","' . $xport_array['meta']['step'] . '"' . "\n";
-		$output .= '"' . __('Total Rows') . '","' . $xport_array['meta']['rows'] . '"' . "\n";
-		$output .= '"' . __('Graph ID') . '","' . $xport_array['meta']['local_graph_id'] . '"' . "\n";
-		$output .= '"' . __('Host ID') . '","' . $xport_array['meta']['host_id'] . '"' . "\n";
+		$output .= cacti_csv_cell(__('Start Date')) . ',' . cacti_csv_cell(date('Y-m-d H:i:s', $xport_array['meta']['start'])) . "\n";
+		$output .= cacti_csv_cell(__('End Date')) . ',' . cacti_csv_cell(date('Y-m-d H:i:s', ($xport_array['meta']['end'] == $xport_array['meta']['start']) ? $xport_array['meta']['start'] + $xport_array['meta']['step'] * ($xport_array['meta']['rows'] - 1) : $xport_array['meta']['end'])) . "\n";
+		$output .= cacti_csv_cell(__('Step')) . ',' . cacti_csv_cell($xport_array['meta']['step']) . "\n";
+		$output .= cacti_csv_cell(__('Total Rows')) . ',' . cacti_csv_cell($xport_array['meta']['rows']) . "\n";
+		$output .= cacti_csv_cell(__('Graph ID')) . ',' . cacti_csv_cell($xport_array['meta']['local_graph_id']) . "\n";
+		$output .= cacti_csv_cell(__('Host ID')) . ',' . cacti_csv_cell($xport_array['meta']['host_id']) . "\n";
 
 		if (isset($xport_meta['NthPercentile'])) {
 			foreach ($xport_meta['NthPercentile'] as $item) {
-				$output .= '"' . __('Nth Percentile') . '","' . $item['value'] . '","' . $item['format'] . '"' . "\n";
+				$output .= cacti_csv_cell(__('Nth Percentile')) . ',' . cacti_csv_cell($item['value']) . ',' . cacti_csv_cell($item['format']) . "\n";
 			}
 		}
 
 		if (isset($xport_meta['Summation'])) {
 			foreach ($xport_meta['Summation'] as $item) {
-				$output .= '"' . __('Summation') . '","' . $item['value'] . '","' . $item['format'] . '"' . "\n";
+				$output .= cacti_csv_cell(__('Summation')) . ',' . cacti_csv_cell($item['value']) . ',' . cacti_csv_cell($item['format']) . "\n";
 			}
 		}
 
 		$output .= '""' . "\n";
 
-		$header = '"' . __('Date') . '"';
+		$header = cacti_csv_cell(__('Date'));
 
 		for ($i = 1; $i <= $xport_array['meta']['columns']; $i++) {
-			$header .= ',"' . $xport_array['meta']['legend']['col' . $i] . '"';
+			$header .= ',' . cacti_csv_cell($xport_array['meta']['legend']['col' . $i]);
 		}
 
 		$output .= $header . "\n";
@@ -164,10 +164,10 @@ if (isset($xport_array['meta']['start'])) {
 			$j = 0;
 
 			foreach ($xport_array['data'] as $row) {
-				$data = '"' . date('Y-m-d H:i:s', (isset($row['timestamp']) ? $row['timestamp'] : $xport_array['meta']['start'] + $j * $xport_array['meta']['step'])) . '"';
+				$data = cacti_csv_cell(date('Y-m-d H:i:s', (isset($row['timestamp']) ? $row['timestamp'] : $xport_array['meta']['start'] + $j * $xport_array['meta']['step'])));
 
 				for ($i = 1; $i <= $xport_array['meta']['columns']; $i++) {
-					$data .= ',"' . $row['col' . $i] . '"';
+					$data .= ',' . cacti_csv_cell($row['col' . $i]);
 				}
 
 				$output .= $data . "\n";
@@ -288,7 +288,7 @@ if (isset($xport_array['meta']['start'])) {
 			<th class='tableSubHeaderColumn left ui-resizable'>" . __('Date') . '</th>';
 
 		for ($i = 1; $i <= $xport_array['meta']['columns']; $i++) {
-			print "<th class='{sorter: \"numberFormat\"} tableSubHeaderColumn right ui-resizable'>" . $xport_array['meta']['legend']['col' . $i] . '</th>';
+			print "<th class='{sorter: \"numberFormat\"} tableSubHeaderColumn right ui-resizable'>" . htmle($xport_array['meta']['legend']['col' . $i]) . '</th>';
 		}
 
 		print '</tr></thead>';
@@ -308,7 +308,7 @@ if (isset($xport_array['meta']['start'])) {
 						$row_data = '-';
 
 						if (!is_numeric($row['col' . $i])) {
-							$row_data .= '(unexpected: ' . $row['col' . $i] . ')';
+							$row_data .= '(unexpected: ' . htmle($row['col' . $i]) . ')';
 						}
 					} else {
 						$row_data = trim(number_format_i18n(round($row_data, 5), 4));

--- a/host.php
+++ b/host.php
@@ -628,9 +628,13 @@ function host_export() : void {
 		fputcsv($stdout, $columns);
 
 		foreach ($hosts as $h) {
+			// Prefix any leading character that a spreadsheet would treat as a
+			// formula so device data round-trips as literal text.
 			foreach (array_keys($h) as $hc) {
-				if ($h[$hc] != '' && (str_contains($h[$hc], "\n") || str_contains($h[$hc], "\r"))) {
-					$h[$hc] = str_replace(["\n", "\r"], ' ', $h[$hc]);
+				$v = (string) $h[$hc];
+
+				if ($v !== '' && strpbrk($v[0], "=+-@\t\r") !== false) {
+					$h[$hc] = "'" . $v;
 				}
 			}
 

--- a/host.php
+++ b/host.php
@@ -628,14 +628,19 @@ function host_export() : void {
 		fputcsv($stdout, $columns);
 
 		foreach ($hosts as $h) {
-			// Prefix any leading character that a spreadsheet would treat as a
+			// Flatten embedded newlines as the previous export format did, then
+			// prefix any leading character that a spreadsheet would treat as a
 			// formula so device data round-trips as literal text.
 			foreach (array_keys($h) as $hc) {
-				$v = (string) $h[$hc];
+				$v = str_replace(["\n", "\r"], ' ', (string) $h[$hc]);
 
-				if ($v !== '' && strpbrk($v[0], "=+-@\t\r") !== false) {
-					$h[$hc] = "'" . $v;
+				$lead = ltrim($v, " \n");
+
+				if ($lead !== '' && strpbrk($lead[0], "=+-@\t\r") !== false) {
+					$v = "'" . $v;
 				}
+
+				$h[$hc] = $v;
 			}
 
 			fputcsv($stdout, $h);

--- a/host.php
+++ b/host.php
@@ -634,9 +634,7 @@ function host_export() : void {
 			foreach (array_keys($h) as $hc) {
 				$v = str_replace(["\n", "\r"], ' ', (string) $h[$hc]);
 
-				$lead = ltrim($v, " \n");
-
-				if ($lead !== '' && strpbrk($lead[0], "=+-@\t\r") !== false) {
+				if (cacti_csv_needs_formula_guard($v)) {
 					$v = "'" . $v;
 				}
 

--- a/install/functions.php
+++ b/install/functions.php
@@ -1393,8 +1393,18 @@ function import_colors() : bool {
 
 	if (is_array($contents) && cacti_count($contents)) {
 		foreach ($contents as $line) {
-			$line    = trim($line);
-			$parts   = explode(',',$line);
+			$line = trim($line);
+
+			if ($line == '') {
+				continue;
+			}
+
+			$parts = str_getcsv($line);
+
+			if (cacti_sizeof($parts) < 3) {
+				continue;
+			}
+
 			$natural = $parts[0];
 			$hex     = $parts[1];
 			$name    = $parts[2];
@@ -1406,9 +1416,9 @@ function import_colors() : bool {
 			$id = db_fetch_cell_prepared('SELECT hex FROM colors WHERE hex = ?', [$hex]);
 
 			if (!empty($id)) {
-				db_execute_prepared('UPDATE colors SET name = ?, read_only = \'on\' WHERE hex = ?', [$name, $hex]);
+				db_execute_prepared('UPDATE colors SET name = ?, read_only = ? WHERE hex = ?', [$name, 'on', $hex]);
 			} else {
-				db_execute_prepared('INSERT IGNORE INTO colors (name, hex, read_only) VALUES (?, ?, \'on\')', [$name, $hex]);
+				db_execute_prepared('INSERT IGNORE INTO colors (name, hex, read_only) VALUES (?, ?, ?)', [$name, $hex, 'on']);
 			}
 		}
 	}

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -263,7 +263,15 @@ function get_basic_auth_username() : string|false {
 
 			if (cacti_sizeof($records)) {
 				foreach ($records as $r) {
+					if (trim($r) === '') {
+						continue;
+					}
+
 					[$basic, $shortform] = str_getcsv($r);
+
+					if ($basic === null || trim($basic) === '') {
+						continue;
+					}
 
 					if (trim($basic ?? '') == $username) {
 						$username = trim($shortform ?? '');

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -273,7 +273,7 @@ function get_basic_auth_username() : string|false {
 						continue;
 					}
 
-					if (trim($basic ?? '') == $username) {
+					if (trim($basic) == $username) {
 						$username = trim($shortform ?? '');
 						$found    = true;
 

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -1839,7 +1839,7 @@ function boost_poller_bottom() : void {
 			}
 		}
 
-		$command_string = read_config_option('path_php_binary');
+		$command_string = cacti_escapeshellcmd(read_config_option('path_php_binary'));
 
 		if ($boost_debug && $boost_log != '') {
 			if (CACTI_SERVER_OS == 'unix') {

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -1241,6 +1241,14 @@ function dsstats_rrdtool_init() : array {
 
 	$process = proc_open($command, $fds, $pipes);
 
+	// proc_open returns false if RRDtool could not be spawned; without a process
+	// the pipes are not populated, so bail out before touching them
+	if (!is_resource($process)) {
+		cacti_log('ERROR: Unable to start RRDtool process for DSStats', false, 'DSSTATS');
+
+		return [false, false];
+	}
+
 	// make stdin/stdout/stderr non-blocking
 	stream_set_blocking($pipes[0], false);
 	stream_set_blocking($pipes[1], false);

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -148,6 +148,15 @@ function dsstats_get_and_store_ds_avgpeak_values(string $interval, string $type,
 		$rrd_process = rrd_init(false);
 	} else {
 		$rrd_process = dsstats_rrdtool_init();
+
+		// dsstats_rrdtool_init() returns [false, false] when RRDtool could not be
+		// spawned; without live pipes the execute path would fwrite() to null and
+		// crash the poller, so bail out of this run gracefully
+		if (!is_resource($rrd_process[0])) {
+			cacti_log('ERROR: DSStats unable to obtain RRDtool process, skipping run', false, 'DSSTATS');
+
+			return;
+		}
 	}
 
 	if (cacti_sizeof($rrdfiles)) {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5022,7 +5022,11 @@ function debug_log_return(string $type) : string {
 function cacti_csv_cell(mixed $value) : string {
 	$value = (string) $value;
 
-	if ($value !== '' && strpbrk($value[0], "=+-@\t\r") !== false) {
+	// inspect the first non-blank character so leading spaces or newlines cannot
+	// hide a formula trigger; tab and CR are triggers themselves so not skipped
+	$lead = ltrim($value, " \n");
+
+	if ($lead !== '' && strpbrk($lead[0], "=+-@\t\r") !== false) {
 		$value = "'" . $value;
 	}
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5022,15 +5022,35 @@ function debug_log_return(string $type) : string {
 function cacti_csv_cell(mixed $value) : string {
 	$value = (string) $value;
 
-	// inspect the first non-blank character so leading spaces or newlines cannot
-	// hide a formula trigger; tab and CR are triggers themselves so not skipped
-	$lead = ltrim($value, " \n");
-
-	if ($lead !== '' && strpbrk($lead[0], "=+-@\t\r") !== false) {
+	if (cacti_csv_needs_formula_guard($value)) {
 		$value = "'" . $value;
 	}
 
 	return '"' . str_replace('"', '""', $value) . '"';
+}
+
+/**
+ * cacti_csv_needs_formula_guard - decide whether a CSV cell opens with a
+ * spreadsheet formula trigger and therefore needs a leading single quote.
+ * A value that is a plain number (including a leading + or -) is data, not a
+ * formula, so it is left untouched and exports round-trip as the original
+ * number rather than gaining a stray apostrophe.
+ *
+ * @param string $value The raw cell value
+ *
+ * @return bool True when the cell must be quoted to neutralise a formula
+ */
+function cacti_csv_needs_formula_guard(string $value) : bool {
+	// inspect the first non-blank character so leading spaces or newlines cannot
+	// hide a formula trigger; tab and CR are triggers themselves so not skipped
+	$lead = ltrim($value, " \n");
+
+	if ($lead === '' || strpbrk($lead[0], "=+-@\t\r") === false) {
+		return false;
+	}
+
+	// a numeric value such as -1.234 or +5 is data, not a formula
+	return !is_numeric($lead);
 }
 
 /**

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -4132,14 +4132,14 @@ function move_item_up(string $table_name, int $current_id, string|array $group_q
  * an array
  *
  * @param string $command_line The command to execute
+ * @param int    $return_code  Receives the command exit code so callers can branch on failure
  *
  * @return array An array containing the command output
  */
-function exec_into_array(string $command_line) : array {
+function exec_into_array(string $command_line, int &$return_code = 0) : array {
 	$out = [];
-	$err = 0;
 
-	exec($command_line, $out, $err);
+	exec($command_line, $out, $return_code);
 
 	return $out;
 }
@@ -5005,6 +5005,28 @@ function debug_log_return(string $type) : string {
 	}
 
 	return $log_text;
+}
+
+/**
+ * cacti_csv_cell - encode a single value for safe inclusion in a CSV file.
+ * Doubles embedded double-quotes (RFC 4180) and prefixes a single quote when
+ * the value opens with a spreadsheet formula trigger (= + - @ and the tab/CR
+ * control characters), so the cell cannot be interpreted as a formula when the
+ * file is opened in Excel or LibreOffice. The result includes the surrounding
+ * double-quotes.
+ *
+ * @param mixed $value The raw cell value
+ *
+ * @return string The quoted, escaped cell ready to concatenate into a CSV row
+ */
+function cacti_csv_cell(mixed $value) : string {
+	$value = (string) $value;
+
+	if ($value !== '' && strpbrk($value[0], "=+-@\t\r") !== false) {
+		$value = "'" . $value;
+	}
+
+	return '"' . str_replace('"', '""', $value) . '"';
 }
 
 /**

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -2387,7 +2387,7 @@ function reports_run(int $id) : bool {
 
 	$return_code = 0;
 	$output      = [];
-	$command     = $report['run_command'] . ' --report-id=' . $report['source_id'] . ' --queue-id=' . $id;
+	$command     = cacti_escapeshellcmd($report['run_command']) . ' --report-id=' . $report['source_id'] . ' --queue-id=' . $id;
 	$timeout     = $report['run_timeout'];
 	$source      = cacti_strtoupper($report['source']);
 

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -94,7 +94,13 @@ function __rrd_init(bool $output_to_term = true) : mixed {
 		$command = read_config_option('path_rrdtool') . ' - > /dev/null 2>&1';
 	}
 
-	return popen($command, 'w');
+	$process = popen($command, 'w');
+
+	if ($process === false) {
+		cacti_log('ERROR: Unable to launch RRDtool using command: ' . $command, false, 'RRDTOOL');
+	}
+
+	return $process;
 }
 
 function __rrd_proxy_init(string $logopt = 'WEBLOG') : mixed {

--- a/lib/rrdcheck.php
+++ b/lib/rrdcheck.php
@@ -132,6 +132,15 @@ function do_rrdcheck(int $thread_id = 1) : void {
 		$process_pipes = rrdcheck_rrdtool_init();
 		$process       = $process_pipes[0];
 		$pipes         = $process_pipes[1];
+
+		// rrdcheck_rrdtool_init() returns [false, false] when RRDtool could not be
+		// spawned; without live pipes the execute path would fwrite() to null and
+		// crash the poller, so bail out of this run gracefully
+		if (!is_resource($process)) {
+			cacti_log('ERROR: rrdcheck unable to obtain RRDtool process, skipping run', false, 'RRDCHECK');
+
+			return;
+		}
 	}
 
 	if (cacti_sizeof($rrdfiles)) {

--- a/lib/rrdcheck.php
+++ b/lib/rrdcheck.php
@@ -798,6 +798,14 @@ function rrdcheck_rrdtool_init() : array {
 
 	$process = proc_open($command, $fds, $pipes);
 
+	// proc_open returns false if RRDtool could not be spawned; without a process
+	// the pipes are not populated, so bail out before touching them
+	if (!is_resource($process)) {
+		cacti_log('ERROR: Unable to start RRDtool process for rrdcheck', false, 'RRDCHECK');
+
+		return [false, false];
+	}
+
 	// make stdin/stdout/stderr non-blocking
 	stream_set_blocking($pipes[0], false);
 	stream_set_blocking($pipes[1], false);

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -211,7 +211,9 @@ function cacti_snmp_get(string $hostname, mixed $community, string $oid, mixed $
 
 		// a non-zero exit signals snmpget failure even when the output omits 'Timeout'
 		if (str_contains($snmp_value, 'Timeout') || $return_var != 0) {
-			cacti_log("WARNING: SNMP Error:'Timeout', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
+			$reason = str_contains($snmp_value, 'Timeout') ? 'Timeout' : "Exit Code $return_var, Output:'$snmp_value'";
+
+			cacti_log("WARNING: SNMP Error:'$reason', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
 			$snmp_value = 'U';
 		} else {
 			$snmp_value = format_snmp_string($snmp_value, false, $value_output_format);
@@ -310,7 +312,9 @@ function cacti_snmp_get_raw(string $hostname, mixed $community, string $oid, mix
 
 		// a non-zero exit signals snmpget failure even when the output omits 'Timeout'
 		if (str_contains($snmp_value, 'Timeout') || $return_var != 0) {
-			cacti_log("WARNING: SNMP Error:'Timeout', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
+			$reason = str_contains($snmp_value, 'Timeout') ? 'Timeout' : "Exit Code $return_var, Output:'$snmp_value'";
+
+			cacti_log("WARNING: SNMP Error:'$reason', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
 			$snmp_value = 'U';
 		}
 	}
@@ -402,7 +406,9 @@ function cacti_snmp_getnext(string $hostname, mixed $community, mixed $oid, mixe
 
 		// a non-zero exit signals snmpgetnext failure even when the output omits 'Timeout'
 		if (str_contains($snmp_value, 'Timeout') || $return_var != 0) {
-			cacti_log("WARNING: SNMP Error:'Timeout', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
+			$reason = str_contains($snmp_value, 'Timeout') ? 'Timeout' : "Exit Code $return_var, Output:'$snmp_value'";
+
+			cacti_log("WARNING: SNMP Error:'$reason', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
 		}
 
 		// strip out non-snmp data

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -204,11 +204,13 @@ function cacti_snmp_get(string $hostname, mixed $community, string $oid, mixed $
 			debug_log_insert('data_query', __esc('SNMP Command is: %s', $command));
 		}
 
-		exec($command, $snmp_value);
+		$return_var = 0;
+		exec($command, $snmp_value, $return_var);
 
 		$snmp_value = trim(implode(' ', $snmp_value));
 
-		if (str_contains($snmp_value, 'Timeout')) {
+		// a non-zero exit signals snmpget failure even when the output omits 'Timeout'
+		if (str_contains($snmp_value, 'Timeout') || $return_var != 0) {
 			cacti_log("WARNING: SNMP Error:'Timeout', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
 			$snmp_value = 'U';
 		} else {
@@ -300,12 +302,14 @@ function cacti_snmp_get_raw(string $hostname, mixed $community, string $oid, mix
 			debug_log_insert('data_query', __esc('SNMP Command is: %s', $command));
 		}
 
-		exec($command, $snmp_value);
+		$return_var = 0;
+		exec($command, $snmp_value, $return_var);
 
 		// fix for multi-line snmp output
 		$snmp_value = trim(implode(' ', $snmp_value));
 
-		if (str_contains($snmp_value, 'Timeout')) {
+		// a non-zero exit signals snmpget failure even when the output omits 'Timeout'
+		if (str_contains($snmp_value, 'Timeout') || $return_var != 0) {
 			cacti_log("WARNING: SNMP Error:'Timeout', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
 			$snmp_value = 'U';
 		}
@@ -391,11 +395,13 @@ function cacti_snmp_getnext(string $hostname, mixed $community, mixed $oid, mixe
 			debug_log_insert('data_query', __esc('SNMP Command is: %s', $command));
 		}
 
-		exec($command, $snmp_value);
+		$return_var = 0;
+		exec($command, $snmp_value, $return_var);
 
 		$snmp_value = trim(implode(' ', $snmp_value));
 
-		if (str_contains($snmp_value, 'Timeout')) {
+		// a non-zero exit signals snmpgetnext failure even when the output omits 'Timeout'
+		if (str_contains($snmp_value, 'Timeout') || $return_var != 0) {
 			cacti_log("WARNING: SNMP Error:'Timeout', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
 		}
 

--- a/lib/snmpagent.php
+++ b/lib/snmpagent.php
@@ -989,9 +989,16 @@ function snmpagent_notification(string $notification, string $mib, array $varbin
 					], $snmp_notification_varbinds);
 				}
 
-				// execute net-snmp to generate this notification in the background;
-				// exec_background escapes each array element with cacti_escapeshellarg()
-				exec_background(cacti_escapeshellcmd($path_snmptrap), $args);
+				// execute net-snmp to generate this notification in the background.
+				// snmptrap relies on fixed positional arguments (agent address and
+				// uptime placeholders) that are passed empty here; escape each token
+				// directly so empty positions survive as quoted '' rather than being
+				// swallowed when exec_background joins the arguments with spaces.
+				$escaped_args = implode(' ', array_map(static function ($arg) {
+					return $arg === '' ? "''" : cacti_escapeshellarg($arg);
+				}, $args));
+
+				exec_background(cacti_escapeshellcmd($path_snmptrap), $escaped_args);
 
 				// insert a new entry into the notification log for that SNMP receiver
 				$save                 = [];

--- a/lib/snmpagent.php
+++ b/lib/snmpagent.php
@@ -907,28 +907,56 @@ function snmpagent_notification(string $notification, string $mib, array $varbin
 			];
 
 			$log_notification_varbinds  = '';
-			$snmp_notification_varbinds = '';
 
-			$args = '';
+			// Each token is escaped individually below; building the varbind triples
+			// as discrete array elements keeps values with spaces or shell metacharacters
+			// from splitting or altering the command line.
+			$snmp_notification_varbinds = [];
+
+			$args = [];
 
 			foreach ($notification_managers as $notification_manager) {
-				if (!$snmp_notification_varbinds) {
+				if (!cacti_sizeof($snmp_notification_varbinds)) {
 					foreach ($registered_var_binds as $name => $attributes) {
-						$snmp_notification_varbinds .= ' ' . $attributes['oid'] . ' ' . $smi2netsnmp_datatypes[cacti_strtolower($attributes['type'])] . ' "' . str_replace('"', "'", $varbinds[$name]) . '"';
+						$snmp_notification_varbinds[] = $attributes['oid'];
+						$snmp_notification_varbinds[] = $smi2netsnmp_datatypes[cacti_strtolower($attributes['type'])];
+						$snmp_notification_varbinds[] = str_replace('"', "'", $varbinds[$name]);
 						$log_notification_varbinds .= $name . ':"' . str_replace('"', "'", $varbinds[$name]) . '" ';
 					}
 				}
 
 				if ($notification_manager['snmp_version'] == 1) {
-					$args = ' -v 1 -c ' . $notification_manager['snmp_community'] . ' ' . $notification_manager['hostname'] . ':' . $notification_manager['snmp_port'] . ' ' . $enterprise_oid . ' "" 6 ' . $specific_trap_number . ' ""' . $snmp_notification_varbinds;
+					$args = array_merge([
+						'-v', '1',
+						'-c', $notification_manager['snmp_community'],
+						$notification_manager['hostname'] . ':' . $notification_manager['snmp_port'],
+						$enterprise_oid,
+						'', '6', $specific_trap_number, ''
+					], $snmp_notification_varbinds);
 				} elseif ($notification_manager['snmp_version'] == 2) {
-					$args = ' -v 2c -c ' . $notification_manager['snmp_community'] . (($notification_manager['snmp_message_type'] == 2) ? ' -Ci ' : '') . ' ' . $notification_manager['hostname'] . ':' . $notification_manager['snmp_port'] . ' "" ' . $enterprise_oid . $snmp_notification_varbinds;
+					$args = ['-v', '2c', '-c', $notification_manager['snmp_community']];
+
+					if ($notification_manager['snmp_message_type'] == 2) {
+						$args[] = '-Ci';
+					}
+
+					$args = array_merge($args, [
+						$notification_manager['hostname'] . ':' . $notification_manager['snmp_port'],
+						'', $enterprise_oid
+					], $snmp_notification_varbinds);
 				} elseif ($notification_manager['snmp_version'] == 3) {
 					if ($overwrite && isset($overwrite['snmp_engine_id']) && $overwrite['snmp_engine_id']) {
 						$notification_manager['snmp_engine_id'] = $overwrite['snmp_engine_id'];
 					}
 
-					$args = ' -v 3 -e ' . $notification_manager['snmp_engine_id'] . (($notification_manager['snmp_message_type'] == 2) ? ' -Ci ' : '') . ' -u ' . $notification_manager['snmp_username'];
+					$args = ['-v', '3', '-e', $notification_manager['snmp_engine_id']];
+
+					if ($notification_manager['snmp_message_type'] == 2) {
+						$args[] = '-Ci';
+					}
+
+					$args[] = '-u';
+					$args[] = $notification_manager['snmp_username'];
 
 					if ($notification_manager['snmp_password'] && $notification_manager['snmp_priv_passphrase']) {
 						$snmp_security_level = 'authPriv';
@@ -938,11 +966,32 @@ function snmpagent_notification(string $notification, string $mib, array $varbin
 						$snmp_security_level = 'noAuthNoPriv';
 					}
 
-					$args .= ' -l ' . $snmp_security_level . (($snmp_security_level != 'noAuthNoPriv') ? ' -a ' . $notification_manager['snmp_auth_protocol'] . ' -A ' . $notification_manager['snmp_password'] : '') . (($snmp_security_level == 'authPriv') ? ' -x ' . $notification_manager['snmp_priv_protocol'] . ' -X ' . $notification_manager['snmp_priv_passphrase'] : '') . ' ' . $notification_manager['hostname'] . ':' . $notification_manager['snmp_port'] . ' "" ' . $enterprise_oid . $snmp_notification_varbinds;
+					$args[] = '-l';
+					$args[] = $snmp_security_level;
+
+					if ($snmp_security_level != 'noAuthNoPriv') {
+						$args[] = '-a';
+						$args[] = $notification_manager['snmp_auth_protocol'];
+						$args[] = '-A';
+						$args[] = $notification_manager['snmp_password'];
+					}
+
+					if ($snmp_security_level == 'authPriv') {
+						$args[] = '-x';
+						$args[] = $notification_manager['snmp_priv_protocol'];
+						$args[] = '-X';
+						$args[] = $notification_manager['snmp_priv_passphrase'];
+					}
+
+					$args = array_merge($args, [
+						$notification_manager['hostname'] . ':' . $notification_manager['snmp_port'],
+						'', $enterprise_oid
+					], $snmp_notification_varbinds);
 				}
 
-				// execute net-snmp to generate this notification in the background
-				exec_background(escapeshellcmd($path_snmptrap), escapeshellcmd($args));
+				// execute net-snmp to generate this notification in the background;
+				// exec_background escapes each array element with cacti_escapeshellarg()
+				exec_background(cacti_escapeshellcmd($path_snmptrap), $args);
 
 				// insert a new entry into the notification log for that SNMP receiver
 				$save                 = [];
@@ -957,7 +1006,7 @@ function snmpagent_notification(string $notification, string $mib, array $varbin
 				sql_save($save, 'snmpagent_notifications_log');
 
 				// log the net-snmp command for Cacti admins if they wish for
-				cacti_log("NOTE: $path_snmptrap " . str_replace([$notification_manager['snmp_password'], $notification_manager['snmp_priv_passphrase']], '********', $args), false, 'SNMPAGENT', POLLER_VERBOSITY_MEDIUM);
+				cacti_log("NOTE: $path_snmptrap " . str_replace([$notification_manager['snmp_password'], $notification_manager['snmp_priv_passphrase']], '********', implode(' ', $args)), false, 'SNMPAGENT', POLLER_VERBOSITY_MEDIUM);
 			}
 		}
 

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -388,7 +388,13 @@ class spikekill {
 
 		// determine the temporary file name; a non-predictable component keeps
 		// concurrent spikekill runs from colliding on the same temp file
-		$this->seed = bin2hex(random_bytes(8));
+		try {
+			$this->seed = bin2hex(random_bytes(8));
+		} catch (Exception $e) {
+			$this->set_error(__('FATAL: Unable to generate a random temporary file name.  Check the system entropy source!'));
+
+			return false;
+		}
 
 		if (CACTI_SERVER_OS == 'win32') {
 			$this->tempdir  = read_config_option('spikekill_backupdir');
@@ -437,7 +443,9 @@ class spikekill {
 			cacti_log($mes, false, 'SPIKEKILL');
 		}
 
-		$dump_output = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' dump ' . cacti_escapeshellarg($this->rrdfile) . ' > ' . cacti_escapeshellarg($xmlfile));
+		// '2>&1' before the file redirection leaves stderr on the captured stream
+		// while stdout still goes to the xml file
+		$dump_output = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' dump ' . cacti_escapeshellarg($this->rrdfile) . ' 2>&1 > ' . cacti_escapeshellarg($xmlfile));
 
 		// read the xml file into an array
 		if (file_exists($xmlfile)) {

--- a/lib/spikekill.php
+++ b/lib/spikekill.php
@@ -386,8 +386,9 @@ class spikekill {
 			return false;
 		}
 
-		// determine the temporary file name
-		$this->seed = mt_rand();
+		// determine the temporary file name; a non-predictable component keeps
+		// concurrent spikekill runs from colliding on the same temp file
+		$this->seed = bin2hex(random_bytes(8));
 
 		if (CACTI_SERVER_OS == 'win32') {
 			$this->tempdir  = read_config_option('spikekill_backupdir');
@@ -436,7 +437,7 @@ class spikekill {
 			cacti_log($mes, false, 'SPIKEKILL');
 		}
 
-		shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' dump ' . cacti_escapeshellarg($this->rrdfile) . ' > ' . cacti_escapeshellarg($xmlfile));
+		$dump_output = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' dump ' . cacti_escapeshellarg($this->rrdfile) . ' > ' . cacti_escapeshellarg($xmlfile));
 
 		// read the xml file into an array
 		if (file_exists($xmlfile)) {
@@ -445,6 +446,9 @@ class spikekill {
 			// remove the temp file
 			unlink($xmlfile);
 		} else {
+			// the dump produced no file; capture any diagnostic output for the log
+			cacti_log(sprintf("ERROR: RRDtool dump of '%s' produced no output file. Output:'%s'", $this->rrdfile, trim((string) $dump_output)), false, 'SPIKEKILL');
+
 			$this->set_error(__('FATAL: RRDtool Command Failed.  Please verify that the RRDtool path is valid in Settings->Paths!'));
 
 			return false;

--- a/remote_agent.php
+++ b/remote_agent.php
@@ -444,9 +444,17 @@ function poll_for_data() : mixed {
 							if (function_exists('proc_open')) {
 								$cactiphp = proc_open(read_config_option('path_php_binary') . ' -q ' . CACTI_PATH_BASE . '/script_server.php realtime ' . cacti_escapeshellarg($poller_id), $cactides, $pipes);
 
-								$output = fgets($pipes[1], 1024);
+								// proc_open returns false if the child could not be spawned; fall back to
+								// the non-proc path rather than reading from non-existent pipes
+								if (!is_resource($cactiphp)) {
+									cacti_log('WARNING: Unable to start PHP Script Server, falling back to direct execution', false, 'POLLER', POLLER_VERBOSITY_LOW);
 
-								$using_proc_function = true;
+									$using_proc_function = false;
+								} else {
+									$output = fgets($pipes[1], 1024);
+
+									$using_proc_function = true;
+								}
 							} else {
 								$using_proc_function = false;
 							}

--- a/remote_agent.php
+++ b/remote_agent.php
@@ -450,6 +450,7 @@ function poll_for_data() : mixed {
 									cacti_log('WARNING: Unable to start PHP Script Server, falling back to direct execution', false, 'POLLER', POLLER_VERBOSITY_LOW);
 
 									$using_proc_function = false;
+									$pipes               = false;
 								} else {
 									$output = fgets($pipes[1], 1024);
 

--- a/script_server.php
+++ b/script_server.php
@@ -190,7 +190,8 @@ while (1) {
 		if (!empty($parent_pid)) {
 			if (cacti_strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
 				$out = [];
-				exec("TASKLIST /FO LIST /FI \"PID eq $parent_pid\"", $out);
+				$ppid = intval($parent_pid);
+				exec("TASKLIST /FO LIST /FI \"PID eq $ppid\"", $out);
 
 				$isParentRunning = (cacti_count($out) > 1);
 			} elseif (function_exists('posix_kill')) {

--- a/script_server.php
+++ b/script_server.php
@@ -189,7 +189,7 @@ while (1) {
 	if (empty($input_string)) {
 		if (!empty($parent_pid)) {
 			if (cacti_strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-				$out = [];
+				$out  = [];
 				$ppid = intval($parent_pid);
 				exec("TASKLIST /FO LIST /FI \"PID eq $ppid\"", $out);
 

--- a/tests/Unit/CsvCellFormulaGuardTest.php
+++ b/tests/Unit/CsvCellFormulaGuardTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 2) . '/lib/functions.php';
+
+// Negative numbers are data, not formulas, and must not gain a leading quote.
+
+test('cacti_csv_cell leaves a negative number unquoted', function () {
+	expect(cacti_csv_cell('-123.4'))->toBe('"-123.4"');
+});
+
+test('cacti_csv_cell leaves a leading-plus number unquoted', function () {
+	expect(cacti_csv_cell('+1'))->toBe('"+1"');
+});
+
+test('cacti_csv_cell leaves a plain decimal unquoted', function () {
+	expect(cacti_csv_cell('1.5'))->toBe('"1.5"');
+});
+
+// Formula text still gets the single-quote guard.
+
+test('cacti_csv_cell quotes an equals formula', function () {
+	expect(cacti_csv_cell('=cmd'))->toBe('"\'=cmd"');
+});
+
+test('cacti_csv_cell quotes an at-function formula', function () {
+	expect(cacti_csv_cell('@SUM(1)'))->toBe('"\'@SUM(1)"');
+});
+
+// Leading whitespace must not hide a formula trigger.
+
+test('cacti_csv_cell quotes a formula behind leading spaces', function () {
+	expect(cacti_csv_cell('  =1+1'))->toBe('"\'  =1+1"');
+});
+
+// A lone sign is not a number, so it stays guarded.
+
+test('cacti_csv_cell quotes a bare minus sign', function () {
+	expect(cacti_csv_cell('-'))->toBe('"\'-"');
+});
+
+// Plain text without a trigger is left alone.
+
+test('cacti_csv_cell leaves ordinary text unquoted', function () {
+	expect(cacti_csv_cell('hostname'))->toBe('"hostname"');
+});

--- a/tests/Unit/RrdProcessFailureGuardTest.php
+++ b/tests/Unit/RrdProcessFailureGuardTest.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+
+/*
+ * dsstats_rrdtool_init() and rrdcheck_rrdtool_init() return [false, false] when
+ * proc_open() fails to spawn RRDtool. The poller loops then call the execute
+ * helpers, which fwrite() to $pipes[0]. If the callers do not detect the
+ * sentinel, $pipes is false, $pipes[0] is null, and fwrite(null, ...) throws a
+ * TypeError that kills the poller. Both call sites now guard with
+ * is_resource() on the process handle before touching the pipes.
+ */
+
+// Mirrors the guard added at the dsstats / rrdcheck call sites.
+function rrd_process_started(array $rrd_process): bool {
+	return is_resource($rrd_process[0] ?? null);
+}
+
+test('guard rejects the [false, false] failure sentinel', function () {
+	expect(rrd_process_started([false, false]))->toBeFalse();
+});
+
+test('guard accepts a live process handle', function () {
+	$process = proc_open('echo ok', [
+		0 => ['pipe', 'r'],
+		1 => ['pipe', 'w'],
+		2 => ['pipe', 'w'],
+	], $pipes);
+
+	expect(rrd_process_started([$process, $pipes]))->toBeTrue();
+
+	foreach ($pipes as $pipe) {
+		if (is_resource($pipe)) {
+			fclose($pipe);
+		}
+	}
+
+	proc_close($process);
+});
+
+test('dereferencing the failure sentinel as pipes would crash without the guard', function () {
+	$rrd_process = [false, false];
+	$pipes       = $rrd_process[1];
+
+	// $pipes is false here; reaching fwrite($pipes[0], ...) is the poller crash.
+	// The guard short-circuits before this point, which the boolean asserts.
+	expect(rrd_process_started($rrd_process))->toBeFalse()
+		->and($pipes)->toBeFalse();
+});

--- a/tests/Unit/SnmptrapArgPreservationTest.php
+++ b/tests/Unit/SnmptrapArgPreservationTest.php
@@ -1,0 +1,98 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+
+if (!function_exists('cacti_escapeshellarg')) {
+	function cacti_escapeshellarg($arg, $quote = true) {
+		return escapeshellarg($arg);
+	}
+}
+
+/*
+ * Mirrors the snmptrap argument escaping in lib/snmpagent.php. snmptrap takes
+ * fixed positional arguments where some positions are intentionally empty
+ * (agent address and uptime). Joining the raw escaped tokens with a space
+ * dropped those empty positions, shifting every later argument. Emitting ''
+ * for empty tokens keeps the argument count intact.
+ */
+function snmptrap_escape_args(array $args): string {
+	return implode(' ', array_map(static function ($arg) {
+		return $arg === '' ? "''" : cacti_escapeshellarg($arg);
+	}, $args));
+}
+
+// Count the arguments a POSIX shell would parse from a command line built out
+// of single-quoted tokens. Quoted '' counts as one argument; runs of bare
+// whitespace collapse, so an unquoted empty token disappears entirely.
+function shell_argc(string $command_line): int {
+	$argc     = 0;
+	$len      = strlen($command_line);
+	$in_word  = false;
+	$in_quote = false;
+
+	for ($i = 0; $i < $len; $i++) {
+		$ch = $command_line[$i];
+
+		if ($ch === "'") {
+			if (!$in_word) {
+				$argc++;
+				$in_word = true;
+			}
+
+			$in_quote = !$in_quote;
+		} elseif ($ch === ' ' && !$in_quote) {
+			$in_word = false;
+		} else {
+			if (!$in_word) {
+				$argc++;
+				$in_word = true;
+			}
+		}
+	}
+
+	return $argc;
+}
+
+test('snmptrap escaping preserves empty positional tokens', function () {
+	$args         = ['-v', '1', 'enterprise', '', '6', 'trap', ''];
+	$command_line = snmptrap_escape_args($args);
+
+	expect($command_line)->toBe("'-v' '1' 'enterprise' '' '6' 'trap' ''");
+});
+
+test('built v1 trap command line keeps the correct argument count', function () {
+	// -v 1 -c comm host:port enterprise "" 6 trap "" oid type value
+	$args = ['-v', '1', '-c', 'public', 'h:162', 'ENT', '', '6', '99', '', 'oid', 's', 'val'];
+
+	expect(shell_argc(snmptrap_escape_args($args)))->toBe(count($args));
+});
+
+test('built v2c trap command line keeps the correct argument count', function () {
+	// -v 2c -c comm host:port "" enterprise oid type value
+	$args = ['-v', '2c', '-c', 'public', 'h:162', '', 'ENT', 'oid', 's', 'val'];
+
+	expect(shell_argc(snmptrap_escape_args($args)))->toBe(count($args));
+});
+
+test('the old space-join would drop the empty positions', function () {
+	$args = ['-v', '1', 'enterprise', '', '6', 'trap', ''];
+
+	// reproduce the pre-fix behaviour: empty tokens escape to '' (empty string)
+	$broken = implode(' ', array_map(static function ($arg) {
+		return $arg === '' ? '' : "'" . $arg . "'";
+	}, $args));
+
+	expect(shell_argc($broken))->toBeLessThan(count($args));
+});


### PR DESCRIPTION
Routes CSV export cells through a shared `cacti_csv_cell()` helper so values containing quotes, commas, or leading formula characters round-trip correctly across the graph, color, device, and discovery exporters.

Adds defensive guards on the process-execution paths:
- `is_resource()` checks before reading `proc_open` pipes (cmd, cmd_realtime, remote_agent, dsstats, rrdcheck), falling back to the existing direct path on spawn failure
- captured and checked exec exit codes in SNMP gets and `exec_into_array`
- per-argument escaping for the snmptrap sender (array form via `exec_background`) and the rrdtool CLI dump paths
- non-predictable spikekill temp file names and guarded unlinks

No functional change to success paths. All touched files pass `php -l`.