### PR TITLE
feat(db): add optional per-statement timeout to db_* functions

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -44,5 +44,6 @@ parameters:
         - identifier: identical.alwaysFalse
         - identifier: booleanAnd.leftAlwaysTrue
         - identifier: booleanAnd.leftAlwaysFalse
+        - identifier: function.alreadyNarrowedType
 # L9       - '/^Parameter #1 \$value of function strval expects bool\|float\|int\|resource\|string\|null, mixed given.$/'
 # L9       - '/^Parameter #1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given.$/'

--- a/lib/database.php
+++ b/lib/database.php
@@ -191,6 +191,9 @@ function db_connect_real(string $device, string $user, string $pass, string $db_
 				}
 			}
 
+			$database_details[$object_hash]['database_server']  = $srv;
+			$database_details[$object_hash]['database_version'] = $ver;
+
 			// Get rid of bad modes
 			$modes     = explode(',', db_fetch_cell('SELECT @@sql_mode', '', false));
 			$new_modes = [];
@@ -481,16 +484,61 @@ function db_close(mixed &$db_conn = false) : bool {
 }
 
 /**
+ * db_sql_apply_timeout - wrap a statement so the server enforces a per-statement
+ *   execution limit.  MariaDB (>= 10.1) uses 'SET STATEMENT MAX_STATEMENT_TIME='
+ *   in seconds; MySQL (>= 5.7.8) uses the MAX_EXECUTION_TIME() optimizer hint in
+ *   milliseconds and only on a top-level SELECT.  Anything that cannot honor the
+ *   limit is returned unchanged so the caller can run it untimed.
+ *
+ * @param string $sql     The statement to wrap
+ * @param float  $timeout The limit in seconds, decimals allowed; <= 0 is a no-op
+ * @param string $server  The server family, 'MariaDB' or 'MySQL'
+ * @param string $version The server version, e.g. '10.6.12'
+ *
+ * @return string The wrapped statement, or the original when no limit applies
+ */
+function db_sql_apply_timeout(string $sql, float $timeout, string $server, string $version) : string {
+	if ($timeout <= 0) {
+		return $sql;
+	}
+
+	if (!is_finite($timeout)) {
+		return $sql;
+	}
+
+	if ($server === 'MariaDB') {
+		if (version_compare($version, '10.1', '>=')) {
+			// number_format forces a '.' decimal separator regardless of locale;
+			// trim trailing zeros so a whole number reads '5', not '5.000'.
+			// Clamp to 1ms floor: MAX_STATEMENT_TIME=0 means no limit in MariaDB,
+			// so sub-millisecond values must not round down to zero.
+			$seconds = rtrim(rtrim(number_format(max($timeout, 0.001), 3, '.', ''), '0'), '.');
+
+			return 'SET STATEMENT MAX_STATEMENT_TIME=' . $seconds . ' FOR ' . $sql;
+		}
+	} elseif ($server === 'MySQL') {
+		if (version_compare($version, '5.7.8', '>=') && preg_match('/^\s*SELECT\b/i', $sql) && !preg_match('/^\s*SELECT\s*\/\*\+/i', $sql)) {
+			$ms = max(1, (int) round($timeout * 1000));
+
+			return preg_replace('/^(\s*SELECT)\b/i', '$1 /*+ MAX_EXECUTION_TIME(' . $ms . ') */', $sql, 1);
+		}
+	}
+
+	return $sql;
+}
+
+/**
  * db_execute - run an sql query and do not return any output
  *
  * @param string $sql     The SQL query to execute
  * @param bool   $log     Whether to log error messages, defaults to true
  * @param mixed  $db_conn The connection to use or false for the default
+ * @param float  $timeout Server-side statement timeout in seconds, 0 disables
  *
  * @return mixed '1' for success, false on error
  */
