### PR TITLE
Use Cacti with OAuth2 Proxy

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -271,6 +271,9 @@ function get_basic_auth_username() : string|false {
 	} elseif (isset($_SERVER['HTTP_REDIRECT_REMOTE_USER'])) {
 		$raw      = is_array($_SERVER['HTTP_REDIRECT_REMOTE_USER']) ? ($_SERVER['HTTP_REDIRECT_REMOTE_USER'][0] ?? '') : $_SERVER['HTTP_REDIRECT_REMOTE_USER'];
 		$username = str_replace('\\', '\\\\', $raw);
+	} elseif (isset($_SERVER['HTTP_X_FORWARDED_USER'])) {
+		$raw      = is_array($_SERVER['HTTP_X_FORWARDED_USER']) ? ($_SERVER['HTTP_X_FORWARDED_USER'][0] ?? '') : $_SERVER['HTTP_X_FORWARDED_USER'];
+		$username = str_replace('\\', '\\\\', $raw);
 	} else {
 		$username = false;
 	}


### PR DESCRIPTION
This pull-request modifies Cacti to read the username from the `X-Forwarded-User` header in [Web Basic Authentication](https://docs.cacti.net/Settings-Auth-Basic.md).
This change is required, so Cacti will work behind [OAuth2-Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) in _reverse proxy_ mode.