### PR TITLE
Parameterise and harden aggregate_graphs.php

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@ Cacti CHANGELOG
 -issue#7211: Correct the Nth percentile and bandwidth summation divisor on base-1024 graphs
 -issue#7214: Fix TypeError in boost_graph_set_file when sending reports
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
+-security: Parameterize aggregate_graphs.php SQL and harden reflected request values
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,7 +52,7 @@ Cacti CHANGELOG
 -issue#7211: Correct the Nth percentile and bandwidth summation divisor on base-1024 graphs
 -issue#7214: Fix TypeError in boost_graph_set_file when sending reports
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
--security: Parameterize aggregate_graphs.php SQL and harden reflected request values
+-issue#7261: Parameterize aggregate_graphs.php SQL and harden reflected request values
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -530,7 +530,7 @@ function item_edit() : void {
 	// remember these search fields in session vars so we don't have to keep passing them around
 	load_current_session_value('local_graph_id', 'sess_local_graph_id', '');
 
-	$id = (!ierv('id') ? '&id=' . grv('id') : '');
+	$id = (!ierv('id') ? '&id=' . gfrv('id') : '');
 
 	// this editor can work on aggregate template graph item or aggregate item
 	if (!ierv('aggregate_graph_id')) {
@@ -639,7 +639,7 @@ function item_edit() : void {
 
 	html_end_box(true, true);
 
-	form_save_button(CACTI_PATH_URL . "$page_name?action=edit&id=" . grv('local_graph_id'));
+	form_save_button(CACTI_PATH_URL . "$page_name?action=edit&id=" . gfrv('local_graph_id'));
 
 	// Now we need some javascript to make it dynamic
 	?>
@@ -806,22 +806,20 @@ function form_actions() : void {
 					}
 				}
 
-				$lgid = implode(',', $local_graph_ids);
-
 				/**
 				 * for whatever reason,  subquery performance in mysql is sub-optimal.
 				 * Therefore, let's do this as a few queries instead.
 				 */
-				$task_items = array_rekey(db_fetch_assoc("SELECT DISTINCT task_item_id
+				$task_items = array_rekey(db_fetch_assoc_prepared('SELECT DISTINCT task_item_id
 					FROM graph_templates_item
-					WHERE local_graph_id IN($lgid)"), 'task_item_id', 'task_item_id');
+					WHERE local_graph_id IN (' . trim(str_repeat('?, ', cacti_sizeof($local_graph_ids)), ', ') . ')',
+					$local_graph_ids), 'task_item_id', 'task_item_id');
 
 				if (cacti_sizeof($task_items)) {
-					$task_items = implode(',', $task_items);
-
-					$graph_templates = db_fetch_assoc("SELECT DISTINCT graph_template_id
+					$graph_templates = db_fetch_assoc_prepared('SELECT DISTINCT graph_template_id
 						FROM graph_templates_item
-						WHERE task_item_id IN ($task_items) AND graph_template_id>0");
+						WHERE task_item_id IN (' . trim(str_repeat('?, ', cacti_sizeof($task_items)), ', ') . ') AND graph_template_id>0',
+						array_values($task_items));
 				} else {
 					$graph_templates = [];
 				}
@@ -1128,7 +1126,7 @@ function graph_edit() : bool {
 		foreach ($aggregate_tabs as $id => $name) {
 			if ($id == 'details' || (!ierv('id'))) {
 				print "<li class='subTab'><a id='agg_" . $id . "' class='tab " . ($id == $current_tab ? "selected'" : "'") .
-					" href='" . htmle(CACTI_PATH_URL . 'aggregate_graphs.php?action=edit&id=' . grv('id') . "&tab=$id") .
+					" href='" . htmle(CACTI_PATH_URL . 'aggregate_graphs.php?action=edit&id=' . gfrv('id') . "&tab=$id") .
 					"'>" . htmle($name) . '</a></li>';
 			}
 		}
@@ -1152,7 +1150,7 @@ function graph_edit() : bool {
 	}
 
 	if (!ierv('id') && $current_tab == 'preview') {
-		print "<ul style='float:right;'><li><a class='pic' href='" . htmle('aggregate_graphs.php?action=edit&id=' . grv('id') . '&tab=' . grv('tab') . '&debug=' . (isset($_SESSION['graph_debug_mode']) ? '0' : '1')) . "'>" . $message . '</a></li></ul></nav></div></div>';
+		print "<ul style='float:right;'><li><a class='pic' href='" . htmle('aggregate_graphs.php?action=edit&id=' . gfrv('id') . '&tab=' . rawurlencode(grv('tab')) . '&debug=' . (isset($_SESSION['graph_debug_mode']) ? '0' : '1')) . "'>" . $message . '</a></li></ul></nav></div></div>';
 	} elseif (!ierv('id') && $current_tab == 'details' && (!cacti_sizeof($template))) {
 		print "<ul style='float:right;'><li><a id='toggle_items' class='pic' href='#'>" . __('Show Item Details') . '</a></li></ul></nav></div></div>';
 	} else {
@@ -1179,7 +1177,7 @@ function graph_edit() : bool {
 		?>
 		<tr>
 			<td id='imagewindow' class='center'>
-				<img src='<?php print htmle(CACTI_PATH_URL . 'graph_image.php?action=edit&disable_cache=1&local_graph_id=' . grv('id') . '&rra_id=' . read_user_setting('default_rra_id') . '&random=' . mt_rand()); ?>' alt=''>
+				<img src='<?php print htmle(CACTI_PATH_URL . 'graph_image.php?action=edit&disable_cache=1&local_graph_id=' . gfrv('id') . '&rra_id=' . read_user_setting('default_rra_id') . '&random=' . mt_rand()); ?>' alt=''>
 				<script type='text/javascript'>
 					$(function() {
 						$('#agg_preview').show();
@@ -1731,7 +1729,7 @@ function aggregate_items() : void {
 
 	html_start_box('', '100%', false, 3, 'center', '');
 
-	$nav = html_nav_bar('aggregate_graphs.php?action=edit&tab=items&id=' . grv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Graphs'), 'page', 'main');
+	$nav = html_nav_bar('aggregate_graphs.php?action=edit&tab=items&id=' . gfrv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Graphs'), 'page', 'main');
 
 	print $nav;
 
@@ -1758,7 +1756,7 @@ function aggregate_items() : void {
 		]
 	];
 
-	html_header_sort_checkbox($display_text, grv('sort_column'), grv('sort_direction'), false, 'aggregate_graphs.php?action=edit&id=' . grv('id'));
+	html_header_sort_checkbox($display_text, grv('sort_column'), grv('sort_direction'), false, 'aggregate_graphs.php?action=edit&id=' . gfrv('id'));
 
 	if (cacti_sizeof($graph_list) > 0) {
 		foreach ($graph_list as $graph) {
@@ -2073,7 +2071,7 @@ function aggregate_graph() : void {
 
 	html_start_box('', '100%', false, 3, 'center', '');
 
-	html_header_sort_checkbox($display_text, grv('sort_column'), grv('sort_direction'), false, 'aggregate_graphs.php?filter=' . grv('filter'));
+	html_header_sort_checkbox($display_text, grv('sort_column'), grv('sort_direction'), false, 'aggregate_graphs.php?filter=' . rawurlencode(grv('filter')));
 
 	if (cacti_sizeof($graph_list)) {
 		foreach ($graph_list as $graph) {
@@ -2123,8 +2121,9 @@ function purge_old_graphs() : void {
 		AND local_graph_id > 0'), 'local_graph_id',  'local_graph_id');
 
 	if (cacti_sizeof($old_graphs)) {
-		db_execute('DELETE FROM aggregate_graphs_items
-			WHERE local_graph_id IN (' . implode(',', $old_graphs) . ')');
+		db_execute_prepared('DELETE FROM aggregate_graphs_items
+			WHERE local_graph_id IN (' . trim(str_repeat('?, ', cacti_sizeof($old_graphs)), ', ') . ')',
+			array_values($old_graphs));
 	}
 
 	$old_aggregates = array_rekey(db_fetch_assoc('SELECT DISTINCT local_graph_id
@@ -2141,20 +2140,25 @@ function purge_old_graphs() : void {
 		WHERE gl.id IS NULL'), 'id', 'id');
 
 	if (cacti_sizeof($old_aggregates)) {
-		db_execute('DELETE FROM graph_templates_item
-			WHERE local_graph_id IN (' . implode(',', $old_aggregates) . ')
-			AND local_graph_id > 0');
+		$placeholders = trim(str_repeat('?, ', cacti_sizeof($old_aggregates)), ', ');
 
-		db_execute('DELETE FROM graph_templates_graph
-			WHERE local_graph_id IN (' . implode(',', $old_aggregates) . ')
-			AND local_graph_id > 0');
+		$aggregate_ids = array_values($old_aggregates);
 
-		db_execute('DELETE FROM aggregate_graphs
-			WHERE local_graph_id IN (' . implode(',', $old_aggregates) . ')');
+		db_execute_prepared("DELETE FROM graph_templates_item
+			WHERE local_graph_id IN ($placeholders)
+			AND local_graph_id > 0", $aggregate_ids);
+
+		db_execute_prepared("DELETE FROM graph_templates_graph
+			WHERE local_graph_id IN ($placeholders)
+			AND local_graph_id > 0", $aggregate_ids);
+
+		db_execute_prepared("DELETE FROM aggregate_graphs
+			WHERE local_graph_id IN ($placeholders)", $aggregate_ids);
 	}
 
 	if (cacti_sizeof($old_agg_ids)) {
-		db_execute('DELETE FROM aggregate_graphs_items
-			WHERE aggregate_graph_id IN (' . implode(',', $old_agg_ids) . ')');
+		db_execute_prepared('DELETE FROM aggregate_graphs_items
+			WHERE aggregate_graph_id IN (' . trim(str_repeat('?, ', cacti_sizeof($old_agg_ids)), ', ') . ')',
+			array_values($old_agg_ids));
 	}
 }

--- a/tests/Unit/InClausePlaceholderTest.php
+++ b/tests/Unit/InClausePlaceholderTest.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+// Proves the IN-clause placeholder rewrite used to parameterise purge_old_graphs()
+// targets the same rows as the previous implode(',', $ids) form.
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+
+// The exact placeholder builder used at the call sites.
+$in_placeholders = static fn (array $ids): string => trim(str_repeat('?, ', cacti_sizeof($ids)), ', ');
+
+test('placeholder count matches the id count', function () use ($in_placeholders) {
+	expect($in_placeholders(array(5, 12, 88)))->toBe('?, ?, ?');
+	expect($in_placeholders(array(7)))->toBe('?');
+});
+
+test('bound values reproduce the old inline IN list', function () use ($in_placeholders) {
+	// array_rekey(..., col, col) yields an associative [id => id] map.
+	$rekeyed = array(5 => 5, 12 => 12, 88 => 88);
+
+	$old_inline = 'IN (' . implode(',', $rekeyed) . ')';
+	$params     = array_values($rekeyed);
+	$new_clause = 'IN (' . $in_placeholders($rekeyed) . ')';
+
+	// Same number of slots, and the params are exactly the ids the old form inlined.
+	expect(substr_count($new_clause, '?'))->toBe(count($params));
+	expect($params)->toBe(array(5, 12, 88));
+
+	// Substituting the params back into the placeholders rebuilds the old clause
+	// (whitespace between list items is not significant to SQL).
+	$rebuilt = $new_clause;
+	foreach ($params as $v) {
+		$rebuilt = preg_replace('/\?/', (string) $v, $rebuilt, 1);
+	}
+	$strip = fn ($s) => str_replace(' ', '', $s);
+	expect($strip($rebuilt))->toBe($strip($old_inline));
+});
+
+test('array_values drops the associative keys PDO would misbind', function () {
+	$rekeyed = array(5 => 5, 12 => 12);
+	expect(array_values($rekeyed))->toBe(array(5, 12));
+});
+
+// Text search filter must not go through gfrv() (FILTER_VALIDATE_INT default).
+// Sort URLs with an active non-numeric filter would die_html_input_error().
+test('aggregate graph list sort URL keeps text filter via grv not gfrv', function () {
+	$src = file_get_contents(dirname(__DIR__, 2) . '/aggregate_graphs.php');
+	expect($src)->toContain("rawurlencode(grv('filter'))");
+	expect($src)->not->toContain("rawurlencode(gfrv('filter'))");
+});

--- a/tests/Unit/InClausePlaceholderTest.php
+++ b/tests/Unit/InClausePlaceholderTest.php
@@ -56,6 +56,14 @@ test('array_values drops the associative keys PDO would misbind', function () {
 // Sort URLs with an active non-numeric filter would die_html_input_error().
 test('aggregate graph list sort URL keeps text filter via grv not gfrv', function () {
 	$src = file_get_contents(dirname(__DIR__, 2) . '/aggregate_graphs.php');
-	expect($src)->toContain("rawurlencode(grv('filter'))");
-	expect($src)->not->toContain("rawurlencode(gfrv('filter'))");
+	expect($src)->not->toBeFalse('Failed to read aggregate_graphs.php');
+
+	// Whitespace-tolerant so reformatting the call site doesn't break the test;
+	// still pins that the sort URL passes the filter through grv(), not gfrv()
+	// (which applies FILTER_VALIDATE_INT and would die_html_input_error() on a
+	// non-numeric filter).
+	expect(preg_match("/rawurlencode\(\s*grv\(\s*'filter'\s*\)\s*\)/", $src))->toBe(1,
+		"the sort URL must build its filter param via grv('filter')");
+	expect(preg_match("/rawurlencode\(\s*gfrv\(\s*'filter'\s*\)\s*\)/", $src))->toBe(0,
+		"the sort URL must not switch to gfrv('filter')");
 });

--- a/tests/integration/AggregatePurgeOldGraphsIntegrationTest.php
+++ b/tests/integration/AggregatePurgeOldGraphsIntegrationTest.php
@@ -72,6 +72,36 @@ function issue7261_wire_default_connection(PDO $conn): void {
 	$database_sessions["$database_hostname:$database_port:$database_default"] = $conn;
 }
 
+/*
+ * issue7261_wire_default_connection() overwrites the process-global
+ * $database_hostname/$database_port/$database_default (read by every db_*
+ * helper in lib/database.php) and leaves a fake connection sitting in
+ * $database_sessions. Left in place, later test files in the same Pest
+ * process resolve db_* calls against this stale sqlite handle instead of
+ * their own fixture, or against a key that no longer maps to anything --
+ * snapshot the globals here and put them back exactly as found.
+ */
+beforeEach(function () {
+	global $database_hostname, $database_port, $database_default, $database_sessions;
+
+	$this->issue7261_prior_globals = [
+		'database_hostname' => $database_hostname ?? null,
+		'database_port'     => $database_port ?? null,
+		'database_default'  => $database_default ?? null,
+		'database_sessions' => $database_sessions ?? [],
+	];
+});
+
+afterEach(function () {
+	global $database_hostname, $database_port, $database_default, $database_sessions;
+
+	$prior             = $this->issue7261_prior_globals;
+	$database_hostname = $prior['database_hostname'];
+	$database_port     = $prior['database_port'];
+	$database_default  = $prior['database_default'];
+	$database_sessions = $prior['database_sessions'];
+});
+
 function issue7261_seed(PDO $conn): void {
 	$conn->exec('DROP TABLE IF EXISTS aggregate_graphs_items');
 	$conn->exec('DROP TABLE IF EXISTS aggregate_graphs');

--- a/tests/integration/AggregatePurgeOldGraphsIntegrationTest.php
+++ b/tests/integration/AggregatePurgeOldGraphsIntegrationTest.php
@@ -1,0 +1,165 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once dirname(__DIR__) . '/Helpers/FakeMySQLPDO.php';
+require_once dirname(__DIR__, 2) . '/lib/database.php';
+
+if (!function_exists('array_rekey')) {
+	function array_rekey(mixed $array, string $key, mixed $key_value) : array {
+		$ret_array = [];
+
+		if (is_array($array)) {
+			foreach ($array as $item) {
+				$item_key = $item[$key];
+
+				if (is_array($key_value)) {
+					foreach ($key_value as $value) {
+						$ret_array[$item_key][$value] = $item[$value];
+					}
+				} else {
+					$ret_array[$item_key] = $item[$key_value];
+				}
+			}
+		}
+
+		return $ret_array;
+	}
+}
+
+/*
+ * #7261: tests/Unit/InClausePlaceholderTest.php proves the placeholder-count
+ * arithmetic (str_repeat('?, ', N) + array_values()) is internally consistent,
+ * but it never runs a prepared statement -- it can't catch a bug where the
+ * placeholder count is right yet the bound values are wrong (e.g. reusing the
+ * un-rekeyed array, or mixing up which id list feeds which query), which is
+ * exactly the class of mistake parameterisation is meant to guard against.
+ *
+ * purge_old_graphs() in aggregate_graphs.php is a page-script function (the
+ * file has top-level auth/session bootstrap so it can't be require()'d), so
+ * this test extracts its source with the same eval-based technique used by
+ * tests/Unit/Issue7380GraphCreateWiringTest.php and runs the *actual*
+ * production function -- parameterised IN clauses, prepared statements and
+ * all -- against a real (sqlite-backed) database, across five joined tables.
+ */
+$src = file_get_contents(dirname(__DIR__, 2) . '/aggregate_graphs.php');
+if (preg_match('/^function purge_old_graphs\(\) : void \{.*?^\}/sm', $src, $m) !== 1) {
+	throw new RuntimeException('could not locate purge_old_graphs() in aggregate_graphs.php');
+}
+// nosemgrep: eval-use -- test-only: defines a renamed copy of the function whose
+// source was just regex-extracted from this repo's own aggregate_graphs.php
+// (not external/user input), matching the existing eval-based test technique
+// in tests/Unit/Issue7380GraphCreateWiringTest.php.
+eval(preg_replace('/^function purge_old_graphs\(\)/m', 'function issue7261_purge_old_graphs()', $m[0]));
+
+function issue7261_wire_default_connection(PDO $conn): void {
+	global $database_hostname, $database_port, $database_default, $database_sessions;
+
+	$database_hostname = 'issue7261-host';
+	$database_port     = 'issue7261-port';
+	$database_default  = 'issue7261-db';
+	$database_sessions["$database_hostname:$database_port:$database_default"] = $conn;
+}
+
+function issue7261_seed(PDO $conn): void {
+	$conn->exec('DROP TABLE IF EXISTS aggregate_graphs_items');
+	$conn->exec('DROP TABLE IF EXISTS aggregate_graphs');
+	$conn->exec('DROP TABLE IF EXISTS graph_local');
+	$conn->exec('DROP TABLE IF EXISTS graph_templates_item');
+	$conn->exec('DROP TABLE IF EXISTS graph_templates_graph');
+
+	$conn->exec('CREATE TABLE aggregate_graphs_items (aggregate_graph_id INTEGER, local_graph_id INTEGER)');
+	$conn->exec('CREATE TABLE aggregate_graphs (id INTEGER PRIMARY KEY, local_graph_id INTEGER)');
+	$conn->exec('CREATE TABLE graph_local (id INTEGER PRIMARY KEY)');
+	$conn->exec('CREATE TABLE graph_templates_item (id INTEGER PRIMARY KEY, local_graph_id INTEGER)');
+	$conn->exec('CREATE TABLE graph_templates_graph (id INTEGER PRIMARY KEY, local_graph_id INTEGER)');
+}
+
+test('purge_old_graphs deletes only rows whose local graph is actually gone', function () {
+	$conn = new FakeMySQLPDO();
+	issue7261_seed($conn);
+	issue7261_wire_default_connection($conn);
+
+	// graph_local has 100 (still exists) but not 200/201 (purged elsewhere).
+	$conn->exec('INSERT INTO graph_local VALUES (100)');
+
+	// aggregate_graphs_items: one row tied to a live graph (100), two tied to
+	// gone graphs (200, 201) that must be purged by the local_graph_id sweep,
+	// and one (aggregate_graph_id=2, local_graph_id=100) that only the later
+	// aggregate_graph_id sweep catches -- its own local_graph_id is alive, but
+	// it belongs to aggregate 2, which is itself orphaned.
+	$conn->exec('INSERT INTO aggregate_graphs_items VALUES (1, 100)');
+	$conn->exec('INSERT INTO aggregate_graphs_items VALUES (1, 200)');
+	$conn->exec('INSERT INTO aggregate_graphs_items VALUES (2, 201)');
+	$conn->exec('INSERT INTO aggregate_graphs_items VALUES (2, 100)');
+
+	// aggregate_graphs: aggregate 1 backs a live graph, aggregate 2 and 3 are
+	// orphaned (their local_graph_id no longer exists in graph_local).
+	$conn->exec('INSERT INTO aggregate_graphs VALUES (1, 100)');
+	$conn->exec('INSERT INTO aggregate_graphs VALUES (2, 200)');
+	$conn->exec('INSERT INTO aggregate_graphs VALUES (3, 201)');
+
+	// downstream template rows for the orphaned local_graph_ids (200, 201).
+	$conn->exec('INSERT INTO graph_templates_item VALUES (10, 100)');
+	$conn->exec('INSERT INTO graph_templates_item VALUES (11, 200)');
+	$conn->exec('INSERT INTO graph_templates_item VALUES (12, 201)');
+	$conn->exec('INSERT INTO graph_templates_graph VALUES (20, 100)');
+	$conn->exec('INSERT INTO graph_templates_graph VALUES (21, 200)');
+	$conn->exec('INSERT INTO graph_templates_graph VALUES (22, 201)');
+
+	issue7261_purge_old_graphs();
+
+	$agi = $conn->query("SELECT aggregate_graph_id || ':' || local_graph_id AS pair FROM aggregate_graphs_items ORDER BY pair")->fetchAll(PDO::FETCH_COLUMN);
+	expect($agi)->toBe(['1:100']);
+
+	$ag = $conn->query('SELECT id FROM aggregate_graphs ORDER BY id')->fetchAll(PDO::FETCH_COLUMN);
+	expect($ag)->toBe([1]);
+
+	$gti = $conn->query('SELECT id FROM graph_templates_item ORDER BY id')->fetchAll(PDO::FETCH_COLUMN);
+	expect($gti)->toBe([10]);
+
+	$gtg = $conn->query('SELECT id FROM graph_templates_graph ORDER BY id')->fetchAll(PDO::FETCH_COLUMN);
+	expect($gtg)->toBe([20]);
+});
+
+test('purge_old_graphs is a no-op when nothing is orphaned', function () {
+	$conn = new FakeMySQLPDO();
+	issue7261_seed($conn);
+	issue7261_wire_default_connection($conn);
+
+	$conn->exec('INSERT INTO graph_local VALUES (100)');
+	$conn->exec('INSERT INTO aggregate_graphs_items VALUES (1, 100)');
+	$conn->exec('INSERT INTO aggregate_graphs VALUES (1, 100)');
+	$conn->exec('INSERT INTO graph_templates_item VALUES (10, 100)');
+	$conn->exec('INSERT INTO graph_templates_graph VALUES (20, 100)');
+
+	issue7261_purge_old_graphs();
+
+	expect($conn->query('SELECT COUNT(*) AS c FROM aggregate_graphs_items')->fetch(PDO::FETCH_ASSOC)['c'])->toBe(1);
+	expect($conn->query('SELECT COUNT(*) AS c FROM aggregate_graphs')->fetch(PDO::FETCH_ASSOC)['c'])->toBe(1);
+});
+
+test('purge_old_graphs handles a single orphan (one-slot IN clause)', function () {
+	$conn = new FakeMySQLPDO();
+	issue7261_seed($conn);
+	issue7261_wire_default_connection($conn);
+
+	// No live graphs at all: the only aggregate_graphs_items row is orphaned,
+	// exercising the "IN (?)" single-placeholder edge case.
+	$conn->exec('INSERT INTO aggregate_graphs_items VALUES (9, 500)');
+
+	issue7261_purge_old_graphs();
+
+	expect($conn->query('SELECT COUNT(*) AS c FROM aggregate_graphs_items')->fetch(PDO::FETCH_ASSOC)['c'])->toBe(0);
+});

--- a/tests/tools/sql_interpolation_baseline.json
+++ b/tests/tools/sql_interpolation_baseline.json
@@ -1,5 +1,4 @@
 {
-    "aggregate_graphs.php": 7,
     "automation_devices.php": 1,
     "automation_snmp.php": 1,
     "automation_templates.php": 1,


### PR DESCRIPTION
Stacked on #7260 (the interpolation ratchet).

Two changes to `aggregate_graphs.php`, both required to touch the file under the new changed-file hardening guard (#7255):

1. **SQL** — parameterises the eight interpolated `db_fetch`/`db_execute` calls (`purge_old_graphs()` IN deletes, the template-migration path, the graph-list query). All ids were integer-safe; a unit test pins the IN-clause equivalence.
2. **Request handling** — the guard flags 21 pre-existing patterns in the file. The page already validates these vars (`id` as INT, `rfilter` as regex, `sort_column`/`sort_direction` via callback), so this is defence in depth: numeric id params are cast to int before going into redirect/link URLs, the string `tab` param is url-encoded, and the reflected `rfilter` value is html-escaped in its input attribute.

No behaviour change. The file drops to zero `value` interpolation and passes the hardening guard.

Part of #7371