### PR TITLE
fix: allow configured external script root in script server

### DIFF
--- a/script_server.php
+++ b/script_server.php
@@ -260,25 +260,21 @@ while (1) {
 			 * passthru, exec satisfy function_exists() without ever loading a
 			 * script file, so the path guard cannot be gated on the function
 			 * being undefined. include_once() is idempotent, so re-running it
-			 * on cached entries is a no-op. */
+			 * on cached entries is a no-op. The scripts_path setting is an
+			 * explicitly configured Cacti script root and may live outside the
+			 * web root, so it is an allowed containment root as well. */
 			$real_include = realpath($include_file);
-			$base_real    = realpath($config['base_path']);
+			$allowed_roots = [$config['base_path']];
 
-			if ($real_include !== false) {
-				$real_include = str_replace('\\', '/', $real_include);
-			}
-			if ($base_real !== false) {
-				$base_real = str_replace('\\', '/', $base_real);
+			if (!empty($config['scripts_path'])) {
+				$allowed_roots[] = $config['scripts_path'];
 			}
 
-			/* On Windows, realpath() may return mixed-case drive letters; use
-			 * case-insensitive comparison to avoid false rejections. */
-			$path_cmp = (DIRECTORY_SEPARATOR === '\\') ? 'stripos' : 'strpos';
-			$path_ok  = ($real_include !== false && $base_real !== false && $path_cmp($real_include, $base_real . '/') === 0);
+			$path_ok = script_server_path_is_allowed($real_include, $allowed_roots);
 
 			if (!$path_ok) {
 				if ($real_include !== false) {
-					cacti_log("WARNING: Script file '$include_file' resolves outside base path. Rejected.", false, 'PHPSVR');
+					cacti_log("WARNING: Script file '$include_file' resolves outside the allowed script roots. Rejected.", false, 'PHPSVR');
 				} else {
 					cacti_log("WARNING: Script file '$include_file' could not be resolved. Rejected.", false, 'PHPSVR');
 				}
@@ -354,8 +350,8 @@ while (1) {
 				$fn_real = str_replace('\\', '/', $fn_real);
 			}
 
-			if ($fn_real === false || $path_cmp($fn_real, $base_real . '/') !== 0) {
-				cacti_log("WARNING: Function '$function' defined outside base path ('$fn_file'). Rejected.", false, 'PHPSVR');
+			if (!script_server_path_is_allowed($fn_real, $allowed_roots)) {
+				cacti_log("WARNING: Function '$function' defined outside the allowed script roots ('$fn_file'). Rejected.", false, 'PHPSVR');
 				fputs(STDOUT, "U\n");
 				fflush(STDOUT);
 				continue;
@@ -494,6 +490,52 @@ function parseArgs($string, &$str_list, $debug = false) {
 }
 
 /**
+ * Check whether a resolved script path is below one of the configured roots.
+ *
+ * @param mixed $resolved_path The realpath() result for the candidate file.
+ * @param array $roots         Configured Cacti path roots.
+ *
+ * @return bool
+ */
+function script_server_path_is_allowed($resolved_path, array $roots) {
+	static $normalized_roots = [];
+
+	if ($resolved_path === false || !is_string($resolved_path)) {
+		return false;
+	}
+
+	$resolved_path = rtrim(str_replace('\\', '/', $resolved_path), '/');
+	$case_insensitive = (DIRECTORY_SEPARATOR === '\\');
+	$cache_key = implode("\0", $roots);
+
+	if (!isset($normalized_roots[$cache_key])) {
+		$normalized_roots[$cache_key] = [];
+
+		foreach ($roots as $root) {
+			$root = realpath($root);
+
+			if ($root !== false) {
+				$normalized_roots[$cache_key][] = rtrim(str_replace('\\', '/', $root), '/');
+			}
+		}
+	}
+
+	foreach ($normalized_roots[$cache_key] as $root) {
+		$prefix = $root . '/';
+
+		if ($case_insensitive) {
+			if (stripos($resolved_path, $prefix) === 0) {
+				return true;
+			}
+		} elseif (strpos($resolved_path, $prefix) === 0) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * sig_handler - properly handle signals and shutdown
  */
 function sig_handler($signo) {
@@ -559,4 +601,3 @@ function display_help () {
 	print 'Script Server.  When doing so you should see the output you expect printed to standard output.  When' . PHP_EOL;
 	print 'running the Script Server, simply enter \'quit\' to exit.' . PHP_EOL . PHP_EOL;
 }
-

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -530,7 +530,7 @@ dynamic_include	./reports_user.php:28	include_once($config['library_path'] . '/t
 dynamic_include	./rrdcheck.php:26	include_once ($config['library_path'] . '/functions.php');
 dynamic_include	./rrdcleaner.php:26	include_once ($config['library_path'] . '/functions.php');
 dynamic_include	./rrdcleaner.php:27	include_once ($config['library_path'] . '/rrd.php');
-dynamic_include	./script_server.php:310				include_once($include_file);
+dynamic_include	./script_server.php:306				include_once($include_file);
 dynamic_include	./scripts/ss_netsnmp_lmsensors.php:24		include($config['base_path'] . '/lib/snmp.php');
 dynamic_include	./snmpagent_persist.php:165				include( $path_mibcache );
 dynamic_include	./spikekill.php:26	include_once($config['base_path'] . '/lib/spikekill.php');

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -527,7 +527,7 @@ dynamic_include	./reports_user.php:28	include_once($config['library_path'] . '/t
 dynamic_include	./rrdcheck.php:26	include_once ($config['library_path'] . '/functions.php');
 dynamic_include	./rrdcleaner.php:26	include_once ($config['library_path'] . '/functions.php');
 dynamic_include	./rrdcleaner.php:27	include_once ($config['library_path'] . '/rrd.php');
-dynamic_include	./script_server.php:310				include_once($include_file);
+dynamic_include	./script_server.php:306				include_once($include_file);
 dynamic_include	./scripts/ss_netsnmp_lmsensors.php:24		include($config['base_path'] . '/lib/snmp.php');
 dynamic_include	./snmpagent_persist.php:165				include( $path_mibcache );
 dynamic_include	./spikekill.php:26	include_once($config['base_path'] . '/lib/spikekill.php');


### PR DESCRIPTION
## Summary

- Fixes #7257.
- Allows the explicitly configured `scripts_path` root in script-server containment checks.
- Keeps canonical `realpath()` resolution, path-boundary checks, and function-source containment protection.
- Applies the same policy to Windows and POSIX path comparisons.

## Root cause

Cacti 1.2.31 rejects script-server files configured through the supported external `scripts_path` setting because the hardening check only allowed `base_path`. Poller requests then return `U`, producing invalid graph data.

## Validation

- `php -l script_server.php`
- `git diff --check`

The PR intentionally does not weaken the containment policy or allow arbitrary paths.
