### PR TITLE
ci: ignore phpstan function.alreadyNarrowedType identifier

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -44,5 +44,6 @@ parameters:
         - identifier: identical.alwaysFalse
         - identifier: booleanAnd.leftAlwaysTrue
         - identifier: booleanAnd.leftAlwaysFalse
+        - identifier: function.alreadyNarrowedType
 # L9       - '/^Parameter #1 \$value of function strval expects bool\|float\|int\|resource\|string\|null, mixed given.$/'
 # L9       - '/^Parameter #1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given.$/'


### PR DESCRIPTION
develop is failing the Cacti Commit Audit (PHP 8.1-8.4) at level 6:

```
lib/data_query.php:2591  Call to function is_numeric() with float|int|numeric-string
                         will always evaluate to true.  (function.alreadyNarrowedType)
```

`.phpstan.neon` already ignores the matching narrowing identifiers (`if.alwaysTrue`, `equal.alwaysTrue`, `identical.alwaysTrue`, the `booleanAnd.*` pair, etc.) under the "PHPStan gets confused" group. `function.alreadyNarrowedType` is the same class of complaint for built-in predicates and was the only one missing. Adding it turns the audit green.

No code behavior change.