### PR TITLE
Fail gracefully when Symfony Mailer dependencies are stale

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5740,6 +5740,13 @@ function mailer(array|string $from, array|string $to, null|array|string $cc = nu
 	null|array $headers = [], bool $html = true, bool $expandIds = false) : string {
 	global $mail_methods;
 
+	// A deployment may have an autoloader generated from a different
+	// composer.lock (or no vendor tree at all).  Fail gracefully instead of
+	// turning a notification attempt into a fatal error.
+	if (!class_exists(Mailer::class) || !class_exists(Email::class)) {
+		return __('Composer mail dependencies are missing or stale. Run composer install and try again.');
+	}
+
 	$start_time = microtime(true);
 
 	$subject ??= '';

--- a/tests/Unit/SymfonyMailerMigrationTest.php
+++ b/tests/Unit/SymfonyMailerMigrationTest.php
@@ -13,6 +13,7 @@ test('mailer implementation uses Symfony Mailer instead of PHPMailer', function 
 		->not->toContain('"phpmailer/phpmailer"');
 
 	expect($functions)->toContain('use Symfony\\Component\\Mailer\\Mailer')
+		->toContain('Composer mail dependencies are missing or stale')
 		->toContain('new Email()')
 		->toContain('new Mailer($transport)')
 		->toContain('new XOAuth2Authenticator()')


### PR DESCRIPTION
## Summary
- detect missing or stale Symfony Mailer/Mime classes before constructing a transport
- return an actionable localized error instead of a fatal error during notifications
- add a regression contract assertion

This complements the existing Symfony Mailer migration while deployments regenerate their Composer vendor tree.