### PR TITLE
fix: keep realtime graphing alive when a poll fails or returns non-JSON (#7212)

### DIFF
--- a/include/realtime.js
+++ b/include/realtime.js
@@ -272,9 +272,15 @@ function realtimeGrapher() {
 
 					$.get(urlPath+'graph_realtime.php?action=countdown&top='+parseInt(position.top)+'&left='+parseInt(position.left)+(isThumb ? '&graph_nolegend=true':'&graph_nolegend=false')+'&graph_end=0&graph_start=-'+(parseInt(graph_start) > 0 ? graph_start:'60')+'&local_graph_id='+local_graph_id+'&ds_step='+ds_step+'&count='+count+'&size='+size)
 						.done(function(data) {
-							var results = $.parseJSON(data);
+							var results;
 
-							if (realtimeArray[results.local_graph_id] == true) {
+							try {
+								results = $.parseJSON(data);
+							} catch (e) {
+								results = null;
+							}
+
+							if (results != null && realtimeArray[results.local_graph_id] == true) {
 								var image_format = (results.image_format == 'svg+xml') ? 'svg+xml' : 'png';
 								$('#graph_'+results.local_graph_id).attr('src', 'data:image/'+image_format+';base64,'+results.data).change();
 
@@ -288,11 +294,12 @@ function realtimeGrapher() {
 							destroy(data);
 							destroy(results);
 							destroy(position);
-
-							graphsRendered++;
 						})
 						.fail(function(data) {
 							getPresentHTTPError(data);
+						})
+						.always(function() {
+							graphsRendered++;
 						});
 				});
 			}

--- a/include/realtime.js
+++ b/include/realtime.js
@@ -325,6 +325,10 @@ function realtimeGrapher() {
 }
 
 function destroy(obj) {
+	if (obj == null) {
+		return;
+	}
+
 	for (var prop in obj){
 		var property = obj[prop];
 


### PR DESCRIPTION
Addresses the realtime graphing hang in #7212.

`realtimeGrapher()` only incremented `graphsRendered` inside `.done`, and `$.parseJSON(data)` ran unguarded. A single failed poll, timeout, or non-JSON body left `graphsRendered` permanently below `totalGraphs`, so the `graphsRendered >= totalGraphs` re-entry guard never fired again and every graph froze until a page reload. That matches the reported "stops graphing at 8:40, needs a refresh".

Changes in `include/realtime.js`:
- wrap `$.parseJSON` in try/catch and null-check the result before use
- move `graphsRendered++` into `.always()` so any poll outcome advances the counter

Risk: low, confined to the realtime poll callback. Verified with `node --check`.

This is separate from #7213 (stray `var key` globals); the steady memory growth from base64 `data:` image churn is a follow-up better fixed with object URLs, which needs Firefox testing.