### PR TITLE
security: harden rrdtool command construction against path injection

### DIFF
--- a/data_sources.php
+++ b/data_sources.php
@@ -290,9 +290,9 @@ function form_save() : void {
 
 						$save3['data_template_id'] = gfrv('data_template_id');
 
-						$save3['rrd_maximum'] = form_input_validate(gnrv("rrd_maximum$name_modifier"), "rrd_maximum$name_modifier", "^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?)|U$|\|query_ifSpeed\||\|query_ifHighSpeed\|", false, 3);
+						$save3['rrd_maximum'] = form_input_validate(gnrv("rrd_maximum$name_modifier"), "rrd_maximum$name_modifier", '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?|U|\|query_ifSpeed\||\|query_ifHighSpeed\|)\z', false, 3);
 
-						$save3['rrd_minimum'] = form_input_validate(gnrv("rrd_minimum$name_modifier"), "rrd_minimum$name_modifier", "^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?)|U$|\|query_ifSpeed\||\|query_ifHighSpeed\|", false, 3);
+						$save3['rrd_minimum'] = form_input_validate(gnrv("rrd_minimum$name_modifier"), "rrd_minimum$name_modifier", '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?|U|\|query_ifSpeed\||\|query_ifHighSpeed\|)\z', false, 3);
 
 						$save3['rrd_heartbeat'] = form_input_validate(gnrv("rrd_heartbeat$name_modifier"), "rrd_heartbeat$name_modifier", '^[0-9]+$', false, 3);
 

--- a/data_templates.php
+++ b/data_templates.php
@@ -121,11 +121,11 @@ function form_save() : void {
 
 		$save3['t_rrd_maximum']         = form_input_validate((isrv('t_rrd_maximum') ? gnrv('t_rrd_maximum') : ''), 't_rrd_maximum', '', true, 3);
 
-		$save3['rrd_maximum']           = form_input_validate(gnrv('rrd_maximum'), 'rrd_maximum', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?)|U|\|query_ifSpeed\|$', (isrv('t_rrd_maximum') ? true : false), 3);
+		$save3['rrd_maximum']           = form_input_validate(gnrv('rrd_maximum'), 'rrd_maximum', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?|U|\|query_ifSpeed\|)\z', (isrv('t_rrd_maximum') ? true : false), 3);
 
 		$save3['t_rrd_minimum']         = form_input_validate((isrv('t_rrd_minimum') ? gnrv('t_rrd_minimum') : ''), 't_rrd_minimum', '', true, 3);
 
-		$save3['rrd_minimum']           = form_input_validate(gnrv('rrd_minimum'), 'rrd_minimum', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?)|U$', (isrv('t_rrd_minimum') ? true : false), 3);
+		$save3['rrd_minimum']           = form_input_validate(gnrv('rrd_minimum'), 'rrd_minimum', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?|U)\z', (isrv('t_rrd_minimum') ? true : false), 3);
 
 		$save3['rrd_heartbeat']         = $rrd_heartbeat;
 

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -237,9 +237,9 @@ function form_save() : void {
 		$save2['t_width']                       = form_input_validate((isrv('t_width') ? gnrv('t_width') : ''), 't_width', '', true, 3);
 		$save2['width']                         = form_input_validate(gnrv('width'), 'width', '^[0-9]+$', (isrv('t_width') ? true : false), 3);
 		$save2['t_upper_limit']                 = form_input_validate((isrv('t_upper_limit') ? gnrv('t_upper_limit') : ''), 't_upper_limit', '', true, 3);
-		$save2['upper_limit']                   = form_input_validate(gnrv('upper_limit'), 'upper_limit', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?)|U$', ((isrv('t_upper_limit') || (strlen(gnrv('upper_limit')) === 0)) ? true : false), 3);
+		$save2['upper_limit']                   = form_input_validate(gnrv('upper_limit'), 'upper_limit', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?|U)\z', ((isrv('t_upper_limit') || (strlen(gnrv('upper_limit')) === 0)) ? true : false), 3);
 		$save2['t_lower_limit']                 = form_input_validate((isrv('t_lower_limit') ? gnrv('t_lower_limit') : ''), 't_lower_limit', '', true, 3);
-		$save2['lower_limit']                   = form_input_validate(gnrv('lower_limit'), 'lower_limit', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?)|U$', ((isrv('t_lower_limit') || (strlen(gnrv('lower_limit')) === 0)) ? true : false), 3);
+		$save2['lower_limit']                   = form_input_validate(gnrv('lower_limit'), 'lower_limit', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?|U)\z', ((isrv('t_lower_limit') || (strlen(gnrv('lower_limit')) === 0)) ? true : false), 3);
 		$save2['t_vertical_label']              = form_input_validate((isrv('t_vertical_label') ? gnrv('t_vertical_label') : ''), 't_vertical_label', '', true, 3);
 		$save2['vertical_label']                = form_input_validate(gnrv('vertical_label'), 'vertical_label', '', true, 3);
 		$save2['t_slope_mode']                  = form_input_validate((isrv('t_slope_mode') ? gnrv('t_slope_mode') : ''), 't_slope_mode', '', true, 3);

--- a/graphs.php
+++ b/graphs.php
@@ -389,8 +389,8 @@ function form_save() : void {
 			$save2['title']                         = form_input_validate(gnrv('title'), 'title', '', false, 3);
 			$save2['height']                        = form_input_validate(gnrv('height'), 'height', '^[0-9]+$', false, 3);
 			$save2['width']                         = form_input_validate(gnrv('width'), 'width', '^[0-9]+$', false, 3);
-			$save2['upper_limit']                   = form_input_validate(gnrv('upper_limit'), 'upper_limit', "^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?)|U$", ((strlen(gnrv('upper_limit')) === 0) ? true : false), 3);
-			$save2['lower_limit']                   = form_input_validate(gnrv('lower_limit'), 'lower_limit', "^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?)|U$", ((strlen(gnrv('lower_limit')) === 0) ? true : false), 3);
+			$save2['upper_limit']                   = form_input_validate(gnrv('upper_limit'), 'upper_limit', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?|U)\z', ((strlen(gnrv('upper_limit')) === 0) ? true : false), 3);
+			$save2['lower_limit']                   = form_input_validate(gnrv('lower_limit'), 'lower_limit', '^(-?([0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+)([eE][+\-]?[0-9]+)?|U)\z', ((strlen(gnrv('lower_limit')) === 0) ? true : false), 3);
 			$save2['vertical_label']                = form_input_validate(gnrv('vertical_label'), 'vertical_label', '', true, 3);
 			$save2['slope_mode']                    = form_input_validate((isrv('slope_mode') ? gnrv('slope_mode') : ''), 'slope_mode', '', true, 3);
 			$save2['auto_scale']                    = form_input_validate((isrv('auto_scale') ? gnrv('auto_scale') : ''), 'auto_scale', '', true, 3);

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -920,8 +920,8 @@ function rrdtool_function_create(int $local_data_id, bool $show_source, mixed $r
 	 */
 	if (read_config_option('extended_paths') == 'on') {
 		if (read_config_option('storage_location')) {
-			if (rrdtool_execute('is_dir ' . dirname($data_source_path), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER') === false) {
-				if (rrdtool_execute('mkdir ' . dirname($data_source_path), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER') === false) {
+			if (rrdtool_execute('is_dir ' . cacti_escapeshellarg(dirname($data_source_path)), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER') === false) {
+				if (rrdtool_execute('mkdir ' . cacti_escapeshellarg(dirname($data_source_path)), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER') === false) {
 					cacti_log("ERROR: Unable to create directory '" . dirname($data_source_path) . "'", false);
 				}
 			}
@@ -968,9 +968,9 @@ function rrdtool_function_create(int $local_data_id, bool $show_source, mixed $r
 	}
 
 	if ($show_source == true) {
-		return read_config_option('path_rrdtool') . ' create' . RRD_NL . "$data_source_path$create_ds$create_rra";
+		return read_config_option('path_rrdtool') . ' create' . RRD_NL . cacti_escapeshellarg($data_source_path) . $create_ds . $create_rra;
 	} else {
-		$success = rrdtool_execute("create $data_source_path $create_ds$create_rra", true, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'POLLER');
+		$success = rrdtool_execute('create ' . cacti_escapeshellarg($data_source_path) . " $create_ds$create_rra", true, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'POLLER');
 
 		if (CACTI_SERVER_OS != 'win32' && posix_getuid() == 0) {
 			if (file_exists($data_source_path)) {
@@ -1059,7 +1059,7 @@ function rrdtool_function_update(array $update_cache_array, mixed $rrdtool_pipe 
 					$update_options = '';
 				}
 
-				rrdtool_execute("update $rrd_path $update_options --template $rrd_update_template $rrd_update_values", true, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'POLLER');
+				rrdtool_execute('update ' . cacti_escapeshellarg($rrd_path) . " $update_options --template $rrd_update_template $rrd_update_values", true, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'POLLER');
 				$rrds_processed++;
 			}
 		}
@@ -1179,8 +1179,13 @@ function rrdtool_function_fetch(int $local_data_id, int $start_time, int $end_ti
 	// update the rrdfile if performing a fetch
 	boost_fetch_cache_check($local_data_id, $rrdtool_pipe);
 
+	// rrdtool consolidation function is a fixed keyword set; never pass it through unchecked
+	if (!in_array($cf, ['AVERAGE', 'MIN', 'MAX', 'LAST'], true)) {
+		$cf = 'AVERAGE';
+	}
+
 	// build and run the rrdtool fetch command with all of our data
-	$cmd_line = "fetch $data_source_path $cf -s $start_time -e $end_time";
+	$cmd_line = 'fetch ' . cacti_escapeshellarg($data_source_path) . " $cf -s $start_time -e $end_time";
 
 	if ($resolution > 0) {
 		$cmd_line .= " -r $resolution";
@@ -3241,7 +3246,7 @@ function rrdtool_function_get_resstep(mixed $local_data_ids, int $graph_start, i
  */
 function rrdtool_file_exists(string $data_source_path, mixed $rrdtool_pipe = null) : bool {
 	if (read_config_option('storage_location')) {
-		if (!rrdtool_execute("file_exists $data_source_path", true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER')) {
+		if (!rrdtool_execute('file_exists ' . cacti_escapeshellarg($data_source_path), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER')) {
 			return false;
 		}
 	} elseif (!file_exists($data_source_path)) {
@@ -3268,7 +3273,7 @@ function rrdtool_function_info(int $local_data_id, mixed $rrdtool_pipe = null) :
 	}
 
 	// Execute rrdtool info command
-	$cmd_line = ' info ' . $data_source_path;
+	$cmd_line = ' info ' . cacti_escapeshellarg($data_source_path);
 	$output   = rrdtool_execute($cmd_line, RRDTOOL_OUTPUT_NULL, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe);
 
 	if (!is_string($output) || $output == '') {


### PR DESCRIPTION
Hardens the rrdtool command path against injection via the data source `data_source_path` and the rrd min/max/limit fields. Two layers, both pre-existing gaps in the same class as prior advisories:

**Output escaping (`lib/rrd.php`).** The same `data_source_path` was already wrapped in `cacti_escapeshellarg()` for graph `DEF` and `tune`, but left raw in `create`, `update`, `fetch`, `info`, `file_exists`, and the `is_dir`/`mkdir` calls. Those now use `cacti_escapeshellarg()` too. The fetch consolidation function is constrained to `AVERAGE|MIN|MAX|LAST`.

**Input anchoring (`data_sources.php`, `data_templates.php`, `graph_templates.php`, `graphs.php`).** The `rrd_minimum`/`rrd_maximum`/`upper_limit`/`lower_limit` validators used `^(num)|U$|...`, where `^` anchored only the first alternative and there was no end anchor, so a value like `0;<payload>` matched the numeric prefix and passed. They now wrap the whole alternation in `^(...)\z`. `\z` (not `$`) is used so a trailing newline cannot slip through. Each field keeps its exact accepted set (number, `U`, and the `|query_*|` branches where they applied before).

Post-auth (data source / graph edit). No behavior change for legitimate values; verified the legit set still passes and prefix/newline/metacharacter injection is rejected.
