### PR TITLE
Show php-snmp bypass state on Technical Support page

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Cacti CHANGELOG
 1.3.0-dev
 -feature: Harden authentication system correctness including 2FA logic, password reset token security, and basic auth status checks
 -feature: Extract remote agent reverse DNS forward-confirmation into the remote_agent_fcrdns_confirmed() helper
+-issue#6669: Show on the Technical Support page whether php-snmp is in use or disabled by $php_snmp_support
 -issue#7131: Fix data_input_data column-expansion bugs in change_data_template and api_data_source_duplicate
 -issue#7137: Fix eleven PHPStan Level 6 errors in form_save error-redirect URLs and lib/html.php right-tab block
 -issue#6762: Harden lib/ping.php: apply cacti_escapeshellarg() to hostname in native ping and fping shell commands

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Notes:
 - A web server with PHP support is required.
 - PHP should be available as CLI or CGI for scheduled polling and maintenance scripts.
 - `php-snmp` is optional; validate behavior carefully if you depend on IPv6 and SNMPv3.
+- To force the Net-SNMP binaries while `php-snmp` remains installed, set `$php_snmp_support = false;` in `include/config.php`.
 
 Operating system guidance:
 

--- a/support.php
+++ b/support.php
@@ -1694,10 +1694,12 @@ function show_tech_summary() : void {
 	print '<td>' . __('PHP SNMP') . '</td>';
 	print '<td>';
 
-	if (function_exists('snmpget')) {
-		print __('Installed. <span class="deviceDown">Note: If you are planning on using SNMPv3, you must remove php-snmp and use the Net-SNMP toolset.</span>');
-	} else {
+	if (!function_exists('snmpget')) {
 		print __('Not Installed');
+	} elseif (!CACTI_PHP_SNMP) {
+		print __('Installed, but disabled by $php_snmp_support in config.php.  The Net-SNMP binaries are used instead.');
+	} else {
+		print __('Installed. <span class="deviceDown">Note: If you are planning on using SNMPv3, you must remove php-snmp and use the Net-SNMP toolset, or set $php_snmp_support = false; in config.php.</span>');
 	}
 	print '</td>';
 	form_end_row();

--- a/support.php
+++ b/support.php
@@ -1697,9 +1697,9 @@ function show_tech_summary() : void {
 	if (!function_exists('snmpget')) {
 		print __('Not Installed');
 	} elseif (!CACTI_PHP_SNMP) {
-		print __('Installed, but disabled by $php_snmp_support in config.php.  The Net-SNMP binaries are used instead.');
+		print __('Installed, but disabled by $php_snmp_support in include/config.php.  The Net-SNMP binaries are used instead.');
 	} else {
-		print __('Installed. <span class="deviceDown">Note: If you are planning on using SNMPv3, you must remove php-snmp and use the Net-SNMP toolset, or set $php_snmp_support = false; in config.php.</span>');
+		print __('Installed. <span class="deviceDown">Note: If you are planning on using SNMPv3, you must remove php-snmp and use the Net-SNMP toolset, or set $php_snmp_support = false; in include/config.php.</span>');
 	}
 	print '</td>';
 	form_end_row();


### PR DESCRIPTION
Fixes #6669

The $php_snmp_support override from #2638 already provides the CLI bypass, so no new setting is needed. This makes the existing flag visible:

- Technical Support page now distinguishes php-snmp in use, disabled by $php_snmp_support, and not installed
- README mentions the flag next to the php-snmp note

Verified with php -l, php-cs-fixer and PHPStan pre-commit checks.