### PR TITLE
security: sanitize ORDER BY sort column and direction on admin list pages

### DIFF
--- a/user_domains.php
+++ b/user_domains.php
@@ -617,7 +617,7 @@ function domains() : void {
 	$domains = db_fetch_assoc_prepared("SELECT *
 		FROM user_domains
 		$sql_where
-		ORDER BY " . grv('sort_column') . ' ' . grv('sort_direction') . '
+		ORDER BY " . sanitize_sql_column(grv('sort_column'), 'domain_name') . ' ' . (strtoupper(grv('sort_direction')) === 'DESC' ? 'DESC' : 'ASC') . '
 		LIMIT ' . ($rows * (grv('page') - 1)) . ',' . $rows,
 		$sql_params);
 

--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -1884,7 +1884,7 @@ function user_group() : void {
 		ON uag.id = uagm.group_id
 		$sql_where
 		GROUP BY uag.id
-		ORDER BY " . grv('sort_column') . ' ' . grv('sort_direction') .
+		ORDER BY " . sanitize_sql_column(grv('sort_column'), 'name') . ' ' . (strtoupper(grv('sort_direction')) === 'DESC' ? 'DESC' : 'ASC') .
 		' LIMIT ' . ($rows * (grv('page') - 1) . ',' . $rows),
 		$sql_params);
 

--- a/user_log.php
+++ b/user_log.php
@@ -101,7 +101,7 @@ function view_user_log() : void {
 		ON ua.username = ul.username
 		AND ua.id = ul.user_id
 		$sql_where
-		ORDER BY " . grv('sort_column') . ' ' . grv('sort_direction') . '
+		ORDER BY " . sanitize_sql_column(grv('sort_column'), 'time') . ' ' . (strtoupper(grv('sort_direction')) === 'DESC' ? 'DESC' : 'ASC') . '
 		LIMIT ' . ($rows * (grv('page') - 1)) . ',' . $rows;
 
 	$user_log = db_fetch_assoc_prepared($user_log_sql, $sql_params);

--- a/utilities.php
+++ b/utilities.php
@@ -593,7 +593,7 @@ function utilities_view_poller_cache() : void {
 		LEFT JOIN host AS h
 		ON pi.host_id = h.id
 		$sql_where
-		ORDER BY " . grv('sort_column') . ' ' . grv('sort_direction') . ', action ASC
+		ORDER BY " . sanitize_sql_column(grv('sort_column'), 'dtd.name_cache') . ' ' . (strtoupper(grv('sort_direction')) === 'DESC' ? 'DESC' : 'ASC') . ', action ASC
 		LIMIT ' . ($rows * (grv('page') - 1)) . ',' . $rows;
 
 	$items = db_fetch_assoc_prepared($poller_sql, $sql_params);


### PR DESCRIPTION
`user_domains.php`, `user_group_admin.php`, `user_log.php`, and the poller-cache view in `utilities.php` concatenated the raw `sort_column`/`sort_direction` request variables straight into `ORDER BY`, bypassing the `get_order_string()` allow-list. The sort vars on these pages are filtered only by `sanitize_search_string`, which permits the characters needed to break out of the identifier position.

Each site now routes the column through `sanitize_sql_column()` and the direction through `strtoupper(...) === 'DESC' ? 'DESC' : 'ASC'`, identical to the handling already in `lib/html_reports.php`. Legitimate sort columns (including dotted `table.column` forms) pass unchanged.

Post-auth (admin consoles).
