### PR TITLE
ci: add ondrej PHP PPA so libapache2-mod-php installs on ubuntu-24.04

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -137,8 +137,10 @@ jobs:
     - name: Check PHP syntax
       run: if find ${{ github.workspace }} -name '*.php' -exec php -l {} 2>&1 \; | grep -iv 'no syntax errors detected'; then exit 1; fi
 
-    - name: Run and apt-get update
-      run: true
+    - name: Add ondrej PHP PPA and apt-get update
+      run: |
+        sudo add-apt-repository -y ppa:ondrej/php
+        sudo apt-get -y update
 
     - name: Install Apache and Tools
       run: |


### PR DESCRIPTION
The `Install Apache and Tools` step fails on the 8.2 and 8.4 matrix legs with "Unable to locate package libapache2-mod-php8.x".

The runner is ubuntu-24.04, whose default repos only ship php8.3, so `libapache2-mod-php8.3` resolves but 8.2 and 8.4 do not. `setup-php` installs the CLI but doesn't leave an apt source for the Apache module. Adding `ppa:ondrej/php` before the install provides the module for all matrix versions.

The 8.3 leg already passes and stays passing (ondrej also carries 8.3). Verified the apt failure is 8.2/8.4-only via the per-leg step results.