### PR TITLE
fix: Data Source Profiles page generates a 500 during callback

### DIFF
--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -93,7 +93,7 @@ switch (grv('action')) {
 		gfrv('id');
 		gfrv('cfs');
 		gfrv('rows');
-		print get_size(grv('id'), gnrv('type'), grv('cfs'), grv('rows'));
+		print get_size(intval(grv('id')), gnrv('type'), grv('cfs'), intval(grv('rows')));
 
 		break;
 	case 'item_edit':

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -1386,7 +1386,7 @@ function profile() : void {
 			'display' => __('Data Source Profile Name'),
 			'align'   => 'left',
 			'sort'    => 'ASC',
-			'tip'     => __('The name of this CDEF.')
+			'tip'     => __('The name of this Data Source Profile.')
 		],
 		'nosort00' => [
 			'display' => __('Default'),


### PR DESCRIPTION
* When editing the Data Source Profiles page, errors are generated due to strict typing on an internal function.
* Corrects one typo in the tooltip for the Profile name.