### PR TITLE
feat(rendering): add view renderer abstraction

### DIFF
--- a/include/global.php
+++ b/include/global.php
@@ -286,6 +286,7 @@ if (isset($i18n_text_log)) {
 // include base modules
 require_once(CACTI_PATH_LIBRARY . '/database.php');
 require_once(CACTI_PATH_LIBRARY . '/functions.php');
+require_once(CACTI_PATH_LIBRARY . '/renderer.php');
 require_once(CACTI_PATH_INCLUDE . '/global_constants.php');
 
 define('CACTI_VERSION', format_cacti_version($cacti_version, CACTI_VERSION_FORMAT_SHORT));

--- a/include/views/index.php
+++ b/include/views/index.php
@@ -22,4 +22,9 @@
  +-------------------------------------------------------------------------+
 */
 
-header('Location:../index.php');
+// This directory doubles as the renderer's template path, so only redirect
+// when the file is requested directly. When included as a template it must
+// stay side-effect free and emit no headers.
+if (isset($_SERVER['SCRIPT_FILENAME']) && realpath($_SERVER['SCRIPT_FILENAME']) === __FILE__) {
+	header('Location:../index.php');
+}

--- a/include/views/index.php
+++ b/include/views/index.php
@@ -29,7 +29,7 @@
 // Canonicalize both sides so a symlinked script path compares equal to this
 // file. When SCRIPT_FILENAME is unset or unresolvable, treat the access as an
 // include rather than a direct request and skip the redirect.
-if (!empty($_SERVER['SCRIPT_FILENAME'])) {
+if (!empty($_SERVER['SCRIPT_FILENAME']) && !str_contains($_SERVER['SCRIPT_FILENAME'], "\0")) {
 	$requested = realpath($_SERVER['SCRIPT_FILENAME']);
 
 	if ($requested !== false && $requested === realpath(__FILE__)) {

--- a/include/views/index.php
+++ b/include/views/index.php
@@ -25,6 +25,14 @@
 // This directory doubles as the renderer's template path, so only redirect
 // when the file is requested directly. When included as a template it must
 // stay side-effect free and emit no headers.
-if (isset($_SERVER['SCRIPT_FILENAME']) && realpath($_SERVER['SCRIPT_FILENAME']) === __FILE__) {
-	header('Location:../index.php');
+//
+// Canonicalize both sides so a symlinked script path compares equal to this
+// file. When SCRIPT_FILENAME is unset or unresolvable, treat the access as an
+// include rather than a direct request and skip the redirect.
+if (!empty($_SERVER['SCRIPT_FILENAME'])) {
+	$requested = realpath($_SERVER['SCRIPT_FILENAME']);
+
+	if ($requested !== false && $requested === realpath(__FILE__)) {
+		header('Location:../index.php');
+	}
 }

--- a/include/views/index.php
+++ b/include/views/index.php
@@ -1,18 +1,25 @@
 <?php
 /*
- +-------------------------------------------------------------------------
- | Copyright (C) 2004-2026 The Cacti Group
- |
- | This program is free software; you can redistribute it and/or
- | modify it under the terms of the GNU General Public License
- | as published by the Free Software Foundation; either version 2
- | of the License, or (at your option) any later version.
- |
- | This program is distributed in the hope that it will be useful,
- | but WITHOUT ANY WARRANTY; without even the implied warranty of
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- | GNU General Public License for more details.
- +-------------------------------------------------------------------------
- | Cacti: The Complete RRDtool-based Graphing Solution
- +-------------------------------------------------------------------------
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
 */
+
+header('Location:../index.php');

--- a/include/views/index.php
+++ b/include/views/index.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ +-------------------------------------------------------------------------
+ | Copyright (C) 2004-2026 The Cacti Group
+ |
+ | This program is free software; you can redistribute it and/or
+ | modify it under the terms of the GNU General Public License
+ | as published by the Free Software Foundation; either version 2
+ | of the License, or (at your option) any later version.
+ |
+ | This program is distributed in the hope that it will be useful,
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ | GNU General Public License for more details.
+ +-------------------------------------------------------------------------
+ | Cacti: The Complete RRDtool-based Graphing Solution
+ +-------------------------------------------------------------------------
+*/

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -38,7 +38,11 @@ final class CactiRenderer {
 			throw new InvalidArgumentException('Renderer template path does not exist');
 		}
 
-		$this->template_path = rtrim($real_path, DIRECTORY_SEPARATOR);
+		// Preserve a non-empty base path so a filesystem root ("/") does not
+		// collapse to "" and turn the prefix check into an always-true match.
+		$trimmed = rtrim($real_path, DIRECTORY_SEPARATOR);
+
+		$this->template_path = $trimmed !== '' ? $trimmed : $real_path;
 	}
 
 	public function render(string $template, array $context = []) : string {

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -1,20 +1,25 @@
 <?php
 /*
- +-------------------------------------------------------------------------
- | Copyright (C) 2004-2026 The Cacti Group
- |
- | This program is free software; you can redistribute it and/or
- | modify it under the terms of the GNU General Public License
- | as published by the Free Software Foundation; either version 2
- | of the License, or (at your option) any later version.
- |
- | This program is distributed in the hope that it will be useful,
- | but WITHOUT ANY WARRANTY; without even the implied warranty of
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- | GNU General Public License for more details.
- +-------------------------------------------------------------------------
- | Cacti: The Complete RRDtool-based Graphing Solution
- +-------------------------------------------------------------------------
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
 */
 
 final class CactiRenderer {

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -59,17 +59,33 @@ final class CactiRenderer {
 	public function renderFile(string $template_file, array $context = []) : string {
 		$template_file = $this->validateTemplateFile($template_file);
 
+		$start_level = ob_get_level();
+
 		ob_start();
 
 		try {
 			$this->includeTemplate($template_file, $context);
 
-			return (string) ob_get_clean();
+			return $this->drainOutputBuffers($start_level);
 		} catch (Throwable $e) {
-			ob_end_clean();
+			$this->drainOutputBuffers($start_level);
 
 			throw $e;
 		}
+	}
+
+	// A template should close any buffer it opens, but a stray ob_start() must
+	// not leak a level or scramble output order. Pop innermost-first (the only
+	// order ob_get_clean() allows), then replay outermost-first so the result
+	// matches the order the template actually wrote it in.
+	private function drainOutputBuffers(int $start_level) : string {
+		$chunks = [];
+
+		while (ob_get_level() > $start_level) {
+			$chunks[] = (string) ob_get_clean();
+		}
+
+		return implode('', array_reverse($chunks));
 	}
 
 	private function resolveTemplate(string $template) : string {
@@ -101,9 +117,13 @@ final class CactiRenderer {
 		// sharing the prefix (".../tmpl-evil" against ".../tmpl") cannot match.
 		// str_starts_with() is case-sensitive, which on a case-insensitive
 		// Windows volume only ever over-rejects (fail-closed), so leave it.
+		//
+		// (No separate $real_path !== $this->template_path check: the is_file()
+		// check above and the is_dir() check in the constructor already make
+		// that comparison unreachable, since the same real path can't be both.)
 		$base_path = rtrim($this->template_path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
-		if ($real_path !== $this->template_path && !str_starts_with($real_path, $base_path)) {
+		if (!str_starts_with($real_path, $base_path)) {
 			throw new InvalidArgumentException('Renderer template file is outside the template path');
 		}
 

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -43,7 +43,7 @@ final readonly class CactiRenderer {
 		// absolute path. Trim both separators so the test holds regardless of the
 		// OS running it, and refuse a POSIX root ("/" -> "") or a Windows drive
 		// root ("C:\" -> "C:") so the check stays fail-closed on either platform.
-		$trimmed = rtrim($real_path, "/\\");
+		$trimmed = rtrim($real_path, '/\\');
 
 		if ($trimmed === '' || preg_match('/^[A-Za-z]:$/', $trimmed) === 1) {
 			throw new InvalidArgumentException('Renderer template path does not exist');

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -22,7 +22,7 @@
  +-------------------------------------------------------------------------+
 */
 
-final class CactiRenderer {
+final readonly class CactiRenderer {
 	private string $template_path;
 
 	public function __construct(string $template_path) {

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -113,6 +113,7 @@ final class CactiRenderer {
 	private function includeTemplate(string $template_file, array $context) : void {
 		(static function (string $__cacti_template_file, array $__cacti_template_context) : void {
 			extract($__cacti_template_context, EXTR_SKIP);
+			unset($__cacti_template_context);
 
 			include $__cacti_template_file;
 		})($template_file, $context);

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -90,7 +90,9 @@ final class CactiRenderer {
 			throw new InvalidArgumentException('Renderer template file does not exist');
 		}
 
-		$base_path = $this->template_path . DIRECTORY_SEPARATOR;
+		// Append exactly one separator so a root template path ("/") does not
+		// produce "//" and reject files that are genuinely inside the root.
+		$base_path = rtrim($this->template_path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
 		if ($real_path !== $this->template_path && !str_starts_with($real_path, $base_path)) {
 			throw new InvalidArgumentException('Renderer template file is outside the template path');

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -26,6 +26,12 @@ final class CactiRenderer {
 	private string $template_path;
 
 	public function __construct(string $template_path) {
+		// realpath() raises a ValueError on a null byte, so reject it up front
+		// and fail through the same "does not exist" path.
+		if (str_contains($template_path, "\0")) {
+			throw new InvalidArgumentException('Renderer template path does not exist');
+		}
+
 		$real_path = realpath($template_path);
 
 		if ($real_path === false || !is_dir($real_path)) {
@@ -68,6 +74,12 @@ final class CactiRenderer {
 	}
 
 	private function validateTemplateFile(string $template_file) : string {
+		// renderFile() reaches here with a caller-supplied path that never passed
+		// through resolveTemplate()'s null-byte check, so guard realpath() here too.
+		if (str_contains($template_file, "\0")) {
+			throw new InvalidArgumentException('Renderer template file does not exist');
+		}
+
 		$real_path = realpath($template_file);
 
 		if ($real_path === false || !is_file($real_path)) {
@@ -97,6 +109,10 @@ function cacti_renderer(?string $template_path = null) : CactiRenderer {
 
 	if ($template_path === null) {
 		$template_path = CACTI_PATH_INCLUDE . '/views';
+	}
+
+	if (str_contains($template_path, "\0")) {
+		throw new InvalidArgumentException('Renderer template path does not exist');
 	}
 
 	$key = realpath($template_path);

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ +-------------------------------------------------------------------------
+ | Copyright (C) 2004-2026 The Cacti Group
+ |
+ | This program is free software; you can redistribute it and/or
+ | modify it under the terms of the GNU General Public License
+ | as published by the Free Software Foundation; either version 2
+ | of the License, or (at your option) any later version.
+ |
+ | This program is distributed in the hope that it will be useful,
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ | GNU General Public License for more details.
+ +-------------------------------------------------------------------------
+ | Cacti: The Complete RRDtool-based Graphing Solution
+ +-------------------------------------------------------------------------
+*/
+
+final class CactiRenderer {
+	private string $template_path;
+
+	public function __construct(string $template_path) {
+		$real_path = realpath($template_path);
+
+		if ($real_path === false || !is_dir($real_path)) {
+			throw new InvalidArgumentException('Renderer template path does not exist');
+		}
+
+		$this->template_path = rtrim($real_path, DIRECTORY_SEPARATOR);
+	}
+
+	public function render(string $template, array $context = []) : string {
+		return $this->renderFile($this->resolveTemplate($template), $context);
+	}
+
+	public function renderFile(string $template_file, array $context = []) : string {
+		$template_file = $this->validateTemplateFile($template_file);
+
+		ob_start();
+
+		try {
+			$this->includeTemplate($template_file, $context);
+
+			return (string) ob_get_clean();
+		} catch (Throwable $e) {
+			ob_end_clean();
+
+			throw $e;
+		}
+	}
+
+	private function resolveTemplate(string $template) : string {
+		if ($template === '' || str_contains($template, "\0")) {
+			throw new InvalidArgumentException('Renderer template name is invalid');
+		}
+
+		if (str_starts_with($template, '/') || preg_match('/^[A-Za-z]:[\/\\\\]/', $template) === 1) {
+			throw new InvalidArgumentException('Renderer template name must be relative');
+		}
+
+		return $this->validateTemplateFile($this->template_path . DIRECTORY_SEPARATOR . $template);
+	}
+
+	private function validateTemplateFile(string $template_file) : string {
+		$real_path = realpath($template_file);
+
+		if ($real_path === false || !is_file($real_path)) {
+			throw new InvalidArgumentException('Renderer template file does not exist');
+		}
+
+		$base_path = $this->template_path . DIRECTORY_SEPARATOR;
+
+		if ($real_path !== $this->template_path && !str_starts_with($real_path, $base_path)) {
+			throw new InvalidArgumentException('Renderer template file is outside the template path');
+		}
+
+		return $real_path;
+	}
+
+	private function includeTemplate(string $template_file, array $context) : void {
+		(static function (string $__cacti_template_file, array $__cacti_template_context) : void {
+			extract($__cacti_template_context, EXTR_SKIP);
+
+			include $__cacti_template_file;
+		})($template_file, $context);
+	}
+}
+
+function cacti_renderer(?string $template_path = null) : CactiRenderer {
+	static $renderers = [];
+
+	if ($template_path === null) {
+		$template_path = CACTI_PATH_INCLUDE . '/views';
+	}
+
+	$key = realpath($template_path);
+
+	if ($key === false) {
+		throw new InvalidArgumentException('Renderer template path does not exist');
+	}
+
+	if (!isset($renderers[$key])) {
+		$renderers[$key] = new CactiRenderer($key);
+	}
+
+	return $renderers[$key];
+}
+
+function cacti_render(string $template, array $context = [], ?string $template_path = null) : string {
+	return cacti_renderer($template_path)->render($template, $context);
+}
+
+function cacti_render_file(string $template_file, array $context = [], ?string $template_path = null) : string {
+	return cacti_renderer($template_path)->renderFile($template_file, $context);
+}

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -38,12 +38,14 @@ final class CactiRenderer {
 			throw new InvalidArgumentException('Renderer template path does not exist');
 		}
 
-		// A renderer rooted at a filesystem root ("/") makes the containment
-		// prefix collapse to "/", which str_starts_with() matches for every
-		// absolute path. Refuse that root so the check stays fail-closed.
-		$trimmed = rtrim($real_path, DIRECTORY_SEPARATOR);
+		// A renderer rooted at a filesystem root makes the containment prefix
+		// collapse to that root, which str_starts_with() then matches for every
+		// absolute path. Trim both separators so the test holds regardless of the
+		// OS running it, and refuse a POSIX root ("/" -> "") or a Windows drive
+		// root ("C:\" -> "C:") so the check stays fail-closed on either platform.
+		$trimmed = rtrim($real_path, "/\\");
 
-		if ($trimmed === '') {
+		if ($trimmed === '' || preg_match('/^[A-Za-z]:$/', $trimmed) === 1) {
 			throw new InvalidArgumentException('Renderer template path does not exist');
 		}
 
@@ -97,6 +99,8 @@ final class CactiRenderer {
 
 		// Anchor containment with a trailing separator so a sibling directory
 		// sharing the prefix (".../tmpl-evil" against ".../tmpl") cannot match.
+		// str_starts_with() is case-sensitive, which on a case-insensitive
+		// Windows volume only ever over-rejects (fail-closed), so leave it.
 		$base_path = rtrim($this->template_path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
 		if ($real_path !== $this->template_path && !str_starts_with($real_path, $base_path)) {

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -22,8 +22,8 @@
  +-------------------------------------------------------------------------+
 */
 
-final readonly class CactiRenderer {
-	private string $template_path;
+final class CactiRenderer {
+	private readonly string $template_path;
 
 	public function __construct(string $template_path) {
 		// realpath() raises a ValueError on a null byte, so reject it up front

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -38,11 +38,16 @@ final class CactiRenderer {
 			throw new InvalidArgumentException('Renderer template path does not exist');
 		}
 
-		// Preserve a non-empty base path so a filesystem root ("/") does not
-		// collapse to "" and turn the prefix check into an always-true match.
+		// A renderer rooted at a filesystem root ("/") makes the containment
+		// prefix collapse to "/", which str_starts_with() matches for every
+		// absolute path. Refuse that root so the check stays fail-closed.
 		$trimmed = rtrim($real_path, DIRECTORY_SEPARATOR);
 
-		$this->template_path = $trimmed !== '' ? $trimmed : $real_path;
+		if ($trimmed === '') {
+			throw new InvalidArgumentException('Renderer template path does not exist');
+		}
+
+		$this->template_path = $trimmed;
 	}
 
 	public function render(string $template, array $context = []) : string {
@@ -90,8 +95,8 @@ final class CactiRenderer {
 			throw new InvalidArgumentException('Renderer template file does not exist');
 		}
 
-		// Append exactly one separator so a root template path ("/") does not
-		// produce "//" and reject files that are genuinely inside the root.
+		// Anchor containment with a trailing separator so a sibling directory
+		// sharing the prefix (".../tmpl-evil" against ".../tmpl") cannot match.
 		$base_path = rtrim($this->template_path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
 		if ($real_path !== $this->template_path && !str_starts_with($real_path, $base_path)) {

--- a/lib/renderer.php
+++ b/lib/renderer.php
@@ -77,7 +77,7 @@ final readonly class CactiRenderer {
 			throw new InvalidArgumentException('Renderer template name is invalid');
 		}
 
-		if (str_starts_with($template, '/') || preg_match('/^[A-Za-z]:[\/\\\\]/', $template) === 1) {
+		if (str_starts_with($template, '/') || str_starts_with($template, '\\') || preg_match('/^[A-Za-z]:[\/\\\\]/', $template) === 1) {
 			throw new InvalidArgumentException('Renderer template name must be relative');
 		}
 

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -111,7 +111,7 @@ it('treats a Windows drive root as a filesystem root', function () {
 	// drive root, so assert the constructor's normalize + root predicate directly:
 	// both "C:" and "" must be refused while an in-drive path is accepted.
 	$is_root = static function (string $path): bool {
-		$trimmed = rtrim($path, "/\\");
+		$trimmed = rtrim($path, '/\\');
 
 		return $trimmed === '' || preg_match('/^[A-Za-z]:$/', $trimmed) === 1;
 	};

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -7,18 +7,8 @@
  | modify it under the terms of the GNU General Public License             |
  | as published by the Free Software Foundation; either version 2          |
  | of the License, or (at your option) any later version.                  |
- |                                                                         |
- | This program is distributed in the hope that it will be useful,         |
- | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
- | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
- | GNU General Public License for more details.                            |
  +-------------------------------------------------------------------------+
  | Cacti: The Complete RRDtool-based Graphing Solution                     |
- +-------------------------------------------------------------------------+
- | This code is designed, written, and maintained by the Cacti Group. See  |
- | about.php and/or the AUTHORS file for specific developer information.   |
- +-------------------------------------------------------------------------+
- | http://www.cacti.net/                                                   |
  +-------------------------------------------------------------------------+
 */
 

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -1,4 +1,26 @@
 <?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
 
 require_once dirname(__DIR__, 2) . '/lib/renderer.php';
 

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -136,3 +136,35 @@ it('rejects a null byte in an explicit template file', function () {
 it('rejects a null byte in the cacti_renderer path', function () {
 	cacti_renderer(cacti_renderer_fixture_dir() . "\0/evil");
 })->throws(InvalidArgumentException::class);
+
+it('rejects a template path that does not exist', function () {
+	new CactiRenderer(cacti_renderer_fixture_dir() . '/does-not-exist');
+})->throws(InvalidArgumentException::class);
+
+it('rejects a template path that is a file rather than a directory', function () {
+	new CactiRenderer(cacti_renderer_fixture_dir() . '/hello.php');
+})->throws(InvalidArgumentException::class);
+
+it('rejects an empty template name', function () {
+	$renderer = new CactiRenderer(cacti_renderer_fixture_dir());
+
+	$renderer->render('');
+})->throws(InvalidArgumentException::class);
+
+it('cleans the output buffer and rethrows when a template errors', function () {
+	$dir = cacti_renderer_fixture_dir();
+	file_put_contents($dir . '/boom.php', '<?php throw new RuntimeException("template failure");');
+
+	$renderer = new CactiRenderer($dir);
+	$depth    = ob_get_level();
+
+	try {
+		expect(fn () => $renderer->render('boom.php'))
+			->toThrow(RuntimeException::class, 'template failure');
+
+		// The catch block must unwind its own buffer, leaving the level intact.
+		expect(ob_get_level())->toBe($depth);
+	} finally {
+		unlink($dir . '/boom.php');
+	}
+});

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -62,13 +62,15 @@ it('rejects absolute template names', function () {
 
 it('rejects template traversal outside the template path', function () {
 	$dir = cacti_renderer_fixture_dir();
+	$filename = sprintf('cacti-renderer-outside-%d-%s.php', getmypid(), bin2hex(random_bytes(8)));
+	$outside = dirname($dir) . '/' . $filename;
 
-	file_put_contents(dirname($dir) . '/cacti-renderer-outside.php', 'outside');
+	file_put_contents($outside, 'outside');
 
 	try {
 		$renderer = new CactiRenderer($dir);
-		$renderer->render('../cacti-renderer-outside.php');
+		$renderer->render('../' . $filename);
 	} finally {
-		unlink(dirname($dir) . '/cacti-renderer-outside.php');
+		unlink($outside);
 	}
 })->throws(InvalidArgumentException::class);

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -15,14 +15,20 @@
 require_once dirname(__DIR__, 2) . '/lib/renderer.php';
 
 function cacti_renderer_fixture_dir() : string {
-	return sys_get_temp_dir() . '/cacti-renderer-test-' . getmypid();
+	static $dir = null;
+
+	if ($dir === null) {
+		$dir = sys_get_temp_dir() . '/cacti-renderer-test-' . getmypid() . '-' . bin2hex(random_bytes(8));
+	}
+
+	return $dir;
 }
 
 beforeEach(function () {
 	$dir = cacti_renderer_fixture_dir();
 
 	if (!is_dir($dir)) {
-		mkdir($dir, 0777, true);
+		mkdir($dir, 0700, true);
 	}
 
 	file_put_contents($dir . '/hello.php', 'Hello <?php print $name; ?>');

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -73,9 +73,9 @@ it('rejects absolute template names', function () {
 })->throws(InvalidArgumentException::class);
 
 it('rejects template traversal outside the template path', function () {
-	$dir = cacti_renderer_fixture_dir();
+	$dir      = cacti_renderer_fixture_dir();
 	$filename = sprintf('cacti-renderer-outside-%d-%s.php', getmypid(), bin2hex(random_bytes(8)));
-	$outside = dirname($dir) . '/' . $filename;
+	$outside  = dirname($dir) . '/' . $filename;
 
 	file_put_contents($outside, 'outside');
 
@@ -85,4 +85,25 @@ it('rejects template traversal outside the template path', function () {
 	} finally {
 		unlink($outside);
 	}
+})->throws(InvalidArgumentException::class);
+
+it('rejects a null byte in the constructor template path', function () {
+	new CactiRenderer(cacti_renderer_fixture_dir() . "\0/evil");
+})->throws(InvalidArgumentException::class);
+
+it('rejects a null byte in the template name', function () {
+	$renderer = new CactiRenderer(cacti_renderer_fixture_dir());
+
+	$renderer->render("hello.php\0.txt");
+})->throws(InvalidArgumentException::class);
+
+it('rejects a null byte in an explicit template file', function () {
+	$dir      = cacti_renderer_fixture_dir();
+	$renderer = new CactiRenderer($dir);
+
+	$renderer->renderFile($dir . "/hello.php\0.txt");
+})->throws(InvalidArgumentException::class);
+
+it('rejects a null byte in the cacti_renderer path', function () {
+	cacti_renderer(cacti_renderer_fixture_dir() . "\0/evil");
 })->throws(InvalidArgumentException::class);

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -1,0 +1,74 @@
+<?php
+
+require_once dirname(__DIR__, 2) . '/lib/renderer.php';
+
+function cacti_renderer_fixture_dir() : string {
+	return sys_get_temp_dir() . '/cacti-renderer-test-' . getmypid();
+}
+
+beforeEach(function () {
+	$dir = cacti_renderer_fixture_dir();
+
+	if (!is_dir($dir)) {
+		mkdir($dir, 0777, true);
+	}
+
+	file_put_contents($dir . '/hello.php', 'Hello <?php print $name; ?>');
+	file_put_contents($dir . '/context.php', '<?php print isset($template_file) ? "leaked" : "isolated"; ?>');
+});
+
+afterEach(function () {
+	$dir = cacti_renderer_fixture_dir();
+
+	foreach (glob($dir . '/*') ?: [] as $file) {
+		unlink($file);
+	}
+
+	if (is_dir($dir)) {
+		rmdir($dir);
+	}
+});
+
+it('renders a relative template with context values', function () {
+	$renderer = new CactiRenderer(cacti_renderer_fixture_dir());
+
+	expect($renderer->render('hello.php', ['name' => 'Cacti']))->toBe('Hello Cacti');
+});
+
+it('renders an explicit template file inside the template path', function () {
+	$dir      = cacti_renderer_fixture_dir();
+	$renderer = new CactiRenderer($dir);
+
+	expect($renderer->renderFile($dir . '/hello.php', ['name' => 'Cacti']))->toBe('Hello Cacti');
+});
+
+it('keeps renderer internals out of the template context', function () {
+	$renderer = new CactiRenderer(cacti_renderer_fixture_dir());
+
+	expect($renderer->render('context.php'))->toBe('isolated');
+});
+
+it('rejects missing templates', function () {
+	$renderer = new CactiRenderer(cacti_renderer_fixture_dir());
+
+	$renderer->render('missing.php');
+})->throws(InvalidArgumentException::class);
+
+it('rejects absolute template names', function () {
+	$renderer = new CactiRenderer(cacti_renderer_fixture_dir());
+
+	$renderer->render('/tmp/hello.php');
+})->throws(InvalidArgumentException::class);
+
+it('rejects template traversal outside the template path', function () {
+	$dir = cacti_renderer_fixture_dir();
+
+	file_put_contents(dirname($dir) . '/cacti-renderer-outside.php', 'outside');
+
+	try {
+		$renderer = new CactiRenderer($dir);
+		$renderer->render('../cacti-renderer-outside.php');
+	} finally {
+		unlink(dirname($dir) . '/cacti-renderer-outside.php');
+	}
+})->throws(InvalidArgumentException::class);

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -78,6 +78,12 @@ it('rejects absolute template names', function () {
 	$renderer->render('/tmp/hello.php');
 })->throws(InvalidArgumentException::class);
 
+it('rejects UNC-style template names with a leading backslash', function () {
+	$renderer = new CactiRenderer(cacti_renderer_fixture_dir());
+
+	$renderer->render('\\\\server\\share\\hello.php');
+})->throws(InvalidArgumentException::class);
+
 it('rejects template traversal outside the template path', function () {
 	$dir      = cacti_renderer_fixture_dir();
 	$filename = sprintf('cacti-renderer-outside-%d-%s.php', getmypid(), bin2hex(random_bytes(8)));

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -99,6 +99,23 @@ it('refuses a filesystem root as the template path', function () {
 	new CactiRenderer('/');
 })->throws(InvalidArgumentException::class);
 
+it('treats a Windows drive root as a filesystem root', function () {
+	// realpath('C:\\') resolves to a bare drive letter, which would collapse the
+	// containment prefix the same way "/" does. A POSIX runner cannot resolve a
+	// drive root, so assert the constructor's normalize + root predicate directly:
+	// both "C:" and "" must be refused while an in-drive path is accepted.
+	$is_root = static function (string $path): bool {
+		$trimmed = rtrim($path, "/\\");
+
+		return $trimmed === '' || preg_match('/^[A-Za-z]:$/', $trimmed) === 1;
+	};
+
+	expect($is_root('C:\\'))->toBeTrue();
+	expect($is_root('C:'))->toBeTrue();
+	expect($is_root(''))->toBeTrue();
+	expect($is_root('C:\\Cacti\\views'))->toBeFalse();
+});
+
 it('rejects a null byte in the constructor template path', function () {
 	new CactiRenderer(cacti_renderer_fixture_dir() . "\0/evil");
 })->throws(InvalidArgumentException::class);

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -174,3 +174,20 @@ it('cleans the output buffer and rethrows when a template errors', function () {
 		unlink($dir . '/boom.php');
 	}
 });
+
+it('collects output from a stray buffer a template leaves open', function () {
+	$dir = cacti_renderer_fixture_dir();
+	file_put_contents($dir . '/leaky.php', '<?php print "before "; ob_start(); print "after";');
+
+	$renderer = new CactiRenderer($dir);
+	$depth    = ob_get_level();
+
+	try {
+		expect($renderer->render('leaky.php'))->toBe('before after');
+
+		// The leaked buffer must be unwound along with the renderer's own.
+		expect(ob_get_level())->toBe($depth);
+	} finally {
+		unlink($dir . '/leaky.php');
+	}
+});

--- a/tests/Unit/CactiRendererTest.php
+++ b/tests/Unit/CactiRendererTest.php
@@ -93,6 +93,12 @@ it('rejects template traversal outside the template path', function () {
 	}
 })->throws(InvalidArgumentException::class);
 
+it('refuses a filesystem root as the template path', function () {
+	// A "/"-rooted renderer would make the containment prefix match every
+	// absolute path, so construction must fail closed.
+	new CactiRenderer('/');
+})->throws(InvalidArgumentException::class);
+
 it('rejects a null byte in the constructor template path', function () {
 	new CactiRenderer(cacti_renderer_fixture_dir() . "\0/evil");
 })->throws(InvalidArgumentException::class);

--- a/tests/integration/CactiRendererIntegrationTest.php
+++ b/tests/integration/CactiRendererIntegrationTest.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 2) . '/lib/renderer.php';
+
+if (!defined('CACTI_PATH_INCLUDE')) {
+	define('CACTI_PATH_INCLUDE', dirname(__DIR__, 2) . '/include');
+}
+
+beforeEach(function () {
+	$this->dir = sys_get_temp_dir() . '/cacti-renderer-int-' . getmypid() . '-' . bin2hex(random_bytes(8));
+	mkdir($this->dir, 0700, true);
+	file_put_contents($this->dir . '/hello.php', 'Hello <?php print $name; ?>');
+});
+
+afterEach(function () {
+	foreach (glob($this->dir . '/*') ?: [] as $file) {
+		unlink($file);
+	}
+
+	if (is_dir($this->dir)) {
+		rmdir($this->dir);
+	}
+});
+
+it('renders a real template through the cacti_render helper', function () {
+	expect(cacti_render('hello.php', ['name' => 'Cacti'], $this->dir))->toBe('Hello Cacti');
+});
+
+it('renders a real explicit file through the cacti_render_file helper', function () {
+	expect(cacti_render_file($this->dir . '/hello.php', ['name' => 'World'], $this->dir))->toBe('Hello World');
+});
+
+it('caches one renderer instance per resolved template path', function () {
+	$first  = cacti_renderer($this->dir);
+	$second = cacti_renderer($this->dir);
+
+	expect($first)->toBeInstanceOf(CactiRenderer::class)
+		->and($first)->toBe($second);
+});
+
+it('defaults to the bundled include/views template path', function () {
+	// Exercises the null-path branch that resolves CACTI_PATH_INCLUDE/views and
+	// renders the side-effect-free index template shipped with the abstraction.
+	$default = cacti_renderer();
+
+	expect($default)->toBeInstanceOf(CactiRenderer::class)
+		->and(cacti_render('index.php'))->toBeString();
+});
+
+it('rejects a non-existent path through cacti_renderer', function () {
+	cacti_renderer($this->dir . '/missing-subtree');
+})->throws(InvalidArgumentException::class);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -120,7 +120,7 @@ dynamic_include	./index.php:49							require_once($file);
 dynamic_include	./lib/installer.php:4103					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
-dynamic_include	./lib/renderer.php:118				include $__cacti_template_file;
+dynamic_include	./lib/renderer.php:138				include $__cacti_template_file;
 dynamic_include	./lib/rrd.php:3052			include($rrdtheme);
 dynamic_include	./lib/rrd.php:4604			include($themefile);
 dynamic_include	./link.php:91					require_once($file);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -120,6 +120,7 @@ dynamic_include	./index.php:49							require_once($file);
 dynamic_include	./lib/installer.php:4103					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
+dynamic_include	./lib/renderer.php:102							include $__cacti_template_file;
 dynamic_include	./lib/rrd.php:3052			include($rrdtheme);
 dynamic_include	./lib/rrd.php:4604			include($themefile);
 dynamic_include	./link.php:91					require_once($file);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -120,7 +120,7 @@ dynamic_include	./index.php:49							require_once($file);
 dynamic_include	./lib/installer.php:4103					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
-dynamic_include	./lib/renderer.php:102							include $__cacti_template_file;
+dynamic_include	./lib/renderer.php:117				include $__cacti_template_file;
 dynamic_include	./lib/rrd.php:3052			include($rrdtheme);
 dynamic_include	./lib/rrd.php:4604			include($themefile);
 dynamic_include	./link.php:91					require_once($file);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -120,7 +120,7 @@ dynamic_include	./index.php:49							require_once($file);
 dynamic_include	./lib/installer.php:4103					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
-dynamic_include	./lib/renderer.php:117				include $__cacti_template_file;
+dynamic_include	./lib/renderer.php:118				include $__cacti_template_file;
 dynamic_include	./lib/rrd.php:3052			include($rrdtheme);
 dynamic_include	./lib/rrd.php:4604			include($themefile);
 dynamic_include	./link.php:91					require_once($file);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -124,6 +124,7 @@ dynamic_include	./index.php:49							require_once($file);
 dynamic_include	./lib/installer.php:4103					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
+dynamic_include	./lib/renderer.php:102							include $__cacti_template_file;
 dynamic_include	./lib/rrd.php:3052			include($rrdtheme);
 dynamic_include	./lib/rrd.php:4604			include($themefile);
 dynamic_include	./link.php:91					require_once($file);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -124,7 +124,7 @@ dynamic_include	./index.php:49							require_once($file);
 dynamic_include	./lib/installer.php:4103					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
-dynamic_include	./lib/renderer.php:118				include $__cacti_template_file;
+dynamic_include	./lib/renderer.php:138				include $__cacti_template_file;
 dynamic_include	./lib/rrd.php:3052			include($rrdtheme);
 dynamic_include	./lib/rrd.php:4604			include($themefile);
 dynamic_include	./link.php:91					require_once($file);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -124,7 +124,7 @@ dynamic_include	./index.php:49							require_once($file);
 dynamic_include	./lib/installer.php:4103					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
-dynamic_include	./lib/renderer.php:102							include $__cacti_template_file;
+dynamic_include	./lib/renderer.php:117				include $__cacti_template_file;
 dynamic_include	./lib/rrd.php:3052			include($rrdtheme);
 dynamic_include	./lib/rrd.php:4604			include($themefile);
 dynamic_include	./link.php:91					require_once($file);
@@ -502,6 +502,7 @@ header_redirect	./include/themes/sunrise/default/index.php:25	header('Location:.
 header_redirect	./include/themes/sunrise/images/index.php:25	header('Location:../index.php');
 header_redirect	./include/themes/sunrise/index.php:25	header('Location:../index.php');
 header_redirect	./include/vendor/index.php:25	header("Location:../index.php");
+header_redirect	./include/views/index.php:36			header('Location:../index.php');
 header_redirect	./install/upgrades/index.php:25	header('Location:../../index.php');
 header_redirect	./lib/auth.php:4240				header('Location: auth_changepassword.php');
 header_redirect	./lib/auth.php:4696					header('Location: ' . $referer);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -124,7 +124,7 @@ dynamic_include	./index.php:49							require_once($file);
 dynamic_include	./lib/installer.php:4103					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
-dynamic_include	./lib/renderer.php:117				include $__cacti_template_file;
+dynamic_include	./lib/renderer.php:118				include $__cacti_template_file;
 dynamic_include	./lib/rrd.php:3052			include($rrdtheme);
 dynamic_include	./lib/rrd.php:4604			include($themefile);
 dynamic_include	./link.php:91					require_once($file);


### PR DESCRIPTION
Adds a small PHP view renderer abstraction that resolves templates within a configured view directory, captures rendered output, and rejects missing, absolute, or path-traversal template references.

This does not migrate any page output or change existing helper behavior. It gives future page-level rendering work one narrow API to build on before any user-facing UI paths are moved.

Validation: php -l on changed PHP files, git diff --check, and unit plus integration coverage for context rendering and traversal rejection. No page is routed through the renderer yet, so no E2E coverage is included; that should be added with the first page or fragment migration.

Part of #7371