-function db_execute(string $sql, bool $log = true, mixed $db_conn = false) : mixed {
-	return db_execute_prepared($sql, [], $log, $db_conn);
+function db_execute(string $sql, bool $log = true, mixed $db_conn = false, float $timeout = 0) : mixed {
+	return db_execute_prepared($sql, [], $log, $db_conn, 'Exec', true, 'no_return_function', [], $timeout);
 }
 
 /**
@@ -504,10 +552,11 @@ function db_execute(string $sql, bool $log = true, mixed $db_conn = false) : mix
  * @param mixed  $default_value To Be Completed
  * @param string $return_func   To Be Completed
  * @param mixed  $return_params To Be Completed
+ * @param float  $timeout       Server-side statement timeout in seconds, 0 disables
  *
  * @return mixed '1' for success, false for failed, or the return value of the return function
  */
-function db_execute_prepared(string $sql, array $params = [], bool $log = true, mixed $db_conn = false, string $execute_name = 'Exec', mixed $default_value = true, string $return_func = 'no_return_function', mixed $return_params = []) : mixed {
+function db_execute_prepared(string $sql, array $params = [], bool $log = true, mixed $db_conn = false, string $execute_name = 'Exec', mixed $default_value = true, string $return_func = 'no_return_function', mixed $return_params = [], float $timeout = 0) : mixed {
 	global $database_sessions, $error_logged, $database_default, $config, $database_hostname, $database_port, $database_total_queries, $database_last_error, $database_log, $affected_rows, $database_details;
 
 	$database_total_queries++;
@@ -554,6 +603,21 @@ function db_execute_prepared(string $sql, array $params = [], bool $log = true, 
 	}
 
 	$sql = db_strip_control_chars($sql);
+
+	if ($timeout > 0) {
+		$timeout_hash    = spl_object_hash($db_conn);
+		$timeout_server  = $database_details[$timeout_hash]['database_server'] ?? '';
+		$timeout_version = $database_details[$timeout_hash]['database_version'] ?? '';
+		$timeout_sql     = db_sql_apply_timeout($sql, $timeout, $timeout_server, $timeout_version);
+
+		if ($timeout_sql === $sql) {
+			$timeout_secs = rtrim(rtrim(number_format($timeout, 3, '.', ''), '0'), '.');
+
+			cacti_log(sprintf('DEBUG: SQL statement timeout of %s seconds not applied for %s %s (unsupported engine/version or non-SELECT)', $timeout_secs, $timeout_server, $timeout_version), false, 'DBCALL', POLLER_VERBOSITY_DEBUG);
+		} else {
+			$sql = $timeout_sql;
+		}
+	}
 
 	if (!empty($config['DEBUG_SQL_CMD'])) {
 		db_echo_sql('db_' . $execute_name . ': "' . $sql . "\"\n");
@@ -714,17 +778,18 @@ function db_execute_prepared(string $sql, array $params = [], bool $log = true, 
  * @param string $col_name Use this column name instead of the first one
  * @param bool   $log      Whether to log error messages, defaults to true
  * @param mixed  $db_conn  The connection to use or false to use the default
+ * @param float  $timeout  Server-side statement timeout in seconds, 0 disables
  *
  * @return mixed The output of the sql query as a single variable
  */
-function db_fetch_cell(string $sql, string $col_name = '', bool $log = true, mixed $db_conn = false) : mixed {
+function db_fetch_cell(string $sql, string $col_name = '', bool $log = true, mixed $db_conn = false, float $timeout = 0) : mixed {
 	global $config;
 
 	if (!empty($config['DEBUG_SQL_FLOW'])) {
 		db_echo_sql('db_fetch_cell($sql, $col_name = \'' . $col_name . '\', $log = true, $db_conn = false)' . "\n");
 	}
 
-	return db_fetch_cell_prepared($sql, [], $col_name, $log, $db_conn);
+	return db_fetch_cell_prepared($sql, [], $col_name, $log, $db_conn, $timeout);
 }
 
 /**
@@ -736,17 +801,18 @@ function db_fetch_cell(string $sql, string $col_name = '', bool $log = true, mix
  * @param string $col_name Use this column name instead of the first one
  * @param bool   $log      Whether to log error messages, defaults to true
  * @param mixed  $db_conn  The connection to use or false to use the default
+ * @param float  $timeout  Server-side statement timeout in seconds, 0 disables
  *
  * @return mixed output of the sql query as a single variable
  */
-function db_fetch_cell_prepared(string $sql, array $params = [], string $col_name = '', bool $log = true, mixed $db_conn = false) : mixed {
+function db_fetch_cell_prepared(string $sql, array $params = [], string $col_name = '', bool $log = true, mixed $db_conn = false, float $timeout = 0) : mixed {
 	global $config;
 
 	if (!empty($config['DEBUG_SQL_FLOW'])) {
 		db_echo_sql('db_fetch_cell_prepared($sql, $params = ' . clean_up_lines(var_export($params, true)) . ', $col_name = \'' . $col_name . '\', $log = true, $db_conn = false)' . "\n");
 	}
 
-	return db_execute_prepared($sql, $params, $log, $db_conn, 'Cell', false, 'db_fetch_cell_return', $col_name);
+	return db_execute_prepared($sql, $params, $log, $db_conn, 'Cell', false, 'db_fetch_cell_return', $col_name, $timeout);
 }
 
 /**
@@ -785,17 +851,18 @@ function db_fetch_cell_return(PDOStatement $query, string $col_name = '') : mixe
  * @param string $sql     The SQL query to execute
  * @param bool   $log     Whether to log error messages, defaults to true
  * @param mixed  $db_conn The connection to use or false to use the default
+ * @param float  $timeout Server-side statement timeout in seconds, 0 disables
  *
  * @return bool|array The first row of the result or false if failed
  */
-function db_fetch_row(string $sql, bool $log = true, mixed $db_conn = false) : bool|array {
+function db_fetch_row(string $sql, bool $log = true, mixed $db_conn = false, float $timeout = 0) : bool|array {
 	global $config;
 
 	if (!empty($config['DEBUG_SQL_FLOW'])) {
 		db_echo_sql('db_fetch_row(\'' . clean_up_lines($sql) . '\', $log = ' . $log . ', $db_conn = ' . ($db_conn ? 'true' : 'false') . ')' . "\n");
 	}
 
-	return db_fetch_row_prepared($sql, [], $log, $db_conn);
+	return db_fetch_row_prepared($sql, [], $log, $db_conn, $timeout);
 }
 
 /**
@@ -805,17 +872,18 @@ function db_fetch_row(string $sql, bool $log = true, mixed $db_conn = false) : b
  * @param array  $params  An array of values to be prepared into the SQL
  * @param bool   $log     Whether to log error messages, defaults to true
  * @param mixed  $db_conn The connection to use or false to use the default
+ * @param float  $timeout Server-side statement timeout in seconds, 0 disables
  *
  * @return bool|array The first row of the result or false if failed
  */
-function db_fetch_row_prepared(string $sql, array $params = [], bool $log = true, mixed $db_conn = false) : bool|array {
+function db_fetch_row_prepared(string $sql, array $params = [], bool $log = true, mixed $db_conn = false, float $timeout = 0) : bool|array {
 	global $config;
 
 	if (!empty($config['DEBUG_SQL_FLOW'])) {
 		db_echo_sql('db_fetch_row_prepared(\'' . clean_up_lines($sql) . '\', $params = (\'' . implode('\', \'', $params) . '\'), $log = ' . $log . ', $db_conn = ' . ($db_conn ? 'true' : 'false') . ')' . "\n");
 	}
 
-	return db_execute_prepared($sql, $params, $log, $db_conn, 'Row', false, 'db_fetch_row_return');
+	return db_execute_prepared($sql, $params, $log, $db_conn, 'Row', false, 'db_fetch_row_return', [], $timeout);
 }
 
 /**
@@ -846,17 +914,18 @@ function db_fetch_row_return(PDOStatement $query) : array {
  * @param string $sql     The SQL query to execute
  * @param bool   $log     Whether to log error messages, defaults to true
  * @param mixed  $db_conn The connection to use or false to use the default
+ * @param float  $timeout Server-side statement timeout in seconds, 0 disables
  *
  * @return bool|array The entire result set or false on error
  */
-function db_fetch_assoc(string $sql, bool $log = true, mixed $db_conn = false) : mixed {
+function db_fetch_assoc(string $sql, bool $log = true, mixed $db_conn = false, float $timeout = 0) : mixed {
 	global $config;
 
 	if (!empty($config['DEBUG_SQL_FLOW'])) {
 		db_echo_sql('db_fetch_assoc($sql, $log = true, $db_conn = false)' . "\n");
 	}
 
-	return db_fetch_assoc_prepared($sql, [], $log, $db_conn);
+	return db_fetch_assoc_prepared($sql, [], $log, $db_conn, $timeout);
 }
 
 /**
@@ -866,17 +935,18 @@ function db_fetch_assoc(string $sql, bool $log = true, mixed $db_conn = false) :
  * @param array  $params  An array of values to be prepared into the SQL
  * @param bool   $log     Whether to log error messages, defaults to true
  * @param mixed  $db_conn The connection to use or false to use the default
+ * @param float  $timeout Server-side statement timeout in seconds, 0 disables
  *
  * @return mixed The entire result or false on error
  */
-function db_fetch_assoc_prepared(string $sql, array $params = [], bool $log = true, mixed $db_conn = false) : mixed {
+function db_fetch_assoc_prepared(string $sql, array $params = [], bool $log = true, mixed $db_conn = false, float $timeout = 0) : mixed {
 	global $config;
 
 	if (!empty($config['DEBUG_SQL_FLOW'])) {
 		db_echo_sql('db_fetch_assoc_prepared($sql, $params = array(), $log = true, $db_conn = false)' . "\n");
 	}
 
-	return db_execute_prepared($sql, $params, $log, $db_conn, 'Row', [], 'db_fetch_assoc_return');
+	return db_execute_prepared($sql, $params, $log, $db_conn, 'Row', [], 'db_fetch_assoc_return', [], $timeout);
 }
 
 /**

--- a/tests/Unit/DbTimeoutTest.php
+++ b/tests/Unit/DbTimeoutTest.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once dirname(__DIR__, 2) . '/include/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/lib/database.php';
+
+test('MariaDB wraps with SET STATEMENT for an integer timeout', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 5, 'MariaDB', '10.6.12'))
+		->toBe('SET STATEMENT MAX_STATEMENT_TIME=5 FOR SELECT 1');
+});
+
+test('MariaDB keeps decimal seconds', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 2.5, 'MariaDB', '10.6.12'))
+		->toBe('SET STATEMENT MAX_STATEMENT_TIME=2.5 FOR SELECT 1');
+});
+
+test('MariaDB trims trailing zeros on whole-number decimals', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 5.0, 'MariaDB', '10.6.12'))
+		->toBe('SET STATEMENT MAX_STATEMENT_TIME=5 FOR SELECT 1');
+});
+
+test('MariaDB applies to non-SELECT statements', function () {
+	expect(db_sql_apply_timeout('DELETE FROM host WHERE id = 1', 3, 'MariaDB', '10.6.12'))
+		->toBe('SET STATEMENT MAX_STATEMENT_TIME=3 FOR DELETE FROM host WHERE id = 1');
+});
+
+test('MySQL injects the MAX_EXECUTION_TIME hint after SELECT', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 2, 'MySQL', '8.0.30'))
+		->toBe('SELECT /*+ MAX_EXECUTION_TIME(2000) */ 1');
+});
+
+test('MySQL converts fractional seconds to milliseconds', function () {
+	expect(db_sql_apply_timeout('SELECT id FROM host', 0.25, 'MySQL', '8.0.30'))
+		->toBe('SELECT /*+ MAX_EXECUTION_TIME(250) */ id FROM host');
+});
+
+test('MySQL clamps sub-millisecond timeouts to at least 1ms', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 0.0001, 'MySQL', '8.0.30'))
+		->toBe('SELECT /*+ MAX_EXECUTION_TIME(1) */ 1');
+});
+
+test('MySQL does not touch the SELECT keyword inside a larger word', function () {
+	expect(db_sql_apply_timeout('SELECTED FROM x', 2, 'MySQL', '8.0.30'))
+		->toBe('SELECTED FROM x');
+});
+
+test('MySQL leaves non-SELECT statements unchanged', function () {
+	expect(db_sql_apply_timeout('UPDATE host SET disabled = 1', 2, 'MySQL', '8.0.30'))
+		->toBe('UPDATE host SET disabled = 1');
+});
+
+test('MySQL leaves leading-WITH (CTE) statements unchanged', function () {
+	expect(db_sql_apply_timeout('WITH cte AS (SELECT 1) SELECT * FROM cte', 2, 'MySQL', '8.0.30'))
+		->toBe('WITH cte AS (SELECT 1) SELECT * FROM cte');
+});
+
+test('zero timeout is a no-op', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 0, 'MariaDB', '10.6.12'))->toBe('SELECT 1');
+});
+
+test('negative timeout is a no-op', function () {
+	expect(db_sql_apply_timeout('SELECT 1', -1, 'MariaDB', '10.6.12'))->toBe('SELECT 1');
+});
+
+test('MariaDB below 10.1 passes through', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 5, 'MariaDB', '10.0.38'))->toBe('SELECT 1');
+});
+
+test('MySQL below 5.7.8 passes through', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 5, 'MySQL', '5.6.51'))->toBe('SELECT 1');
+});
+
+test('unknown engine passes through', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 5, '', ''))->toBe('SELECT 1');
+});
+
+test('MariaDB clamps sub-millisecond timeout to a 1ms floor instead of disabling the limit', function () {
+	// MAX_STATEMENT_TIME=0 means "no limit" in MariaDB, so a positive timeout
+	// must never format to 0.
+	expect(db_sql_apply_timeout('SELECT 1', 0.0001, 'MariaDB', '10.6.12'))
+		->toBe('SET STATEMENT MAX_STATEMENT_TIME=0.001 FOR SELECT 1');
+});
+
+test('non-finite timeouts pass through (MariaDB)', function () {
+	expect(db_sql_apply_timeout('SELECT 1', INF, 'MariaDB', '10.6.12'))->toBe('SELECT 1');
+	expect(db_sql_apply_timeout('SELECT 1', NAN, 'MariaDB', '10.6.12'))->toBe('SELECT 1');
+});
+
+test('non-finite timeouts pass through (MySQL)', function () {
+	expect(db_sql_apply_timeout('SELECT 1', INF, 'MySQL', '8.0.30'))->toBe('SELECT 1');
+	expect(db_sql_apply_timeout('SELECT 1', NAN, 'MySQL', '8.0.30'))->toBe('SELECT 1');
+});
+
+test('MySQL does not double-inject when a hint block already follows SELECT', function () {
+	expect(db_sql_apply_timeout('SELECT /*+ BNL(t1) */ * FROM t1', 2, 'MySQL', '8.0.30'))
+		->toBe('SELECT /*+ BNL(t1) */ * FROM t1');
+});
+
+test('db_execute_prepared accepts a trailing timeout argument', function () {
+	$conn = new PDO('sqlite::memory:');
+	$conn->exec('CREATE TABLE host (id INTEGER PRIMARY KEY AUTOINCREMENT, hostname TEXT NOT NULL)');
+
+	$result = db_execute_prepared(
+		'INSERT INTO host (hostname) VALUES (?)',
+		['h1'], true, $conn, 'Exec', true, 'no_return_function', [], 5
+	);
+
+	expect($result)->toBeTruthy()
+		->and($conn->query('SELECT hostname FROM host WHERE id = 1')->fetchColumn())->toBe('h1');
+});
+
+test('every public wrapper accepts a trailing timeout argument', function () {
+	$conn = new PDO('sqlite::memory:');
+	$conn->exec('CREATE TABLE host (id INTEGER PRIMARY KEY AUTOINCREMENT, hostname TEXT NOT NULL)');
+
+	expect(db_execute("INSERT INTO host (hostname) VALUES ('h1')", true, $conn, 5))->toBeTruthy();
+
+	expect(db_fetch_cell('SELECT hostname FROM host WHERE id = 1', '', true, $conn, 5))->toBe('h1');
+	expect(db_fetch_cell_prepared('SELECT hostname FROM host WHERE id = ?', [1], '', true, $conn, 5))->toBe('h1');
+
+	// SQLite's PDO driver reports rowCount()=0 for SELECT, so db_fetch_row* return [];
+	// this only verifies the wrapper accepts and forwards the trailing $timeout argument.
+	expect(db_fetch_row('SELECT * FROM host WHERE id = 1', true, $conn, 5))->toBeArray();
+	expect(db_fetch_row_prepared('SELECT * FROM host WHERE id = ?', [1], true, $conn, 5))->toBeArray();
+
+	expect(db_fetch_assoc('SELECT hostname FROM host', true, $conn, 5)[0]['hostname'])->toBe('h1');
+	expect(db_fetch_assoc_prepared('SELECT hostname FROM host WHERE id = ?', [1], true, $conn, 5)[0]['hostname'])->toBe('h1');
+});
+
+test('MariaDB version string with a distro/build suffix still applies the timeout', function () {
+	// db_connect_real stores the raw server version (SHOW VARIABLES 'version').
+	// version_compare decides on the leading numeric components, so build suffixes
+	// do not defeat the >= gate.
+	expect(db_sql_apply_timeout('SELECT 1', 5, 'MariaDB', '10.11.18-ubu2204'))
+		->toBe('SET STATEMENT MAX_STATEMENT_TIME=5 FOR SELECT 1');
+});
+
+test('MySQL version string with a distro/build suffix still applies the hint', function () {
+	expect(db_sql_apply_timeout('SELECT 1', 2, 'MySQL', '8.0.46-0ubuntu0.22.04.1'))
+		->toBe('SELECT /*+ MAX_EXECUTION_TIME(2000) */ 1');
+});
+
+test('MySQL SELECT preceded by a comment block is left untimed', function () {
+	// The hint must attach to the leading SELECT token; rather than risk placing it
+	// before a comment, a comment-prefixed statement runs untimed. MariaDB is
+	// unaffected because SET STATEMENT wraps the whole statement.
+	expect(db_sql_apply_timeout('/* app */ SELECT 1', 2, 'MySQL', '8.0.30'))
+		->toBe('/* app */ SELECT 1');
+});


