### PR TITLE
hardening(rendering): encode pagination URLs and scripts

### DIFF
--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -1653,20 +1653,33 @@ function aggregate_items() : void {
 	?>
 	<script type='text/javascript'>
 		var totalItems = <?php print $total_items; ?>;
+		var aggregateItemsFilter = <?php print cacti_js_encode([
+			'url'    => 'aggregate_graphs.php',
+			'action' => 'edit',
+			'tab'    => 'items'
+		]); ?>;
 
 		function applyFilter() {
-			strURL = 'aggregate_graphs.php' +
-				'?action=edit&tab=items&id=' + $('#id').val() +
-				'&rows=' + $('#rows').val() +
-				'&rfilter=' + base64_encode($('#rfilter').val()) +
-				'&matching=' + $('#matching').is(':checked');
+			strURL = aggregateItemsFilter.url + '?' + $.param({
+				action: aggregateItemsFilter.action,
+				tab: aggregateItemsFilter.tab,
+				id: $('#id').val(),
+				rows: $('#rows').val(),
+				rfilter: base64_encode($('#rfilter').val()),
+				matching: $('#matching').is(':checked')
+			});
 			loadUrl({
 				url: strURL
 			})
 		}
 
 		function clearFilter() {
-			strURL = 'aggregate_graphs.php?action=edit&tab=items&id=' + $('#id').val() + '&clear=true';
+			strURL = aggregateItemsFilter.url + '?' + $.param({
+				action: aggregateItemsFilter.action,
+				tab: aggregateItemsFilter.tab,
+				id: $('#id').val(),
+				clear: true
+			});
 			loadUrl({
 				url: strURL
 			})
@@ -1756,7 +1769,7 @@ function aggregate_items() : void {
 
 	html_start_box('', '100%', false, 3, 'center', '');
 
-	$nav = html_nav_bar('aggregate_graphs.php?action=edit&tab=items&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Graphs'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('aggregate_graphs.php', ['action' => 'edit', 'tab' => 'items', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Graphs'), 'page', 'main');
 
 	print $nav;
 

--- a/automation_graph_rules.php
+++ b/automation_graph_rules.php
@@ -975,7 +975,7 @@ function automation_graph_rules() : void {
 		$sql_limit",
 		$sql_params);
 
-	$nav = html_nav_bar('automation_graph_rules.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 7, __('Graph Rules'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('automation_graph_rules.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 7, __('Graph Rules'), 'page', 'main');
 
 	form_start('automation_graph_rules.php', 'chk');
 

--- a/automation_snmp.php
+++ b/automation_snmp.php
@@ -930,7 +930,7 @@ function automation_snmp() : void {
 		$sql_order
 		$sql_limit");
 
-	$nav = html_nav_bar('automation_snmp.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 12, __('SNMP Option Sets'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('automation_snmp.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 12, __('SNMP Option Sets'), 'page', 'main');
 
 	form_start('automation_snmp.php', 'chk');
 

--- a/automation_tree_rules.php
+++ b/automation_tree_rules.php
@@ -1105,7 +1105,7 @@ function automation_tree_rules() : void {
 		$sql_limit",
 		$sql_params);
 
-	$nav = html_nav_bar('automation_tree_rules.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Tree Rules'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('automation_tree_rules.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Tree Rules'), 'page', 'main');
 
 	form_start('automation_tree_rules.php', 'chk');
 

--- a/cdef.php
+++ b/cdef.php
@@ -733,7 +733,7 @@ function cdef() : void {
 		$sql_order
 		$sql_limit");
 
-	$nav = html_nav_bar('cdef.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('CDEFs'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('cdef.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('CDEFs'), 'page', 'main');
 
 	form_start('cdef.php', 'chk');
 

--- a/color.php
+++ b/color.php
@@ -492,7 +492,7 @@ function color() : void {
 		$sql_order
 		$sql_limit");
 
-	$nav = html_nav_bar('color.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('Colors'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('color.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('Colors'), 'page', 'main');
 
 	form_start('color.php', 'chk');
 

--- a/data_input.php
+++ b/data_input.php
@@ -766,7 +766,7 @@ function data() : void {
 		$sql_order
 		$sql_limit");
 
-	$nav = html_nav_bar('data_input.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 6, __('Input Methods'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('data_input.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 6, __('Input Methods'), 'page', 'main');
 
 	form_start('data_input.php', 'chk');
 

--- a/data_queries.php
+++ b/data_queries.php
@@ -1354,7 +1354,7 @@ function data_query() : void {
 		]
 	];
 
-	$nav = html_nav_bar('data_queries.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Data Queries'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('data_queries.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Data Queries'), 'page', 'main');
 
 	form_start('data_queries.php', 'chk');
 

--- a/data_source_profiles.php
+++ b/data_source_profiles.php
@@ -1429,7 +1429,7 @@ function profile() : void {
 		]
 	];
 
-	$nav = html_nav_bar('data_source_profiles.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Profiles'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('data_source_profiles.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Profiles'), 'page', 'main');
 
 	form_start('data_source_profiles.php', 'chk');
 

--- a/data_templates.php
+++ b/data_templates.php
@@ -1146,7 +1146,7 @@ function data_templates() : void {
 		]
 	];
 
-	$nav = html_nav_bar('data_templates.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Data Templates'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('data_templates.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Data Templates'), 'page', 'main');
 
 	form_start('data_templates.php', 'chk');
 

--- a/gprint_presets.php
+++ b/gprint_presets.php
@@ -254,7 +254,7 @@ function gprint_presets() : void {
 		]
 	];
 
-	$nav = html_nav_bar('gprint_presets.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('GPRINTs'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('gprint_presets.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('GPRINTs'), 'page', 'main');
 
 	form_start('gprint_presets.php', 'chk');
 

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -1711,7 +1711,7 @@ function graph_templates() : void {
 		]
 	];
 
-	$nav = html_nav_bar('graph_templates.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Graph Templates'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('graph_templates.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Graph Templates'), 'page', 'main');
 
 	form_start('graph_templates.php', 'chk');
 

--- a/graphs_new.php
+++ b/graphs_new.php
@@ -849,7 +849,7 @@ function graphs() : void {
 							load_current_session_value('page' . $snmp_query['id'], 'sess_grn_page' . $snmp_query['id'], '1');
 						}
 
-						$nav = html_nav_bar('graphs_new.php?host_id=' . grv('host_id'), MAX_DISPLAY_PAGES, $page, $rows, $total_rows, 15, __('Items'), 'page' . $snmp_query['id']);
+						$nav = html_nav_bar(cacti_url('graphs_new.php', ['host_id' => grv('host_id')]), MAX_DISPLAY_PAGES, $page, $rows, $total_rows, 15, __('Items'), 'page' . $snmp_query['id']);
 
 						print $nav;
 

--- a/host.php
+++ b/host.php
@@ -1721,7 +1721,7 @@ function host() : void {
 
 	$hosts = get_device_records($total_rows, $rows);
 
-	$nav = html_nav_bar('host.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Devices'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('host.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Devices'), 'page', 'main');
 
 	form_start('host.php', 'chk');
 

--- a/host_templates.php
+++ b/host_templates.php
@@ -1090,7 +1090,7 @@ function device_templates() : void {
 		]
 	];
 
-	$nav = html_nav_bar('host_templates.php?action=templates', MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Device Templates'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('host_templates.php', ['action' => 'templates']), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Device Templates'), 'page', 'main');
 
 	form_start('host_templates.php?action=templates', 'chk');
 
@@ -1494,7 +1494,7 @@ function device_archives() : void {
 		]
 	];
 
-	$nav = html_nav_bar('host_templates.php?action=archives', MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Device Templates'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('host_templates.php', ['action' => 'archives']), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Device Templates'), 'page', 'main');
 
 	form_start('host_templates.php?action=archives', 'chk');
 

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -942,7 +942,7 @@ function display_new_graphs(array $rule, string $url) : void {
 		$rows = $details['rows'];
 		$name = $details['name'];
 
-		$nav = html_nav_bar('automation_graph_rules.php?action=edit&id=' . $rule['id'], MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 30, __('Matching Indexes'), 'page', 'main');
+		$nav = html_nav_bar(cacti_url('automation_graph_rules.php', ['action' => 'edit', 'id' => $rule['id']]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 30, __('Matching Indexes'), 'page', 'main');
 
 		print $nav;
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5066,6 +5066,44 @@ function debug_log_return(string $type) : string {
 }
 
 /**
+ * Encodes a PHP value for direct inclusion in JavaScript.
+ *
+ * @param mixed $value The value to encode
+ *
+ * @return string The JavaScript-safe JSON literal
+ */
+function cacti_js_encode(mixed $value) : string {
+	$encoded = json_encode(
+		$value,
+		JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+	);
+
+	return $encoded !== false ? $encoded : 'null';
+}
+
+/**
+ * Builds a URL with RFC3986-encoded query parameters.
+ *
+ * @param string $path   The base URL or relative path
+ * @param array  $params Query parameters to append
+ *
+ * @return string The encoded URL
+ */
+function cacti_url(string $path, array $params = []) : string {
+	if (cacti_sizeof($params) == 0) {
+		return $path;
+	}
+
+	$query = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+
+	if ($query == '') {
+		return $path;
+	}
+
+	return $path . (str_contains($path, '?') ? '&' : '?') . $query;
+}
+
+/**
  * Strips any character that cannot safely appear in a SQL identifier.
  * Allows word characters, dots (table.column), parentheses and INET_ATON-style
  * wrappers already used by the sort helpers.  Use before concatenating a

--- a/lib/html.php
+++ b/lib/html.php
@@ -662,7 +662,8 @@ function html_nav_bar(string $base_url, int $max_pages, int $current_page, int $
 				$return_to = 'main';
 			}
 
-			$url  = $base_url . $page_var;
+			$url       = cacti_js_encode($base_url . $page_var);
+			$return_to = cacti_js_encode($return_to);
 			$nav .= "<script type='text/javascript'>
 			function goto$page_var(pageNo) {
 				if (typeof url_graph === 'function') {
@@ -671,11 +672,11 @@ function html_nav_bar(string $base_url, int $max_pages, int $current_page, int $
 					var url_add='';
 				};
 
-				strURL = '$url='+pageNo+url_add;
+				strURL = $url+'='+pageNo+url_add;
 
 				loadUrl({
 					url: strURL,
-					elementId: '$return_to',
+					elementId: $return_to,
 				});
 			}</script>";
 		}

--- a/lib/html.php
+++ b/lib/html.php
@@ -1346,6 +1346,40 @@ function htmle(mixed $string) : string {
 }
 
 /**
+ * html_escape_attr - sanitizes a string for display in an HTML attribute
+ *
+ * @param mixed $string String the attribute value to escape
+ *
+ * @return string The escaped attribute value to be returned.
+ */
+function html_escape_attr(mixed $string = '') : string {
+	return html_escape($string);
+}
+
+/**
+ * html_escape_url - sanitizes a URL for display in an HTML attribute
+ *
+ * @param mixed $url URL the attribute value to escape
+ *
+ * @return string The escaped URL value to be returned.
+ */
+function html_escape_url(mixed $url = '') : string {
+	return html_escape_attr($url);
+}
+
+/**
+ * cacti_script_data - renders JSON data for scripts to read from the DOM
+ *
+ * @param string $id   HTML id for the script element
+ * @param mixed  $data Data to encode as a JavaScript-safe JSON literal
+ *
+ * @return string The script tag containing JSON data.
+ */
+function cacti_script_data(string $id, mixed $data) : string {
+	return "<script type='application/json' id='" . html_escape_attr($id) . "'>" . cacti_js_encode($data) . '</script>';
+}
+
+/**
  * html_escape - sanitizes a string for display
  *
  * @param mixed $string String the string to escape

--- a/lib/html_graph.php
+++ b/lib/html_graph.php
@@ -1265,7 +1265,7 @@ function html_graph_list_view() : void {
 
 	$graphs = get_allowed_graphs($sql_where, 'gtg.title_cache', $sql_limit, $total_rows);
 
-	$nav = html_nav_bar('graph_view.php?action=list', MAX_DISPLAY_PAGES, grv('page'), $graph_rows, $total_rows, 5, __('Graphs'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('graph_view.php', ['action' => 'list']), MAX_DISPLAY_PAGES, grv('page'), $graph_rows, $total_rows, 5, __('Graphs'), 'page', 'main');
 
 	print $nav;
 

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -1531,7 +1531,7 @@ function grow_right_pane_tree(int $tree_id, int $leaf_id, string $host_group_dat
 	$total_rows = cacti_sizeof($graph_list);
 
 	// generate page list
-	$nav = html_nav_bar(CACTI_PATH_URL . 'graph_view.php?action=tree_content&tree_id=' . $tree_id . '&leaf_id=' . $leaf_id . '&node=' . grv('node') . '&hgd=' . $host_group_data, MAX_DISPLAY_PAGES, grv('page'), $graph_rows, $total_rows, grv('columns'), __('Graphs'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url(CACTI_PATH_URL . 'graph_view.php', ['action' => 'tree_content', 'tree_id' => $tree_id, 'leaf_id' => $leaf_id, 'node' => grv('node'), 'hgd' => $host_group_data]), MAX_DISPLAY_PAGES, grv('page'), $graph_rows, $total_rows, grv('columns'), __('Graphs'), 'page', 'main');
 
 	print $nav;
 

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1837,7 +1837,8 @@ function get_page_list(int $current_page, int $pages_per_screen, int $rows_per_p
 		$return_to = 'main';
 	}
 
-	$url .= $page_var;
+	$url       = cacti_js_encode($url . $page_var);
+	$return_to = cacti_js_encode($return_to);
 	$url_page_select .= "<script type='text/javascript'>
 	function goto$page_var(pageNo) {
 		if (typeof url_graph === 'function') {
@@ -1846,11 +1847,11 @@ function get_page_list(int $current_page, int $pages_per_screen, int $rows_per_p
 			var url_add='';
 		};
 
-		strURL = '$url='+pageNo+url_add;
+		strURL = $url+'='+pageNo+url_add;
 
 		loadUrl({
 			url: strURL,
-			elementId: '$return_to',
+			elementId: $return_to,
 		});
 	}</script>";
 

--- a/managers.php
+++ b/managers.php
@@ -127,7 +127,7 @@ function manager() : void {
 	];
 
 	// generate page list
-	$nav = html_nav_bar('managers.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Receivers'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('managers.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Receivers'), 'page', 'main');
 
 	form_start('managers.php', 'chk');
 
@@ -431,7 +431,7 @@ function manager_notifications(int $id, string $header_label) : void {
 	];
 
 	// generate page list
-	$nav = html_nav_bar('managers.php?action=edit&id=' . $id . '&tab=notifications&mib=' . grv('mib') . '&filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Notifications'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('managers.php', ['action' => 'edit', 'id' => $id, 'tab' => 'notifications', 'mib' => grv('mib'), 'filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Notifications'), 'page', 'main');
 
 	print $nav;
 
@@ -629,7 +629,7 @@ function manager_logs(int $id, string $header_label) : void {
 		__('Varbinds')
 	];
 
-	$nav = html_nav_bar('managers.php?action=exit&id=' . $id . '&tab=logs&mib=' . grv('mib') . '&filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text), __('Receivers'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('managers.php', ['action' => 'exit', 'id' => $id, 'tab' => 'logs', 'mib' => grv('mib'), 'filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text), __('Receivers'), 'page', 'main');
 
 	print $nav;
 

--- a/plugins.php
+++ b/plugins.php
@@ -1094,7 +1094,7 @@ function update_show_current() : void {
 
 	$plugins = db_fetch_assoc($sql);
 
-	$nav = html_nav_bar('plugins.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('Plugins'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('plugins.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('Plugins'), 'page', 'main');
 
 	form_start('plugins.php', 'chk');
 

--- a/pollers.php
+++ b/pollers.php
@@ -945,7 +945,7 @@ function pollers() : void {
 		$sql_order
 		$sql_limit");
 
-	$nav = html_nav_bar('pollers.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Pollers'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('pollers.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Pollers'), 'page', 'main');
 
 	form_start('pollers.php', 'chk');
 

--- a/rrdcheck.php
+++ b/rrdcheck.php
@@ -117,7 +117,7 @@ function rrdcheck_display_problems() : void {
 		$sql_limit",
 		$sql_params);
 
-	$nav = html_nav_bar(CACTI_PATH_URL . 'rrdcheck.php?filter' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('RRDcheck Problems'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url(CACTI_PATH_URL . 'rrdcheck.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('RRDcheck Problems'), 'page', 'main');
 
 	form_start('rrdcheck.php');
 

--- a/rrdcleaner.php
+++ b/rrdcleaner.php
@@ -326,7 +326,7 @@ function list_rrd() : void {
 		$sql_limit",
 		$sql_params);
 
-	$nav = html_nav_bar(CACTI_PATH_URL . 'rrdcleaner.php?filter' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('RRDfiles'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url(CACTI_PATH_URL . 'rrdcleaner.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('RRDfiles'), 'page', 'main');
 
 	form_start('rrdcleaner.php');
 

--- a/sites.php
+++ b/sites.php
@@ -525,7 +525,7 @@ function sites() : void {
 		$sql_order
 		$sql_limit");
 
-	$nav = html_nav_bar('sites.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Sites'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('sites.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Sites'), 'page', 'main');
 
 	form_start('sites.php', 'chk');
 

--- a/support.php
+++ b/support.php
@@ -446,7 +446,7 @@ function show_database_processes() : void {
 		]
 	];
 
-	$nav = html_nav_bar('support.php?tab=processes', MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 7, __('Queries'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('support.php', ['tab' => 'processes']), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 7, __('Queries'), 'page', 'main');
 
 	print $nav;
 
@@ -784,7 +784,7 @@ function show_cacti_processes() : void {
 		]
 	];
 
-	$nav = html_nav_bar('support.php?tab=background', MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('Processes'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('support.php', ['tab' => 'background']), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('Processes'), 'page', 'main');
 
 	print $nav;
 

--- a/tests/Unit/HtmlEscapeTest.php
+++ b/tests/Unit/HtmlEscapeTest.php
@@ -59,6 +59,53 @@ test('html_escape handles ampersand in plain text', function () {
 	expect(html_escape('a&b'))->toBe('a&amp;b');
 });
 
+test('html_escape_attr encodes attribute delimiters', function () {
+	$result = html_escape_attr('" onmouseover="alert(1)');
+
+	expect($result)->toBe('&quot; onmouseover=&quot;alert(1)');
+});
+
+test('html_escape_attr encodes backticks', function () {
+	expect(html_escape_attr('` autofocus onfocus=alert(1)'))->toBe('&#96; autofocus onfocus=alert(1)');
+});
+
+test('html_escape_url encodes URL attribute delimiters', function () {
+	expect(html_escape_url('https://example.invalid/?q=" onmouseover="alert(1)'))
+		->toBe('https://example.invalid/?q=&quot; onmouseover=&quot;alert(1)');
+});
+
+test('cacti_js_encode escapes script-sensitive characters', function () {
+	$result = cacti_js_encode("</script><img src=x onerror='alert(1)'>");
+
+	expect($result)->toContain('\u003C')
+		->and($result)->toContain('\u0027')
+		->and($result)->not->toContain('</script>');
+});
+
+test('cacti_url appends encoded query parameters', function () {
+	expect(cacti_url('foo.php', [
+		'filter' => "a b&c'",
+		'page'   => 2,
+	]))->toBe('foo.php?filter=a%20b%26c%27&page=2');
+});
+
+test('cacti_url preserves existing query strings', function () {
+	expect(cacti_url('foo.php?action=view', [
+		'filter' => 'a+b',
+	]))->toBe('foo.php?action=view&filter=a%2Bb');
+});
+
+test('cacti_script_data renders JSON without exposing script delimiters', function () {
+	$result = cacti_script_data('ctx" onmouseover="alert(1)', [
+		'message' => "</script><img src=x onerror='alert(1)'>",
+	]);
+
+	expect($result)->toContain("type='application/json'")
+		->and($result)->toContain("id='ctx&quot; onmouseover=&quot;alert(1)'")
+		->and($result)->toContain('\u003C\/script\u003E')
+		->and($result)->not->toContain('</script><img');
+});
+
 // =====================================================================
 // html_split_string tests
 // =====================================================================

--- a/tests/Unit/HtmlEscapeTest.php
+++ b/tests/Unit/HtmlEscapeTest.php
@@ -106,6 +106,25 @@ test('cacti_script_data renders JSON without exposing script delimiters', functi
 		->and($result)->not->toContain('</script><img');
 });
 
+test('html_nav_bar encodes URL and target values for JavaScript context', function () {
+	$result = html_nav_bar(
+		"foo.php?filter=</script><img src=x onerror='alert(1)'>",
+		10,
+		1,
+		10,
+		100,
+		5,
+		'Rows',
+		'page',
+		"main');alert(1)//"
+	);
+
+	expect($result)->toContain('\u003C\/script\u003E')
+		->and($result)->toContain('\u0027')
+		->and($result)->not->toContain("</script><img")
+		->and($result)->not->toContain("main');alert(1)//");
+});
+
 // =====================================================================
 // html_split_string tests
 // =====================================================================

--- a/tree.php
+++ b/tree.php
@@ -2100,7 +2100,7 @@ function tree() : void {
 
 	$total_rows = get_total_row_data($_SESSION[SESS_USER_ID], $sql, $sql_params, 'tree');
 
-	$nav = html_nav_bar('tree.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Trees'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('tree.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Trees'), 'page', 'main');
 
 	form_start('tree.php', 'chk');
 

--- a/user_admin.php
+++ b/user_admin.php
@@ -890,7 +890,7 @@ function graph_perms_edit(string $tab, string $header_label) : void {
 				ON h.id = gl.host_id
 				$sql_where");
 
-			$nav = html_nav_bar('user_admin.php?action=user_edit&tab=permsg&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Graphs'), 'page', 'main');
+			$nav = html_nav_bar(cacti_url('user_admin.php', ['action' => 'user_edit', 'tab' => 'permsg', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Graphs'), 'page', 'main');
 
 			form_start('user_admin.php?tab=permsg&id=' . grv('id'), 'chk');
 
@@ -1012,7 +1012,7 @@ function graph_perms_edit(string $tab, string $header_label) : void {
 
 			$groups = db_fetch_assoc($sql_query);
 
-			$nav = html_nav_bar('user_admin.php?action=user_edit&tab=permsgr&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Groups'), 'page', 'main');
+			$nav = html_nav_bar(cacti_url('user_admin.php', ['action' => 'user_edit', 'tab' => 'permsgr', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Groups'), 'page', 'main');
 
 			form_start('user_admin.php?tab=permsd&id=' . grv('id'), 'chk');
 
@@ -1161,7 +1161,7 @@ function graph_perms_edit(string $tab, string $header_label) : void {
 
 			$hosts = db_fetch_assoc_prepared($sql_query, $sql_params);
 
-			$nav = html_nav_bar('user_admin.php?action=user_edit&tab=permsd&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Devices'), 'page', 'main');
+			$nav = html_nav_bar(cacti_url('user_admin.php', ['action' => 'user_edit', 'tab' => 'permsd', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Devices'), 'page', 'main');
 
 			form_start('user_admin.php?tab=permsd&id=' . grv('id'), 'chk');
 
@@ -1321,7 +1321,7 @@ function graph_perms_edit(string $tab, string $header_label) : void {
 				__('Total Graphs')
 			];
 
-			$nav = html_nav_bar('user_admin.php?action=user_edit&tab=permste&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Graph Templates'), 'page', 'main');
+			$nav = html_nav_bar(cacti_url('user_admin.php', ['action' => 'user_edit', 'tab' => 'permste', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Graph Templates'), 'page', 'main');
 
 			form_start('user_admin.php?tab=permste&id=' . grv('id'), 'chk');
 
@@ -1468,7 +1468,7 @@ function graph_perms_edit(string $tab, string $header_label) : void {
 
 			html_header_checkbox($display_text, false);
 
-			$nav = html_nav_bar('user_admin.php?action=user_edit&tab=permstr&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Trees'), 'page', 'main');
+			$nav = html_nav_bar(cacti_url('user_admin.php', ['action' => 'user_edit', 'tab' => 'permstr', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Trees'), 'page', 'main');
 
 			form_start('user_admin.php?tab=permstr&id=' . grv('id'), 'chk');
 
@@ -2264,7 +2264,7 @@ function user() : void {
 		]
 	];
 
-	$nav = html_nav_bar('user_admin.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 9, __('Users'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('user_admin.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 9, __('Users'), 'page', 'main');
 
 	form_start('user_admin.php', 'chk');
 

--- a/user_domains.php
+++ b/user_domains.php
@@ -652,7 +652,7 @@ function domains() : void {
 		]
 	];
 
-	$nav = html_nav_bar('user_user_domains.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('User Domains'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('user_user_domains.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 8, __('User Domains'), 'page', 'main');
 
 	form_start('user_domains.php', 'chk');
 

--- a/user_group_admin.php
+++ b/user_group_admin.php
@@ -654,7 +654,7 @@ function user_group_members_edit(string $header_label) : void {
 		__('Realm')
 	];
 
-	$nav = html_nav_bar('user_group_admin.php?action=edit&tab=members&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Users'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('user_group_admin.php', ['action' => 'edit', 'tab' => 'members', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Users'), 'page', 'main');
 
 	form_start('user_group_admin.php?tab=members&id=' . grv('id'), 'chk');
 
@@ -866,7 +866,7 @@ function user_group_graph_perms_edit(string $tab, string $header_label) : void {
 				ON h.id = gl.host_id
 				$sql_where");
 
-			$nav = html_nav_bar('user_group_admin.php?action=edit&tab=permsg&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 7, __('Graphs'), 'page', 'main');
+			$nav = html_nav_bar(cacti_url('user_group_admin.php', ['action' => 'edit', 'tab' => 'permsg', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 7, __('Graphs'), 'page', 'main');
 
 			form_start('user_group_admin.php?tab=permsg&id=' . grv('id'), 'chk');
 
@@ -1042,7 +1042,7 @@ function user_group_graph_perms_edit(string $tab, string $header_label) : void {
 				__('Hostname')
 			];
 
-			$nav = html_nav_bar('user_group_admin.php?action=edit&tab=permsd&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Devices'), 'page', 'main');
+			$nav = html_nav_bar(cacti_url('user_group_admin.php', ['action' => 'edit', 'tab' => 'permsd', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Devices'), 'page', 'main');
 
 			form_start('user_group_admin.php?tab=permsd&id=' . grv('id'), 'chk');
 
@@ -1188,7 +1188,7 @@ function user_group_graph_perms_edit(string $tab, string $header_label) : void {
 
 			$graphs = db_fetch_assoc_prepared($sql_query, [grv('id')]);
 
-			$nav = html_nav_bar('user_group_admin.php?action=edit&tab=permste&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Graph Templates'), 'page', 'main');
+			$nav = html_nav_bar(cacti_url('user_group_admin.php', ['action' => 'edit', 'tab' => 'permste', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Graph Templates'), 'page', 'main');
 
 			form_start('user_group_admin.php?tab=permste&id=' . grv('id'), 'chk');
 
@@ -1322,7 +1322,7 @@ function user_group_graph_perms_edit(string $tab, string $header_label) : void {
 
 			$trees = db_fetch_assoc($sql_query);
 
-			$nav = html_nav_bar('user_group_admin.php?action=edit&tab=permstr&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Trees'), 'page', 'main');
+			$nav = html_nav_bar(cacti_url('user_group_admin.php', ['action' => 'edit', 'tab' => 'permstr', 'id' => grv('id')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Trees'), 'page', 'main');
 
 			form_start('user_group_admin.php?tab=permstr&id=' . grv('id'), 'chk');
 
@@ -1919,7 +1919,7 @@ function user_group() : void {
 		]
 	];
 
-	$nav = html_nav_bar('user_group_admin.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Groups'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('user_group_admin.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Groups'), 'page', 'main');
 
 	form_start('user_group_admin.php', 'chk');
 

--- a/user_log.php
+++ b/user_log.php
@@ -115,7 +115,7 @@ function view_user_log() : void {
 		'ip'        => [__('IP Address'), 'DESC']
 	];
 
-	$nav = html_nav_bar('user_log.php?user_id=' . grv('user_id') . '&filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 6, __('Login Attempts'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('user_log.php', ['user_id' => grv('user_id'), 'filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 6, __('Login Attempts'), 'page', 'main');
 
 	print $nav;
 

--- a/utilities.php
+++ b/utilities.php
@@ -463,7 +463,7 @@ function utilities_view_snmp_cache() : void {
 		__('OID')
 	];
 
-	$nav = html_nav_bar('utilities.php?action=view_snmp_cache&host_id=' . grv('host_id') . '&filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 6, __('Entries'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('utilities.php', ['action' => 'view_snmp_cache', 'host_id' => grv('host_id'), 'filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 6, __('Entries'), 'page', 'main');
 
 	print $nav;
 
@@ -604,7 +604,7 @@ function utilities_view_poller_cache() : void {
 		'nosort'         => [__('Details'), 'ASC']
 	];
 
-	$nav = html_nav_bar('utilities.php?action=view_poller_cache&filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 3, __('Entries'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('utilities.php', ['action' => 'view_poller_cache', 'filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 3, __('Entries'), 'page', 'main');
 
 	print $nav;
 
@@ -1632,7 +1632,7 @@ function snmpagent_utilities_run_cache() : void {
 	];
 
 	// generate page list
-	$nav = html_nav_bar('utilities.php?action=view_snmpagent_cache&mib=' . grv('mib') . '&filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Entries'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('utilities.php', ['action' => 'view_snmpagent_cache', 'mib' => grv('mib'), 'filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Entries'), 'page', 'main');
 
 	print $nav;
 
@@ -1848,7 +1848,7 @@ function snmpagent_utilities_run_eventlog() : void {
 
 	$logs = db_fetch_assoc_prepared($sql_query, $sql_params);
 
-	$nav = html_nav_bar('utilities.php?action=view_snmpagent_events&severity=' . grv('severity') . '&receiver=' . grv('receiver') . '&filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Log Entries'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('utilities.php', ['action' => 'view_snmpagent_events', 'severity' => grv('severity'), 'receiver' => grv('receiver'), 'filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 11, __('Log Entries'), 'page', 'main');
 
 	form_start('managers.php', 'chk');
 

--- a/vdef.php
+++ b/vdef.php
@@ -736,7 +736,7 @@ function vdef(bool $refresh = true) : void {
 
 	$vdefs = get_vdef_records($total_rows, $rows);
 
-	$nav = html_nav_bar('vdef.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('VDEFs'), 'page', 'main');
+	$nav = html_nav_bar(cacti_url('vdef.php', ['filter' => grv('filter')]), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('VDEFs'), 'page', 'main');
 
 	form_start('vdef.php', 'chk');
 


### PR DESCRIPTION
Stacked on #7252. Review this after the output-context helper PR; until #7252 merges, GitHub's develop-based diff may also show the helper commit.

Routes pagination/filter URLs through `cacti_url()` and encodes pagination JavaScript values with `cacti_js_encode()` before they enter inline scripts. This keeps the helper PR focused while moving the first batch of list-page pagination call sites to structured URL construction.

Also adds focused coverage that `html_nav_bar()` encodes URL and target values before rendering JavaScript.

Validation: `php -l lib/html.php`; `php -l lib/html_utility.php`; `php -l tests/Unit/HtmlEscapeTest.php`; `git diff --check`. Pest was not run locally because this worktree's vendored Composer tree is incomplete.
