### PR TITLE
hardening(rendering): move inline page data to encoded contexts

### DIFF
--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -1408,14 +1408,14 @@ function graph_edit() : bool {
 				}
 
 				function changeTotalsType() {
-					if ($('#total_type').val() == '<?php print AGGREGATE_TOTAL_TYPE_SIMILAR; ?>') {
+					if ($('#total_type').val() == <?php print cacti_js_encode((string) AGGREGATE_TOTAL_TYPE_SIMILAR); ?>) {
 						if ($('#total_prefix').val() == '' && $('#id').val() == 0) {
-							$('#total_prefix').attr('value', '<?php print __('Total'); ?>');
+							$('#total_prefix').val(<?php print cacti_js_encode(__('Total')); ?>);
 						}
-					} else if ($('#total_type').val() == '<?php print AGGREGATE_TOTAL_TYPE_ALL; ?>') {
+					} else if ($('#total_type').val() == <?php print cacti_js_encode((string) AGGREGATE_TOTAL_TYPE_ALL); ?>) {
 						if ($('#total_prefix').val() == '' && $('#id').val() == 0) {
 							if ($('#total_prefix').val() == '') {
-								$('#total_prefix').attr('value', '<?php print __('All Items'); ?>');
+								$('#total_prefix').val(<?php print cacti_js_encode(__('All Items')); ?>);
 							}
 						}
 					}

--- a/aggregate_templates.php
+++ b/aggregate_templates.php
@@ -501,7 +501,7 @@ function aggregate_template_edit() : void {
 		}
 
 		function changeTotals() {
-			var showField = $('#total').val() == '<?php print AGGREGATE_TOTAL_NONE; ?>';
+			var showField = $('#total').val() == <?php print cacti_js_encode((string) AGGREGATE_TOTAL_NONE); ?>;
 
 			toggleField({
 				total_type: showField,
@@ -515,11 +515,11 @@ function aggregate_template_edit() : void {
 		function changeTotalsType() {
 			if ($('#total_type').val() == <?php print AGGREGATE_TOTAL_TYPE_SIMILAR; ?>) {
 				if ($('#total_prefix').val() == '' && $('#id').val() == 0) {
-					$('#total_prefix').attr('value', '<?php print __('Total'); ?>');
+					$('#total_prefix').val(<?php print cacti_js_encode(__('Total')); ?>);
 				}
 			} else if ($('#total_type').val() == <?php print AGGREGATE_TOTAL_TYPE_ALL; ?>) {
 				if ($('#total_prefix').val() == '' && $('#id').val() == 0) {
-					$('#total_prefix').attr('value', '<?php print __('All Items'); ?>');
+					$('#total_prefix').val(<?php print cacti_js_encode(__('All Items')); ?>);
 				}
 			}
 		}

--- a/auth_profile.php
+++ b/auth_profile.php
@@ -119,7 +119,7 @@ switch (grv('action')) {
 
 			foreach ($tabs as $tab_short_name => $attribs) {
 				print "<li class='subTab'><a class='tab" . (($tab_short_name == $current_tab) ? " selected'" : "'") .
-					" href='" . htmle($attribs['url']) .
+					" href='" . html_escape_url($attribs['url']) .
 					"'>" . $attribs['display'] . '</a></li>';
 
 				$i++;
@@ -617,12 +617,19 @@ function settings_2fa() : bool {
 
 	form_save_buttons($buttons, $_SESSION['profile_referer']);
 
+	print cacti_script_data('auth-profile-2fa-context', [
+		'enabled'  => $current_user['tfa_enabled'] != '',
+		'enabling' => __('Enabling...'),
+		'text'     => $current_user['tfa_enabled'] != '' ? __('Enabled') : __('Disabled'),
+	]);
+
 	?>
 	<script type='text/javascript'>
-		var tfa_enabled = <?php print $current_user['tfa_enabled'] != '' ? 'true' : 'false'; ?>;
-		var tfa_text = '<?php print $current_user['tfa_enabled']   != '' ? __('Enabled') : __('Disabled'); ?>';
+		var authProfile2fa = JSON.parse(document.getElementById('auth-profile-2fa-context').textContent);
+		var tfa_enabled = authProfile2fa.enabled;
+		var tfa_text = authProfile2fa.text;
 		var tfa_verified = false;
-		var tfa_enabling = '<?php print __('Enabling...'); ?>';
+		var tfa_enabling = authProfile2fa.enabling;
 
 		function set2FAText(text, id, cls) {
 			if (id === undefined) {
@@ -662,13 +669,13 @@ function settings_2fa() : bool {
 					} else {
 						$('#tfa_enabled').prop('disabled', false);
 					}
-				} else {
-					$.post('auth_profile.php?action=disable_2fa', {__csrf_magic: csrfMagicToken}, function(data) {
-						$('#tfa_enabled').prop('disabled', false);
-						set2FAText('<?php print __('Disabled') ?>');
-						$('#row_tfa_token,#row_tfa_verify').hide();
-					}, 'json');
-				}
+					} else {
+						$.post('auth_profile.php?action=disable_2fa', {__csrf_magic: csrfMagicToken}, function(data) {
+							$('#tfa_enabled').prop('disabled', false);
+							set2FAText(<?php print cacti_js_encode(__('Disabled')); ?>);
+							$('#row_tfa_token,#row_tfa_verify').hide();
+						}, 'json');
+					}
 			});
 			$('#tfa_verify').click(function(e) {
 				var code = $('#tfa_token').val();
@@ -694,13 +701,35 @@ function settings_2fa() : bool {
 }
 
 function settings_javascript() : void {
+	print cacti_script_data('auth-profile-settings-context', [
+		'authMethod'         => read_config_option('auth_method'),
+		'authMethodBasic'    => AUTH_METHOD_BASIC,
+		'currentLang'        => read_config_option('user_language'),
+		'currentTab'         => (string) grv('tab'),
+		'currentTheme'       => get_selected_theme(),
+		'privateDataCleared' => __('Private Data Cleared'),
+		'privateDataMessage' => __('Your Private Data has been cleared.'),
+		'reset'              => __('Reset'),
+		'sessionsCleared'    => __('User Sessions Cleared'),
+		'sessionsMessage'    => __('All your login sessions have been cleared.'),
+		'themeFonts'         => read_config_option('font_method'),
+	]);
 	?>
 	<script type='text/javascript'>
-		var themeFonts = <?php print read_config_option('font_method'); ?>;
-		var currentTab = <?php print json_encode((string) grv('tab')); ?>;
-		var currentTheme = '<?php print get_selected_theme(); ?>';
-		var currentLang = '<?php print read_config_option('user_language'); ?>';
-		var authMethod = '<?php print read_config_option('auth_method'); ?>';
+		var authProfileSettings = JSON.parse(document.getElementById('auth-profile-settings-context').textContent);
+		var themeFonts = authProfileSettings.themeFonts;
+		var currentTab = authProfileSettings.currentTab;
+		var currentTheme = authProfileSettings.currentTheme;
+		var currentLang = authProfileSettings.currentLang;
+		var authMethod = authProfileSettings.authMethod;
+
+		function appendProfileDialog(id, title, message) {
+			$('<div>', {
+				style: 'display:none;',
+				id: id,
+				title: title
+			}).append($('<p>').text(message)).appendTo('body');
+		}
 
 		function clearUserSettings() {
 			$('#clear_settings').blur();
@@ -715,7 +744,7 @@ function settings_javascript() : void {
 			Storages.localStorage.removeAll();
 			Storages.sessionStorage.removeAll();
 
-			$('body').append('<div style="display:none;" id="cleared" title="<?php print __esc('Private Data Cleared'); ?>"><p><?php print __('Your Private Data has been cleared.'); ?></p></div>');
+			appendProfileDialog('cleared', authProfileSettings.privateDataCleared, authProfileSettings.privateDataMessage);
 
 			$('#private_data').blur();
 			$('#cleared').dialog({
@@ -737,7 +766,7 @@ function settings_javascript() : void {
 		function logoutEverywhere() {
 			$('#logout_everywhere').blur();
 			$.get('auth_profile.php?action=logout_everywhere', function(data) {
-				$('body').append('<div style="display:none;" id="cleared" title="<?php print __esc('User Sessions Cleared'); ?>"><p><?php print __('All your login sessions have been cleared.'); ?></p></div>');
+				appendProfileDialog('cleared', authProfileSettings.sessionsCleared, authProfileSettings.sessionsMessage);
 
 				$('#cleared').dialog({
 					modal: true,
@@ -796,7 +825,7 @@ function settings_javascript() : void {
 			$('#navigation, #navigation_right').show();
 			$('#tabs').find('li a.selected').removeClass('selected');
 
-			if (authMethod == <?= AUTH_METHOD_BASIC ?>) {
+			if (authMethod == authProfileSettings.authMethodBasic) {
 				$('#row_logout_everywhere').hide();
 			}
 
@@ -806,7 +835,13 @@ function settings_javascript() : void {
 						function() {
 							var id = $(this).find('select, input[type!="button"]').attr('id');
 
-							$('<a class="resetHover" data-id="' + id + '" style="padding-left:10px" href="#"><?php print __('Reset'); ?></a>').appendTo($(this));
+							$('<a>', {
+								class: 'resetHover',
+								'data-id': id,
+								style: 'padding-left:10px',
+								href: '#',
+								text: authProfileSettings.reset
+							}).appendTo($(this));
 							$('.resetHover').on('click', function(event) {
 								event.preventDefault();
 
@@ -814,7 +849,11 @@ function settings_javascript() : void {
 
 								if (id != undefined) {
 									var resetOptions = {
-										url: 'auth_profile.php?tab=' + currentTab + '&action=reset_default&name=' + id,
+										url: 'auth_profile.php?' + $.param({
+											tab: currentTab,
+											action: 'reset_default',
+											name: id
+										}),
 										noState: true,
 									};
 
@@ -849,7 +888,10 @@ function settings_javascript() : void {
 				}
 
 				var options = {
-					url: 'auth_profile.php?tab=' + currentTab + '&action=update_data',
+					url: 'auth_profile.php?' + $.param({
+						tab: currentTab,
+						action: 'update_data'
+					}),
 					handle: false
 				}
 
@@ -874,7 +916,10 @@ function settings_javascript() : void {
 				}
 
 				var options = {
-					url: 'auth_profile.php?tab=' + currentTab + '&action=update_data',
+					url: 'auth_profile.php?' + $.param({
+						tab: currentTab,
+						action: 'update_data'
+					}),
 					handle: false
 				}
 

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5066,6 +5066,44 @@ function debug_log_return(string $type) : string {
 }
 
 /**
+ * Encodes a PHP value for direct inclusion in JavaScript.
+ *
+ * @param mixed $value The value to encode
+ *
+ * @return string The JavaScript-safe JSON literal
+ */
+function cacti_js_encode(mixed $value) : string {
+	$encoded = json_encode(
+		$value,
+		JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+	);
+
+	return $encoded !== false ? $encoded : 'null';
+}
+
+/**
+ * Builds a URL with RFC3986-encoded query parameters.
+ *
+ * @param string $path   The base URL or relative path
+ * @param array  $params Query parameters to append
+ *
+ * @return string The encoded URL
+ */
+function cacti_url(string $path, array $params = []) : string {
+	if (cacti_sizeof($params) == 0) {
+		return $path;
+	}
+
+	$query = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+
+	if ($query == '') {
+		return $path;
+	}
+
+	return $path . (str_contains($path, '?') ? '&' : '?') . $query;
+}
+
+/**
  * Strips any character that cannot safely appear in a SQL identifier.
  * Allows word characters, dots (table.column), parentheses and INET_ATON-style
  * wrappers already used by the sort helpers.  Use before concatenating a

--- a/lib/html.php
+++ b/lib/html.php
@@ -1346,6 +1346,40 @@ function htmle(mixed $string) : string {
 }
 
 /**
+ * html_escape_attr - sanitizes a string for display in an HTML attribute
+ *
+ * @param mixed $string String the attribute value to escape
+ *
+ * @return string The escaped attribute value to be returned.
+ */
+function html_escape_attr(mixed $string = '') : string {
+	return html_escape($string);
+}
+
+/**
+ * html_escape_url - sanitizes a URL for display in an HTML attribute
+ *
+ * @param mixed $url URL the attribute value to escape
+ *
+ * @return string The escaped URL value to be returned.
+ */
+function html_escape_url(mixed $url = '') : string {
+	return html_escape_attr($url);
+}
+
+/**
+ * cacti_script_data - renders JSON data for scripts to read from the DOM
+ *
+ * @param string $id   HTML id for the script element
+ * @param mixed  $data Data to encode as a JavaScript-safe JSON literal
+ *
+ * @return string The script tag containing JSON data.
+ */
+function cacti_script_data(string $id, mixed $data) : string {
+	return "<script type='application/json' id='" . html_escape_attr($id) . "'>" . cacti_js_encode($data) . '</script>';
+}
+
+/**
  * html_escape - sanitizes a string for display
  *
  * @param mixed $string String the string to escape

--- a/tests/Unit/HtmlEscapeTest.php
+++ b/tests/Unit/HtmlEscapeTest.php
@@ -59,6 +59,53 @@ test('html_escape handles ampersand in plain text', function () {
 	expect(html_escape('a&b'))->toBe('a&amp;b');
 });
 
+test('html_escape_attr encodes attribute delimiters', function () {
+	$result = html_escape_attr('" onmouseover="alert(1)');
+
+	expect($result)->toBe('&quot; onmouseover=&quot;alert(1)');
+});
+
+test('html_escape_attr encodes backticks', function () {
+	expect(html_escape_attr('` autofocus onfocus=alert(1)'))->toBe('&#96; autofocus onfocus=alert(1)');
+});
+
+test('html_escape_url encodes URL attribute delimiters', function () {
+	expect(html_escape_url('https://example.invalid/?q=" onmouseover="alert(1)'))
+		->toBe('https://example.invalid/?q=&quot; onmouseover=&quot;alert(1)');
+});
+
+test('cacti_js_encode escapes script-sensitive characters', function () {
+	$result = cacti_js_encode("</script><img src=x onerror='alert(1)'>");
+
+	expect($result)->toContain('\u003C')
+		->and($result)->toContain('\u0027')
+		->and($result)->not->toContain('</script>');
+});
+
+test('cacti_url appends encoded query parameters', function () {
+	expect(cacti_url('foo.php', [
+		'filter' => "a b&c'",
+		'page'   => 2,
+	]))->toBe('foo.php?filter=a%20b%26c%27&page=2');
+});
+
+test('cacti_url preserves existing query strings', function () {
+	expect(cacti_url('foo.php?action=view', [
+		'filter' => 'a+b',
+	]))->toBe('foo.php?action=view&filter=a%2Bb');
+});
+
+test('cacti_script_data renders JSON without exposing script delimiters', function () {
+	$result = cacti_script_data('ctx" onmouseover="alert(1)', [
+		'message' => "</script><img src=x onerror='alert(1)'>",
+	]);
+
+	expect($result)->toContain("type='application/json'")
+		->and($result)->toContain("id='ctx&quot; onmouseover=&quot;alert(1)'")
+		->and($result)->toContain('\u003C\/script\u003E')
+		->and($result)->not->toContain('</script><img');
+});
+
 // =====================================================================
 // html_split_string tests
 // =====================================================================

--- a/tests/Unit/JsContextHardeningTest.php
+++ b/tests/Unit/JsContextHardeningTest.php
@@ -29,9 +29,25 @@ $dataDebugPath = __DIR__ . '/../../data_debug.php';
 test('auth_profile encodes tab for JavaScript and redirect URL', function () use ($authProfilePath) {
 	$contents = file_get_contents($authProfilePath);
 
-	expect($contents)->toContain("json_encode((string) grv('tab'))");
+	expect($contents)->toContain("cacti_script_data('auth-profile-settings-context'");
+	expect($contents)->toContain("'currentTab'         => (string) grv('tab')");
+	expect($contents)->toContain("JSON.parse(document.getElementById('auth-profile-settings-context').textContent)");
+	expect($contents)->toContain("url: 'auth_profile.php?' + $.param({");
 	expect($contents)->toContain("gfrv('tab', FILTER_VALIDATE_REGEXP");
 	expect($contents)->toContain('rawurlencode($currentTab)');
+});
+
+test('auth_profile does not interpolate profile settings directly into JavaScript strings', function () use ($authProfilePath) {
+	$contents = file_get_contents($authProfilePath);
+
+	expect($contents)->toContain("cacti_script_data('auth-profile-2fa-context'");
+	expect($contents)->toContain("JSON.parse(document.getElementById('auth-profile-2fa-context').textContent)");
+	expect($contents)->not->toContain("var currentTheme = '<?php print get_selected_theme(); ?>';");
+	expect($contents)->not->toContain("var currentLang = '<?php print read_config_option('user_language'); ?>';");
+	expect($contents)->not->toContain("var authMethod = '<?php print read_config_option('auth_method'); ?>';");
+	expect($contents)->not->toContain("var tfa_text = '<?php print");
+	expect($contents)->not->toContain("var tfa_enabling = '<?php print");
+	expect($contents)->not->toContain("<?php print __('Reset'); ?></a>");
 });
 
 test('plugins page normalizes state and encodes sort column in JavaScript', function () use ($pluginsPath) {


### PR DESCRIPTION
Stacked on #7252. Review this after the output-context helper PR; until #7252 merges, GitHub's develop-based diff may also show the helper commit.

Moves a narrow set of inline page-script values to explicit encoded contexts. `auth_profile.php` now passes settings and 2FA text through JSON script-data blocks and builds dynamic profile URLs with `$.param()`. The aggregate total-prefix scripts now use `cacti_js_encode()` for translated strings and constants, and write values with `.val()` instead of string-built attribute writes.

Includes source-regression checks to keep the converted auth profile patterns from reverting to direct PHP-in-JS string interpolation.

Validation: `php -l auth_profile.php`; `php -l aggregate_templates.php`; `php -l aggregate_graphs.php`; `php -l tests/Unit/JsContextHardeningTest.php`; `git diff --check`. Pest was not run locally because this worktree's vendored Composer tree is incomplete.
