### PR TITLE
Fix: #6945 PHP 8.5 Deprecation Warning

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -81,6 +81,7 @@ Cacti CHANGELOG
 -issue#6605: Prevent Row Data Loss When Rebuilding RRD Files
 -issue#6606: When using SpikeKill, actions would not always lead to expected results
 -issue#6706: Fix false device down status in GUI for device that use empty SNMP OID System
+-issue#6945: Fix PHP 8.5 deprecation with xml_parser_free function
 -issue#7121: Restore valid quoted and digit-suffixed placeholders in input_string templates
 -issue#7133: Fix poller cache integrity bugs in update_poller_cache, push_out_data_input_method, and push_out_host
 -issue#7135: Reset loop-scoped $oid and $script_path between iterations in poller cache builders and test_data_source

--- a/lib/xml.php
+++ b/lib/xml.php
@@ -32,7 +32,10 @@ function xml2array($data) {
 	xml_parser_set_option($p, XML_OPTION_SKIP_WHITE, 1);
 	xml_parser_set_option($p, XML_OPTION_CASE_FOLDING, 0);
 	xml_parse_into_struct($p, $data, $vals, $index);
-	xml_parser_free($p);
+
+	if (version_compare(PHP_VERSION, '8.5', '<')) {
+		xml_parser_free($p);
+	}
 
 	$tree = array();
 	$i = 0;
@@ -116,7 +119,10 @@ function rrdxport2array($data) {
 	xml_parser_set_option($p, XML_OPTION_CASE_FOLDING, 0);
 	xml_parser_set_option($p, XML_OPTION_TARGET_ENCODING, 'UTF-8');
 	xml_parse_into_struct($p, $data, $vals, $index);
-	xml_parser_free($p);
+
+	if (version_compare(PHP_VERSION, '8.5', '<')) {
+		xml_parser_free($p);
+	}
 
 	$tree = array();
 	$i = 0;


### PR DESCRIPTION
Fixes issues with the function xml_parser_free() deprecation warnings.

Closes: #6945