### PR TITLE
Allow installer to repair missing Composer vendor tree

### DIFF
--- a/include/global.php
+++ b/include/global.php
@@ -356,7 +356,12 @@ $il = $config['is_web'] ? '</li>' : '';
 
 /* Git checkouts and interrupted upgrades do not ship include/vendor.  Without
    this check the autoload require below produces a bare fatal error. */
-if (!is_file(CACTI_PATH_INCLUDE . '/vendor/autoload.php')) {
+// The installer can repair a missing vendor tree before application classes
+// are loaded.  All normal entry points still fail closed with an actionable
+// message rather than emitting a raw require() fatal.
+$vendor_autoload = CACTI_PATH_INCLUDE . '/vendor/autoload.php';
+
+if (!is_file($vendor_autoload) && !defined('IN_CACTI_INSTALL')) {
 	print $ps . 'FATAL: The include/vendor directory is not populated.  Cacti requires its Composer dependencies before it can start.  From the Cacti directory, run:' . $sp;
 	print $ps . 'composer install' . $sp;
 	print $ps . 'Then reload this page.  See the README for details.' . $sp;
@@ -703,7 +708,9 @@ require_once(CACTI_PATH_LIBRARY . '/snmpagent.php');
 require_once(CACTI_PATH_LIBRARY . '/aggregate.php');
 require_once(CACTI_PATH_LIBRARY . '/api_automation.php');
 require_once(CACTI_PATH_INCLUDE . '/csrf.php');
-require_once(CACTI_PATH_INCLUDE . '/vendor/autoload.php');
+if (is_file($vendor_autoload)) {
+	require_once($vendor_autoload);
+}
 
 if ($config['is_web']) {
 	// raise a message and perform a page refresh if we've changed modes

--- a/include/global.php
+++ b/include/global.php
@@ -708,6 +708,7 @@ require_once(CACTI_PATH_LIBRARY . '/snmpagent.php');
 require_once(CACTI_PATH_LIBRARY . '/aggregate.php');
 require_once(CACTI_PATH_LIBRARY . '/api_automation.php');
 require_once(CACTI_PATH_INCLUDE . '/csrf.php');
+
 if (is_file($vendor_autoload)) {
 	require_once($vendor_autoload);
 }

--- a/tests/integration/InstallerVendorRefreshContractTest.php
+++ b/tests/integration/InstallerVendorRefreshContractTest.php
@@ -46,6 +46,14 @@ test('vendor refresh bails out without a configured composer binary', function (
 		->and(strpos($body, 'addError'))->toBeFalse('refresh must never fail the install');
 });
 
+test('global bootstrap permits the installer to repair a missing vendor tree', function () use ($root) {
+	$src = file_get_contents($root . '/include/global.php');
+
+	expect($src)->not->toBeFalse()
+		->and(strpos($src, "!defined('IN_CACTI_INSTALL')"))->not->toBeFalse()
+		->and(strpos($src, 'if (is_file($vendor_autoload))'))->not->toBeFalse();
+});
+
 test('refresh gating requires pure installs', function () use ($root) {
 	$src = file_get_contents($root . '/lib/installer.php');
 


### PR DESCRIPTION
## Summary
- keep normal application startup fail-closed when Composer dependencies are missing
- allow the installer bootstrap to run far enough to refresh vendor dependencies
- add a contract test covering the guarded bootstrap path

Fixes the circular failure where install/install.php cannot invoke Installer::refreshVendorDependencies() because include/global.php exits first.