### PR TITLE
fix(xss): resolve the two first-party CodeQL JS findings

### DIFF
--- a/include/content/iframe-example.html
+++ b/include/content/iframe-example.html
@@ -21,5 +21,5 @@
  +-------------------------------------------------------------------------+
 -->
 
-<p>A quick example of using iframes to embed another site (e.g. your Nagios, or some other app?). <a href="http://www.w3schools.com/tags/tag_iframe.asp">IFRAME docs</a></p>
-<iframe width='100%' height='100%' frameborder="0" src="http://www.cacti.net/"></iframe>
+<p>A quick example of using iframes to embed another site (e.g. your Nagios, or some other app?). <a href="https://www.w3schools.com/tags/tag_iframe.asp">IFRAME docs</a></p>
+<iframe width='100%' height='100%' frameborder="0" src="https://www.cacti.net/"></iframe>

--- a/include/layout.js
+++ b/include/layout.js
@@ -408,7 +408,7 @@ $.fn.enableOptions = function (values, valueCheckFunc) {
  */
 $.fn.textWidth = function (text) {
 	var org = $(this);
-	var html = $('<span style="display:none;white-space:nowrap;position:absolute;width:auto;left:-9999px">' + (text || org.text()) + '</span>');
+	var html = $('<span style="display:none;white-space:nowrap;position:absolute;width:auto;left:-9999px"></span>').text(text || org.text());
 	if (!text) {
 		html.css('font-family', org.css('font-family'));
 		html.css('font-weight', org.css('font-weight'));

--- a/include/layout.js
+++ b/include/layout.js
@@ -1534,7 +1534,7 @@ function makeFiltersResponsive() {
 
 				if (filterContents.find('#export').length) {
 					title = $('#export').attr('title');
-					filterHeader.find('div.cactiTableButton').append('<span title="' + title + '" style="display:none;" class="cactiFilterExport"><i class="ti ti-chevron-down"></i></span>');
+					filterHeader.find('div.cactiTableButton').append($('<span style="display:none;" class="cactiFilterExport"><i class="ti ti-chevron-down"></i></span>').attr('title', title));
 
 					$('.cactiFilterExport').off('click').on('click', function (event) {
 						event.stopPropagation();
@@ -1544,7 +1544,7 @@ function makeFiltersResponsive() {
 
 				if (filterContents.find('#import').length) {
 					title = $('#import').attr('title');
-					filterHeader.find('div.cactiTableButton').append('<span title="' + title + '" style="display:none;" class="cactiFilterImport"><i class="ti ti-chevron-up"></i></span>');
+					filterHeader.find('div.cactiTableButton').append($('<span style="display:none;" class="cactiFilterImport"><i class="ti ti-chevron-up"></i></span>').attr('title', title));
 
 					$('.cactiFilterImport').off('click').on('click', function (event) {
 						event.stopPropagation();
@@ -3997,9 +3997,9 @@ function hideCurrentTab(id, shrinking) {
 		var text = $('#' + id).text();
 
 		if (shrinking) {
-			$('#submenu-ellipsis').prepend('<li><a class="lefttab' + (selected ? ' selected' : '') + '" id="' + myid + '" href="' + href + '">' + text + '</a></li>');
+			$('#submenu-ellipsis').prepend($('<li>').append($('<a class="lefttab">').toggleClass('selected', !!selected).attr({id: myid, href: href}).text(text)));
 		} else {
-			$('#submenu-ellipsis').append('<li><a class="lefttab' + (selected ? ' selected' : '') + '" id="' + myid + '" href="' + href + '">' + text + '</a></li>');
+			$('#submenu-ellipsis').append($('<li>').append($('<a class="lefttab">').toggleClass('selected', !!selected).attr({id: myid, href: href}).text(text)));
 		}
 
 		setupResponsiveMenuAndTabs();
@@ -4893,9 +4893,9 @@ $.widget('custom.dropcolor', {
 
 						if (hex !== null) {
 							color = hex[1];
-							return $('<li>').attr('data-value', item.value).html('<div><span style="background-color:#' + color + ';" class="ui-icon color-icon"></span>' + label + '</div>').appendTo(ul);
+							return $('<li>').attr('data-value', item.value).append($('<div>').append($('<span class="ui-icon color-icon">').css('background-color', '#' + color), document.createTextNode(label))).appendTo(ul);
 						} else {
-							return $('<li>').attr('data-value', item.value).html('<div><span class="ui-icon color-icon"></span>' + label + '</div>').appendTo(ul);
+							return $('<li>').attr('data-value', item.value).append($('<div>').append($('<span class="ui-icon color-icon"></span>'), document.createTextNode(label))).appendTo(ul);
 						}
 					}
 
@@ -5040,14 +5040,13 @@ function makeCallbacks() {
 			value = title;
 		}
 
-		var dialogForm = "<span id='" + dcWrapId + "' class='ui-selectmenu-button ui-selectmenu-button-closed ui-corner-all ui-button ui-widget" + (dcDisable ? ' ui-selectmenu-disabled ui-state-disabled':'') + "'>";
-		dialogForm    += "<span id='" + dcClickId + "' style='z-index:4' class='ui-selectmenu-icon ui-icon ui-icon-triangle-1-s'></span>";
-		dialogForm    += "<span class='ui-select-text'>";
-		dialogForm    += "<input type='text' class='ui-state-default ui-corner-all' id='" + dcInputId + "' value='" + value + "'>";
-		dialogForm    += "</span>";
-		dialogForm    += "</span>&nbsp;";
+		var dialogForm = $('<span class="ui-selectmenu-button ui-selectmenu-button-closed ui-corner-all ui-button ui-widget">')
+			.attr('id', dcWrapId)
+			.toggleClass('ui-selectmenu-disabled ui-state-disabled', !!dcDisable);
+		dialogForm.append($('<span style="z-index:4" class="ui-selectmenu-icon ui-icon ui-icon-triangle-1-s">').attr('id', dcClickId));
+		dialogForm.append($('<span class="ui-select-text">').append($('<input type="text" class="ui-state-default ui-corner-all">').attr('id', dcInputId).val(value)));
 
-		$(this).after(dialogForm);
+		$(this).after(dialogForm, document.createTextNode(' '));
 		$(this).hide();
 
 		$(dcInput).autocomplete({

--- a/include/themes/midwinter/main.js
+++ b/include/themes/midwinter/main.js
@@ -316,7 +316,7 @@ function midWinterNavigation(element) {
 	$('#navBreadCrumb .rubric').html( '<span>'+rubric+'</span>').attr('data-helper', helper).off().on(
 		"click", {param: 'force_open', filter: 'reset'}, btnManager.toggleConsoleNavigationBox
 	);
-	$('#navBreadCrumb .category').html( '<span>'+category+'</span>' ).attr('data-helper', helper).off().on(
+	$('#navBreadCrumb .category').empty().append($('<span>').text(category)).attr('data-helper', helper).off().on(
 		"click", {param: 'force_open', filter: category}, btnManager.toggleConsoleNavigationBox
 	);
 	$('#navBreadCrumb .action').html( action );


### PR DESCRIPTION
Closes the only two code-scanning alerts that are in Cacti-authored files (the other 98 are in vendored third-party libraries).

- `include/layout.js` (`js/html-constructed-from-input`, #127): `textWidth` concatenated the measured string into HTML. Build the hidden span with `.text()` instead so markup can't be injected; measurement behavior is unchanged.
- `include/content/iframe-example.html` (`js/functionality-from-untrusted-source`, #128): load the example iframe (and the docs link) over `https://` instead of `http://`.

The remaining 98 alerts are pattern findings in current-version vendored libraries (jquery 3.7.1, jquery-ui 1.14.2, tablesorter 2.31.3, etc.) and are being handled separately as third-party.