### PR TITLE
fix: make cacti.sql portable across MySQL and MariaDB clients

### DIFF
--- a/cacti.sql
+++ b/cacti.sql
@@ -21,12 +21,6 @@
   +-------------------------------------------------------------------------+
 */
 
---
--- Allow MySQL to handle Cacti's legacy syntax
---
-
-DELIMITER //
-
 SET @sqlmode= "";
 SET SESSION sql_mode = @sqlmode;
 


### PR DESCRIPTION
## Summary

- Remove the obsolete `DELIMITER //` client directive from `cacti.sql`.
- Keep the SQL dump consumable by both MySQL and MariaDB command-line clients.

## Root cause

Some MySQL 8.4 clients pass `DELIMITER //` through to MariaDB 10.6 during non-interactive imports, producing `ERROR 1064` before schema creation. The dump contains no stored routines requiring a custom delimiter, so the directive is unnecessary.

## Validation

- `git diff --check`
- Confirmed no `DELIMITER` directive remains in `cacti.sql`.

Relates to #7084.