### PR TITLE
fix: align percentile rank with observed export samples

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@ Cacti CHANGELOG
 -issue#6760: Harden link.php: apply sanitize_uri() to HTTP_REFERER before redirect
 -issue#6761: Harden auth_changepassword.php: apply sanitize_uri() to HTTP_REFERER in all redirect paths
 -issue#6762: Harden lib/ping.php: apply cacti_escapeshellarg() to hostname in native ping and fping shell commands
+-issue#7070: Align percentile rank with observed samples and expose missing export rows
 -issue#7131: Fix data_input_data column-expansion bugs in change_data_template and api_data_source_duplicate
 -issue#7137: Fix eleven PHPStan Level 6 errors in form_save error-redirect URLs and lib/html.php right-tab block
 -issue: Fix loose $db_conn comparison in db_table_exists and db_column_exists

--- a/graph_xport.php
+++ b/graph_xport.php
@@ -104,6 +104,24 @@ if (!is_array($xport_array) || !isset($xport_array['meta']['start'])) {
 	exit;
 }
 
+// Percentile summaries use the observed finite samples. Expose the expected
+// row count so sparse periods are visible instead of being mistaken for zero.
+$xport_array['meta']['expected_rows'] = 0;
+$xport_array['meta']['missing_rows']  = 0;
+
+if ($xport_array['meta']['step'] > 0) {
+	$effective_end = $xport_array['meta']['end'];
+
+	if ($effective_end == $xport_array['meta']['start'] && $xport_array['meta']['rows'] > 0) {
+		$effective_end = $xport_array['meta']['start'] + $xport_array['meta']['step'] * ($xport_array['meta']['rows'] - 1);
+	}
+
+	$xport_array['meta']['expected_rows'] = (int) floor(
+		($effective_end - $xport_array['meta']['start']) / $xport_array['meta']['step']
+	) + 1;
+	$xport_array['meta']['missing_rows'] = max(0, $xport_array['meta']['expected_rows'] - $xport_array['meta']['rows']);
+}
+
 // Make graph title the suggested file name
 $filename = $xport_array['meta']['title_cache'] . '.csv';
 
