### PR TITLE
docs: document CHANGELOG ordering convention

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,6 +59,10 @@
   - Must have an `INFO` file (INI format).
   - Use `top_header()`/`bottom_footer()` (no direct includes).
   - Add `&header=false` to URLs for AJAX requests.
+- **CHANGELOG**:
+  - Within each release section, keep `-issue` entries first and `-feature` entries after them.
+  - Append new issue entries at the end of the issue block and new feature entries at the end of the feature block.
+  - Preserve the existing entry prefixes, release headings, and blank-line spacing.
 
 ## Workflows you’ll actually use
 - Install deps: `composer install` (CI validates via `.github/workflows/syntax.yml`).
@@ -88,4 +92,3 @@
 - **Formatting**: Enforce tabs for indentation (no spaces for indentation).
 - **Legacy**: Avoid `preg_*` if simple string functions work. Use `preg_*` over `ereg_*`.
 - Avoid drive-by rewrites: no repo-wide formatting, no unrelated cleanup, and preserve existing file conventions (keep the GPL header blocks).
-

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,7 @@
 - **CHANGELOG**:
   - Within each release section, keep `-issue` entries first and `-feature` entries after them.
   - Append new issue entries at the end of the issue block and new feature entries at the end of the feature block.
+  - Keep numbered entries in their existing numeric order; every new entry must include an issue or pull-request number (`#1234`).
   - Preserve the existing entry prefixes, release headings, and blank-line spacing.
 
 ## Workflows you’ll actually use

--- a/.github/scripts/check-changelog.py
+++ b/.github/scripts/check-changelog.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import re
+import os
+import subprocess
 import sys
 from pathlib import Path
 
 
 RELEASE_HEADING = re.compile(r"^(?:\d+\.\d+\.\d+(?:-[\w.]+)?|\d+\.\d+\.x)$")
 ENTRY = re.compile(r"^-(issue|feature)(?:#\d+)?:\s+\S.*$")
+NUMBERED_ENTRY = re.compile(r"^-(?:issue|feature)#\d+:")
 
 
 def main() -> int:
@@ -55,6 +58,24 @@ def main() -> int:
 
 	if end < len(lines) and lines[end - 1].strip():
 		errors.append(f"line {end + 1}: release headings must be separated by a blank line")
+
+	# Existing releases contain legacy unnumbered entries. New entries must be
+	# traceable to an issue or pull request, so enforce that only on PR additions.
+	base_ref = os.environ.get("GITHUB_BASE_REF")
+	if base_ref:
+		result = subprocess.run(
+			["git", "diff", "--unified=0", f"origin/{base_ref}...HEAD", "--", "CHANGELOG"],
+			capture_output=True,
+			text=True,
+			check=False,
+		)
+		if result.returncode == 0:
+			for added in result.stdout.splitlines():
+				if added.startswith(("+++", "---")):
+					continue
+				line = added[1:] if added.startswith("+") else ""
+				if line.startswith(("-issue", "-feature")) and not NUMBERED_ENTRY.match(line):
+					errors.append(f"new CHANGELOG entries must include an issue or pull-request number: {line}")
 
 	if errors:
 		print("CHANGELOG validation failed:", file=sys.stderr)

--- a/.github/scripts/check-changelog.py
+++ b/.github/scripts/check-changelog.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate the repository CHANGELOG grouping and entry format."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+RELEASE_HEADING = re.compile(r"^(?:\d+\.\d+\.\d+(?:-[\w.]+)?|\d+\.\d+\.x)$")
+ENTRY = re.compile(r"^-(issue|feature)(?:#\d+)?:\s+\S.*$")
+
+
+def main() -> int:
+	path = Path("CHANGELOG")
+	if not path.is_file():
+		print("CHANGELOG is missing", file=sys.stderr)
+		return 1
+
+	lines = path.read_text(encoding="utf-8").splitlines()
+	try:
+		start = lines.index("1.3.0-dev")
+	except ValueError:
+		print("CHANGELOG is missing the 1.3.0-dev section", file=sys.stderr)
+		return 1
+
+	end = len(lines)
+	for index in range(start + 1, len(lines)):
+		if RELEASE_HEADING.fullmatch(lines[index]):
+			end = index
+			break
+
+	errors: list[str] = []
+	seen_feature = False
+
+	for index in range(start + 1, end):
+		line = lines[index].rstrip()
+		number = index + 1
+		if not line:
+			continue
+		if not line.startswith(("-issue", "-feature")):
+			if line.startswith("-"):
+				errors.append(f"line {number}: malformed CHANGELOG entry: {line}")
+			continue
+		if not ENTRY.fullmatch(line):
+			errors.append(f"line {number}: malformed CHANGELOG entry: {line}")
+			continue
+
+		kind = "feature" if line.startswith("-feature") else "issue"
+		if kind == "feature":
+			seen_feature = True
+		elif seen_feature:
+			errors.append(f"line {number}: issue entry appears after feature entries")
+
+	if end < len(lines) and lines[end - 1].strip():
+		errors.append(f"line {end + 1}: release headings must be separated by a blank line")
+
+	if errors:
+		print("CHANGELOG validation failed:", file=sys.stderr)
+		print("\n".join(f"- {error}" for error in errors), file=sys.stderr)
+		return 1
+
+	print("CHANGELOG format is valid")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -333,3 +333,13 @@ jobs:
 
     - name: View Contents of Logs
       run: sudo cat ${{ github.workspace }}/log/cacti.log
+
+  changelog:
+    name: CHANGELOG format
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate CHANGELOG ordering and entry format
+        run: python3 .github/scripts/check-changelog.py

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -340,6 +340,8 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
 
       - name: Validate CHANGELOG ordering and entry format
         run: python3 .github/scripts/check-changelog.py

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,7 +82,7 @@ Cacti CHANGELOG
 -feature#3513: Add hooks for plugins to show customize graph source and customize template url
 -feature#3518: Allow for 2 Levels of Poller sync
 -feature#3558: Allow copy_user cli script to set various additional fields
--feature#3568; Allow exclusion of snmp fields / value(s) when adding graphs via CLI
+-feature#3568: Allow exclusion of snmp fields / value(s) when adding graphs via CLI
 -feature#3584: Verify passwords against Pwned databases using API
 -feature#3585: CLI script to show database permissions that Cacti has
 -feature#3608: Graphs should be able to use |input_field_name| replacement variables


### PR DESCRIPTION
## Summary
- document the canonical issue-before-feature CHANGELOG ordering
- require appending new entries within their existing type block
- preserve release headings, prefixes, and spacing

## Validation
- git diff --check