### PR TITLE
refactor(support): register process tables via support_process_tables hook

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@ Cacti CHANGELOG
 -issue#7211: Correct the Nth percentile and bandwidth summation divisor on base-1024 graphs
 -issue#7214: Fix TypeError in boost_graph_set_file when sending reports
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
+-feature#7370: Allow plugins to register process tables for the technical support view
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/support.php
+++ b/support.php
@@ -597,26 +597,148 @@ function draw_cacti_process_filter(bool $render = false, array $tables = []) : v
 	}
 }
 
+/**
+ * support_process_tables - return the process-table definitions used to build
+ * the background process view.  Core registers the tables it ships with, then
+ * exposes the set through the 'support_process_tables' plugin hook so a plugin
+ * can add its own process table (or override a core one) instead of core having
+ * to carry every plugin's schema.
+ *
+ * Definitions are keyed by a unique task key (also the value used by the 'tasks'
+ * filter).  Each definition contains:
+ *   'label'  - task label shown in the filter and the Task Type column
+ *   'table'  - database table probed with db_table_exists() before inclusion
+ *   'select' - a SELECT fragment returning the common process columns in order:
+ *              pid, tasktype, taskname, taskid, timeout, started, last_update, runtime
+ *
+ * @return array<string,array{label:string,table:string,select:string}>
+ */
+function support_process_tables() : array {
+	$poller_interval = read_config_option('poller_interval');
+
+	// the full set of process tables known to Cacti.  the key is the table name
+	// for core entries so the db_table_exists() gate below matches prior behavior.
+	$poller_label     = __('Cacti Poller');
+	$process_label    = __('Cacti Process');
+	$grid_label       = __('RTM Process');
+	$automation_label = __('Automation Process');
+	$hmib_label       = __('HMIB Process');
+	$mikrotik_label   = __('MikroTik Process');
+	$webseer_label    = __('WebSeer Process');
+	$servcheck_label  = __('Service Check Process');
+	$mactrack_label   = __('MacTrack Process');
+
+	$defaults = [
+		'poller_time' => [
+			'label'  => $poller_label,
+			'table'  => 'poller_time',
+			'select' => 'SELECT pid, ' . db_qstr($poller_label) . " AS tasktype,
+					CONCAT('PollerID:', poller_id) AS taskname,
+					id AS taskid, '$poller_interval' AS timeout,
+					start_time AS started,
+					start_time AS last_update,
+					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(start_time) AS runtime
+					FROM poller_time WHERE UNIX_TIMESTAMP(end_time) = 0",
+		],
+		'processes' => [
+			'label'  => $process_label,
+			'table'  => 'processes',
+			'select' => 'SELECT pid, CONCAT(' . db_qstr($process_label) . ", ' (', tasktype, ')') AS tasktype,
+					taskname, taskid, timeout,
+					started, last_update,
+					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(started) AS runtime
+					FROM processes",
+		],
+		'grid_processes' => [
+			'label'  => $grid_label,
+			'table'  => 'grid_processes',
+			'select' => 'SELECT pid, ' . db_qstr($grid_label) . " AS tasktype,
+					taskname, taskid, 'N/A' AS timeout,
+					'-' AS started, heartbeat AS last_update,
+					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(heartbeat) AS runtime
+					FROM grid_processes",
+		],
+		'automation_processes' => [
+			'label'  => $automation_label,
+			'table'  => 'automation_processes',
+			'select' => 'SELECT pid, ' . db_qstr($automation_label) . ' AS tasktype,
+					CONCAT(' . db_qstr(__('Poller:')) . ", an.poller_id) AS taskname,
+					network_id AS taskid, 'N/A' AS timeout, an.last_started AS started, ap.heartbeat AS last_update,
+					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(an.last_started) AS runtime
+					FROM automation_processes AS ap INNER JOIN automation_networks AS an ON an.id = ap.network_id",
+		],
+		'plugin_hmib_processes' => [
+			'label'  => $hmib_label,
+			'table'  => 'plugin_hmib_processes',
+			'select' => 'SELECT pid, ' . db_qstr($hmib_label) . ' AS tasktype,
+					' . db_qstr(__('Collector')) . " AS taskname, taskid, 'N/A' AS timeout,
+					started, 'N/A' AS last_update,
+					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(started) AS runtime
+					FROM plugin_hmib_processes",
+		],
+		'plugin_mikrotik_processes' => [
+			'label'  => $mikrotik_label,
+			'table'  => 'plugin_mikrotik_processes',
+			'select' => 'SELECT pid, ' . db_qstr($mikrotik_label) . ' AS tasktype,
+				' . db_qstr(__('Collector')) . " AS taskname, taskid, 'N/A' AS timeout,
+				started, 'N/A' AS last_update,
+				UNIX_TIMESTAMP() - UNIX_TIMESTAMP(started) AS runtime
+				FROM plugin_mikrotik_processes",
+		],
+		'plugin_webseer_processes' => [
+			'label'  => $webseer_label,
+			'table'  => 'plugin_webseer_processes',
+			'select' => 'SELECT pid, ' . db_qstr($webseer_label) . ' AS tasktype,
+					CONCAT(' . db_qstr(__('Poller:')) . ", poller_id) AS taskname, url_id AS taskid, 'N/A' AS timeout,
+					time AS started, 'N/A' AS last_update,
+					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(time) AS runtime
+					FROM plugin_webseer_processes",
+		],
+		'plugin_servcheck_processes' => [
+			'label'  => $servcheck_label,
+			'table'  => 'plugin_servcheck_processes',
+			'select' => 'SELECT pid, ' . db_qstr($servcheck_label) . ' AS tasktype,
+					CONCAT(' . db_qstr(__('Poller:')) . ", poller_id) AS taskname, test_id AS taskid, 'N/A' AS timeout,
+					time AS started, 'N/A' AS last_update,
+					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(time) AS runtime
+					FROM plugin_servcheck_processes",
+		],
+		'mac_track_processes' => [
+			'label'  => $mactrack_label,
+			'table'  => 'mac_track_processes',
+			'select' => 'SELECT process_id AS pid, ' . db_qstr($mactrack_label) . ' AS tasktype,
+					CONCAT(' . db_qstr(__('Device:')) . ", device_id) AS taskname, device_id AS taskid, 'N/A' AS timeout,
+					start_date AS started, 'N/A' AS last_update,
+					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(start_date) AS runtime
+					FROM mac_track_processes",
+		],
+	];
+
+	$definitions = api_plugin_hook_function('support_process_tables', $defaults);
+
+	// discard anything a plugin registered that is not a well formed definition
+	// so a broken hook cannot fatal the process view or corrupt the UNION.
+	foreach ($definitions as $key => $definition) {
+		if (!is_array($definition) || !isset($definition['label'], $definition['table'], $definition['select'])) {
+			unset($definitions[$key]);
+		}
+	}
+
+	return $definitions;
+}
+
 function show_cacti_processes() : void {
 	global $item_rows;
 
-	// the full set of process tables known to Cacti
-	$tables = [
-		'poller_time'                   => __('Cacti Poller'),          // Core Cacti poller table
-		'processes'                     => __('Cacti Process'),         // Cacti process table
-		'grid_processes'                => __('RTM Process'),           // RTM process table
-		'automation_processes'          => __('Automation Process'),    // Automation process table
-		'plugin_hmib_processes'         => __('HMIB Process'),          // HMIB process table
-		'plugin_mikrotik_processes'     => __('MikroTik Process'),      // MikroTik process table
-		'plugin_webseer_processes'      => __('WebSeer Process'),       // WebSeer process table
-		'plugin_servcheck_processes'    => __('Service Check Process'), // Service Check process table
-		'mac_track_processes'           => __('MacTrack Process'),      // MacTrack process table
-	];
+	$definitions = support_process_tables();
 
-	// reduce the set of tables based if they exist
-	foreach ($tables as $table => $name) {
-		if (!db_table_exists($table)) {
-			unset($tables[$table]);
+	// reduce the set of tables to those that actually exist, preserving the
+	// registration order so the generated UNION is unchanged.
+	$tables = [];
+
+	foreach ($definitions as $key => $definition) {
+		if (db_table_exists($definition['table'])) {
+			$tables[$key] = $definition['label'];
 		}
 	}
 
@@ -627,8 +749,6 @@ function show_cacti_processes() : void {
 	} else {
 		$rows = grv('rows');
 	}
-
-	$poller_interval = read_config_option('poller_interval');
 
 	$sql_where  = '';
 	$sql_params = [];
@@ -652,91 +772,7 @@ function show_cacti_processes() : void {
 	$sql_inner = '';
 
 	foreach ($tables as $table => $name) {
-		switch($table) {
-			case 'poller_time':
-				$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') .
-					'SELECT pid, ' . db_qstr(__('Cacti Poller')) . " AS tasktype,
-						CONCAT('PollerID:', poller_id) AS taskname,
-						id AS taskid, '$poller_interval' AS timeout,
-						start_time AS started,
-						start_time AS last_update,
-						UNIX_TIMESTAMP() - UNIX_TIMESTAMP(start_time) AS runtime
-						FROM poller_time WHERE UNIX_TIMESTAMP(end_time) = 0";
-
-				break;
-			case 'processes':
-				$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') .
-					'SELECT pid, CONCAT(' . db_qstr($name) . ", ' (', tasktype, ')') AS tasktype,
-						taskname, taskid, timeout,
-						started, last_update,
-						UNIX_TIMESTAMP() - UNIX_TIMESTAMP(started) AS runtime
-						FROM processes";
-
-				break;
-			case 'grid_processes':
-				$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') .
-					'SELECT pid, ' . db_qstr($name) . " AS tasktype,
-						taskname, taskid, 'N/A' AS timeout,
-						'-' AS started, heartbeat AS last_update,
-						UNIX_TIMESTAMP() - UNIX_TIMESTAMP(heartbeat) AS runtime
-						FROM grid_processes";
-
-				break;
-			case 'automation_processes':
-				$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') .
-					'SELECT pid, ' . db_qstr($name) . ' AS tasktype,
-						CONCAT(' . db_qstr(__('Poller:')) . ", an.poller_id) AS taskname,
-						network_id AS taskid, 'N/A' AS timeout, an.last_started AS started, ap.heartbeat AS last_update,
-						UNIX_TIMESTAMP() - UNIX_TIMESTAMP(an.last_started) AS runtime
-						FROM automation_processes AS ap INNER JOIN automation_networks AS an ON an.id = ap.network_id";
-
-				break;
-			case 'mac_track_processes':
-				$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') .
-					'SELECT process_id AS pid, ' . db_qstr($name) . ' AS tasktype,
-						CONCAT(' . db_qstr(__('Device:')) . ", device_id) AS taskname, device_id AS taskid, 'N/A' AS timeout,
-						start_date AS started, 'N/A' AS last_update,
-						UNIX_TIMESTAMP() - UNIX_TIMESTAMP(start_date) AS runtime
-						FROM mac_track_processes";
-
-				break;
-			case 'plugin_hmib_processes':
-				$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') .
-					'SELECT pid, ' . db_qstr($name) . ' AS tasktype,
-						' . db_qstr(__('Collector')) . " AS taskname, taskid, 'N/A' AS timeout,
-						started, 'N/A' AS last_update,
-						UNIX_TIMESTAMP() - UNIX_TIMESTAMP(started) AS runtime
-						FROM plugin_hmib_processes";
-
-				break;
-			case 'plugin_mikrotik_processes':
-				$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') .
-					'SELECT pid, ' . db_qstr($name) . ' AS tasktype,
-					' . db_qstr(__('Collector')) . " AS taskname, taskid, 'N/A' AS timeout,
-					started, 'N/A' AS last_update,
-					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(started) AS runtime
-					FROM plugin_mikrotik_processes";
-
-				break;
-			case 'plugin_webseer_processes':
-				$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') .
-					'SELECT pid, ' . db_qstr($name) . ' AS tasktype,
-						CONCAT(' . db_qstr(__('Poller:')) . ", poller_id) AS taskname, url_id AS taskid, 'N/A' AS timeout,
-						time AS started, 'N/A' AS last_update,
-						UNIX_TIMESTAMP() - UNIX_TIMESTAMP(time) AS runtime
-						FROM plugin_webseer_processes";
-
-				break;
-			case 'plugin_servcheck_processes':
-				$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') .
-					'SELECT pid, ' . db_qstr($name) . ' AS tasktype,
-						CONCAT(' . db_qstr(__('Poller:')) . ", poller_id) AS taskname, test_id AS taskid, 'N/A' AS timeout,
-						time AS started, 'N/A' AS last_update,
-						UNIX_TIMESTAMP() - UNIX_TIMESTAMP(time) AS runtime
-						FROM plugin_servcheck_processes";
-
-				break;
-		}
+		$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') . $definitions[$table]['select'];
 	}
 
 	$total_rows = db_fetch_cell_prepared("SELECT COUNT(*)

--- a/support.php
+++ b/support.php
@@ -724,10 +724,10 @@ function support_process_tables() : array {
 		$definitions = $defaults;
 	}
 
-	// discard anything a plugin registered that is not a well formed definition
-	// so a broken hook cannot fatal the process view or corrupt the UNION.  the
-	// three members are used directly in SQL and markup, so each must be a string;
-	// a plugin passing an array/object for any of them gets the entry skipped.
+	// discard anything a plugin registered that is not a well formed definition.
+	// this only enforces that label/table/select are present and are strings; it
+	// does not validate that 'select' is syntactically valid SQL or returns the
+	// expected columns, so a malformed plugin SELECT can still break the UNION.
 	foreach ($definitions as $key => $definition) {
 		if (!is_array($definition) ||
 			!isset($definition['label'], $definition['table'], $definition['select']) ||
@@ -870,7 +870,10 @@ function show_cacti_processes() : void {
 
 	if (cacti_sizeof($processes)) {
 		foreach ($processes as $p) {
-			form_alternate_row('line' . $p['pid'], false);
+			// pid backs the SELECT fragments plugins register, so cast it before
+			// using it to build the row id -- a non-numeric value could otherwise
+			// break out of the id='...' attribute in form_alternate_row().
+			form_alternate_row('line' . (int) $p['pid'], false);
 
 			if ($p['timeout'] != 'N/A') {
 				$timeout_time = $p['timeout'];
@@ -885,18 +888,20 @@ function show_cacti_processes() : void {
 
 			// escape every column: plugins can contribute the SELECT fragments
 			// behind these rows via the support_process_tables hook, so the
-			// values are not trusted (taskname is already escaped by filter_value)
-			form_selectable_cell(html_escape($p['tasktype']), $p['pid']);
+			// values are not trusted (taskname is already escaped by filter_value).
+			// use form_selectable_ecell(), the file's existing escaping helper,
+			// rather than hand-wrapping form_selectable_cell() with html_escape().
+			form_selectable_ecell($p['tasktype'], $p['pid']);
 			form_selectable_cell(filter_value(cacti_strtoupper($p['taskname']), ''), $p['pid']);
-			form_selectable_cell(html_escape($p['taskid']), $p['pid'], '', 'right');
-			form_selectable_cell(html_escape($p['runtime']), $p['pid'], '', 'right');
-			form_selectable_cell(html_escape($p['pid']), $p['pid'], '', 'right');
+			form_selectable_ecell($p['taskid'], $p['pid'], '', 'right');
+			form_selectable_ecell($p['runtime'], $p['pid'], '', 'right');
+			form_selectable_ecell($p['pid'], $p['pid'], '', 'right');
 
 			// form_selectable_cell($p['timeout'], $p['pid'], '', 'right');
 
-			form_selectable_cell(html_escape($timeout_date), $p['pid'], '', 'right');
-			form_selectable_cell(html_escape($p['started']), $p['pid'], '', 'right');
-			form_selectable_cell(html_escape($p['last_update']), $p['pid'], '', 'right');
+			form_selectable_ecell($timeout_date, $p['pid'], '', 'right');
+			form_selectable_ecell($p['started'], $p['pid'], '', 'right');
+			form_selectable_ecell($p['last_update'], $p['pid'], '', 'right');
 
 			form_end_row();
 		}

--- a/support.php
+++ b/support.php
@@ -637,7 +637,7 @@ function support_process_tables() : array {
 			'table'  => 'poller_time',
 			'select' => 'SELECT pid, ' . db_qstr($poller_label) . " AS tasktype,
 					CONCAT('PollerID:', poller_id) AS taskname,
-					id AS taskid, $poller_interval AS timeout,
+					id AS taskid, " . db_qstr((string) $poller_interval) . " AS timeout,
 					start_time AS started,
 					start_time AS last_update,
 					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(start_time) AS runtime
@@ -725,15 +725,23 @@ function support_process_tables() : array {
 	}
 
 	// discard anything a plugin registered that is not a well formed definition.
-	// this only enforces that label/table/select are present and are strings; it
-	// does not validate that 'select' is syntactically valid SQL or returns the
-	// expected columns, so a malformed plugin SELECT can still break the UNION.
+	// this only enforces stable filter keys and non-empty label/table/select
+	// strings; it does not validate that 'select' is syntactically valid SQL or
+	// returns the expected columns, so a malformed plugin SELECT can still break
+	// the UNION.
 	foreach ($definitions as $key => $definition) {
-		if (!is_array($definition) ||
+		if (!is_string($key) ||
+			$key === 'all' ||
+			preg_match('/^[A-Za-z0-9_]+$/', $key) !== 1 ||
+			!is_array($definition) ||
 			!isset($definition['label'], $definition['table'], $definition['select']) ||
 			!is_string($definition['label']) ||
 			!is_string($definition['table']) ||
-			!is_string($definition['select'])) {
+			!is_string($definition['select']) ||
+			trim($definition['label']) === '' ||
+			trim($definition['table']) === '' ||
+			trim($definition['select']) === '' ||
+			preg_match('/^[A-Za-z0-9_]+$/', $definition['table']) !== 1) {
 			unset($definitions[$key]);
 		}
 	}

--- a/support.php
+++ b/support.php
@@ -614,7 +614,7 @@ function draw_cacti_process_filter(bool $render = false, array $tables = []) : v
  * @return array<string,array{label:string,table:string,select:string}>
  */
 function support_process_tables() : array {
-	$poller_interval = read_config_option('poller_interval');
+	$poller_interval = (int) read_config_option('poller_interval');
 
 	// the full set of process tables known to Cacti.  the key is the table name
 	// for core entries so the db_table_exists() gate below matches prior behavior.
@@ -634,7 +634,7 @@ function support_process_tables() : array {
 			'table'  => 'poller_time',
 			'select' => 'SELECT pid, ' . db_qstr($poller_label) . " AS tasktype,
 					CONCAT('PollerID:', poller_id) AS taskname,
-					id AS taskid, '$poller_interval' AS timeout,
+					id AS taskid, $poller_interval AS timeout,
 					start_time AS started,
 					start_time AS last_update,
 					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(start_time) AS runtime
@@ -722,9 +722,15 @@ function support_process_tables() : array {
 	}
 
 	// discard anything a plugin registered that is not a well formed definition
-	// so a broken hook cannot fatal the process view or corrupt the UNION.
+	// so a broken hook cannot fatal the process view or corrupt the UNION.  the
+	// three members are used directly in SQL and markup, so each must be a string;
+	// a plugin passing an array/object for any of them gets the entry skipped.
 	foreach ($definitions as $key => $definition) {
-		if (!is_array($definition) || !isset($definition['label'], $definition['table'], $definition['select'])) {
+		if (!is_array($definition) ||
+			!isset($definition['label'], $definition['table'], $definition['select']) ||
+			!is_string($definition['label']) ||
+			!is_string($definition['table']) ||
+			!is_string($definition['select'])) {
 			unset($definitions[$key]);
 		}
 	}

--- a/support.php
+++ b/support.php
@@ -637,11 +637,11 @@ function support_process_tables() : array {
 			'table'  => 'poller_time',
 			'select' => 'SELECT pid, ' . db_qstr($poller_label) . " AS tasktype,
 					CONCAT('PollerID:', poller_id) AS taskname,
-					id AS taskid, " . db_qstr((string) $poller_interval) . " AS timeout,
+					id AS taskid, " . db_qstr((string) $poller_interval) . ' AS timeout,
 					start_time AS started,
 					start_time AS last_update,
 					UNIX_TIMESTAMP() - UNIX_TIMESTAMP(start_time) AS runtime
-					FROM poller_time WHERE UNIX_TIMESTAMP(end_time) = 0",
+					FROM poller_time WHERE UNIX_TIMESTAMP(end_time) = 0',
 		],
 		'processes' => [
 			'label'  => $process_label,
@@ -738,8 +738,8 @@ function support_process_tables() : array {
 			!is_string($definition['label']) ||
 			!is_string($definition['table']) ||
 			!is_string($definition['select']) ||
-			trim($definition['label']) === '' ||
-			trim($definition['table']) === '' ||
+			trim($definition['label'])  === '' ||
+			trim($definition['table'])  === '' ||
 			trim($definition['select']) === '' ||
 			preg_match('/^[A-Za-z0-9_]+$/', $definition['table']) !== 1) {
 			unset($definitions[$key]);

--- a/support.php
+++ b/support.php
@@ -716,6 +716,11 @@ function support_process_tables() : array {
 
 	$definitions = api_plugin_hook_function('support_process_tables', $defaults);
 
+	// a misbehaving plugin can return a non-array; fall back to the built-in set
+	if (!is_array($definitions)) {
+		$definitions = $defaults;
+	}
+
 	// discard anything a plugin registered that is not a well formed definition
 	// so a broken hook cannot fatal the process view or corrupt the UNION.
 	foreach ($definitions as $key => $definition) {
@@ -775,20 +780,27 @@ function show_cacti_processes() : void {
 		$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') . $definitions[$table]['select'];
 	}
 
-	$total_rows = db_fetch_cell_prepared("SELECT COUNT(*)
-		FROM ($sql_inner) AS rs
-		$sql_where",
-		$sql_params);
+	if ($sql_inner == '') {
+		// no process tables available; render the empty result rather than
+		// building a broken 'FROM ()' UNION
+		$total_rows = 0;
+		$processes  = [];
+	} else {
+		$total_rows = db_fetch_cell_prepared("SELECT COUNT(*)
+			FROM ($sql_inner) AS rs
+			$sql_where",
+			$sql_params);
 
-	$sql_order = get_order_string();
-	$sql_limit = ' LIMIT ' . ((int) $rows * ((int) grv('page') - 1)) . ',' . (int) $rows;
+		$sql_order = get_order_string();
+		$sql_limit = ' LIMIT ' . ((int) $rows * ((int) grv('page') - 1)) . ',' . (int) $rows;
 
-	$processes = db_fetch_assoc_prepared("SELECT *
-		FROM ($sql_inner) AS rs
-		$sql_where
-		$sql_order
-		$sql_limit",
-		$sql_params);
+		$processes = db_fetch_assoc_prepared("SELECT *
+			FROM ($sql_inner) AS rs
+			$sql_where
+			$sql_order
+			$sql_limit",
+			$sql_params);
+	}
 
 	$display_text = [
 		'tasktype' => [

--- a/support.php
+++ b/support.php
@@ -43,14 +43,30 @@ switch(grv('action')) {
 }
 
 function support_lockout() : void {
+	// this toggles a system-wide state, so require POST. csrf_check() only
+	// validates the token on POST, so a GET would slip past CSRF protection.
+	if (strtoupper($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+		header('Location: support.php?tab=summary');
+
+		exit;
+	}
+
 	$admin = read_config_option('admin_user', true);
 
 	if (read_config_option('admin_user') != $_SESSION[SESS_USER_ID]) {
 		raise_message('lockout_user', __('Only the Primary Cacti Administrator \'%s\' can lockout the Cacti system.', get_username($admin)), MESSAGE_LEVEL_ERROR);
 	} else {
-		$status = read_config_option('cacti_lockout_status', true);
+		$status    = read_config_option('cacti_lockout_status', true);
+		$is_locked = ($status != '');
 
-		if ($status == '') {
+		// 'expected' reflects the state the button showed when the page was
+		// rendered. Only toggle if the stored state still matches it, so two
+		// administrators acting at once cannot flip each other's change.
+		$expected_locked = (gnrv('expected') == 'locked');
+
+		if ($is_locked !== $expected_locked) {
+			raise_message('lockout', __('The Cacti maintenance lockout state was changed by another administrator since this page was loaded.  Please review the current status and try again.'), MESSAGE_LEVEL_INFO);
+		} elseif (!$is_locked) {
 			raise_message('lockout', __('Cacti has been locked out by \'%s\'.  Press the button again after Cacti maintenance is over.', get_username($admin)), MESSAGE_LEVEL_WARN);
 			cacti_log('WARNING: Cacti has been locked out by the primary administrator!');
 			set_config_option('cacti_lockout_status', json_encode(['session' => session_id(), 'time' => time()]));
@@ -221,7 +237,10 @@ function support_view_tech() : void {
 		});
 
 		$('#lockout').click(function() {
-			loadUrl({ url: 'support.php?action=lockout' });
+			postUrl({ url: 'support.php?action=lockout' }, {
+				__csrf_magic: csrfMagicToken,
+				expected: $(this).attr('data-expected')
+			});
 		});
 	});
 	</script>
@@ -1194,9 +1213,9 @@ function show_tech_summary() : void {
 			$unlock_time = $lockout['time'] + (30 * 60);
 			$unlock_hms  = date('H:i', $unlock_time);
 
-			print '<td><button class="deviceDown" type="button" id="lockout" title="' . __('To Unlock, press this button again.') . '">' . __('Cacti in Maintenance Mode until approximately %s!', $unlock_hms) . '</button></td>';
+			print '<td><button class="deviceDown" type="button" id="lockout" data-expected="locked" title="' . __('To Unlock, press this button again.') . '">' . __('Cacti in Maintenance Mode until approximately %s!', $unlock_hms) . '</button></td>';
 		} else {
-			print '<td><button type="button" id="lockout" title="' . __('Press this button to Lockout Cacti for 30 minutes for maintenance.') . '">' . __('Lockout Cacti for Maintenance') . '</button></td>';
+			print '<td><button type="button" id="lockout" data-expected="unlocked" title="' . __('Press this button to Lockout Cacti for 30 minutes for maintenance.') . '">' . __('Lockout Cacti for Maintenance') . '</button></td>';
 		}
 	} else {
 		print '<td><button class="deviceDisabled" type="button" id="lockout" disabled="disabled" title="' . __('To enable this feature, goto Settings > Authentication.') . '">' . __('Cacti Maintenance Mode feature is disabled') . '</button></td>';

--- a/support.php
+++ b/support.php
@@ -53,7 +53,7 @@ function support_lockout() : void {
 
 	$admin = read_config_option('admin_user', true);
 
-	if (read_config_option('admin_user') != $_SESSION[SESS_USER_ID]) {
+	if ($admin != $_SESSION[SESS_USER_ID]) {
 		raise_message('lockout_user', __('Only the Primary Cacti Administrator \'%s\' can lockout the Cacti system.', get_username($admin)), MESSAGE_LEVEL_ERROR);
 	} else {
 		$status    = read_config_option('cacti_lockout_status', true);
@@ -61,8 +61,11 @@ function support_lockout() : void {
 
 		// 'expected' reflects the state the button showed when the page was
 		// rendered. Only toggle if the stored state still matches it, so two
-		// administrators acting at once cannot flip each other's change.
-		$expected_locked = (gnrv('expected') == 'locked');
+		// administrators acting at once cannot flip each other's change.  the
+		// request var is unfiltered and may arrive as an array, so compare
+		// only when it is a string to avoid an array-to-string coercion.
+		$expected        = gnrv('expected');
+		$expected_locked = (is_string($expected) && $expected == 'locked');
 
 		if ($is_locked !== $expected_locked) {
 			raise_message('lockout', __('The Cacti maintenance lockout state was changed by another administrator since this page was loaded.  Please review the current status and try again.'), MESSAGE_LEVEL_INFO);
@@ -782,7 +785,7 @@ function show_cacti_processes() : void {
 
 	$sql_inner = '';
 
-	foreach ($tables as $table => $name) {
+	foreach (array_keys($tables) as $table) {
 		$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') . $definitions[$table]['select'];
 	}
 

--- a/support.php
+++ b/support.php
@@ -883,17 +883,20 @@ function show_cacti_processes() : void {
 				$timeout_date = $p['timeout'];
 			}
 
-			form_selectable_cell($p['tasktype'], $p['pid']);
+			// escape every column: plugins can contribute the SELECT fragments
+			// behind these rows via the support_process_tables hook, so the
+			// values are not trusted (taskname is already escaped by filter_value)
+			form_selectable_cell(html_escape($p['tasktype']), $p['pid']);
 			form_selectable_cell(filter_value(cacti_strtoupper($p['taskname']), ''), $p['pid']);
-			form_selectable_cell($p['taskid'], $p['pid'], '', 'right');
-			form_selectable_cell($p['runtime'], $p['pid'], '', 'right');
-			form_selectable_cell($p['pid'], $p['pid'], '', 'right');
+			form_selectable_cell(html_escape($p['taskid']), $p['pid'], '', 'right');
+			form_selectable_cell(html_escape($p['runtime']), $p['pid'], '', 'right');
+			form_selectable_cell(html_escape($p['pid']), $p['pid'], '', 'right');
 
 			// form_selectable_cell($p['timeout'], $p['pid'], '', 'right');
 
-			form_selectable_cell($timeout_date, $p['pid'], '', 'right');
-			form_selectable_cell($p['started'], $p['pid'], '', 'right');
-			form_selectable_cell($p['last_update'], $p['pid'], '', 'right');
+			form_selectable_cell(html_escape($timeout_date), $p['pid'], '', 'right');
+			form_selectable_cell(html_escape($p['started']), $p['pid'], '', 'right');
+			form_selectable_cell(html_escape($p['last_update']), $p['pid'], '', 'right');
 
 			form_end_row();
 		}

--- a/tests/Unit/SupportProcessTablesHookTest.php
+++ b/tests/Unit/SupportProcessTablesHookTest.php
@@ -1,0 +1,125 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 2) . '/include/global.php';
+
+/*
+ * support_process_tables() (support.php, #7353) publishes the built-in process
+ * tables through the 'support_process_tables' plugin hook, then discards any
+ * definition a plugin returns that is not well formed so a broken plugin cannot
+ * fatal the process view or corrupt the UNION.
+ *
+ * The function is extracted from support.php and evaluated with its hook call
+ * redirected to a test-controlled value, so the plugin return can be driven
+ * without a registered plugin. This mirrors the source-extraction convention in
+ * Issue7070PercentileContractTest; eval() runs only Cacti's own source with no
+ * external input.
+ */
+function process_tables_define_probe(): void {
+	if (function_exists('support_process_tables_probe')) {
+		return;
+	}
+
+	$src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
+
+	preg_match('/function support_process_tables\(\) : array \{.*?^\}/sm', $src, $m);
+
+	$body = $m[0];
+
+	// Redirect the hook call to a global the test controls. When the global is
+	// unset the real hook runs (no registered plugins, so it returns $defaults).
+	$body = str_replace(
+		"\$definitions = api_plugin_hook_function('support_process_tables', \$defaults);",
+		"\$definitions = array_key_exists('__test_process_hook', \$GLOBALS) ? \$GLOBALS['__test_process_hook'] : api_plugin_hook_function('support_process_tables', \$defaults);",
+		$body
+	);
+
+	$body = preg_replace('/^function support_process_tables\(\)/m', 'function support_process_tables_probe()', $body);
+
+	eval($body);
+}
+
+process_tables_define_probe();
+
+beforeEach(function () {
+	unset($GLOBALS['__test_process_hook']);
+});
+
+test('the built-in process tables are all well formed', function () {
+	$tables = support_process_tables_probe();
+
+	expect($tables)->toBeArray()
+		->and($tables)->toHaveKeys([
+			'poller_time', 'processes', 'grid_processes', 'automation_processes',
+			'plugin_hmib_processes', 'plugin_mikrotik_processes',
+			'plugin_webseer_processes', 'plugin_servcheck_processes',
+			'mac_track_processes',
+		]);
+
+	foreach ($tables as $definition) {
+		expect($definition['label'])->toBeString()
+			->and($definition['table'])->toBeString()
+			->and($definition['select'])->toBeString();
+	}
+});
+
+test('a non-array hook result falls back to the built-in tables', function () {
+	$GLOBALS['__test_process_hook'] = 'a plugin returned a string';
+
+	$tables = support_process_tables_probe();
+
+	expect($tables)->toBeArray()
+		->and($tables)->toHaveKey('poller_time');
+});
+
+test('malformed plugin definitions are discarded and valid ones kept', function () {
+	$GLOBALS['__test_process_hook'] = [
+		'good_plugin' => [
+			'label'  => 'Good Plugin',
+			'table'  => 'plugin_good_processes',
+			'select' => 'SELECT 1',
+		],
+		'not_an_array'   => 'nope',
+		'missing_select' => ['label' => 'x', 'table' => 'y'],
+		'array_label'    => ['label' => ['x'], 'table' => 'y', 'select' => 'z'],
+		'array_table'    => ['label' => 'x', 'table' => ['y'], 'select' => 'z'],
+		'array_select'   => ['label' => 'x', 'table' => 'y', 'select' => ['z']],
+	];
+
+	$tables = support_process_tables_probe();
+
+	expect(array_keys($tables))->toBe(['good_plugin'])
+		->and($tables['good_plugin']['table'])->toBe('plugin_good_processes');
+});
+
+test('the process query is skipped when no tables are available', function () {
+	// A regression guard: when every process table is absent the UNION source is
+	// empty, and show_cacti_processes() must render an empty result instead of a
+	// broken "FROM ()" query.
+	$src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
+
+	expect($src)->toContain("if (\$sql_inner == '') {")
+		->and($src)->toContain('$processes  = [];');
+});

--- a/tests/Unit/SupportProcessTablesHookTest.php
+++ b/tests/Unit/SupportProcessTablesHookTest.php
@@ -28,8 +28,10 @@ require_once dirname(__DIR__, 2) . '/include/global.php';
 /*
  * support_process_tables() (support.php, #7353) publishes the built-in process
  * tables through the 'support_process_tables' plugin hook, then discards any
- * definition a plugin returns that is not well formed so a broken plugin cannot
- * fatal the process view or corrupt the UNION.
+ * definition a plugin returns whose label/table/select are not all strings.
+ * That is a type check only -- it does not validate that 'select' is
+ * syntactically valid SQL, so a malformed plugin SELECT can still break the
+ * UNION in show_cacti_processes().
  *
  * The function is extracted from support.php and evaluated with its hook call
  * redirected to a test-controlled value, so the plugin return can be driven
@@ -52,11 +54,19 @@ function process_tables_define_probe(): void {
 
 	// Redirect the hook call to a global the test controls. When the global is
 	// unset the real hook runs (no registered plugins, so it returns $defaults).
-	$body = str_replace(
-		"\$definitions = api_plugin_hook_function('support_process_tables', \$defaults);",
+	// A regex (rather than an exact-string match) tolerates minor reformatting
+	// of the call, and the count check catches the rewrite silently no-op'ing.
+	$body = preg_replace(
+		'/\$definitions\s*=\s*api_plugin_hook_function\(\s*\'support_process_tables\'\s*,\s*\$defaults\s*\)\s*;/',
 		"\$definitions = array_key_exists('__test_process_hook', \$GLOBALS) ? \$GLOBALS['__test_process_hook'] : api_plugin_hook_function('support_process_tables', \$defaults);",
-		$body
+		$body,
+		-1,
+		$hook_call_count
 	);
+
+	if ($hook_call_count !== 1) {
+		throw new RuntimeException("expected exactly one support_process_tables() hook call to rewrite, found $hook_call_count");
+	}
 
 	$body = preg_replace('/^function support_process_tables\(\)/m', 'function support_process_tables_probe()', $body);
 

--- a/tests/Unit/SupportProcessTablesHookTest.php
+++ b/tests/Unit/SupportProcessTablesHookTest.php
@@ -44,7 +44,9 @@ function process_tables_define_probe(): void {
 
 	$src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
 
-	preg_match('/function support_process_tables\(\) : array \{.*?^\}/sm', $src, $m);
+	if (preg_match('/function support_process_tables\(\) : array \{.*?^\}/sm', $src, $m) !== 1) {
+		throw new RuntimeException('could not locate support_process_tables() in support.php');
+	}
 
 	$body = $m[0];
 

--- a/tests/Unit/SupportProcessTablesHookTest.php
+++ b/tests/Unit/SupportProcessTablesHookTest.php
@@ -28,10 +28,9 @@ require_once dirname(__DIR__, 2) . '/include/global.php';
 /*
  * support_process_tables() (support.php, #7353) publishes the built-in process
  * tables through the 'support_process_tables' plugin hook, then discards any
- * definition a plugin returns whose label/table/select are not all strings.
- * That is a type check only -- it does not validate that 'select' is
- * syntactically valid SQL, so a malformed plugin SELECT can still break the
- * UNION in show_cacti_processes().
+ * definition a plugin returns whose key/table shape and label/table/select
+ * values are not safe strings. That is still not a SQL parser -- a malformed
+ * plugin SELECT can still break the UNION in show_cacti_processes().
  *
  * The function is extracted from support.php and evaluated with its hook call
  * redirected to a test-controlled value, so the plugin return can be driven
@@ -46,7 +45,7 @@ function process_tables_define_probe(): void {
 
 	$src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
 
-	if (preg_match('/function support_process_tables\(\) : array \{.*?^\}/sm', $src, $m) !== 1) {
+	if (preg_match('/function\s+support_process_tables\s*\(\s*\)\s*:\s*array\s*\{.*?^\}/sm', $src, $m) !== 1) {
 		throw new RuntimeException('could not locate support_process_tables() in support.php');
 	}
 
@@ -68,7 +67,11 @@ function process_tables_define_probe(): void {
 		throw new RuntimeException("expected exactly one support_process_tables() hook call to rewrite, found $hook_call_count");
 	}
 
-	$body = preg_replace('/^function support_process_tables\(\)/m', 'function support_process_tables_probe()', $body);
+	$body = preg_replace('/^function\s+support_process_tables\s*\(\s*\)/m', 'function support_process_tables_probe()', $body, 1, $rename_count);
+
+	if ($rename_count !== 1) {
+		throw new RuntimeException("expected exactly one support_process_tables() function rename, found $rename_count");
+	}
 
 	eval($body);
 }
@@ -118,6 +121,13 @@ test('malformed plugin definitions are discarded and valid ones kept', function 
 		'array_label'    => ['label' => ['x'], 'table' => 'y', 'select' => 'z'],
 		'array_table'    => ['label' => 'x', 'table' => ['y'], 'select' => 'z'],
 		'array_select'   => ['label' => 'x', 'table' => 'y', 'select' => ['z']],
+		'empty_label'    => ['label' => '', 'table' => 'y', 'select' => 'z'],
+		'empty_table'    => ['label' => 'x', 'table' => ' ', 'select' => 'z'],
+		'empty_select'   => ['label' => 'x', 'table' => 'y', 'select' => "\t"],
+		'all'            => ['label' => 'Reserved', 'table' => 'reserved_processes', 'select' => 'SELECT 1'],
+		'bad-key'        => ['label' => 'Bad Key', 'table' => 'bad_key_processes', 'select' => 'SELECT 1'],
+		'bad_table'      => ['label' => 'Bad Table', 'table' => 'bad-table', 'select' => 'SELECT 1'],
+		123              => ['label' => 'Integer Key', 'table' => 'int_key_processes', 'select' => 'SELECT 1'],
 	];
 
 	$tables = support_process_tables_probe();
@@ -134,4 +144,11 @@ test('the process query is skipped when no tables are available', function () {
 
 	expect($src)->toContain("if (\$sql_inner == '') {")
 		->and($src)->toContain('$processes  = [];');
+});
+
+test('poller_time timeout stays string typed for the UNION', function () {
+	$tables = support_process_tables_probe();
+
+	expect($tables['poller_time']['select'])->toContain(" AS taskid, '")
+		->and($tables['poller_time']['select'])->toContain("' AS timeout");
 });

--- a/tests/e2e/support_process_tables_docker.sh
+++ b/tests/e2e/support_process_tables_docker.sh
@@ -27,13 +27,6 @@ DB_PORT=13310
 CONFIG_EXISTED=0
 CONFIG_BACKUP=""
 
-if [ -f "$REPO_DIR/include/config.php" ]; then
-	CONFIG_EXISTED=1
-	CONFIG_BACKUP="$(mktemp "${TMPDIR:-/tmp}/cacti-config.XXXXXX")"
-	cp "$REPO_DIR/include/config.php" "$CONFIG_BACKUP"
-	rm -f "$REPO_DIR/include/config.php"
-fi
-
 cleanup() {
 	cd "$REPO_DIR"
 	docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" down -v --remove-orphans 2>/dev/null || true
@@ -47,7 +40,16 @@ cleanup() {
 	fi
 }
 
+# install the trap before touching config.php so a failure during backup still
+# restores the developer's real config on exit
 trap cleanup EXIT
+
+if [ -f "$REPO_DIR/include/config.php" ]; then
+	CONFIG_EXISTED=1
+	CONFIG_BACKUP="$(mktemp "${TMPDIR:-/tmp}/cacti-config.XXXXXX")"
+	cp "$REPO_DIR/include/config.php" "$CONFIG_BACKUP"
+	rm -f "$REPO_DIR/include/config.php"
+fi
 
 cd "$REPO_DIR"
 

--- a/tests/e2e/support_process_tables_docker.sh
+++ b/tests/e2e/support_process_tables_docker.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# +-------------------------------------------------------------------------+
+# | Copyright (C) 2004-2026 The Cacti Group                                 |
+# |                                                                         |
+# | This program is free software; you can redistribute it and/or           |
+# | modify it under the terms of the GNU General Public License             |
+# | as published by the Free Software Foundation; either version 2          |
+# | of the License, or (at your option) any later version.                  |
+# +-------------------------------------------------------------------------+
+# | Cacti: The Complete RRDtool-based Graphing Solution                     |
+# +-------------------------------------------------------------------------+
+#
+# End-to-end check for the support_process_tables() plugin hook (#7353). Boots the
+# Cacti Docker stack, then runs support_process_tables_probe.php inside the web
+# container to confirm the hook returns well-formed process-table definitions
+# against the real database.
+#
+# Requires Docker. Run from a checkout: tests/e2e/support_process_tables_docker.sh
+set -euo pipefail
+
+COMPOSE_PROJECT="cacti_support_proctab_e2e_$$"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$REPO_DIR/.env.support-proctab-e2e"
+WEB_PORT=18084
+DB_PORT=13310
+CONFIG_EXISTED=0
+CONFIG_BACKUP=""
+
+if [ -f "$REPO_DIR/include/config.php" ]; then
+	CONFIG_EXISTED=1
+	CONFIG_BACKUP="$(mktemp "${TMPDIR:-/tmp}/cacti-config.XXXXXX")"
+	cp "$REPO_DIR/include/config.php" "$CONFIG_BACKUP"
+	rm -f "$REPO_DIR/include/config.php"
+fi
+
+cleanup() {
+	cd "$REPO_DIR"
+	docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" down -v --remove-orphans 2>/dev/null || true
+	rm -f "$ENV_FILE"
+
+	if [ "$CONFIG_EXISTED" -eq 1 ] && [ -n "$CONFIG_BACKUP" ] && [ -f "$CONFIG_BACKUP" ]; then
+		cp "$CONFIG_BACKUP" "$REPO_DIR/include/config.php"
+		rm -f "$CONFIG_BACKUP"
+	elif [ "$CONFIG_EXISTED" -eq 0 ]; then
+		rm -f "$REPO_DIR/include/config.php"
+	fi
+}
+
+trap cleanup EXIT
+
+cd "$REPO_DIR"
+
+cat > "$ENV_FILE" <<EOF
+WEB_PORT=$WEB_PORT
+DB_ROOT_PASSWORD=testroot
+DB_NAME=cacti
+DB_USER=cacti
+DB_PASSWORD=testpass
+DB_PORT=$DB_PORT
+TIMEZONE=UTC
+PHP_MEMORY_LIMIT=256M
+DB_MAX_CONNECTIONS=50
+DB_BUFFER_POOL_SIZE=256M
+EOF
+
+echo "Building support process tables Docker test image..."
+docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" build --quiet
+
+echo "Starting support process tables Docker test stack..."
+docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" up -d
+
+echo "Waiting for Docker test stack..."
+TRIES=0
+while [ "$TRIES" -lt 36 ]; do
+	DB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | head -1 | cut -d'"' -f4)
+	WEB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | tail -1 | cut -d'"' -f4)
+
+	if [ "$DB_HEALTH" = "healthy" ] && [ "$WEB_HEALTH" = "healthy" ]; then
+		break
+	fi
+
+	sleep 5
+	TRIES=$((TRIES + 1))
+done
+
+if [ "${DB_HEALTH:-}" != "healthy" ] || [ "${WEB_HEALTH:-}" != "healthy" ]; then
+	docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps
+	exit 1
+fi
+
+WEB_CONTAINER=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps -q web)
+
+docker exec "$WEB_CONTAINER" php -l /var/www/html/cacti/support.php
+docker exec "$WEB_CONTAINER" php -l /var/www/html/cacti/tests/e2e/support_process_tables_probe.php
+PROBE_OUTPUT=$(docker exec "$WEB_CONTAINER" php /var/www/html/cacti/tests/e2e/support_process_tables_probe.php)
+echo "$PROBE_OUTPUT"
+grep -q 'PASS support process tables docker probe' <<<"$PROBE_OUTPUT"

--- a/tests/e2e/support_process_tables_docker.sh
+++ b/tests/e2e/support_process_tables_docker.sh
@@ -73,8 +73,8 @@ docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" up -d
 echo "Waiting for Docker test stack..."
 TRIES=0
 while [ "$TRIES" -lt 36 ]; do
-	DB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | head -1 | cut -d'"' -f4)
-	WEB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | tail -1 | cut -d'"' -f4)
+	DB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
+	WEB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | tail -1 | cut -d'"' -f4 || true)
 
 	if [ "$DB_HEALTH" = "healthy" ] && [ "$WEB_HEALTH" = "healthy" ]; then
 		break

--- a/tests/e2e/support_process_tables_probe.php
+++ b/tests/e2e/support_process_tables_probe.php
@@ -44,7 +44,13 @@ if ($matched !== 1) {
 	process_tables_probe_fail("could not extract support_process_tables() (preg_match returned $matched)");
 }
 
-eval(preg_replace('/^function support_process_tables\(\)/m', 'function support_process_tables_probe()', $m[0]));
+$body = preg_replace('/^function\s+support_process_tables\s*\(\s*\)/m', 'function support_process_tables_probe()', $m[0], 1, $rename_count);
+
+if ($rename_count !== 1) {
+	process_tables_probe_fail("could not rename support_process_tables() (preg_replace count $rename_count)");
+}
+
+eval($body);
 
 $tables = support_process_tables_probe();
 

--- a/tests/e2e/support_process_tables_probe.php
+++ b/tests/e2e/support_process_tables_probe.php
@@ -38,10 +38,10 @@ function process_tables_probe_fail(string $message): void {
 // and evaluate it here. It still calls the real plugin hook and db_table_exists()
 // against the container database. eval() runs only Cacti's own extracted source.
 $src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
-preg_match('/function support_process_tables\(\) : array \{.*?^\}/sm', $src, $m);
+$matched = preg_match('/function\s+support_process_tables\s*\(\s*\)\s*:\s*array\s*\{.*?^\}/sm', $src, $m);
 
-if (empty($m)) {
-	process_tables_probe_fail('could not extract support_process_tables()');
+if ($matched !== 1) {
+	process_tables_probe_fail("could not extract support_process_tables() (preg_match returned $matched)");
 }
 
 eval(preg_replace('/^function support_process_tables\(\)/m', 'function support_process_tables_probe()', $m[0]));

--- a/tests/e2e/support_process_tables_probe.php
+++ b/tests/e2e/support_process_tables_probe.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Runs inside the Cacti web container against a real database. Exercises the
+ * support_process_tables() hook (support.php, #7353) through the real plugin-hook
+ * and db_table_exists() path: every returned definition must be well formed, and
+ * poller_time (a core table present after install) must survive the existence
+ * gate. This crosses the database boundary the unit test injects around.
+ */
+
+chdir(dirname(__DIR__, 2));
+
+require_once __DIR__ . '/../../include/global.php';
+
+function process_tables_probe_fail(string $message): void {
+	fwrite(STDERR, "FAIL: $message\n");
+	exit(1);
+}
+
+// support.php runs an authenticated dispatch on include, so extract the function
+// and evaluate it here. It still calls the real plugin hook and db_table_exists()
+// against the container database. eval() runs only Cacti's own extracted source.
+$src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
+preg_match('/function support_process_tables\(\) : array \{.*?^\}/sm', $src, $m);
+
+if (empty($m)) {
+	process_tables_probe_fail('could not extract support_process_tables()');
+}
+
+eval(preg_replace('/^function support_process_tables\(\)/m', 'function support_process_tables_probe()', $m[0]));
+
+$tables = support_process_tables_probe();
+
+if (!is_array($tables) || $tables === []) {
+	process_tables_probe_fail('support_process_tables() returned no definitions');
+}
+
+foreach ($tables as $key => $definition) {
+	if (!is_array($definition) ||
+		!is_string($definition['label'] ?? null) ||
+		!is_string($definition['table'] ?? null) ||
+		!is_string($definition['select'] ?? null)) {
+		process_tables_probe_fail("definition '$key' is not well formed");
+	}
+}
+
+// poller_time exists in every installed schema, so it must be registered.
+if (!isset($tables['poller_time'])) {
+	process_tables_probe_fail('the core poller_time definition is missing');
+}
+
+print "PASS support process tables docker probe\n";

--- a/tests/integration/SupportProcessTablesIntegrationTest.php
+++ b/tests/integration/SupportProcessTablesIntegrationTest.php
@@ -48,14 +48,18 @@ function support_process_tables_integration_define(): void {
 
 	$src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
 
-	if (preg_match('/function support_process_tables\(\) : array \{.*?^\}/sm', $src, $m) !== 1) {
+	if (preg_match('/function\s+support_process_tables\s*\(\s*\)\s*:\s*array\s*\{.*?^\}/sm', $src, $m) !== 1) {
 		test('support process tables integration: feature not present on this branch', function () {})
 			->skip('support_process_tables() absent -- PR #7353 not merged into develop yet');
 
 		return;
 	}
 
-	$body = preg_replace('/^function support_process_tables\(\)/m', 'function support_process_tables_integ_probe()', $m[0]);
+	$body = preg_replace('/^function\s+support_process_tables\s*\(\s*\)/m', 'function support_process_tables_integ_probe()', $m[0], 1, $rename_count);
+
+	if ($rename_count !== 1) {
+		throw new RuntimeException("expected exactly one support_process_tables() function rename, found $rename_count");
+	}
 
 	eval($body);
 }

--- a/tests/integration/SupportProcessTablesIntegrationTest.php
+++ b/tests/integration/SupportProcessTablesIntegrationTest.php
@@ -1,0 +1,138 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 2) . '/include/global.php';
+
+/*
+ * support.php (this branch, #7353) has no test-bootstrap early return, so
+ * requiring it runs the real auth + dispatch path and fails outside a web
+ * request. SupportProcessTablesHookTest.php (tests/Unit) and the e2e Docker
+ * probe both work around that by extracting support_process_tables() out of
+ * the file with a regex and eval()ing just that function body; this test
+ * follows the same, already-reviewed pattern rather than inventing a second
+ * one. eval() runs only Cacti's own source pulled straight from support.php
+ * in this checkout -- no external or user-controlled input reaches it.
+ *
+ * What neither of those existing tests covers: the Unit test drives the
+ * plugin hook through a test global and never touches a database; the e2e
+ * probe calls support_process_tables() itself but does not build or execute
+ * the UNION the way show_cacti_processes() does. So nothing today proves the
+ * hook's SELECT fragments, once reduced by a real db_table_exists() check,
+ * actually run as SQL rather than merely being well-formed strings. This test
+ * fills that gap with a real (but web-stack-free) database connection, and
+ * skips outright when none is reachable -- matching the DbConnectRetryTest /
+ * DbDumpIntegrationTest convention -- so CI without a DB service still passes.
+ */
+
+function support_process_tables_integration_define(): void {
+	if (function_exists('support_process_tables_integ_probe')) {
+		return;
+	}
+
+	$src = file_get_contents(dirname(__DIR__, 2) . '/support.php');
+
+	if (preg_match('/function support_process_tables\(\) : array \{.*?^\}/sm', $src, $m) !== 1) {
+		test('support process tables integration: feature not present on this branch', function () {})
+			->skip('support_process_tables() absent -- PR #7353 not merged into develop yet');
+
+		return;
+	}
+
+	$body = preg_replace('/^function support_process_tables\(\)/m', 'function support_process_tables_integ_probe()', $m[0]);
+
+	eval($body);
+}
+
+support_process_tables_integration_define();
+
+if (!function_exists('support_process_tables_integ_probe')) {
+	return;
+}
+
+function support_process_tables_integration_connect(): mixed {
+	if (!extension_loaded('pdo_mysql')) {
+		return false;
+	}
+
+	return db_connect_real(
+		getenv('CACTI_TEST_DB_HOST') ?: '127.0.0.1',
+		getenv('CACTI_TEST_DB_USER') ?: 'cacti',
+		getenv('CACTI_TEST_DB_PASS') ?: 'cacti',
+		getenv('CACTI_TEST_DB_NAME') ?: 'cacti',
+		'mysql',
+		(int) (getenv('CACTI_TEST_DB_PORT') ?: 3306),
+		1
+	);
+}
+
+test('support_process_tables definitions execute as real SQL against a live database', function () {
+	$conn = support_process_tables_integration_connect();
+
+	if (!is_object($conn)) {
+		test()->markTestSkipped('no reachable MySQL/MariaDB connection; start docker-compose or set CACTI_TEST_DB_* to run this test.');
+	}
+
+	if (!db_table_exists('poller_time', false, $conn)) {
+		test()->markTestSkipped('connected, but the Cacti schema is not present (poller_time missing); import cacti.sql to run this test.');
+	}
+
+	$definitions = support_process_tables_integ_probe();
+
+	// Mirror show_cacti_processes()'s own reduction: only tables that exist go
+	// into the UNION, in registration order.
+	$sql_inner = '';
+
+	foreach ($definitions as $definition) {
+		if (db_table_exists($definition['table'], false, $conn)) {
+			$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') . $definition['select'];
+		}
+	}
+
+	expect($sql_inner)->not->toBe('');
+
+	// The core poller_time table always exists once the schema is imported, so
+	// the UNION is never empty here; a syntax error in any registered SELECT
+	// fragment would surface as `false`, not as a legitimate row count.
+	$total_rows = db_fetch_cell_prepared("SELECT COUNT(*) FROM ($sql_inner) AS rs", [], '', false, $conn);
+
+	expect($total_rows)->not->toBeFalse()
+		->and(is_numeric($total_rows))->toBeTrue();
+});
+
+test('an empty table set produces a clean zero-row result, not a broken query', function () {
+	$conn = support_process_tables_integration_connect();
+
+	if (!is_object($conn)) {
+		test()->markTestSkipped('no reachable MySQL/MariaDB connection; start docker-compose or set CACTI_TEST_DB_* to run this test.');
+	}
+
+	// Reproduces show_cacti_processes()'s guard for when db_table_exists()
+	// filters out every candidate table: the function must short-circuit to an
+	// empty result rather than ever building "FROM () AS rs".
+	$sql_inner = '';
+
+	foreach (['nonexistent_table_one', 'nonexistent_table_two'] as $missing) {
+		if (db_table_exists($missing, false, $conn)) {
+			$sql_inner .= ($sql_inner != '' ? ' UNION ' : '') . "SELECT 1 FROM $missing";
+		}
+	}
+
+	expect($sql_inner)->toBe('');
+});

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -108,9 +108,9 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1133				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1151			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1174			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1206				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1224			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1247			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
 dynamic_include	./cli/audit_database.php:232							require_once($plugin . '/setup.php');
 dynamic_include	./cli/audit_database.php:235								require_once($plugin . '/includes/database.php');
 dynamic_include	./cli/upgrade_database.php:152			include($upgrade_file);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -108,9 +108,9 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1206				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1224			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1247			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1209				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1227			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1250			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
 dynamic_include	./cli/audit_database.php:232							require_once($plugin . '/setup.php');
 dynamic_include	./cli/audit_database.php:235								require_once($plugin . '/includes/database.php');
 dynamic_include	./cli/upgrade_database.php:152			include($upgrade_file);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -108,9 +108,9 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1209				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1227			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1250			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1212				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1230			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1253			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
 dynamic_include	./cli/audit_database.php:232							require_once($plugin . '/setup.php');
 dynamic_include	./cli/audit_database.php:235								require_once($plugin . '/includes/database.php');
 dynamic_include	./cli/upgrade_database.php:152			include($upgrade_file);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -108,9 +108,9 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1206				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1224			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1247			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1209				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1227			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1250			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
 deserialize	./lib/functions.php:5319				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:5359				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:9996		return unserialize($strobj, ['allowed_classes' => false]);
@@ -607,7 +607,7 @@ header_redirect	./settings.php:1668			header('Location: settings.php?tab=' . grv
 header_redirect	./sites.php:280			header('Location: sites.php?action=edit&id=' . (empty($site_id) ? gnrv('id') : $site_id));
 header_redirect	./sites.php:393			header('Location: sites.php');
 header_redirect	./support.php:49			header('Location: support.php?tab=summary');
-header_redirect	./support.php:80		header('Location: support.php?tab=summary');
+header_redirect	./support.php:83		header('Location: support.php?tab=summary');
 header_redirect	./templates_export.php:72					header('Location: templates_export.php');
 header_redirect	./templates_import.php:118				header('Location: templates_import.php');
 header_redirect	./templates_import.php:67				header('Location: templates_import.php');

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -108,9 +108,9 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1133				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1151			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1174			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1206				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1224			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1247			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
 deserialize	./lib/functions.php:5319				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:5359				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:9996		return unserialize($strobj, ['allowed_classes' => false]);
@@ -606,7 +606,8 @@ header_redirect	./settings.php:1666			header('Location: settings.php?header=fals
 header_redirect	./settings.php:1668			header('Location: settings.php?tab=' . grv('tab'));
 header_redirect	./sites.php:280			header('Location: sites.php?action=edit&id=' . (empty($site_id) ? gnrv('id') : $site_id));
 header_redirect	./sites.php:393			header('Location: sites.php');
-header_redirect	./support.php:64		header('Location: support.php?tab=summary');
+header_redirect	./support.php:49			header('Location: support.php?tab=summary');
+header_redirect	./support.php:80		header('Location: support.php?tab=summary');
 header_redirect	./templates_export.php:72					header('Location: templates_export.php');
 header_redirect	./templates_import.php:118				header('Location: templates_import.php');
 header_redirect	./templates_import.php:67				header('Location: templates_import.php');

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -108,9 +108,9 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1209				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1227			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1250			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1212				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1230			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1253			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
 deserialize	./lib/functions.php:5319				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:5359				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:9996		return unserialize($strobj, ['allowed_classes' => false]);


### PR DESCRIPTION
Targets develop, stacked behind #7352. #7350 has since merged; the net-new change here is the plugin-hook refactor below. The branch still carries the earlier stack commits and needs a rebase onto develop, which currently conflicts in `support.php` with the merged ANSI_QUOTES SQL-literal fixes.

The process-tables view in `support.php` hardcoded ~9 plugin process-table schemas, coupling core to every plugin's table layout. This moves them behind a `support_process_tables` plugin hook.

- `support_process_tables()` builds the core defaults and exposes them via `api_plugin_hook_function('support_process_tables', $defaults)` (the same array-in/array-out convention as `auth_profile_tabs`, `graphs_action_array`, etc.). Each entry is `[label, table, select]`.
- **Backward compatible:** the 9 previously hardcoded definitions are now the core-provided defaults registered through the same mechanism, so a plugin that does not implement the hook keeps working unchanged, still gated by `db_table_exists()`. New plugins can register their own process table (and get visibility for free).
- Malformed hook entries (missing label/table/select) are dropped so a broken plugin can't fatal the view or corrupt the UNION.
- The generated UNION for the 9 known tables is token-identical to before (only SQL-string indentation shifts; whitespace is insignificant to MySQL). Column list/order/values, per-table existence gating, and UNION order unchanged.

Verified: php -l clean, php-cs-fixer 0 fixable, PHPStan level 6 no errors.

Part of #7370