@@ -135,6 +153,8 @@ if (isset($xport_array['meta']['start'])) {
 		$output .= cacti_csv_cell(__('End Date')) . ',' . cacti_csv_cell(date('Y-m-d H:i:s', ($xport_array['meta']['end'] == $xport_array['meta']['start']) ? $xport_array['meta']['start'] + $xport_array['meta']['step'] * ($xport_array['meta']['rows'] - 1) : $xport_array['meta']['end'])) . "\n";
 		$output .= cacti_csv_cell(__('Step')) . ',' . cacti_csv_cell($xport_array['meta']['step']) . "\n";
 		$output .= cacti_csv_cell(__('Total Rows')) . ',' . cacti_csv_cell($xport_array['meta']['rows']) . "\n";
+		$output .= cacti_csv_cell(__('Expected Rows')) . ',' . cacti_csv_cell($xport_array['meta']['expected_rows']) . "\n";
+		$output .= cacti_csv_cell(__('Missing Rows')) . ',' . cacti_csv_cell($xport_array['meta']['missing_rows']) . "\n";
 		$output .= cacti_csv_cell(__('Graph ID')) . ',' . cacti_csv_cell($xport_array['meta']['local_graph_id']) . "\n";
 		$output .= cacti_csv_cell(__('Host ID')) . ',' . cacti_csv_cell($xport_array['meta']['host_id']) . "\n";
 
@@ -210,6 +230,13 @@ if (isset($xport_array['meta']['start'])) {
 		print '<td style="width:25%">' . $xport_array['meta']['step'] . '</td>';
 		print '<td style="width:25%">' . __('Total Rows') . '</td>';
 		print '<td style="width:25%">' . $xport_array['meta']['rows'] . '</td>';
+		print '</tr>';
+
+		print "<tr class='odd'>";
+		print '<td style="width:25%">' . __('Expected Rows') . '</td>';
+		print '<td style="width:25%">' . $xport_array['meta']['expected_rows'] . '</td>';
+		print '<td style="width:25%">' . __('Missing Rows') . '</td>';
+		print '<td style="width:25%">' . $xport_array['meta']['missing_rows'] . '</td>';
 		print '</tr>';
 
 		print "<tr class='odd'>";

--- a/lib/graph_variables.php
+++ b/lib/graph_variables.php
@@ -309,6 +309,18 @@ function nth_percentile_fetch_statistics(int $percentile, array &$local_data_ids
 	return $stats;
 }
 
+function cacti_percentile_index(int $elements, int $percentile) : int {
+	if ($elements <= 0 || $percentile <= 0 || $percentile >= 100) {
+		return 0;
+	}
+
+	// Values are sorted descending. Return the zero-based index of the
+	// percentile value after discarding the upper (100 - percentile)%.
+	$discard_count = intdiv($elements * (100 - $percentile) + 99, 100);
+
+	return max(0, $discard_count - 1);
+}
+
 function cacti_stats_calc(array $array, int $ptile = 95) : array {
 	rsort($array, SORT_NUMERIC);
 
@@ -350,12 +362,12 @@ function cacti_stats_calc(array $array, int $ptile = 95) : array {
 
 	$variance = $rsquared / $elements;
 
-	$ptile_index = intval(ceil($elements * (1 - ($ptile / 100))));
-	$p95n_index  = intval(ceil($elements * 0.05));
-	$p90n_index  = intval(ceil($elements * 0.1));
-	$p75n_index  = intval(ceil($elements * 0.25));
-	$p50n_index  = intval(ceil($elements * 0.50));
-	$p25n_index  = intval(ceil($elements * 0.75));
+	$ptile_index = cacti_percentile_index($elements, $ptile);
+	$p95n_index  = cacti_percentile_index($elements, 95);
+	$p90n_index  = cacti_percentile_index($elements, 90);
+	$p75n_index  = cacti_percentile_index($elements, 75);
+	$p50n_index  = cacti_percentile_index($elements, 50);
+	$p25n_index  = cacti_percentile_index($elements, 25);
 
 	$results = [
 		'p95n'     => $array[$p95n_index] ?? 0,

--- a/tests/Unit/Issue7070PercentileContractTest.php
+++ b/tests/Unit/Issue7070PercentileContractTest.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$graphVariables = file_get_contents(__DIR__ . '/../../lib/graph_variables.php');
+$graphXport     = file_get_contents(__DIR__ . '/../../graph_xport.php');
+
+test('percentile index is based on observed samples', function () use ($graphVariables) {
+	preg_match('/^function cacti_percentile_index\([^)]*\).*?\{.*?^\}/sm', $graphVariables, $matches);
+	expect($matches)->not->toBeEmpty();
+
+	$source = preg_replace('/^function cacti_percentile_index\(/m', 'function issue7070_percentile_index(', $matches[0]);
+	eval($source);
+
+	// 8,640 observed samples discard 432 high values; index 431 is the 432nd.
+	expect(issue7070_percentile_index(8640, 95))->toBe(431);
+	expect(issue7070_percentile_index(8664, 95))->toBe(433);
+	// A missing sample is visible in coverage, not converted to a zero value.
+	expect(issue7070_percentile_index(0, 95))->toBe(0);
+});
+
+test('CSV export exposes sparse-period coverage', function () use ($graphXport) {
+	expect($graphXport)->toContain("__('Expected Rows')");
+	expect($graphXport)->toContain("__('Missing Rows')");
+	expect($graphXport)->toContain("['meta']['missing_rows']");
+});


### PR DESCRIPTION
## Summary

- Implements the agreed direction for #7070.
- Uses integer percentile-rank arithmetic so exact sample counts do not drift because of floating-point rounding.
- Aligns graph percentile selection with observed finite samples.
- Exposes expected and missing row counts in CSV and table exports so sparse periods are explicit instead of being mistaken for zero.
- Adds regression coverage for 8,640 versus 8,664 observed samples and sparse export metadata.

## Design

Percentiles are calculated from observed samples. Missing samples are not converted to zero. Export metadata reports expected rows and missing rows so billing/report consumers can apply a coverage policy explicitly.

PR #7273 remains separate for the base-1024 divisor correction.

## Validation

- PHP lint for changed files
- Targeted percentile contract test
- `git diff --check`
- Changelog format validation
