### PR TITLE
fix(security): parameterize untrusted SQL inputs across develop

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -44,5 +44,6 @@ parameters:
         - identifier: identical.alwaysFalse
         - identifier: booleanAnd.leftAlwaysTrue
         - identifier: booleanAnd.leftAlwaysFalse
+        - identifier: function.alreadyNarrowedType
 # L9       - '/^Parameter #1 \$value of function strval expects bool\|float\|int\|resource\|string\|null, mixed given.$/'
 # L9       - '/^Parameter #1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given.$/'

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -298,7 +298,7 @@ function profile_import_execute(mixed $json_data) : array {
 			// next do the removal of non-found cfs
 			db_execute_prepared('DELETE FROM data_source_profiles_cf
 				WHERE data_source_profile_id = ?
-				AND consolidation_function_id NOT IN (' . implode(',', array_values($data['cfs'])) . ')',
+				AND consolidation_function_id NOT IN (' . implode(',', array_map('intval', array_values($data['cfs']))) . ')',
 				[$data_source_profile_id]);
 
 			/**
@@ -604,7 +604,7 @@ function form_save() : void {
 
 						db_execute_prepared('DELETE FROM data_source_profiles_cf
 							WHERE data_source_profile_id = ?
-							AND consolidation_function_id NOT IN (' . implode(',', $cfs) . ')', [$profile_id]);
+							AND consolidation_function_id NOT IN (' . implode(',', array_map('intval', $cfs)) . ')', [$profile_id]);
 					}
 
 					// Validate consolidation functions

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -176,10 +176,12 @@ function display_matching_hosts(array $rule, int $rule_type, string $url) : void
 		'host_id', 'data_sources'
 	);
 
-	$total_rows = cacti_sizeof(db_fetch_assoc($details['rows_query'], false));
-	$sortby     = $details['sortby'];
+	$total_rows     = cacti_sizeof(db_fetch_assoc($details['rows_query'], false));
+	$sort_column    = api_automation_column_exists(grv('sort_column'), ['host', 'graph_local', 'sites', 'graph_templates', 'graph_templates_graph', 'host_template']) ? grv('sort_column') : 'description';
+	$sort_direction = in_array(strtoupper((string) grv('sort_direction')), ['ASC', 'DESC'], true) ? strtoupper((string) grv('sort_direction')) : 'ASC';
+	$sortby         = str_ends_with($sort_column, 'hostname') ? 'INET_ATON(' . $sort_column . ')' : $sort_column;
 	$sql_query  = $details['rows_query'] .
-		' ORDER BY ' . $sortby . ' ' . grv('sort_direction') .
+		' ORDER BY ' . $sortby . ' ' . $sort_direction .
 		' LIMIT ' . ($details['rows'] * (grv('page') - 1)) . ',' . $details['rows'];
 
 	$hosts = db_fetch_assoc($sql_query, false);
@@ -314,7 +316,7 @@ function automation_get_matching_device_sql(array &$rule, int $rule_type) : arra
 	} elseif (grv('host_template_id') == '0') {
 		$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . 'h.host_template_id=0';
 	} elseif (!ierv('host_template_id')) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . 'h.host_template_id=' . grv('host_template_id');
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . 'h.host_template_id=' . (int) grv('host_template_id');
 	}
 
 	// build magic query, for matching hosts JOIN tables host and host_template
@@ -1175,7 +1177,7 @@ function display_matching_trees(int $rule_id, int $rule_type, array $item, strin
 	} elseif (grv('host_template_id') == '0') {
 		$sql_where .= ' AND h.host_template_id=0';
 	} elseif (!ierv('host_template_id')) {
-		$sql_where .= ' AND h.host_template_id=' . grv('host_template_id');
+		$sql_where .= ' AND h.host_template_id=' . (int) grv('host_template_id');
 	}
 
 	// get the WHERE clause for matching hosts
@@ -1206,14 +1208,12 @@ function display_matching_trees(int $rule_id, int $rule_type, array $item, strin
 
 	$total_rows = cacti_sizeof(db_fetch_assoc($rows_query, false));
 
-	$sortby = grv('sort_column');
-
-	if ($sortby == 'h.hostname') {
-		$sortby = 'INET_ATON(h.hostname)';
-	}
+	$sort_column    = api_automation_column_exists(grv('sort_column'), ['host', 'graph_local', 'sites', 'graph_templates', 'graph_templates_graph', 'host_template']) ? grv('sort_column') : 'description';
+	$sort_direction = in_array(strtoupper((string) grv('sort_direction')), ['ASC', 'DESC'], true) ? strtoupper((string) grv('sort_direction')) : 'ASC';
+	$sortby         = str_ends_with($sort_column, 'hostname') ? 'INET_ATON(' . $sort_column . ')' : $sort_column;
 
 	$sql_query = "$rows_query ORDER BY $sortby " .
-		grv('sort_direction') . ' LIMIT ' .
+		$sort_direction . ' LIMIT ' .
 		($rows * (grv('page') - 1)) . ',' . $rows;
 
 	$templates = db_fetch_assoc($sql_query, false);

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -180,7 +180,7 @@ function display_matching_hosts(array $rule, int $rule_type, string $url) : void
 	$sort_column    = api_automation_column_exists(grv('sort_column'), ['host', 'graph_local', 'sites', 'graph_templates', 'graph_templates_graph', 'host_template']) ? grv('sort_column') : 'description';
 	$sort_direction = in_array(strtoupper((string) grv('sort_direction')), ['ASC', 'DESC'], true) ? strtoupper((string) grv('sort_direction')) : 'ASC';
 	$sortby         = str_ends_with($sort_column, 'hostname') ? 'INET_ATON(' . $sort_column . ')' : $sort_column;
-	$sql_query  = $details['rows_query'] .
+	$sql_query      = $details['rows_query'] .
 		' ORDER BY ' . $sortby . ' ' . $sort_direction .
 		' LIMIT ' . ($details['rows'] * (grv('page') - 1)) . ',' . $details['rows'];
 

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -117,21 +117,23 @@ function api_device_purge_from_remote(array|int $device_ids, int $poller_id = 0)
 	if ($poller_id > 1) {
 		if (remote_poller_up($poller_id)) {
 			if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
-				db_execute('DELETE FROM host             WHERE      id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM host_graph       WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM host_snmp_query  WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM host_snmp_cache  WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM host_value_cache WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM poller_item      WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM poller_reindex   WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM graph_tree_items WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM reports_items    WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
+				$int_device_ids = array_map('intval', $device_ids);
+
+				db_execute('DELETE FROM host             WHERE      id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM host_graph       WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM host_snmp_query  WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM host_snmp_cache  WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM host_value_cache WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM poller_item      WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM poller_reindex   WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM graph_tree_items WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM reports_items    WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
 
 				db_execute('DELETE FROM poller_command
-					WHERE SUBSTRING_INDEX(command, ":", 1) IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
+					WHERE SUBSTRING_INDEX(command, ":", 1) IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
 
-				db_execute('DELETE FROM data_local       WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM graph_local      WHERE host_id IN (' . implode(', ', $device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM data_local       WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM graph_local      WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
 			} else {
 				raise_message('poller_down_' . $poller_id, __('Remote Poller %s is Down, you will need to perform a FullSync once it is up again', $poller_id), MESSAGE_LEVEL_WARN);
 			}
@@ -207,26 +209,28 @@ function api_device_remove_multi(array $device_ids, int $delete_type = 2) : void
 		$data_sources = [];
 		$graphs       = [];
 
+		$int_device_ids = array_map('intval', $device_ids);
+
 		$data_sources = array_rekey(
 			db_fetch_assoc('SELECT id
 				FROM data_local
-				WHERE host_id IN (' . implode(', ', $device_ids) . ')'),
+				WHERE host_id IN (' . implode(', ', $int_device_ids) . ')'),
 			'id', 'id'
 		);
 
 		$graphs = array_rekey(
 			db_fetch_assoc('SELECT id
 				FROM graph_local
-				WHERE host_id IN (' . implode(', ', $device_ids) . ')'),
+				WHERE host_id IN (' . implode(', ', $int_device_ids) . ')'),
 			'id', 'id'
 		);
 
 		// build the list
 		foreach ($device_ids as $device_id) {
 			if ($i == 0) {
-				$devices_to_delete .= $device_id;
+				$devices_to_delete .= intval($device_id);
 			} else {
-				$devices_to_delete .= ', ' . $device_id;
+				$devices_to_delete .= ', ' . intval($device_id);
 			}
 
 			// poller commands go one at a time due to trashy logic

--- a/lib/html.php
+++ b/lib/html.php
@@ -2433,7 +2433,7 @@ function html_transform_graph_template_ids(mixed $ids) : string {
 		if (is_numeric($id)) {
 			$return_ids[] = $id;
 		} elseif (str_contains($id, 'cg_')) {
-			$new_id       = str_replace('cg_', '', $id);
+			$new_id       = (int) str_replace('cg_', '', $id);
 			$return_ids[] = $new_id;
 		} else {
 			$id = str_replace('dq_', '', $id);

--- a/lib/html_graph.php
+++ b/lib/html_graph.php
@@ -855,7 +855,7 @@ function html_graph_preview_view() : void {
 	$sql_where  = '';
 
 	if (!ierv('rfilter')) {
-		$sql_where .= " gtg.title_cache RLIKE '" . grv('rfilter') . "'";
+		$sql_where .= " gtg.title_cache RLIKE " . db_qstr(grv('rfilter'));
 	}
 
 	$sql_where .= ($sql_or != '' && $sql_where != '' ? ' AND ' : '') . $sql_or;
@@ -1231,7 +1231,7 @@ function html_graph_list_view() : void {
 	$sql_where  = '';
 
 	if (!ierv('rfilter')) {
-		$sql_where .= " gtg.title_cache RLIKE '" . grv('rfilter') . "'";
+		$sql_where .= " gtg.title_cache RLIKE " . db_qstr(grv('rfilter'));
 	}
 
 	if (!ierv('site_id') && grv('site_id') > 0) {

--- a/lib/html_graph.php
+++ b/lib/html_graph.php
@@ -855,7 +855,7 @@ function html_graph_preview_view() : void {
 	$sql_where  = '';
 
 	if (!ierv('rfilter')) {
-		$sql_where .= " gtg.title_cache RLIKE " . db_qstr(grv('rfilter'));
+		$sql_where .= ' gtg.title_cache RLIKE ' . db_qstr(grv('rfilter'));
 	}
 
 	$sql_where .= ($sql_or != '' && $sql_where != '' ? ' AND ' : '') . $sql_or;
@@ -1231,7 +1231,7 @@ function html_graph_list_view() : void {
 	$sql_where  = '';
 
 	if (!ierv('rfilter')) {
-		$sql_where .= " gtg.title_cache RLIKE " . db_qstr(grv('rfilter'));
+		$sql_where .= ' gtg.title_cache RLIKE ' . db_qstr(grv('rfilter'));
 	}
 
 	if (!ierv('site_id') && grv('site_id') > 0) {

--- a/lib/html_reports.php
+++ b/lib/html_reports.php
@@ -358,7 +358,16 @@ function reports_form_save() : void {
 		$save['tree_id']           = (isrv('tree_id') ? form_input_validate(gnrv('tree_id'), 'tree_id', '^[-0-9]+$', true, 3) : 0);
 		$save['branch_id']         = (isrv('branch_id') ? form_input_validate(gnrv('branch_id'), 'branch_id', '^[-0-9]+$', true, 3) : 0);
 		$save['tree_cascade']      = (isrv('tree_cascade') ? 'on' : '');
-		$save['graph_name_regexp'] = gnrv('graph_name_regexp');
+		$save['graph_name_regexp'] = form_input_validate(gnrv('graph_name_regexp'), 'graph_name_regexp', '', true, 3);
+
+		if ($save['graph_name_regexp'] != '') {
+			$regex_valid = validate_is_regex($save['graph_name_regexp']);
+
+			if ($regex_valid !== true) {
+				$_SESSION[SESS_ERROR_FIELDS]['graph_name_regexp'] = 3;
+				raise_message('custom', __('The regular expression "%s" is not valid. Error is %s', htmle($save['graph_name_regexp']), htmle($regex_valid)), MESSAGE_LEVEL_ERROR);
+			}
+		}
 		$save['site_id']           = (isrv('site_id') ? form_input_validate(gnrv('site_id'), 'site_id', '^[-0-9]+$', true, 3) : 0);
 		$save['host_template_id']  = (isrv('host_template_id') ? form_input_validate(gnrv('host_template_id'), 'host_template_id', '^[-0-9]+$', true, 3) : 0);
 		$save['host_id']           = (isrv('host_id') ? form_input_validate(gnrv('host_id'), 'host_id', '^[-0-9]+$', true, 3) : 0);

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -1017,7 +1017,7 @@ function create_tree_filter() : array {
 					'method'         => 'drop_multi',
 					'friendly_name'  => __('Template'),
 					'filter'         => FILTER_VALIDATE_REGEXP,
-					'filter_options' => ['options' => ['regexp' => '(cg_[0-9]|dq_[0-9]|[\-0-9])']],
+					'filter_options' => ['options' => ['regexp' => '^(cg_[0-9]+|dq_[0-9]+|-?[0-9]+)(,(cg_[0-9]+|dq_[0-9]+|-?[0-9]+))*$']],
 					'default'        => '-1',
 					'dynamic'        => false,
 					'class'          => 'graph-multiselect',
@@ -1429,7 +1429,7 @@ function grow_right_pane_tree(int $tree_id, int $leaf_id, string $host_group_dat
 		$sql_where = '';
 
 		if (grv('rfilter') != '') {
-			$sql_where .= " (gtg.title_cache RLIKE '" . grv('rfilter') . "' OR gtg.title RLIKE '" . grv('rfilter') . "')";
+			$sql_where .= " (gtg.title_cache RLIKE " . db_qstr(grv('rfilter')) . " OR gtg.title RLIKE " . db_qstr(grv('rfilter')) . ")";
 		}
 
 		if (isrv('graph_template_id') && grv('graph_template_id') != '' && grv('graph_template_id') != -1) {
@@ -1486,7 +1486,7 @@ function grow_right_pane_tree(int $tree_id, int $leaf_id, string $host_group_dat
 		}
 
 		if (grv('rfilter') != '') {
-			$sql_where .= ($sql_where != '' ? ' AND ' : '') . "(gtg.title_cache RLIKE '" . grv('rfilter') . "')";
+			$sql_where .= ($sql_where != '' ? ' AND ' : '') . "(gtg.title_cache RLIKE " . db_qstr(grv('rfilter')) . ")";
 		}
 
 		if (isrv('graph_template_id') && grv('graph_template_id') != '') {
@@ -1637,7 +1637,7 @@ function get_host_graph_list(int $host_id, int $graph_template_id, int $data_que
 			$sql_where = '';
 
 			if (grv('rfilter') != '') {
-				$sql_where .= " (gtg.title_cache RLIKE '" . grv('rfilter') . "')";
+				$sql_where .= " (gtg.title_cache RLIKE " . db_qstr(grv('rfilter')) . ")";
 			}
 
 			if ($host_id > 0) {
@@ -1721,7 +1721,7 @@ function get_host_graph_list(int $host_id, int $graph_template_id, int $data_que
 				$sfd = get_formatted_data_query_indexes($host_id, $data_query['id']);
 
 				if (grv('rfilter') != '') {
-					$sql_where = " (gtg.title_cache RLIKE '" . grv('rfilter') . "')";
+					$sql_where = " (gtg.title_cache RLIKE " . db_qstr(grv('rfilter')) . ")";
 				}
 
 				// grab a list of all graphs for this host/data query combination

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -1429,7 +1429,7 @@ function grow_right_pane_tree(int $tree_id, int $leaf_id, string $host_group_dat
 		$sql_where = '';
 
 		if (grv('rfilter') != '') {
-			$sql_where .= " (gtg.title_cache RLIKE " . db_qstr(grv('rfilter')) . " OR gtg.title RLIKE " . db_qstr(grv('rfilter')) . ")";
+			$sql_where .= ' (gtg.title_cache RLIKE ' . db_qstr(grv('rfilter')) . ' OR gtg.title RLIKE ' . db_qstr(grv('rfilter')) . ')';
 		}
 
 		if (isrv('graph_template_id') && grv('graph_template_id') != '' && grv('graph_template_id') != -1) {
@@ -1486,7 +1486,7 @@ function grow_right_pane_tree(int $tree_id, int $leaf_id, string $host_group_dat
 		}
 
 		if (grv('rfilter') != '') {
-			$sql_where .= ($sql_where != '' ? ' AND ' : '') . "(gtg.title_cache RLIKE " . db_qstr(grv('rfilter')) . ")";
+			$sql_where .= ($sql_where != '' ? ' AND ' : '') . '(gtg.title_cache RLIKE ' . db_qstr(grv('rfilter')) . ')';
 		}
 
 		if (isrv('graph_template_id') && grv('graph_template_id') != '') {
@@ -1637,7 +1637,7 @@ function get_host_graph_list(int $host_id, int $graph_template_id, int $data_que
 			$sql_where = '';
 
 			if (grv('rfilter') != '') {
-				$sql_where .= " (gtg.title_cache RLIKE " . db_qstr(grv('rfilter')) . ")";
+				$sql_where .= ' (gtg.title_cache RLIKE ' . db_qstr(grv('rfilter')) . ')';
 			}
 
 			if ($host_id > 0) {
@@ -1721,7 +1721,7 @@ function get_host_graph_list(int $host_id, int $graph_template_id, int $data_que
 				$sfd = get_formatted_data_query_indexes($host_id, $data_query['id']);
 
 				if (grv('rfilter') != '') {
-					$sql_where = " (gtg.title_cache RLIKE " . db_qstr(grv('rfilter')) . ")";
+					$sql_where = ' (gtg.title_cache RLIKE ' . db_qstr(grv('rfilter')) . ')';
 				}
 
 				// grab a list of all graphs for this host/data query combination

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -713,7 +713,7 @@ function reports_tree_has_graphs(int $tree_id,int  $branch_id,int  $effective_us
 	$new_graphs = [];
 
 	if ($search_key != '') {
-		$sql_swhere = " AND gtg.title_cache REGEXP '" . $search_key . "'";
+		$sql_swhere = ' AND gtg.title_cache REGEXP ' . db_qstr($search_key);
 	}
 
 	$device_id = db_fetch_cell_prepared('SELECT host_id
@@ -1233,7 +1233,7 @@ function reports_expand_device(array &$report, array $item, int $device_id, int 
 	if (cacti_sizeof($graph_templates)) {
 		foreach ($graph_templates as $id => $name) {
 			if ($item['graph_name_regexp'] != '') {
-				$sql_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+				$sql_where .= ' AND title_cache REGEXP ' . db_qstr($item['graph_name_regexp']);
 			}
 
 			$graphs = db_fetch_assoc_prepared("SELECT
@@ -1424,7 +1424,7 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 			}
 
 			if ($item['graph_name_regexp'] != '') {
-				$sql_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+				$sql_where .= ' AND title_cache REGEXP ' . db_qstr($item['graph_name_regexp']);
 			}
 
 			if ($leaf_type == 'header' && $nested) {
@@ -1470,7 +1470,7 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 				$gr_where = '';
 
 				if ($item['graph_name_regexp'] != '') {
-					$gr_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+					$gr_where .= ' AND title_cache REGEXP ' . db_qstr($item['graph_name_regexp']);
 				}
 
 				$graph = db_fetch_row('SELECT local_graph_id, title_cache
@@ -1486,7 +1486,7 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 				$gr_where = '';
 
 				if ($item['graph_name_regexp'] != '') {
-					$gr_where .= " AND title_cache REGEXP '" . $item['graph_name_regexp'] . "'";
+					$gr_where .= ' AND title_cache REGEXP ' . db_qstr($item['graph_name_regexp']);
 				}
 
 				$graph = db_fetch_cell('SELECT count(*)

--- a/managers.php
+++ b/managers.php
@@ -753,17 +753,19 @@ function form_actions() : void {
 
 	if (isrv('selected_items')) {
 		if (isrv('action_receivers')) {
-			$selected_items = cacti_unserialize(stripslashes(gnrv('selected_graphs_array')));
+			$selected_items = sanitize_unserialize_selected_items(gnrv('selected_graphs_array'));
 
-			if ($selected_items != false) {
+			if (!empty($selected_items) && is_array($selected_items)) {
+				$selected_ids = implode(',', array_map('intval', $selected_items));
+
 				if (gnrv('drp_action') == '1') { // delete
-					db_execute('DELETE FROM snmpagent_managers WHERE id IN (' . implode(',' ,$selected_items) . ')');
-					db_execute('DELETE FROM snmpagent_managers_notifications WHERE manager_id IN (' . implode(',' ,$selected_items) . ')');
-					db_execute('DELETE FROM snmpagent_notifications_log WHERE manager_id IN (' . implode(',' ,$selected_items) . ')');
+					db_execute('DELETE FROM snmpagent_managers WHERE id IN (' . $selected_ids . ')');
+					db_execute('DELETE FROM snmpagent_managers_notifications WHERE manager_id IN (' . $selected_ids . ')');
+					db_execute('DELETE FROM snmpagent_notifications_log WHERE manager_id IN (' . $selected_ids . ')');
 				} elseif (gnrv('drp_action') == '2') { // disable
-					db_execute("UPDATE snmpagent_managers SET disabled = 'on' WHERE id IN (" . implode(',' ,$selected_items) . ')');
+					db_execute("UPDATE snmpagent_managers SET disabled = 'on' WHERE id IN (" . $selected_ids . ')');
 				} elseif (gnrv('drp_action') == '3') { // enable
-					db_execute("UPDATE snmpagent_managers SET disabled = '' WHERE id IN (" . implode(',' ,$selected_items) . ')');
+					db_execute("UPDATE snmpagent_managers SET disabled = '' WHERE id IN (" . $selected_ids . ')');
 				}
 
 				header('Location: managers.php');


### PR DESCRIPTION
Hardens develop against SQL injection by binding, `db_qstr`-quoting, or integer-casting request-derived values that previously reached SQL via interpolation. No functional change for legitimate input.

Sites fixed:
- RLIKE/REGEXP filters in graph/tree/report views (`lib/html_graph.php`, `lib/html_tree.php`, `lib/reports.php`) → `db_qstr`. Covers CVE-2026-46531 and the rfilter/report-regexp class.
- `IN()` id lists in device, data-source-profile, and SNMP-receiver management (`lib/api_device.php`, `data_source_profiles.php`, `managers.php`) → `array_map('intval', ...)`; SNMP-receiver path also switched to `sanitize_unserialize_selected_items()`.
- `host_template_id` in automation matching (`lib/api_automation.php`) → int cast.
- `ORDER BY` on both automation match pages (hosts + trees) → column allowlist via `api_automation_column_exists()` + `ASC`/`DESC` normalization, mirroring the existing hardened path.
- `graph_name_regexp` validated at save (`lib/html_reports.php`); `graph_template_id` filter regex anchored (`lib/html_tree.php`).

Verification:
- `php -l` clean on all 9 files.
- Independent security review of the full diff: each tainted value bound/escaped/cast at every sink, `db_qstr` preserves RLIKE/REGEXP semantics, `intval` mapping and the anchored regex accept all legitimate inputs (incl. multi-digit `cg_12` and comma lists), ORDER BY allowlist falls back to a real column.

Scope: the SQL-injection class only; output-encoding/XSS, path-containment, redirect, and auth/session passes will follow separately.