### PR TITLE
feat(support): add diagnostics export and environment checks

### DIFF
--- a/support.php
+++ b/support.php
@@ -79,6 +79,10 @@ function support_view_tech() : void {
 			'display' => __('Summary'),
 			'header'  => true
 		],
+		'environment' => [
+			'display' => __('Environment'),
+			'header'  => true
+		],
 		'database' => [
 			'display' => __('Database Tables'),
 			'header'  => true
@@ -165,6 +169,10 @@ function support_view_tech() : void {
 			show_tech_summary();
 
 			break;
+		case 'environment':
+			show_tech_environment();
+
+			break;
 		case 'dbstatus':
 			show_database_status();
 
@@ -223,8 +231,35 @@ function support_view_tech() : void {
 		$('#lockout').click(function() {
 			loadUrl({ url: 'support.php?action=lockout' });
 		});
+
+		$('#copy_diag').click(function() {
+			var report = $('#diag_report').val();
+			var done   = <?php print json_encode(__('Copied to clipboard')); ?>;
+			var failed = <?php print json_encode(__('Copy failed, select the text manually')); ?>;
+
+			if (navigator.clipboard && navigator.clipboard.writeText) {
+				navigator.clipboard.writeText(report).then(function() {
+					$('#copy_diag_status').text(done);
+				}, function() {
+					$('#copy_diag_status').text(failed);
+				});
+			} else {
+				var el = document.getElementById('diag_report');
+				el.style.display = 'block';
+				el.select();
+
+				try {
+					document.execCommand('copy');
+					$('#copy_diag_status').text(done);
+				} catch (e) {
+					$('#copy_diag_status').text(failed);
+				}
+
+				el.style.display = 'none';
+			}
+		});
 	});
-	</script>
+</script>
 	<?php
 
 	bottom_footer();
@@ -1180,6 +1215,11 @@ function show_tech_summary() : void {
 
 	html_section_header(__('General Information'), 2);
 
+	form_alternate_row();
+	print '<td>' . __('Diagnostics Export') . '</td>';
+	print '<td><button type="button" id="copy_diag" title="' . __esc('Copy a redacted, shareable diagnostics report to the clipboard.') . '">' . __('Copy Diagnostics') . '</button> <span id="copy_diag_status" class="deviceUp"></span></td>';
+	form_end_row();
+
 	$lockout = read_config_option('cacti_lockout_status', true);
 	$enabled = read_config_option('auth_maint_lockout_type', true);
 
@@ -1747,4 +1787,167 @@ function show_tech_summary() : void {
 	form_end_row();
 
 	utilities_get_mysql_recommendations();
+
+	// Redacted, shareable diagnostics report (Feature: Copy Diagnostics).
+	// Deliberately excludes hostnames, IP addresses, the DB host, credentials,
+	// absolute paths and the full RSA fingerprint so it is safe to paste into
+	// a public issue.  Versions, counts and settings only.
+	$snmp_line     = trim(explode("\n", strip_tags($snmp_version))[0]);
+	$web_server    = $_SERVER['SERVER_SOFTWARE'] ?? __('Unknown');
+	$poller_report = $poller_options[read_config_option('poller_type')] ?? __('Unknown');
+
+	if ($poller_report == 'spine' && $spine_version != 'Unknown') {
+		$poller_report = $spine_version;
+	}
+
+	$rsa           = read_config_option('rsa_fingerprint');
+	$rsa_report    = ($rsa != '' ? substr($rsa, 0, 8) . '… (' . __('masked') . ')' : __('N/A'));
+
+	$report  = "### Cacti Diagnostics\n";
+	$report .= '- ' . __('Cacti Version') . ': ' . CACTI_VERSION . "\n";
+	$report .= '- ' . __('Cacti OS') . ': ' . CACTI_SERVER_OS . "\n";
+	$report .= '- ' . __('Web Server') . ': ' . $web_server . "\n";
+	$report .= '- ' . __('PHP Version') . ': ' . PHP_VERSION . "\n";
+	$report .= '- ' . __('PHP OS') . ': ' . PHP_OS . "\n";
+	$report .= '- ' . __('Database') . ': ' . trim($database . ' ' . $version) . "\n";
+	$report .= '- ' . __('RRDtool Version Configured') . ': ' . get_rrdtool_version() . "+\n";
+	$report .= '- ' . __('RRDtool Version Found') . ': ' . $rrdtool_release . "\n";
+	$report .= '- ' . __('NET-SNMP Version') . ': ' . $snmp_line . "\n";
+	$report .= '- ' . __('Poller Interval') . ': ' . read_config_option('poller_interval') . "\n";
+	$report .= '- ' . __('Poller Type') . ': ' . $poller_report . "\n";
+	$report .= '- ' . __('Last Run Statistics') . ': ' . read_config_option('stats_poller') . "\n";
+	$report .= '- ' . 'memory_limit: ' . ini_get('memory_limit') . "\n";
+	$report .= '- ' . 'max_execution_time: ' . ini_get('max_execution_time') . "\n";
+	$report .= '- ' . __('System Memory') . ': ' . ($total_memory > 0 ? number_format_i18n($total_memory, 2, 1000) . ' GB' : __('N/A')) . "\n";
+	$report .= '- ' . __('RSA Fingerprint') . ': ' . $rsa_report . "\n";
+
+	form_alternate_row();
+	print "<td colspan='2'><textarea id='diag_report' style='display:none' readonly='readonly'>" . html_escape($report) . '</textarea></td>';
+	form_end_row();
+}
+
+function show_tech_environment() : void {
+	// Required PHP extensions, cross-checked against install/cli_check.php.
+	$extensions = false;
+	utility_php_verify_extensions($extensions, 'web');
+
+	html_section_header(__('Required PHP Extensions'), 2);
+
+	foreach ($extensions as $name => $extension) {
+		$loaded = !empty($extension['web']);
+
+		form_alternate_row();
+		print '<td>' . html_escape($name) . '</td>';
+		print '<td>' . tech_env_status($loaded ? DB_STATUS_SUCCESS : DB_STATUS_ERROR, $loaded ? __('Installed') : __('Missing')) . '</td>';
+		form_end_row();
+	}
+
+	// Recommended (optional) extensions such as php-snmp.
+	$optionals = false;
+	utility_php_verify_optionals($optionals, 'web');
+
+	html_section_header(__('Recommended PHP Extensions'), 2);
+
+	foreach ($optionals as $name => $optional) {
+		$loaded = !empty($optional['web']);
+
+		form_alternate_row();
+		print '<td>' . html_escape($name) . '</td>';
+		print '<td>' . tech_env_status($loaded ? DB_STATUS_SUCCESS : DB_STATUS_WARNING, $loaded ? __('Installed') : __('Not installed')) . '</td>';
+		form_end_row();
+	}
+
+	// Key php.ini values and thresholds (reuses the installer's recommendations).
+	$recommends = false;
+	utility_php_verify_recommends($recommends, 'web');
+
+	html_section_header(__('PHP Configuration'), 2);
+
+	foreach ($recommends as $recommend) {
+		if ($recommend['name'] == 'location' || $recommend['name'] == 'version') {
+			continue;
+		}
+
+		form_alternate_row();
+		print '<td>' . html_escape($recommend['name']) . '</td>';
+		print '<td>' . tech_env_status((int) $recommend['status'], __('Current: %s, Recommended: %s', html_escape($recommend['current']), html_escape($recommend['value']))) . '</td>';
+		form_end_row();
+	}
+
+	$file_uploads = (bool) ini_get('file_uploads');
+
+	form_alternate_row();
+	print '<td>file_uploads</td>';
+	print '<td>' . tech_env_status($file_uploads ? DB_STATUS_SUCCESS : DB_STATUS_ERROR, $file_uploads ? __('On') : __('Off')) . '</td>';
+	form_end_row();
+
+	// Required binaries: existence + version.
+	$binaries = [
+		'path_php_binary' => '-v',
+		'path_rrdtool'    => '--version',
+		'path_snmpget'    => '-V',
+	];
+
+	html_section_header(__('Required Binaries'), 2);
+
+	foreach ($binaries as $option => $arg) {
+		$path = read_config_option($option);
+
+		form_alternate_row();
+		print '<td>' . html_escape($option) . '</td>';
+
+		if ($path != '' && file_exists($path) && function_exists('is_executable') && is_executable($path)) {
+			if (is_function_enabled('shell_exec')) {
+				$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
+				$version = ($out != '' ? trim(explode("\n", $out)[0]) : __('Unknown version'));
+
+				print '<td>' . tech_env_status(DB_STATUS_SUCCESS, html_escape($version)) . '</td>';
+			} else {
+				print '<td>' . tech_env_status(DB_STATUS_WARNING, __('Version unavailable: shell_exec() is disabled')) . '</td>';
+			}
+		} else {
+			print '<td>' . tech_env_status(DB_STATUS_ERROR, __('Not found or not executable: %s', html_escape($path))) . '</td>';
+		}
+
+		form_end_row();
+	}
+
+	// Writable directories.  cache/rra/log must be writable; scripts/resource
+	// are usually read-only so a non-writable result is only a warning.
+	$directories = [
+		CACTI_PATH_CACHE    => true,
+		CACTI_PATH_RRA      => true,
+		CACTI_PATH_LOG      => true,
+		CACTI_PATH_SCRIPTS  => false,
+		CACTI_PATH_RESOURCE => false,
+	];
+
+	html_section_header(__('Writable Directories'), 2);
+
+	foreach ($directories as $directory => $required) {
+		$writable = is_writable($directory);
+
+		if ($writable) {
+			$status = DB_STATUS_SUCCESS;
+			$text   = __('Writable');
+		} else {
+			$status = ($required ? DB_STATUS_ERROR : DB_STATUS_WARNING);
+			$text   = __('Not writable');
+		}
+
+		form_alternate_row();
+		print '<td>' . html_escape($directory) . '</td>';
+		print '<td>' . tech_env_status($status, $text) . '</td>';
+		form_end_row();
+	}
+}
+
+function tech_env_status(int $status, string $text) : string {
+	[$class, $icon] = match ($status) {
+		DB_STATUS_SUCCESS => ['deviceUp', 'fa-check-circle'],
+		DB_STATUS_ERROR   => ['deviceDown', 'fa-times-circle'],
+		default           => ['deviceRecovering', 'fa-exclamation-triangle'],
+	};
+
+	return "<span class='$class'><i class='fa $icon'></i> " . $text . '</span>';
 }

--- a/support.php
+++ b/support.php
@@ -248,20 +248,28 @@ function support_view_tech() : void {
 
 			if (navigator.clipboard && navigator.clipboard.writeText) {
 				navigator.clipboard.writeText(report).then(function() {
-					$('#copy_diag_status').text(done);
+					$('#copy_diag_status').attr('class', 'deviceUp').text(done);
 				}, function() {
-					$('#copy_diag_status').text(failed);
+					$('#copy_diag_status').attr('class', 'deviceDown').text(failed);
 				});
 			} else {
 				var el = document.getElementById('diag_report');
 				el.style.display = 'block';
+				el.focus();
 				el.select();
 
+				var ok = false;
+
 				try {
-					document.execCommand('copy');
-					$('#copy_diag_status').text(done);
+					ok = document.execCommand('copy');
 				} catch (e) {
-					$('#copy_diag_status').text(failed);
+					ok = false;
+				}
+
+				if (ok) {
+					$('#copy_diag_status').attr('class', 'deviceUp').text(done);
+				} else {
+					$('#copy_diag_status').attr('class', 'deviceDown').text(failed);
 				}
 
 				el.style.display = 'none';
@@ -1226,7 +1234,7 @@ function show_tech_summary() : void {
 
 	form_alternate_row();
 	print '<td>' . __('Diagnostics Export') . '</td>';
-	print '<td><button type="button" id="copy_diag" title="' . __esc('Copy a redacted, shareable diagnostics report to the clipboard.') . '">' . __('Copy Diagnostics') . '</button> <span id="copy_diag_status" class="deviceUp"></span></td>';
+	print '<td><button type="button" id="copy_diag" title="' . __esc('Copy a redacted, shareable diagnostics report to the clipboard.') . '">' . __('Copy Diagnostics') . '</button> <span id="copy_diag_status" aria-live="polite"></span></td>';
 	form_end_row();
 
 	$lockout = read_config_option('cacti_lockout_status', true);
@@ -1801,7 +1809,7 @@ function show_tech_summary() : void {
 	// Deliberately excludes hostnames, IP addresses, the DB host, credentials,
 	// absolute paths and the full RSA fingerprint so it is safe to paste into
 	// a public issue.  Versions, counts and settings only.
-	$snmp_line     = trim(explode("\n", strip_tags($snmp_version))[0]);
+	$snmp_line     = trim(explode("\n", strip_tags((string) $snmp_version))[0]);
 	$web_server    = $_SERVER['SERVER_SOFTWARE'] ?? __('Unknown');
 	$poller_report = $poller_options[read_config_option('poller_type')] ?? __('Unknown');
 

--- a/support.php
+++ b/support.php
@@ -246,17 +246,25 @@ function support_view_tech() : void {
 			var done   = <?php print json_encode(__('Copied to clipboard')); ?>;
 			var failed = <?php print json_encode(__('Copy failed, select the text manually')); ?>;
 
+			var el = document.getElementById('diag_report');
+
+			// Reveal the textarea and select its contents so the "select the text
+			// manually" fallback message is actionable when copying fails.
+			var reveal = function() {
+				el.style.display = 'block';
+				el.focus();
+				el.select();
+			};
+
 			if (navigator.clipboard && navigator.clipboard.writeText) {
 				navigator.clipboard.writeText(report).then(function() {
 					$('#copy_diag_status').attr('class', 'deviceUp').text(done);
 				}, function() {
 					$('#copy_diag_status').attr('class', 'deviceDown').text(failed);
+					reveal();
 				});
 			} else {
-				var el = document.getElementById('diag_report');
-				el.style.display = 'block';
-				el.focus();
-				el.select();
+				reveal();
 
 				var ok = false;
 
@@ -268,11 +276,10 @@ function support_view_tech() : void {
 
 				if (ok) {
 					$('#copy_diag_status').attr('class', 'deviceUp').text(done);
+					el.style.display = 'none';
 				} else {
 					$('#copy_diag_status').attr('class', 'deviceDown').text(failed);
 				}
-
-				el.style.display = 'none';
 			}
 		});
 	});
@@ -1851,7 +1858,10 @@ function show_tech_environment() : void {
 	html_section_header(__('Required PHP Extensions'), 2);
 
 	foreach ($extensions as $name => $extension) {
-		$loaded = !empty($extension['web']);
+		// utility_php_verify_extensions() seeds CLI-only extensions such as
+		// pcntl with 'web' => true (meaning "not required in web"), so the flag
+		// does not track whether the module is actually loaded. Check directly.
+		$loaded = extension_loaded($name);
 
 		form_alternate_row();
 		print '<td>' . html_escape($name) . '</td>';

--- a/support.php
+++ b/support.php
@@ -1851,17 +1851,38 @@ function show_tech_summary() : void {
 }
 
 function show_tech_environment() : void {
-	// Required PHP extensions, cross-checked against install/cli_check.php.
+	// utility_php_verify_extensions() alone can't tell whether a module is
+	// really loaded in both contexts: it seeds CLI-only extensions such as
+	// pcntl with 'web' => true (not required in web), so checking either the
+	// seeded flag or a bare extension_loaded() in isolation misreports one
+	// context or the other. Verify web in-process, shell out to cli_check.php
+	// for the real CLI state (same path_php_binary lookup already used below
+	// for rrdtool/snmpget), and combine with the web && cli rule from
+	// utility_php_set_installed(), the same one lib/installer.php relies on.
 	$extensions = false;
 	utility_php_verify_extensions($extensions, 'web');
+
+	$php_binary = read_config_option('path_php_binary');
+
+	if ($php_binary != '' && file_exists($php_binary) && is_executable($php_binary)) {
+		$cli_json = shell_exec(cacti_escapeshellcmd($php_binary) . ' -q ' . cacti_escapeshellarg(CACTI_PATH_INSTALL . '/cli_check.php') . ' extensions');
+		$cli_ext  = @json_decode($cli_json, true);
+
+		if (is_array($cli_ext)) {
+			foreach ($cli_ext as $name => $ext) {
+				if (isset($extensions[$name])) {
+					$extensions[$name]['cli'] = !empty($ext['cli']);
+				}
+			}
+		}
+	}
+
+	utility_php_set_installed($extensions);
 
 	html_section_header(__('Required PHP Extensions'), 2);
 
 	foreach ($extensions as $name => $extension) {
-		// utility_php_verify_extensions() seeds CLI-only extensions such as
-		// pcntl with 'web' => true (meaning "not required in web"), so the flag
-		// does not track whether the module is actually loaded. Check directly.
-		$loaded = extension_loaded($name);
+		$loaded = !empty($extension['installed']);
 
 		form_alternate_row();
 		print '<td>' . html_escape($name) . '</td>';

--- a/support.php
+++ b/support.php
@@ -22,6 +22,15 @@
  +-------------------------------------------------------------------------+
 */
 
+// A test bootstrap includes this file only to reach the function definitions
+// below; it cannot satisfy the auth and database dispatch that follows. Return
+// before that runs. Top-level function declarations are hoisted at compile time
+// so they stay callable after this early return. The predicate matches
+// include/global.php's test-bootstrap gate, so production always falls through.
+if (defined('PHP_TESTING') && getenv('CACTI_TEST_BOOTSTRAP', true) === '1') {
+	return;
+}
+
 require('./include/auth.php');
 require_once(CACTI_PATH_LIBRARY . '/api_data_source.php');
 require_once(CACTI_PATH_LIBRARY . '/boost.php');

--- a/tests/Unit/SupportDiagnosticsTest.php
+++ b/tests/Unit/SupportDiagnosticsTest.php
@@ -1,0 +1,192 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 2) . '/include/global.php';
+require_once dirname(__DIR__, 2) . '/lib/utility.php';
+
+// support.php returns early under the test-bootstrap gate, so only its function
+// declarations load here. That skips the auth + dispatch path a unit test cannot
+// satisfy while leaving the diagnostics helpers callable.
+require_once dirname(__DIR__, 2) . '/support.php';
+
+test('show_tech_environment renders the environment sections without a database', function () {
+	global $config;
+
+	// Seed the binary paths so read_config_option() serves from the CLI option
+	// cache instead of reaching the sentinel database, which throws under the
+	// test bootstrap.
+	$config[OPTIONS_CLI]['path_php_binary'] = PHP_BINARY;
+	$config[OPTIONS_CLI]['path_rrdtool']    = '/cacti-tests/definitely-missing-rrdtool';
+	$config[OPTIONS_CLI]['path_snmpget']    = PHP_BINARY;
+
+	ob_start();
+	show_tech_environment();
+	$html = ob_get_clean();
+
+	expect($html)->toContain(__('Required PHP Extensions'))
+		->and($html)->toContain(__('Recommended PHP Extensions'))
+		->and($html)->toContain(__('PHP Configuration'))
+		->and($html)->toContain(__('Required Binaries'))
+		->and($html)->toContain(__('Writable Directories'))
+		->and($html)->toContain('file_uploads');
+});
+
+test('show_tech_environment flags a directory that is not writable', function () {
+	global $config;
+
+	$config[OPTIONS_CLI]['path_php_binary'] = PHP_BINARY;
+	$config[OPTIONS_CLI]['path_rrdtool']    = PHP_BINARY;
+	$config[OPTIONS_CLI]['path_snmpget']    = PHP_BINARY;
+
+	// CACTI_PATH_RESOURCE is one of the directories the report inspects and is
+	// not a required path, so making it read-only exercises the not-writable
+	// warning branch. Restore the mode in finally{} so a failure never leaves
+	// the checkout in a read-only state.
+	$dir  = CACTI_PATH_RESOURCE;
+	$mode = fileperms($dir) & 0777;
+
+	expect(chmod($dir, 0555))->toBeTrue();
+
+	try {
+		clearstatcache(true, $dir);
+
+		ob_start();
+		show_tech_environment();
+		$html = ob_get_clean();
+
+		expect($html)->toContain(__('Not writable'));
+	} finally {
+		chmod($dir, $mode);
+		clearstatcache(true, $dir);
+	}
+})->skip(posix_getuid() === 0, 'root bypasses directory write permissions');
+
+/*
+ * The redacted report is assembled inside show_tech_summary(), which runs a long
+ * sequence of database queries before reaching the report block. The test
+ * bootstrap's sentinel connection throws on the first query, so the function
+ * cannot be called in-process. Extract the assembly block (the security-relevant
+ * added code) and exercise it directly with controlled inputs, matching the
+ * source-extraction convention in Issue7070PercentileContractTest.
+ */
+function support_diag_build_report(array $vars): string {
+	$src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
+
+	// The block runs from the first assignment to the last $report line.
+	$start = strpos($src, '$snmp_line     = trim(');
+	$end   = strpos($src, "\$report .= '- ' . __('RSA Fingerprint')");
+	$end   = strpos($src, "\n", $end);
+
+	$block = substr($src, $start, $end - $start);
+
+	extract($vars);
+
+	eval($block);
+
+	return $report;
+}
+
+test('diagnostics report masks the RSA fingerprint and hides infrastructure', function () {
+	global $config;
+
+	$config[OPTIONS_CLI]['poller_type']     = '2';
+	$config[OPTIONS_CLI]['rsa_fingerprint'] = 'abcdef0123456789deadbeefcafebabe';
+	$config[OPTIONS_CLI]['poller_interval'] = '60';
+	$config[OPTIONS_CLI]['stats_poller']    = 'Time:1.0';
+
+	$report = support_diag_build_report([
+		'snmp_version'    => "NET-SNMP 5.9\nextra line",
+		'poller_options'  => [1 => 'cactid', 2 => 'spine'],
+		'spine_version'   => 'Spine 1.2.99',
+		'database'        => 'MariaDB',
+		'version'         => '10.11',
+		'rrdtool_release' => '1.8.0',
+		'total_memory'    => 16,
+		'_SERVER'         => ['SERVER_SOFTWARE' => 'nginx'],
+	]);
+
+	// Only the first 8 fingerprint characters survive, tagged as masked.
+	expect($report)->toContain('abcdef01')
+		->and($report)->toContain(__('masked'))
+		->and($report)->not->toContain('deadbeefcafebabe');
+
+	// The spine branch replaces the poller label with the spine version.
+	expect($report)->toContain('Spine 1.2.99');
+
+	// The single SNMP line is kept; the trailing line is dropped.
+	expect($report)->toContain('NET-SNMP 5.9')
+		->and($report)->not->toContain('extra line');
+});
+
+test('diagnostics report reports N/A when RSA and memory are absent', function () {
+	global $config;
+
+	$config[OPTIONS_CLI]['poller_type']     = '1';
+	$config[OPTIONS_CLI]['rsa_fingerprint'] = '';
+	$config[OPTIONS_CLI]['poller_interval'] = '60';
+	$config[OPTIONS_CLI]['stats_poller']    = '';
+
+	$report = support_diag_build_report([
+		'snmp_version'    => 'NET-SNMP 5.9',
+		'poller_options'  => [1 => 'cactid'],
+		'spine_version'   => 'Unknown',
+		'database'        => 'MySQL',
+		'version'         => '8.0',
+		'rrdtool_release' => '1.8.0',
+		'total_memory'    => 0,
+		'_SERVER'         => [],
+	]);
+
+	// Empty fingerprint and zero memory both collapse to the N/A label.
+	expect(substr_count($report, __('N/A')))->toBeGreaterThanOrEqual(2)
+		->and($report)->not->toContain(__('masked'));
+
+	// Missing SERVER_SOFTWARE falls back to Unknown, not a leaked value.
+	expect($report)->toContain(__('Unknown'));
+});
+
+test('tech_env_status renders a success span with a check icon', function () {
+	$html = tech_env_status(DB_STATUS_SUCCESS, 'Installed');
+
+	expect($html)->toContain("class='deviceUp'")
+		->and($html)->toContain('fa-check-circle')
+		->and($html)->toContain('Installed');
+});
+
+test('tech_env_status renders an error span with a times icon', function () {
+	$html = tech_env_status(DB_STATUS_ERROR, 'Missing');
+
+	expect($html)->toContain("class='deviceDown'")
+		->and($html)->toContain('fa-times-circle')
+		->and($html)->toContain('Missing');
+});
+
+test('tech_env_status falls back to a warning span for any other status', function () {
+	$html = tech_env_status(DB_STATUS_WARNING, 'Not installed');
+
+	expect($html)->toContain("class='deviceRecovering'")
+		->and($html)->toContain('fa-exclamation-triangle')
+		->and($html)->toContain('Not installed');
+});

--- a/tests/Unit/SupportDiagnosticsTest.php
+++ b/tests/Unit/SupportDiagnosticsTest.php
@@ -81,7 +81,7 @@ test('show_tech_environment flags a directory that is not writable', function ()
 		chmod($dir, $mode);
 		clearstatcache(true, $dir);
 	}
-})->skip(posix_getuid() === 0, 'root bypasses directory write permissions');
+})->skip(function_exists('posix_getuid') && posix_getuid() === 0, 'root bypasses directory write permissions');
 
 /*
  * The redacted report is assembled inside show_tech_summary(), which runs a long

--- a/tests/Unit/SupportDiagnosticsTest.php
+++ b/tests/Unit/SupportDiagnosticsTest.php
@@ -92,12 +92,31 @@ test('show_tech_environment flags a directory that is not writable', function ()
  * source-extraction convention in Issue7070PercentileContractTest.
  */
 function support_diag_build_report(array $vars): string {
-	$src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
+	$path = dirname(__DIR__, 2) . '/support.php';
+	$src  = file_get_contents($path);
+
+	if ($src === false) {
+		throw new RuntimeException("support_diag_build_report(): unable to read $path");
+	}
 
 	// The block runs from the first assignment to the last $report line.
 	$start = strpos($src, '$snmp_line     = trim(');
-	$end   = strpos($src, "\$report .= '- ' . __('RSA Fingerprint')");
-	$end   = strpos($src, "\n", $end);
+
+	if ($start === false) {
+		throw new RuntimeException('support_diag_build_report(): start marker not found in support.php; has the report block moved?');
+	}
+
+	$end = strpos($src, "\$report .= '- ' . __('RSA Fingerprint')");
+
+	if ($end === false) {
+		throw new RuntimeException('support_diag_build_report(): end marker not found in support.php; has the report block moved?');
+	}
+
+	$end = strpos($src, "\n", $end);
+
+	if ($end === false) {
+		throw new RuntimeException('support_diag_build_report(): no newline after end marker in support.php');
+	}
 
 	$block = substr($src, $start, $end - $start);
 

--- a/tests/e2e/support_diagnostics_docker.sh
+++ b/tests/e2e/support_diagnostics_docker.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# +-------------------------------------------------------------------------+
+# | Copyright (C) 2004-2026 The Cacti Group                                 |
+# |                                                                         |
+# | This program is free software; you can redistribute it and/or           |
+# | modify it under the terms of the GNU General Public License             |
+# | as published by the Free Software Foundation; either version 2          |
+# | of the License, or (at your option) any later version.                  |
+# +-------------------------------------------------------------------------+
+# | Cacti: The Complete RRDtool-based Graphing Solution                     |
+# +-------------------------------------------------------------------------+
+#
+# End-to-end check for the Copy Diagnostics redaction feature (#7349). Boots the
+# Cacti Docker stack, then runs support_diagnostics_probe.php inside the web
+# container against a real database to confirm the diagnostics report never
+# leaks the database host, password or full RSA fingerprint.
+#
+# Requires Docker. Run from a checkout: tests/e2e/support_diagnostics_docker.sh
+set -euo pipefail
+
+COMPOSE_PROJECT="cacti_support_diag_e2e_$$"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$REPO_DIR/.env.support-diag-e2e"
+WEB_PORT=18082
+DB_PORT=13308
+CONFIG_EXISTED=0
+CONFIG_BACKUP=""
+
+if [ -f "$REPO_DIR/include/config.php" ]; then
+	CONFIG_EXISTED=1
+	CONFIG_BACKUP="$(mktemp "${TMPDIR:-/tmp}/cacti-config.XXXXXX")"
+	cp "$REPO_DIR/include/config.php" "$CONFIG_BACKUP"
+	rm -f "$REPO_DIR/include/config.php"
+fi
+
+cleanup() {
+	cd "$REPO_DIR"
+	docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" down -v --remove-orphans 2>/dev/null || true
+	rm -f "$ENV_FILE"
+
+	if [ "$CONFIG_EXISTED" -eq 1 ] && [ -n "$CONFIG_BACKUP" ] && [ -f "$CONFIG_BACKUP" ]; then
+		cp "$CONFIG_BACKUP" "$REPO_DIR/include/config.php"
+		rm -f "$CONFIG_BACKUP"
+	elif [ "$CONFIG_EXISTED" -eq 0 ]; then
+		rm -f "$REPO_DIR/include/config.php"
+	fi
+}
+
+trap cleanup EXIT
+
+cd "$REPO_DIR"
+
+cat > "$ENV_FILE" <<EOF
+WEB_PORT=$WEB_PORT
+DB_ROOT_PASSWORD=testroot
+DB_NAME=cacti
+DB_USER=cacti
+DB_PASSWORD=testpass
+DB_PORT=$DB_PORT
+TIMEZONE=UTC
+PHP_MEMORY_LIMIT=256M
+DB_MAX_CONNECTIONS=50
+DB_BUFFER_POOL_SIZE=256M
+EOF
+
+echo "Building support diagnostics Docker test image..."
+docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" build --quiet
+
+echo "Starting support diagnostics Docker test stack..."
+docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" up -d
+
+echo "Waiting for Docker test stack..."
+TRIES=0
+while [ "$TRIES" -lt 36 ]; do
+	DB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | head -1 | cut -d'"' -f4)
+	WEB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | tail -1 | cut -d'"' -f4)
+
+	if [ "$DB_HEALTH" = "healthy" ] && [ "$WEB_HEALTH" = "healthy" ]; then
+		break
+	fi
+
+	sleep 5
+	TRIES=$((TRIES + 1))
+done
+
+if [ "${DB_HEALTH:-}" != "healthy" ] || [ "${WEB_HEALTH:-}" != "healthy" ]; then
+	docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps
+	exit 1
+fi
+
+WEB_CONTAINER=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps -q web)
+
+docker exec "$WEB_CONTAINER" php -l /var/www/html/cacti/support.php
+docker exec "$WEB_CONTAINER" php -l /var/www/html/cacti/tests/e2e/support_diagnostics_probe.php
+PROBE_OUTPUT=$(docker exec "$WEB_CONTAINER" php /var/www/html/cacti/tests/e2e/support_diagnostics_probe.php)
+echo "$PROBE_OUTPUT"
+grep -q 'PASS support diagnostics docker probe' <<<"$PROBE_OUTPUT"

--- a/tests/e2e/support_diagnostics_probe.php
+++ b/tests/e2e/support_diagnostics_probe.php
@@ -50,9 +50,23 @@ function support_diag_probe_report(): string {
 	$rrdtool_release = get_installed_rrdtool_version() ?: 'Unknown';
 	$total_memory    = 0;
 
-	$src   = file_get_contents(dirname(__DIR__, 2) . '/support.php');
+	$path = dirname(__DIR__, 2) . '/support.php';
+	$src  = file_get_contents($path);
+
+	support_diag_probe_assert($src !== false, "unable to read $path");
+
 	$start = strpos($src, '$snmp_line     = trim(');
-	$end   = strpos($src, "\n", strpos($src, "\$report .= '- ' . __('RSA Fingerprint')"));
+
+	support_diag_probe_assert($start !== false, 'start marker not found in support.php; has the report block moved?');
+
+	$marker = strpos($src, "\$report .= '- ' . __('RSA Fingerprint')");
+
+	support_diag_probe_assert($marker !== false, 'end marker not found in support.php; has the report block moved?');
+
+	$end = strpos($src, "\n", $marker);
+
+	support_diag_probe_assert($end !== false, 'no newline after end marker in support.php');
+
 	$block = substr($src, $start, $end - $start);
 
 	eval($block);

--- a/tests/e2e/support_diagnostics_probe.php
+++ b/tests/e2e/support_diagnostics_probe.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Runs inside the Cacti web container against a real database. Verifies the
+ * Copy Diagnostics report (support.php, #7349) is safe to paste into a public
+ * issue: the RSA fingerprint is truncated and the live database host and
+ * password never appear. The report block is extracted from support.php and
+ * evaluated with the container's real settings, so a regression that widens the
+ * report to include an infrastructure value fails here.
+ */
+
+chdir(dirname(__DIR__, 2));
+
+require_once __DIR__ . '/../../include/global.php';
+require_once CACTI_PATH_LIBRARY . '/functions.php';
+
+function support_diag_probe_assert(bool $condition, string $message): void {
+	if (!$condition) {
+		fwrite(STDERR, "FAIL: $message\n");
+		exit(1);
+	}
+}
+
+function support_diag_probe_report(): string {
+	global $snmp_version, $poller_options, $spine_version, $database, $version,
+		$rrdtool_release, $total_memory;
+
+	$snmp_version    = shell_exec('snmpget -V 2>&1') ?: 'NET-SNMP Unknown';
+	$poller_options  = [1 => 'cactid', 2 => 'spine'];
+	$spine_version   = 'Unknown';
+	$database        = db_fetch_cell('SELECT VERSION()') ?: 'Unknown';
+	$version         = '';
+	$rrdtool_release = get_installed_rrdtool_version() ?: 'Unknown';
+	$total_memory    = 0;
+
+	$src   = file_get_contents(dirname(__DIR__, 2) . '/support.php');
+	$start = strpos($src, '$snmp_line     = trim(');
+	$end   = strpos($src, "\n", strpos($src, "\$report .= '- ' . __('RSA Fingerprint')"));
+	$block = substr($src, $start, $end - $start);
+
+	eval($block);
+
+	return $report;
+}
+
+$report = support_diag_probe_report();
+
+support_diag_probe_assert($report !== '', 'diagnostics report must not be empty');
+
+$rsa = read_config_option('rsa_fingerprint');
+
+if ($rsa != '') {
+	support_diag_probe_assert(
+		strpos($report, $rsa) === false && strpos($report, substr($rsa, 0, 8)) !== false,
+		'RSA fingerprint must be truncated, not printed in full'
+	);
+}
+
+global $database_hostname, $database_password;
+
+if (!empty($database_hostname) && $database_hostname != 'localhost' && $database_hostname != '127.0.0.1') {
+	support_diag_probe_assert(
+		strpos($report, $database_hostname) === false,
+		'diagnostics report must not contain the database hostname'
+	);
+}
+
+if (!empty($database_password)) {
+	support_diag_probe_assert(
+		strpos($report, $database_password) === false,
+		'diagnostics report must not contain the database password'
+	);
+}
+
+print "PASS support diagnostics docker probe\n";

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -108,11 +108,11 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1185				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1203			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1226			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-cmd_exec	./support.php:1918					$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
-cmd_exec	./support.php:1923					print '<td>' . tech_env_status(DB_STATUS_WARNING, __('Version unavailable: shell_exec() is disabled')) . '</td>';
+cmd_exec	./support.php:1192				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1210			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1233			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1928					$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1933					print '<td>' . tech_env_status(DB_STATUS_WARNING, __('Version unavailable: shell_exec() is disabled')) . '</td>';
 dynamic_include	./cli/audit_database.php:232							require_once($plugin . '/setup.php');
 dynamic_include	./cli/audit_database.php:235								require_once($plugin . '/includes/database.php');
 dynamic_include	./cli/upgrade_database.php:152			include($upgrade_file);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -108,10 +108,11 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1168				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1186			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1209			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-cmd_exec	./support.php:1900				$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1185				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1203			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1226			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1918					$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1923					print '<td>' . tech_env_status(DB_STATUS_WARNING, __('Version unavailable: shell_exec() is disabled')) . '</td>';
 dynamic_include	./cli/audit_database.php:232							require_once($plugin . '/setup.php');
 dynamic_include	./cli/audit_database.php:235								require_once($plugin . '/includes/database.php');
 dynamic_include	./cli/upgrade_database.php:152			include($upgrade_file);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -108,9 +108,10 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1133				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1151			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1174			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1168				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1186			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1209			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1900				$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
 dynamic_include	./cli/audit_database.php:232							require_once($plugin . '/setup.php');
 dynamic_include	./cli/audit_database.php:235								require_once($plugin . '/includes/database.php');
 dynamic_include	./cli/upgrade_database.php:152			include($upgrade_file);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -108,9 +108,10 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1133				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1151			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1174			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1168				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1186			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1209			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1900				$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
 deserialize	./lib/functions.php:5319				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:5359				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:9996		return unserialize($strobj, ['allowed_classes' => false]);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -108,11 +108,11 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1185				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1203			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1226			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-cmd_exec	./support.php:1918					$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
-cmd_exec	./support.php:1923					print '<td>' . tech_env_status(DB_STATUS_WARNING, __('Version unavailable: shell_exec() is disabled')) . '</td>';
+cmd_exec	./support.php:1192				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1210			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1233			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1928					$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1933					print '<td>' . tech_env_status(DB_STATUS_WARNING, __('Version unavailable: shell_exec() is disabled')) . '</td>';
 deserialize	./lib/functions.php:5319				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:5359				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:9996		return unserialize($strobj, ['allowed_classes' => false]);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -108,10 +108,11 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1168				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1186			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1209			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-cmd_exec	./support.php:1900				$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1185				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1203			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1226			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1918					$out     = shell_exec(cacti_escapeshellarg($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1923					print '<td>' . tech_env_status(DB_STATUS_WARNING, __('Version unavailable: shell_exec() is disabled')) . '</td>';
 deserialize	./lib/functions.php:5319				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:5359				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:9996		return unserialize($strobj, ['allowed_classes' => false]);
@@ -607,7 +608,7 @@ header_redirect	./settings.php:1666			header('Location: settings.php?header=fals
 header_redirect	./settings.php:1668			header('Location: settings.php?tab=' . grv('tab'));
 header_redirect	./sites.php:280			header('Location: sites.php?action=edit&id=' . (empty($site_id) ? gnrv('id') : $site_id));
 header_redirect	./sites.php:393			header('Location: sites.php');
-header_redirect	./support.php:64		header('Location: support.php?tab=summary');
+header_redirect	./support.php:73		header('Location: support.php?tab=summary');
 header_redirect	./templates_export.php:72					header('Location: templates_export.php');
 header_redirect	./templates_import.php:118				header('Location: templates_import.php');
 header_redirect	./templates_import.php:67				header('Location: templates_import.php');


### PR DESCRIPTION
Two additions to the Technical Support page (`support.php`).

**Copy Diagnostics** - a button on the Summary tab that copies a redacted Markdown report (Cacti/PHP/RRDtool/SNMP/DB versions, poller summary, system memory, php.ini limits) for pasting into issues and forum posts. Redaction: DB host and passwords omitted, no monitored-device names or IPs, no absolute paths, RSA fingerprint masked.

**Environment tab** - a pass/warn/fail panel that reuses the installer's own checks (`utility_php_verify_extensions/optionals/recommends`) for required and optional PHP extensions and php.ini values, plus binary path/version checks (php/rrdtool/snmpget) and writability of the cache/rra/log/scripts/resource directories.

Verified: `php -l` clean, php-cs-fixer 0 fixable, PHPStan level 6 no errors.

Note for review: the reused `utility_php_verify_recommends()` emits a couple of `cacti_log()` lines when the Environment tab renders (existing installer-helper behavior). Happy to silence it there if preferred.

Base: develop.

Part of #7370