### PR TITLE
ci: add Rocky Linux container compatibility coverage

### DIFF
--- a/.github/workflows/rocky-linux.yml
+++ b/.github/workflows/rocky-linux.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run PHP checks in Rocky Linux 9
         run: |
@@ -27,8 +27,8 @@ jobs:
             --volume "$GITHUB_WORKSPACE:/workspace:ro" \
             --workdir /workspace \
             rockylinux:9 \
-            bash -euo pipefail -c '''
+            bash -euo pipefail -c '
               dnf -y install php-cli php-common php-curl php-gd php-intl php-mbstring php-mysqlnd php-xml php-zip
               php --version
               find . -path ./vendor -prune -o -type f -name "*.php" -print0 | xargs -0 -r -n1 php -l
-            '''
+            '

--- a/.github/workflows/rocky-linux.yml
+++ b/.github/workflows/rocky-linux.yml
@@ -1,0 +1,34 @@
+name: Rocky Linux compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 6"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rocky-linux-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rocky-linux:
+    name: Rocky Linux 9 PHP compatibility
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Run PHP checks in Rocky Linux 9
+        run: |
+          docker run --rm \
+            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+            --workdir /workspace \
+            rockylinux:9 \
+            bash -euo pipefail -c '''
+              dnf -y install php-cli php-common php-curl php-gd php-intl php-mbstring php-mysqlnd php-xml php-zip
+              php --version
+              find . -path ./vendor -prune -o -type f -name "*.php" -print0 | xargs -0 -r -n1 php -l
+            '''


### PR DESCRIPTION
## Summary
- add scheduled and manual Rocky Linux 9 compatibility coverage
- run tests in Docker on GitHub-hosted Ubuntu runners
- keep the required pull-request gate unchanged

## Validation
- workflow YAML parsed successfully
- no self-hosted runner is required