### PR TITLE
security: html-escape imported object names in import preview

### DIFF
--- a/lib/import.php
+++ b/lib/import.php
@@ -1972,7 +1972,7 @@ function xml_to_host_template(string $hash, array &$xml_array, array &$hash_cach
 						[$dhash]);
 
 					if (!$exists1) {
-						$import_debug_info['differences'][] = __('New Graph Template: %s', $dname);
+						$import_debug_info['differences'][] = __('New Graph Template: %s', htmle($dname));
 						$status++;
 					} elseif ($save['id']) {
 						// For existing, we have to perform two checks
@@ -1989,7 +1989,7 @@ function xml_to_host_template(string $hash, array &$xml_array, array &$hash_cach
 								[$exists1]);
 
 							if (!$data_query_id) {
-								$import_debug_info['differences'][] = __('New Graph Template: %s', $dname);
+								$import_debug_info['differences'][] = __('New Graph Template: %s', htmle($dname));
 								$status++;
 							}
 						}
@@ -2001,7 +2001,7 @@ function xml_to_host_template(string $hash, array &$xml_array, array &$hash_cach
 						[$dhash]);
 
 					if (!$exists) {
-						$import_debug_info['differences'][] = __('New Data Query: %s', $dname);
+						$import_debug_info['differences'][] = __('New Data Query: %s', htmle($dname));
 						$status++;
 					} elseif ($save['id']) {
 						$exists = db_fetch_cell_prepared('SELECT COUNT(*)
@@ -2011,7 +2011,7 @@ function xml_to_host_template(string $hash, array &$xml_array, array &$hash_cach
 							[$save['id'], $exists]);
 
 						if (!$exists) {
-							$import_debug_info['differences'][] = __('New Data Query: %s', $dname);
+							$import_debug_info['differences'][] = __('New Data Query: %s', htmle($dname));
 							$status++;
 						}
 					}

--- a/package_import.php
+++ b/package_import.php
@@ -793,11 +793,11 @@ function package_verify_key() : void {
 		}
 
 		foreach ($authors as $author => $email) {
-			$message .= ($message != '' ? '<br>' : '') . __('<b>Author:</b> &lt;%s&gt; %s.<br>', $author, $email);
+			$message .= ($message != '' ? '<br>' : '') . __('<b>Author:</b> &lt;%s&gt; %s.<br>', htmle($author), htmle($email));
 		}
 
 		foreach ($packages as $package) {
-			$message .= ($message != '' ? '<br>' : '') . __('<b>Package:</b> %s', $package['name']);
+			$message .= ($message != '' ? '<br>' : '') . __('<b>Package:</b> %s', htmle($package));
 		}
 
 		$message .= '<br><br>' . __('Press \'Ok\' to start Trusting the Signer.  Press \'Cancel\' or hit escape to Cancel.');


### PR DESCRIPTION
The template/package import preview echoes values taken straight from the uploaded XML without escaping:

- `lib/import.php` builds `differences[]` entries from imported object names (`$dname`) and schema-diff values (`$newvalue`), then `import.php` prints them raw inside `<li>` and `templates_import.php` renders them in a `pre-wrap` cell.
- `package_import.php` echoes the package `author`/`email` from the manifest into a message rendered with `.html()`.

A crafted graph-template/data-query name or package author therefore runs as stored XSS in the importing admin's browser. The untrusted values are now escaped at the source with `htmle()`, which fixes both display paths at once and leaves the intended `<br>` separators intact. The package-name line, which indexed a string with `['name']` instead of using the name, is corrected in the same block.

Post-auth (Import realm).
