### PR TITLE
Parameterise IN-clause SQL in lib/ (utility, device, data source)

### DIFF
--- a/lib/api_data_source.php
+++ b/lib/api_data_source.php
@@ -229,11 +229,11 @@ function api_data_source_remove_multi(array $local_data_ids, bool $update_totals
 	foreach ($local_data_ids_chunks as $ids_to_delete) {
 		$poller_ids = get_remote_poller_ids_from_data_sources($ids_to_delete);
 
-		$ids_to_delete = implode(', ', array_map('intval', $ids_to_delete));
+		$ids_to_delete = array_map('intval', $ids_to_delete);
 
 		$data_template_data_ids = db_fetch_assoc('SELECT id
 			FROM data_template_data
-			WHERE local_data_id IN (' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		if (cacti_sizeof($data_template_data_ids)) {
 			$dtd_ids_to_delete = [];
@@ -243,13 +243,13 @@ function api_data_source_remove_multi(array $local_data_ids, bool $update_totals
 
 				if (cacti_sizeof($dtd_ids_to_delete) >= 1000) {
 					db_execute('DELETE FROM data_input_data
-						WHERE data_template_data_id IN (' . implode(',', $dtd_ids_to_delete) . ')');
+						WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id') . '');
 
 					if (cacti_sizeof($poller_ids)) {
 						foreach ($poller_ids as $poller_id) {
 							if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
 								db_execute('DELETE FROM data_input_data
-									WHERE data_template_data_id IN (' . implode(',', $dtd_ids_to_delete) . ')', true, $rcnn_id);
+									WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id') . '', true, $rcnn_id);
 							}
 						}
 					}
@@ -260,13 +260,13 @@ function api_data_source_remove_multi(array $local_data_ids, bool $update_totals
 
 			if (cacti_sizeof($dtd_ids_to_delete)) {
 				db_execute('DELETE FROM data_input_data
-					WHERE data_template_data_id IN (' . implode(',', $dtd_ids_to_delete) . ')');
+					WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id') . '');
 
 				if (cacti_sizeof($poller_ids)) {
 					foreach ($poller_ids as $poller_id) {
 						if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
 							db_execute('DELETE FROM data_input_data
-								WHERE data_template_data_id IN (' . implode(',', $dtd_ids_to_delete) . ')', true, $rcnn_id);
+								WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id') . '', true, $rcnn_id);
 						}
 					}
 				}
@@ -275,80 +275,81 @@ function api_data_source_remove_multi(array $local_data_ids, bool $update_totals
 
 		// prepare auto-clean if enabled
 		if ($autoclean == 'on') {
-			db_execute("INSERT INTO data_source_purge_action (local_data_id, name, action)
-				SELECT local_data_id, REPLACE(data_source_path, '<path_rra>/', ''), '" . $acmethod . "'
+			db_execute_prepared("INSERT INTO data_source_purge_action (local_data_id, name, action)
+				SELECT local_data_id, REPLACE(data_source_path, '<path_rra>/', ''), ?
 				FROM data_template_data
-				WHERE local_data_id IN (" . $ids_to_delete . ')
-				ON DUPLICATE KEY UPDATE action=VALUES(action)');
+				WHERE " . array_to_sql_or($ids_to_delete, 'local_data_id') . '
+				ON DUPLICATE KEY UPDATE action=VALUES(action)',
+				[$acmethod]);
 		}
 
 		// core data
 		db_execute('DELETE FROM data_template_data
-			WHERE local_data_id IN (' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM data_template_rrd
-			WHERE local_data_id IN (' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM poller_item
-			WHERE local_data_id IN (' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM data_local
-			WHERE id IN (' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'id') . '');
 
 		db_execute('DELETE FROM data_debug
-			WHERE datasource IN (' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'datasource') . '');
 
 		// dsstats
 		db_execute('DELETE FROM data_source_stats_daily
-			WHERE local_data_id IN(' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM data_source_stats_hourly
-			WHERE local_data_id IN(' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM data_source_stats_hourly_cache
-			WHERE local_data_id IN(' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM data_source_stats_hourly_last
-			WHERE local_data_id IN(' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM data_source_stats_monthly
-			WHERE local_data_id IN(' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM data_source_stats_weekly
-			WHERE local_data_id IN(' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM data_source_stats_yearly
-			WHERE local_data_id IN(' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		// boost
 		db_execute('DELETE FROM poller_output
-			WHERE local_data_id IN (' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		db_execute('DELETE FROM poller_output_boost
-			WHERE local_data_id IN (' . $ids_to_delete . ')');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
 
 		if (cacti_sizeof($poller_ids)) {
 			foreach ($poller_ids as $poller_id) {
 				if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
 					// core data
 					db_execute('DELETE FROM data_template_data
-						WHERE local_data_id IN (' . $ids_to_delete . ')', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
 
 					db_execute('DELETE FROM data_template_rrd
-						WHERE local_data_id IN (' . $ids_to_delete . ')', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
 
 					db_execute('DELETE FROM poller_item
-						WHERE local_data_id IN (' . $ids_to_delete . ')', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
 
 					db_execute('DELETE FROM data_local
-						WHERE id IN (' . $ids_to_delete . ')', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'id') . '', true, $rcnn_id);
 
 					// boost
 					db_execute('DELETE FROM poller_output
-						WHERE local_data_id IN (' . $ids_to_delete . ')', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
 
 					db_execute('DELETE FROM poller_output_boost
-						WHERE local_data_id IN (' . $ids_to_delete . ')', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
 				}
 
 				api_data_source_cache_crc_update($poller_id);
@@ -440,23 +441,21 @@ function api_data_source_disable_multi(array $local_data_ids) : void {
 	$local_data_ids_chunks = array_chunk(array_map('intval', $local_data_ids), 1000);
 
 	foreach ($local_data_ids_chunks as $ids_to_disable) {
-		$ids_to_disable = implode(', ', $ids_to_disable);
-
 		$poller_ids += array_rekey(
 			db_fetch_assoc('SELECT poller_id
 				FROM poller_item
-				WHERE local_data_id IN(' . $ids_to_disable . ')'),
+				WHERE ' . array_to_sql_or($ids_to_disable, 'local_data_id') . ''),
 			'poller_id', 'poller_id'
 		);
 
-		db_execute("DELETE FROM poller_item WHERE local_data_id IN ($ids_to_disable)");
-		db_execute("UPDATE data_template_data SET active='' WHERE local_data_id IN ($ids_to_disable)");
+		db_execute('DELETE FROM poller_item WHERE ' . array_to_sql_or($ids_to_disable, 'local_data_id'));
+		db_execute("UPDATE data_template_data SET active='' WHERE " . array_to_sql_or($ids_to_disable, 'local_data_id'));
 
 		if (cacti_sizeof($poller_ids)) {
 			foreach ($poller_ids as $poller_id) {
 				if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
-					db_execute("DELETE FROM poller_item WHERE local_data_id IN ($ids_to_disable)", true, $rcnn_id);
-					db_execute("UPDATE data_template_data SET active='' WHERE local_data_id IN ($ids_to_disable)", true, $rcnn_id);
+					db_execute('DELETE FROM poller_item WHERE ' . array_to_sql_or($ids_to_disable, 'local_data_id'), true, $rcnn_id);
+					db_execute("UPDATE data_template_data SET active='' WHERE " . array_to_sql_or($ids_to_disable, 'local_data_id'), true, $rcnn_id);
 				}
 			}
 		}

--- a/lib/api_data_source.php
+++ b/lib/api_data_source.php
@@ -233,7 +233,7 @@ function api_data_source_remove_multi(array $local_data_ids, bool $update_totals
 
 		$data_template_data_ids = db_fetch_assoc('SELECT id
 			FROM data_template_data
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		if (cacti_sizeof($data_template_data_ids)) {
 			$dtd_ids_to_delete = [];
@@ -243,13 +243,13 @@ function api_data_source_remove_multi(array $local_data_ids, bool $update_totals
 
 				if (cacti_sizeof($dtd_ids_to_delete) >= 1000) {
 					db_execute('DELETE FROM data_input_data
-						WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id') . '');
+						WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id'));
 
 					if (cacti_sizeof($poller_ids)) {
 						foreach ($poller_ids as $poller_id) {
 							if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
 								db_execute('DELETE FROM data_input_data
-									WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id') . '', true, $rcnn_id);
+									WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id'), true, $rcnn_id);
 							}
 						}
 					}
@@ -260,13 +260,13 @@ function api_data_source_remove_multi(array $local_data_ids, bool $update_totals
 
 			if (cacti_sizeof($dtd_ids_to_delete)) {
 				db_execute('DELETE FROM data_input_data
-					WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id') . '');
+					WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id'));
 
 				if (cacti_sizeof($poller_ids)) {
 					foreach ($poller_ids as $poller_id) {
 						if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
 							db_execute('DELETE FROM data_input_data
-								WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id') . '', true, $rcnn_id);
+								WHERE ' . array_to_sql_or($dtd_ids_to_delete, 'data_template_data_id'), true, $rcnn_id);
 						}
 					}
 				}
@@ -285,71 +285,71 @@ function api_data_source_remove_multi(array $local_data_ids, bool $update_totals
 
 		// core data
 		db_execute('DELETE FROM data_template_data
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM data_template_rrd
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM poller_item
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM data_local
-			WHERE ' . array_to_sql_or($ids_to_delete, 'id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'id'));
 
 		db_execute('DELETE FROM data_debug
-			WHERE ' . array_to_sql_or($ids_to_delete, 'datasource') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'datasource'));
 
 		// dsstats
 		db_execute('DELETE FROM data_source_stats_daily
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM data_source_stats_hourly
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM data_source_stats_hourly_cache
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM data_source_stats_hourly_last
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM data_source_stats_monthly
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM data_source_stats_weekly
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM data_source_stats_yearly
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		// boost
 		db_execute('DELETE FROM poller_output
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		db_execute('DELETE FROM poller_output_boost
-			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '');
+			WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'));
 
 		if (cacti_sizeof($poller_ids)) {
 			foreach ($poller_ids as $poller_id) {
 				if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
 					// core data
 					db_execute('DELETE FROM data_template_data
-						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'), true, $rcnn_id);
 
 					db_execute('DELETE FROM data_template_rrd
-						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'), true, $rcnn_id);
 
 					db_execute('DELETE FROM poller_item
-						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'), true, $rcnn_id);
 
 					db_execute('DELETE FROM data_local
-						WHERE ' . array_to_sql_or($ids_to_delete, 'id') . '', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'id'), true, $rcnn_id);
 
 					// boost
 					db_execute('DELETE FROM poller_output
-						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'), true, $rcnn_id);
 
 					db_execute('DELETE FROM poller_output_boost
-						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id') . '', true, $rcnn_id);
+						WHERE ' . array_to_sql_or($ids_to_delete, 'local_data_id'), true, $rcnn_id);
 				}
 
 				api_data_source_cache_crc_update($poller_id);
@@ -444,7 +444,7 @@ function api_data_source_disable_multi(array $local_data_ids) : void {
 		$poller_ids += array_rekey(
 			db_fetch_assoc('SELECT poller_id
 				FROM poller_item
-				WHERE ' . array_to_sql_or($ids_to_disable, 'local_data_id') . ''),
+				WHERE ' . array_to_sql_or($ids_to_disable, 'local_data_id')),
 			'poller_id', 'poller_id'
 		);
 

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -119,21 +119,21 @@ function api_device_purge_from_remote(array|int $device_ids, int $poller_id = 0)
 			if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
 				$int_device_ids = array_map('intval', $device_ids);
 
-				db_execute('DELETE FROM host             WHERE      ' . array_to_sql_or($int_device_ids, 'id') . '', true, $rcnn_id);
-				db_execute('DELETE FROM host_graph       WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
-				db_execute('DELETE FROM host_snmp_query  WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
-				db_execute('DELETE FROM host_snmp_cache  WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
-				db_execute('DELETE FROM host_value_cache WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
-				db_execute('DELETE FROM poller_item      WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
-				db_execute('DELETE FROM poller_reindex   WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
-				db_execute('DELETE FROM graph_tree_items WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
-				db_execute('DELETE FROM reports_items    WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM host             WHERE      ' . array_to_sql_or($int_device_ids, 'id'), true, $rcnn_id);
+				db_execute('DELETE FROM host_graph       WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
+				db_execute('DELETE FROM host_snmp_query  WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
+				db_execute('DELETE FROM host_snmp_cache  WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
+				db_execute('DELETE FROM host_value_cache WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
+				db_execute('DELETE FROM poller_item      WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
+				db_execute('DELETE FROM poller_reindex   WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
+				db_execute('DELETE FROM graph_tree_items WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
+				db_execute('DELETE FROM reports_items    WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
 
 				db_execute('DELETE FROM poller_command
 					WHERE ' . array_to_sql_or($int_device_ids, 'SUBSTRING_INDEX(command, ":", 1)'), true, $rcnn_id);
 
-				db_execute('DELETE FROM data_local       WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
-				db_execute('DELETE FROM graph_local      WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM data_local       WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
+				db_execute('DELETE FROM graph_local      WHERE ' . array_to_sql_or($int_device_ids, 'host_id'), true, $rcnn_id);
 			} else {
 				raise_message('poller_down_' . $poller_id, __('Remote Poller %s is Down, you will need to perform a FullSync once it is up again', $poller_id), MESSAGE_LEVEL_WARN);
 			}
@@ -214,14 +214,14 @@ function api_device_remove_multi(array $device_ids, int $delete_type = 2) : void
 		$data_sources = array_rekey(
 			db_fetch_assoc('SELECT id
 				FROM data_local
-				WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . ''),
+				WHERE ' . array_to_sql_or($int_device_ids, 'host_id')),
 			'id', 'id'
 		);
 
 		$graphs = array_rekey(
 			db_fetch_assoc('SELECT id
 				FROM graph_local
-				WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . ''),
+				WHERE ' . array_to_sql_or($int_device_ids, 'host_id')),
 			'id', 'id'
 		);
 

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -119,21 +119,21 @@ function api_device_purge_from_remote(array|int $device_ids, int $poller_id = 0)
 			if (($rcnn_id = poller_push_to_remote_db_connect($poller_id, true)) !== false) {
 				$int_device_ids = array_map('intval', $device_ids);
 
-				db_execute('DELETE FROM host             WHERE      id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM host_graph       WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM host_snmp_query  WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM host_snmp_cache  WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM host_value_cache WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM poller_item      WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM poller_reindex   WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM graph_tree_items WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM reports_items    WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM host             WHERE      ' . array_to_sql_or($int_device_ids, 'id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM host_graph       WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM host_snmp_query  WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM host_snmp_cache  WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM host_value_cache WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM poller_item      WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM poller_reindex   WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM graph_tree_items WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM reports_items    WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
 
 				db_execute('DELETE FROM poller_command
-					WHERE SUBSTRING_INDEX(command, ":", 1) IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+					WHERE ' . array_to_sql_or($int_device_ids, 'SUBSTRING_INDEX(command, ":", 1)'), true, $rcnn_id);
 
-				db_execute('DELETE FROM data_local       WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
-				db_execute('DELETE FROM graph_local      WHERE host_id IN (' . implode(', ', $int_device_ids) . ')', true, $rcnn_id);
+				db_execute('DELETE FROM data_local       WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
+				db_execute('DELETE FROM graph_local      WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . '', true, $rcnn_id);
 			} else {
 				raise_message('poller_down_' . $poller_id, __('Remote Poller %s is Down, you will need to perform a FullSync once it is up again', $poller_id), MESSAGE_LEVEL_WARN);
 			}
@@ -214,14 +214,14 @@ function api_device_remove_multi(array $device_ids, int $delete_type = 2) : void
 		$data_sources = array_rekey(
 			db_fetch_assoc('SELECT id
 				FROM data_local
-				WHERE host_id IN (' . implode(', ', $int_device_ids) . ')'),
+				WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . ''),
 			'id', 'id'
 		);
 
 		$graphs = array_rekey(
 			db_fetch_assoc('SELECT id
 				FROM graph_local
-				WHERE host_id IN (' . implode(', ', $int_device_ids) . ')'),
+				WHERE ' . array_to_sql_or($int_device_ids, 'host_id') . ''),
 			'id', 'id'
 		);
 
@@ -249,23 +249,23 @@ function api_device_remove_multi(array $device_ids, int $delete_type = 2) : void
 		$poller_ids = get_remote_poller_ids_from_devices($devices_to_delete);
 
 		// handle removal or mark for removal as required
-		db_execute("DELETE FROM host WHERE id IN ($devices_to_delete) AND poller_id = 1");
-		db_execute("UPDATE host SET deleted = 'on' WHERE id IN ($devices_to_delete) AND poller_id != 1");
+		db_execute('DELETE FROM host WHERE ' . array_to_sql_or($int_device_ids, 'id') . ' AND poller_id = 1');
+		db_execute("UPDATE host SET deleted = 'on' WHERE " . array_to_sql_or($int_device_ids, 'id') . ' AND poller_id != 1');
 
-		db_execute("DELETE FROM host_graph       WHERE host_id IN ($devices_to_delete)");
-		db_execute("DELETE FROM host_snmp_query  WHERE host_id IN ($devices_to_delete)");
-		db_execute("DELETE FROM host_snmp_cache  WHERE host_id IN ($devices_to_delete)");
-		db_execute("DELETE FROM host_value_cache WHERE host_id IN ($devices_to_delete)");
-		db_execute("DELETE FROM graph_tree_items WHERE host_id IN ($devices_to_delete)");
-		db_execute("DELETE FROM reports_items    WHERE host_id IN ($devices_to_delete)");
+		db_execute('DELETE FROM host_graph       WHERE ' . array_to_sql_or($int_device_ids, 'host_id'));
+		db_execute('DELETE FROM host_snmp_query  WHERE ' . array_to_sql_or($int_device_ids, 'host_id'));
+		db_execute('DELETE FROM host_snmp_cache  WHERE ' . array_to_sql_or($int_device_ids, 'host_id'));
+		db_execute('DELETE FROM host_value_cache WHERE ' . array_to_sql_or($int_device_ids, 'host_id'));
+		db_execute('DELETE FROM graph_tree_items WHERE ' . array_to_sql_or($int_device_ids, 'host_id'));
+		db_execute('DELETE FROM reports_items    WHERE ' . array_to_sql_or($int_device_ids, 'host_id'));
 
 		if ($delete_type == 2) {
 			api_delete_graphs($graphs, $delete_type, false);
 		} else {
 			api_data_source_disable_multi($data_sources);
 
-			db_execute("UPDATE graph_local SET host_id = 0 WHERE host_id IN($devices_to_delete)");
-			db_execute("UPDATE data_local  SET host_id = 0 WHERE host_id IN($devices_to_delete)");
+			db_execute('UPDATE graph_local SET host_id = 0 WHERE ' . array_to_sql_or($int_device_ids, 'host_id'));
+			db_execute('UPDATE data_local  SET host_id = 0 WHERE ' . array_to_sql_or($int_device_ids, 'host_id'));
 		}
 
 		if (cacti_sizeof($poller_ids)) {
@@ -2442,7 +2442,7 @@ function api_clone_device_template_get_objects(int $device_template_id) : array 
 				FROM graph_templates AS gt
 				INNER JOIN snmp_query_graph AS sqg
 				ON gt.id = sqg.graph_template_id
-				WHERE sqg.snmp_query_id IN (' . implode(',', array_keys($objects['data_queries'])) . ')'),
+				WHERE ' . array_to_sql_or(array_keys($objects['data_queries']), 'sqg.snmp_query_id')),
 			'id', ['name', 'hash', 'snmp_query_id', 'sqname']
 		);
 
@@ -2458,7 +2458,7 @@ function api_clone_device_template_get_objects(int $device_template_id) : array 
 				INNER JOIN snmp_query AS sq
 				ON sq.id = sqg.snmp_query_id
 				WHERE dtd.local_data_id = 0
-				AND sq.id IN (' . implode(',', array_keys($objects['data_queries'])) . ')'),
+				AND ' . array_to_sql_or(array_keys($objects['data_queries']), 'sq.id')),
 			'id', ['name', 'hash', 'data_input_id', 'snmp_query_id']
 		);
 	}

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -2091,7 +2091,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 		case 'device_delete':
 			$data = db_fetch_assoc('SELECT host_id AS id, COUNT(*) AS totals
 				FROM data_local AS dl
-				WHERE host_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY host_id');
 
 			if (cacti_sizeof($data)) {
@@ -2100,7 +2100,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT host_id AS id, COUNT(*) AS totals
 				FROM graph_local AS gl
-				WHERE host_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY host_id');
 
 			if (cacti_sizeof($data)) {
@@ -2109,7 +2109,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT site_id AS id, COUNT(*) AS totals
 				FROM host AS h
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY site_id');
 
 			if (cacti_sizeof($data)) {
@@ -2118,7 +2118,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT host_template_id AS id, COUNT(*) AS totals
 				FROM host AS h
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY host_template_id');
 
 			if (cacti_sizeof($data)) {
@@ -2127,7 +2127,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT graph_template_id AS id, COUNT(*) AS totals
 				FROM graph_local AS gl
-				WHERE host_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY graph_template_id');
 
 			if (cacti_sizeof($data)) {
@@ -2136,7 +2136,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT data_template_id AS id, COUNT(*) AS totals
 				FROM data_local AS dl
-				WHERE host_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY data_template_id');
 
 			if (cacti_sizeof($data)) {
@@ -2145,7 +2145,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT snmp_query_id AS id, COUNT(*) AS totals
 				FROM data_local AS dl
-				WHERE host_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY snmp_query_id');
 
 			if (cacti_sizeof($data)) {
@@ -2157,7 +2157,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE cdef_id > 0
-				AND host_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY cdef_id');
 
 			if (cacti_sizeof($data)) {
@@ -2169,7 +2169,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE vdef_id > 0
-				AND host_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY vdef_id');
 
 			if (cacti_sizeof($data)) {
@@ -2181,7 +2181,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE color_id > 0
-				AND host_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY color_id');
 
 			if (cacti_sizeof($data)) {
@@ -2193,7 +2193,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE gprint_id > 0
-				AND host_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY gprint_id');
 
 			if (cacti_sizeof($data)) {
@@ -2205,7 +2205,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN data_local AS dl
 				ON dl.id = dtd.local_data_id
 				WHERE data_input_id > 0
-				AND host_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY data_input_id');
 
 			if (cacti_sizeof($data)) {
@@ -2217,7 +2217,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN data_local AS dl
 				ON dl.id = dtd.local_data_id
 				WHERE data_source_profile_id > 0
-				AND host_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY data_source_profile_id');
 
 			if (cacti_sizeof($data)) {
@@ -2228,7 +2228,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 		case 'device_leave':
 			$data = db_fetch_assoc('SELECT host_id AS id, COUNT(*) AS totals
 				FROM data_local AS dl
-				WHERE host_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY host_id');
 
 			if (cacti_sizeof($data)) {
@@ -2237,7 +2237,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT host_id AS id, COUNT(*) AS totals
 				FROM graph_local AS gl
-				WHERE host_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'host_id') . '
 				GROUP BY host_id');
 
 			if (cacti_sizeof($data)) {
@@ -2246,7 +2246,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT site_id AS id, COUNT(*) AS totals
 				FROM host AS h
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY site_id');
 
 			if (cacti_sizeof($data)) {
@@ -2255,7 +2255,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT host_template_id AS id, COUNT(*) AS totals
 				FROM host AS h
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY host_template_id');
 
 			if (cacti_sizeof($data)) {
@@ -2266,7 +2266,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 		case 'graph_delete':
 			$data = db_fetch_assoc('SELECT host_id AS id, COUNT(*) AS totals
 				FROM graph_local AS gl
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY host_id');
 
 			if (cacti_sizeof($data)) {
@@ -2279,7 +2279,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				ON dl.id = dtr.local_data_id
 				INNER JOIN graph_templates_item AS gti
 				ON dtr.id = gti.task_item_id
-				WHERE local_graph_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY host_id');
 
 			if (cacti_sizeof($data)) {
@@ -2288,7 +2288,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT graph_template_id AS id, COUNT(*) AS totals
 				FROM graph_local AS gl
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY graph_template_id');
 
 			if (cacti_sizeof($data)) {
@@ -2299,7 +2299,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				FROM data_template_rrd AS dtr
 				INNER JOIN graph_templates_item AS gti
 				ON dtr.id = gti.task_item_id
-				WHERE local_graph_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY data_template_id');
 
 			if (cacti_sizeof($data)) {
@@ -2312,7 +2312,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				ON dl.id = dtr.local_data_id
 				INNER JOIN graph_templates_item AS gti
 				ON dtr.id = gti.task_item_id
-				WHERE local_graph_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY snmp_query_id');
 
 			if (cacti_sizeof($data)) {
@@ -2324,7 +2324,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE cdef_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY cdef_id');
 
 			if (cacti_sizeof($data)) {
@@ -2336,7 +2336,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE vdef_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY vdef_id');
 
 			if (cacti_sizeof($data)) {
@@ -2348,7 +2348,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE color_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY color_id');
 
 			if (cacti_sizeof($data)) {
@@ -2360,7 +2360,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE gprint_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY gprint_id');
 
 			if (cacti_sizeof($data)) {
@@ -2374,7 +2374,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_templates_item AS gti
 				ON dtd.id = gti.task_item_id
 				WHERE data_input_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY data_input_id');
 
 			if (cacti_sizeof($data)) {
@@ -2388,7 +2388,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_templates_item AS gti
 				ON dtd.id = gti.task_item_id
 				WHERE data_input_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY data_source_profile_id');
 
 			if (cacti_sizeof($data)) {
@@ -2399,7 +2399,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 		case 'graph_leave':
 			$data = db_fetch_assoc('SELECT host_id AS id, COUNT(*) AS totals
 				FROM graph_local AS gl
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY host_id');
 
 			if (cacti_sizeof($data)) {
@@ -2408,7 +2408,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT graph_template_id AS id, COUNT(*) AS totals
 				FROM graph_local AS gl
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY graph_template_id');
 
 			if (cacti_sizeof($data)) {
@@ -2420,7 +2420,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE cdef_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY cdef_id');
 
 			if (cacti_sizeof($data)) {
@@ -2432,7 +2432,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE vdef_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY vdef_id');
 
 			if (cacti_sizeof($data)) {
@@ -2444,7 +2444,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE color_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY color_id');
 
 			if (cacti_sizeof($data)) {
@@ -2456,7 +2456,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 				INNER JOIN graph_local AS gl
 				ON gl.id = gti.local_graph_id
 				WHERE gprint_id > 0
-				AND local_graph_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_graph_id') . '
 				GROUP BY gprint_id');
 
 			if (cacti_sizeof($data)) {
@@ -2467,7 +2467,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 		case 'data_source':
 			$data = db_fetch_assoc('SELECT host_id AS id, COUNT(*) AS totals
 				FROM data_local AS dl
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY host_id');
 
 			if (cacti_sizeof($data)) {
@@ -2476,7 +2476,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT data_template_id AS id, COUNT(*) AS totals
 				FROM data_template_data AS dtd
-				WHERE local_data_id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'local_data_id') . '
 				GROUP BY data_template_id');
 
 			if (cacti_sizeof($data)) {
@@ -2485,7 +2485,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 
 			$data = db_fetch_assoc('SELECT snmp_query_id AS id, COUNT(*) AS totals
 				FROM data_local AS dl
-				WHERE id IN(' . implode(', ', $object_ids) . ')
+				WHERE ' . array_to_sql_or($object_ids, 'id') . '
 				GROUP BY snmp_query_id');
 
 			if (cacti_sizeof($data)) {
@@ -2495,7 +2495,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 			$data = db_fetch_assoc('SELECT data_input_id AS id, COUNT(*) AS totals
 				FROM data_template_data AS dtd
 				WHERE data_input_id > 0
-				AND local_data_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_data_id') . '
 				GROUP BY data_input_id');
 
 			if (cacti_sizeof($data)) {
@@ -2505,7 +2505,7 @@ function object_cache_get_totals(string $class, mixed $object_ids, bool $diff = 
 			$data = db_fetch_assoc('SELECT data_source_profile_id AS id, COUNT(*) AS totals
 				FROM data_template_data AS dtd
 				WHERE data_source_profile_id > 0
-				AND local_data_id IN(' . implode(', ', $object_ids) . ')
+				AND ' . array_to_sql_or($object_ids, 'local_data_id') . '
 				GROUP BY data_source_profile_id');
 
 			if (cacti_sizeof($data)) {

--- a/tests/Unit/InClauseParameterisationTest.php
+++ b/tests/Unit/InClauseParameterisationTest.php
@@ -1,0 +1,133 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for the IN-clause parameterisation in lib/api_data_source.php,
+ * lib/api_device.php and lib/utility.php.
+ *
+ * Those files built delete/update predicates by imploding a caller-supplied
+ * id list straight into "column IN (...)". The fix routes every such list
+ * through array_to_sql_or(), which quotes each element with db_qstr() before
+ * emitting "(column IN('a','b'))".
+ *
+ * Two things are checked:
+ *   1. array_to_sql_or() quotes and escapes values, so an injected quote
+ *      stays inside the string literal instead of breaking out of it.
+ *   2. Each converted file now calls array_to_sql_or() and no longer carries
+ *      the raw implode()/interpolated IN() constructs it replaced. The lib
+ *      files run code at include time, so the call sites are asserted against
+ *      the file source rather than executed.
+ */
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once dirname(__DIR__, 2) . '/include/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/lib/database.php';
+
+$libDir = dirname(__DIR__, 2) . '/lib';
+
+// =====================================================================
+// array_to_sql_or(): the shared quoting helper the fix relies on
+// =====================================================================
+
+test('array_to_sql_or builds a parenthesised IN() predicate', function () {
+	expect(array_to_sql_or([1, 2], 'host_id'))->toBe("(host_id IN('1','2'))");
+});
+
+test('array_to_sql_or quotes and escapes a value carrying a single quote', function () {
+	// The escaped quote keeps the payload inside the string literal.
+	expect(array_to_sql_or(["a'b", 3], 'id'))->toBe("(id IN('a\\'b','3'))");
+});
+
+test('array_to_sql_or wraps every element in quotes, never bare', function () {
+	$sql = array_to_sql_or([10, 20, 30], 'local_data_id');
+
+	expect($sql)->toBe("(local_data_id IN('10','20','30'))");
+	expect($sql)->not->toContain('IN(10');
+});
+
+test('array_to_sql_or keeps a column expression verbatim', function () {
+	// api_device.php passes SUBSTRING_INDEX(command, ":", 1) as the column.
+	expect(array_to_sql_or([5], 'SUBSTRING_INDEX(command, ":", 1)'))
+		->toBe('(SUBSTRING_INDEX(command, ":", 1) IN(\'5\'))');
+});
+
+test('array_to_sql_or yields an empty string for an empty list', function () {
+	expect(array_to_sql_or([], 'id'))->toBe('');
+});
+
+// =====================================================================
+// lib/api_data_source.php source guards
+// =====================================================================
+
+test('api_data_source.php routes id lists through array_to_sql_or', function () use ($libDir) {
+	$src = file_get_contents($libDir . '/api_data_source.php');
+
+	expect($src)->toContain('array_to_sql_or($ids_to_delete, ');
+	expect($src)->toContain('array_to_sql_or($dtd_ids_to_delete, ');
+	expect($src)->toContain('array_to_sql_or($ids_to_disable, ');
+});
+
+test('api_data_source.php drops the raw imploded IN() interpolation', function () use ($libDir) {
+	$src = file_get_contents($libDir . '/api_data_source.php');
+
+	expect($src)->not->toContain("IN (' . \$ids_to_delete . ')");
+	expect($src)->not->toContain("IN(' . \$ids_to_delete . ')");
+	expect($src)->not->toContain("implode(',', \$dtd_ids_to_delete)");
+	expect($src)->not->toContain('IN ($ids_to_disable)');
+	expect($src)->not->toContain('$ids_to_disable = implode');
+});
+
+test('api_data_source.php purge action binds the method as a placeholder', function () use ($libDir) {
+	$src = file_get_contents($libDir . '/api_data_source.php');
+
+	// The REPLACE(...) action value moved from inline concat to a bound ?.
+	expect($src)->toContain("REPLACE(data_source_path, '<path_rra>/', ''), ?");
+	expect($src)->not->toContain("''), '\" . \$acmethod . \"'");
+});
+
+// =====================================================================
+// lib/api_device.php source guards
+// =====================================================================
+
+test('api_device.php routes device and data-query id lists through array_to_sql_or', function () use ($libDir) {
+	$src = file_get_contents($libDir . '/api_device.php');
+
+	expect($src)->toContain('array_to_sql_or($int_device_ids, ');
+	expect($src)->toContain("array_to_sql_or(array_keys(\$objects['data_queries']), ");
+});
+
+test('api_device.php drops the raw imploded/interpolated device IN() clauses', function () use ($libDir) {
+	$src = file_get_contents($libDir . '/api_device.php');
+
+	expect($src)->not->toContain("implode(', ', \$int_device_ids)");
+	expect($src)->not->toContain("implode(',', array_keys(\$objects['data_queries']))");
+	expect($src)->not->toContain('IN ($devices_to_delete)');
+	expect($src)->not->toContain('IN($devices_to_delete)');
+});
+
+// =====================================================================
+// lib/utility.php source guards
+// =====================================================================
+
+test('utility.php routes object id lists through array_to_sql_or', function () use ($libDir) {
+	$src = file_get_contents($libDir . '/utility.php');
+
+	expect($src)->toContain('array_to_sql_or($object_ids, ');
+});
+
+test('utility.php drops the raw imploded object_ids IN() interpolation', function () use ($libDir) {
+	$src = file_get_contents($libDir . '/utility.php');
+
+	expect($src)->not->toContain("implode(', ', \$object_ids)");
+});

--- a/tests/Unit/InClauseParameterisationTest.php
+++ b/tests/Unit/InClauseParameterisationTest.php
@@ -46,7 +46,7 @@ test('array_to_sql_or builds a parenthesised IN() predicate', function () {
 
 test('array_to_sql_or quotes and escapes a value carrying a single quote', function () {
 	// The escaped quote keeps the payload inside the string literal.
-	expect(array_to_sql_or(["a'b", 3], 'id'))->toBe("(id IN('a\\'b','3'))");
+	expect(array_to_sql_or(["a'b", 3], 'id'))->toMatch("/^\\(id IN\\('a(?:\\\\'|'')b','3'\\)\\)$/");
 });
 
 test('array_to_sql_or wraps every element in quotes, never bare', function () {


### PR DESCRIPTION
Stacked on #7260 (the interpolation ratchet). Independent of the aggregate PR.

Parameterises the IN-clause interpolation in three `lib/` files, routing each id list through the existing `array_to_sql_or()` helper (db_qstr-escaped) instead of `implode()`:

- `lib/utility.php` `object_cache_get_totals()`: 39 count queries. Callers pass request-derived ids (`grv('host_id')`).
- `lib/api_device.php` device delete/purge: id chunks are `array_map('intval', ...)`; the list is validated once and escaped at each sink.
- `lib/api_data_source.php` data source delete/disable: same pattern; the auto-clean INSERT also binds the config-sourced method value instead of interpolating it.

All ids were integer-safe already, so this is hardening, not a fix for a live issue. Behaviour is unchanged. The three files drop from 96 `value` sites to zero; an integration test keeps them there.
