### PR TITLE
Allow Users to Switch Devices for Data Query Graphs (#7247)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -212,6 +212,10 @@ Cacti CHANGELOG
 -feature: Fortigate firewall template extension with SDWAN tests
 -feature: Continue to support MD5() for the password verifications but also support SHA256
 
+1.2.x
+-issue: #7212: Address a few small memory leaks in realtime graphing
+-feature#7246: It should be possible to change the Device of a Graph if both Devices include the Data Query
+
 1.2.31
 -security#GHSA-6RVG-2VM8-5WRF: CVE-2026-22802 Authentication Bypass leads to information disclosure
 -security#GHSA-9wvp-cfx6-hj7p: CVE-2026-24482 1st argument to preg_replace is not sanitized and given from user_inputs

--- a/graphs.php
+++ b/graphs.php
@@ -1396,7 +1396,7 @@ function form_actions() : void {
 				$success  = 0;
 				$host_id  = gfrv('host_id');
 
-				for ($i=0; ($i < cacti_count($selected_items)); $i++) {
+				for ($i = 0; ($i < cacti_count($selected_items)); $i++) {
 					$local_graph_id = $selected_items[$i];
 
 					$title = db_fetch_cell_prepared('SELECT title_cache

--- a/graphs.php
+++ b/graphs.php
@@ -1392,16 +1392,24 @@ function form_actions() : void {
 					api_tree_item_save(0, gnrv('tree_id'), TREE_ITEM_TYPE_GRAPH, gnrv('tree_item_id'), '', $selected_items[$i], 0, 0, 0, 0, false);
 				}
 			} elseif (grv('drp_action') == '5') { // change host
-				gfrv('host_id');
-				$failures = false;
+				$failures = 0;
+				$success  = 0;
+				$host_id  = gfrv('host_id');
 
-				for ($i = 0; ($i < cacti_count($selected_items)); $i++) {
-					if (!api_graph_change_device($selected_items[$i], grv('host_id'))) {
-						$failures = true;
-					}
+				for ($i=0;($i<cacti_count($selected_items));$i++) {
+					$local_graph_id = $selected_items[$i];
 
-					if ($failures) {
-						raise_message(33);
+					$title = db_fetch_cell_prepared('SELECT title_cache
+						FROM graph_templates_graph
+						WHERE local_graph_id = ?',
+						array($local_graph_id));
+
+					if (api_graph_change_device($local_graph_id, $host_id)) {
+						raise_message('moved_' . $local_graph_id, __('Graph %s Moved to new Device', $title), MESSAGE_LEVEL_INFO);
+						$success++;
+					} else {
+						raise_message('notmoved_' . $local_graph_id, __('Graph %s not Moved.  Device missing Data Query', $title), MESSAGE_LEVEL_WARN);
+						$failures++;
 					}
 				}
 			} elseif (grv('drp_action') == '6') { // reapply suggested naming

--- a/graphs.php
+++ b/graphs.php
@@ -1396,13 +1396,13 @@ function form_actions() : void {
 				$success  = 0;
 				$host_id  = gfrv('host_id');
 
-				for ($i=0;($i<cacti_count($selected_items));$i++) {
+				for ($i=0; ($i < cacti_count($selected_items)); $i++) {
 					$local_graph_id = $selected_items[$i];
 
 					$title = db_fetch_cell_prepared('SELECT title_cache
 						FROM graph_templates_graph
 						WHERE local_graph_id = ?',
-						array($local_graph_id));
+						[$local_graph_id]);
 
 					if (api_graph_change_device($local_graph_id, $host_id)) {
 						raise_message('moved_' . $local_graph_id, __('Graph %s Moved to new Device', $title), MESSAGE_LEVEL_INFO);

--- a/lib/api_graph.php
+++ b/lib/api_graph.php
@@ -705,12 +705,30 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
  * @return bool Returns true if the device was successfully changed, false otherwise.
  */
 function api_graph_change_device(int $local_graph_id, int $host_id) : bool {
-	$dqgraph = db_fetch_cell_prepared('SELECT snmp_query_id
+	$proceed = false;
+
+	$graph = db_fetch_row_prepared('SELECT *
 		FROM graph_local
 		WHERE id = ?',
 		[$local_graph_id]);
 
-	if (empty($dqgraph)) {
+	if (cacti_sizeof($graph)) {
+		if ($graph['snmp_query_id'] > 0) {
+			$exists = db_fetch_cell_prepared('SELECT snmp_query_id
+				FROM host_snmp_query
+				WHERE snmp_query_id = ?
+				AND host_id = ?',
+				[$graph['snmp_query_id'], $host_id]);
+
+			if ($exists > 0) {
+				$proceed = true;
+			}
+		} else {
+			$proceed = true;
+		}
+	}
+
+	if ($proceed) {
 		db_execute_prepared('UPDATE graph_local
 			SET host_id = ?
 			WHERE id = ?',
@@ -722,7 +740,7 @@ function api_graph_change_device(int $local_graph_id, int $host_id) : bool {
 		$data_ids = db_fetch_assoc_prepared('SELECT DISTINCT dtr.local_data_id
 			FROM graph_templates_item AS gti
 			INNER JOIN data_template_rrd AS dtr
-			ON gti.task_item_id=dtr.id
+			ON gti.task_item_id = dtr.id
 			WHERE gti.local_graph_id = ?',
 			[$local_graph_id]);
 


### PR DESCRIPTION
* fix: Testing using 22.04 only

* fix: Remove matrix version in hopes that will fix it

* feature: #7246 - It should be possible to change device for Data Query Graph

* fix: Remove filter as it's done in separate section

* Potential fix for pull request finding



* Replace sizeof with cacti_sizeof for graph check

* chore: Update sinks

---------