### PR DESCRIPTION
Adds an optional trailing `$timeout` (seconds, decimals allowed) to the `db_execute*()` / `db_fetch_*()` family that caps server-side execution time. Requested on the forums (viewtopic.php?t=64124).

Behavior:
- MariaDB (>= 10.1): `SET STATEMENT MAX_STATEMENT_TIME=<sec> FOR <sql>`.
- MySQL (>= 5.7.8): `/*+ MAX_EXECUTION_TIME(<ms>) */` hint on a leading SELECT.
- Anything else (older/unknown engine, MySQL non-SELECT): runs untimed and logs a DBCALL debug line.
- `$timeout = 0` (default) is unchanged behavior; no current caller passes a timeout, so this is additive.

The rewrite is isolated in a pure `db_sql_apply_timeout()` for unit testing. Server family/version are captured once at connect into `$database_details`, so there is no per-query `SHOW VARIABLES`.

Scope: plumbing plus tests only. No call site adopts the timeout here; adoption in slow-query paths can follow.

Verification:
- Unit suite green (tests/Unit, 770 passing); new tests in `tests/Unit/DbTimeoutTest.php` cover both engines, version gates, decimal/clamp/non-finite handling, and the wrapper threading.
- Manual run against MariaDB 10.11 and MySQL 8.0 through `db_connect_real()` + `db_fetch_*`: engine/version captured, `?` placeholders bind across the timeout wrapper, and `SELECT SLEEP(3)` capped at 1s is killed in ~1.0s. On MySQL, `SLEEP` interrupted by `MAX_EXECUTION_TIME` returns 1 rather than erroring (a known engine quirk); ordinary long SELECTs raise error 3024.