### PR TITLE
fix: explain missing special type for host fields

### DIFF
--- a/data_input.php
+++ b/data_input.php
@@ -174,6 +174,11 @@ function form_save() {
 		$save['regexp_match']  = form_input_validate((isset_request_var('regexp_match') ? get_nfilter_request_var('regexp_match') : ''), 'regexp_match', '', true, 3);
 		$save['allow_nulls']   = form_input_validate((isset_request_var('allow_nulls') ? get_nfilter_request_var('allow_nulls') : ''), 'allow_nulls', '', true, 3);
 
+		if (!is_error_message() && $save['input_output'] == 'in' && $save['type_code'] == '' && defined('VALID_HOST_FIELDS') && preg_match('/^(?:' . VALID_HOST_FIELDS . ')$/i', $save['data_name']) === 1) {
+			$_SESSION[SESS_ERROR_FIELDS]['type_code'] = 'type_code';
+			raise_message('validation_error', __esc('Input field <%s> requires Special Type Code "%s".', $save['data_name'], $save['data_name']), MESSAGE_LEVEL_ERROR);
+		}
+
 		if (!is_error_message()) {
 			$data_input_field_id = sql_save($save, 'data_input_fields');
 
@@ -988,4 +993,3 @@ function data() {
 
 	form_end();
 }
-

--- a/tests/Unit/Issue7076SpecialTypeValidationTest.php
+++ b/tests/Unit/Issue7076SpecialTypeValidationTest.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$dataInputSource = file_get_contents(__DIR__ . '/../../data_input.php');
+
+test('host placeholders require a special type code', function () use ($dataInputSource) {
+	expect($dataInputSource)->toContain("\$save['type_code'] == ''");
+	expect($dataInputSource)->toContain("preg_match('/^(?:' . VALID_HOST_FIELDS . ')$/i', \$save['data_name']) === 1");
+	expect($dataInputSource)->toContain("\$_SESSION[SESS_ERROR_FIELDS]['type_code'] = 'type_code'");
+});
+
+test('data input field save validates missing special type codes', function () use ($dataInputSource) {
+	expect($dataInputSource)->toContain('requires Special Type Code');
+});

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -705,12 +705,12 @@ header_redirect	./data_debug.php:53				header('Location: data_debug.php?action=v
 header_redirect	./data_debug.php:76				header('Location: data_debug.php?action=view&id=' . get_filter_request_var('id'));
 header_redirect	./data_input.php:124					header('Location: data_input.php?action=edit&id=' . (empty($save['id']) ? '' : $save['id']));
 header_redirect	./data_input.php:156			header('Location: data_input.php?header=false&action=edit&id=' . (empty($data_input_id) ? get_nfilter_request_var('id') : $data_input_id));
-header_redirect	./data_input.php:194				header('Location: data_input.php?header=false&action=field_edit&data_input_id=' . get_request_var('data_input_id') . '&id=' . (empty($data_input_field_id) ? get_request_var('id') : $data_input_field_id) . (!isempty_request_var('input_output') ? '&type=' . get_request_var('input_output') : ''));
-header_redirect	./data_input.php:196				header('Location: data_input.php?header=false&action=edit&id=' . get_request_var('data_input_id'));
-header_redirect	./data_input.php:251			header('Location: data_input.php?header=false');
-header_redirect	./data_input.php:301			header('Location: data_input.php?header=none');
-header_redirect	./data_input.php:463			header('Location: data_input.php?header=false&action=edit&id=' . get_filter_request_var('data_input_id'));
-header_redirect	./data_input.php:526				header('Location: data_input.php');
+header_redirect	./data_input.php:199				header('Location: data_input.php?header=false&action=field_edit&data_input_id=' . get_request_var('data_input_id') . '&id=' . (empty($data_input_field_id) ? get_request_var('id') : $data_input_field_id) . (!isempty_request_var('input_output') ? '&type=' . get_request_var('input_output') : ''));
+header_redirect	./data_input.php:201				header('Location: data_input.php?header=false&action=edit&id=' . get_request_var('data_input_id'));
+header_redirect	./data_input.php:256			header('Location: data_input.php?header=false');
+header_redirect	./data_input.php:306			header('Location: data_input.php?header=none');
+header_redirect	./data_input.php:468			header('Location: data_input.php?header=false&action=edit&id=' . get_filter_request_var('data_input_id'));
+header_redirect	./data_input.php:531				header('Location: data_input.php');
 header_redirect	./data_input.php:55			header('Location: data_input.php?header=false&action=edit&id=' . get_filter_request_var('data_input_id'));
 header_redirect	./data_input.php:74				header('Location: data_input.php?header=false&action=edit&id=' . get_filter_request_var('id'));
 header_redirect	./data_queries.php:1107				header('Location: data_queries.php');


### PR DESCRIPTION
## Summary

- Fixes #7076.
- Validates host placeholder input fields before saving them.
- Reports the exact Special Type Code required when a host placeholder such as `<hostname>` has no type code.
- Adds regression coverage for the validation rule.

## Root cause

A data input field could use a reserved host placeholder while leaving `type_code` empty. The later data-source template form then failed generically with “field input errors,” without identifying the missing configuration.

## Validation

- `php -l lib/functions.php`
- `php -l data_input.php`
- `php -l tests/Unit/Issue7076SpecialTypeValidationTest.php`
- `git diff --check`

This is intentionally limited to clearer server-side validation; it does not infer or silently mutate Special Type Codes.
