### PR TITLE
ci: add ondrej PHP PPA so libapache2-mod-php installs on ubuntu-24.04

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -190,8 +190,10 @@ jobs:
         cp -p ${{ github.workspace }}/plugins/syslog/config.php.dist ${{ github.workspace }}/plugins/syslog/config.php
         sed -i 's/\/\/\$/\$/g' ${{ github.workspace }}/plugins/syslog/config.php
 
-    - name: Run apt-get update
-      run: sudo apt-get -y update
+    - name: Add ondrej PHP PPA and apt-get update
+      run: |
+        sudo add-apt-repository -y ppa:ondrej/php
+        sudo apt-get -y update
 
     - name: Install Apache and Tools
       run: sudo apt-get install apache2 snmp snmpd rrdtool fping libapache2-mod-php${{ matrix.php }}


### PR DESCRIPTION
The `Install Apache and Tools` step installs `libapache2-mod-php${{ matrix.php }}` from apt, but the ubuntu-24.04 runner's default repos only ship php8.3. So 8.1, 8.2, and 8.4 fail with "Unable to locate package".

`setup-php` installs the CLI PHP (so `php -v` passes) but doesn't leave an apt source for the Apache module. Adding `ppa:ondrej/php` before the install provides `libapache2-mod-php8.1/8.2/8.4` on 24.04.

Note: this is the second CI wall on develop. The legs currently fail earlier at PHPStan (`function.alreadyNarrowedType` in `data_query.php`); that ignore is in #7208. With both landed the full matrix should go green.