### PR TITLE
ci(semgrep): add Cacti-aware taint scanning

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,44 @@
+# +-------------------------------------------------------------------------+
+# | Copyright (C) 2004-2026 The Cacti Group                                 |
+# |                                                                         |
+# | This program is free software; you can redistribute it and/or           |
+# | modify it under the terms of the GNU General Public License             |
+# | as published by the Free Software Foundation; either version 2          |
+# | of the License, or (at your option) any later version.                  |
+# +-------------------------------------------------------------------------+
+
+name: Semgrep
+
+on:
+  pull_request:
+    branches: [develop, 1.2.x]
+  push:
+    branches: [develop, 1.2.x]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semgrep-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Taint scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Semgrep
+        run: python3 -m pip install semgrep==1.152.0
+
+      - name: Run Semgrep
+        run: semgrep --config .semgrep.yml --error .

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,69 @@
+# Cacti-aware Semgrep rules.
+#
+# Taint-mode rules that understand Cacti's own escapers, so findings are
+# limited to request input that reaches a browser sink without passing through
+# one of them. htmle()/html_escape() run htmlspecialchars(); htmlerv() and
+# html_escape_request_var() are their request-var wrappers; sanitize_uri()
+# cleans redirect targets. get_request_var() and get_nfilter_request_var()
+# both return $_REQUEST values untouched (the filtering variant is
+# get_filter_request_var()), so they are unsanitized sources.
+rules:
+  - id: cacti-reflected-xss
+    mode: taint
+    languages: [php]
+    severity: ERROR
+    message: >-
+      Request input reaches echo/print without an HTML escaper. Wrap the value
+      in htmle()/html_escape() (or htmlerv()/html_escape_request_var() for
+      request vars) before output to prevent reflected XSS.
+    metadata:
+      cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation (Cross-site Scripting)"
+      owasp: "A03:2021 - Injection"
+      category: security
+      confidence: MEDIUM
+    pattern-sources:
+      - pattern: $_GET[...]
+      - pattern: $_POST[...]
+      - pattern: $_REQUEST[...]
+      - pattern: get_request_var(...)
+      - pattern: get_nfilter_request_var(...)
+    pattern-sanitizers:
+      - pattern: htmle(...)
+      - pattern: html_escape(...)
+      - pattern: html_escape_request_var(...)
+      - pattern: htmlerv(...)
+      - pattern: sanitize_uri(...)
+    pattern-sinks:
+      - pattern: echo $SINK;
+      - pattern: print $SINK;
+
+  - id: cacti-header-injection
+    mode: taint
+    languages: [php]
+    severity: ERROR
+    message: >-
+      Request input reaches header() without sanitization. Validate or escape
+      the value (e.g. sanitize_uri() for redirect targets) before setting a
+      response header to prevent header injection and open redirects.
+    metadata:
+      cwe: "CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers (HTTP Response Splitting)"
+      owasp: "A03:2021 - Injection"
+      category: security
+      confidence: MEDIUM
+    # Only raw superglobals are sources here. The get_*_request_var() helpers
+    # feed the standard redirect idiom (header('Location: page.php?id=' .
+    # get_request_var('id'))) where 'id' is separately int-validated via
+    # get_filter_request_var(), so treating them as header sinks is low signal.
+    # A raw superglobal concatenated into header() is the genuine injection.
+    pattern-sources:
+      - pattern: $_GET[...]
+      - pattern: $_POST[...]
+      - pattern: $_REQUEST[...]
+    pattern-sanitizers:
+      - pattern: htmle(...)
+      - pattern: html_escape(...)
+      - pattern: html_escape_request_var(...)
+      - pattern: htmlerv(...)
+      - pattern: sanitize_uri(...)
+    pattern-sinks:
+      - pattern: header(...)

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,7 @@
+# Third-party and generated assets. CLI scripts are not listed here on
+# purpose: they take filenames from argv, which the web-sink rules in
+# .semgrep.yml do not match, so no blanket ignore is needed for them.
+include/vendor/
+include/fa/
+node_modules/
+tests/e2e/node_modules/


### PR DESCRIPTION
Adds a Cacti-aware Semgrep taint config and a CI gate.

The upstream php/security-audit packs produce only false positives on Cacti: they don't know `htmle()`/`html_escape()` escape output, and they flag CLI argv. This defines two taint rules that treat those functions as sanitizers and scope sinks to `echo`/`print`/`header()`, so a finding means request input actually reaches a browser sink unescaped. develop scans clean (0 findings, 513 files).

The workflow runs `semgrep --config .semgrep.yml --error` on PRs and pushes to develop/1.2.x. `contents: read` only; checkout pinned to SHA; semgrep pinned.
