### PR TITLE
feat(support): add redaction toggle and recent-log panel

### DIFF
--- a/support.php
+++ b/support.php
@@ -81,7 +81,7 @@ function support_view_tech() : void {
 	// ================= input validation =================
 	gfrv('tab', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => '/^([a-z_A-Z]+)$/']]);
 	// redact is a display-only toggle; coerce to a strict 0/1 and never fail on bad input
-	set_request_var('redact', gnrv('redact') == 1 ? 1 : 0);
+	set_request_var('redact', gnrv('redact') === '1' ? 1 : 0);
 	// ====================================================
 
 	// present a tabbed interface
@@ -151,7 +151,7 @@ function support_view_tech() : void {
 	$redact = (grv('redact') == 1);
 
 	// the processes and background will set their own timeouts
-	$page = 'support.php?tab=' . $current_tab;
+	$page = 'support.php?tab=' . $current_tab . ($redact ? '&redact=1' : '');
 
 	if ($current_tab != 'processes' && $current_tab != 'background') {
 		$refresh = [
@@ -1321,7 +1321,7 @@ function show_tech_summary() : void {
 		// Pre-built status span; already markup, render as-is.
 		print '<td>' . $snmp_version . '</td>';
 	} else {
-		print '<td>' . ($redact ? html_escape(support_redact(strip_tags($snmp_version))) : html_escape($snmp_version)) . '</td>';
+		print '<td>' . ($redact ? html_escape(support_redact($snmp_version)) : html_escape($snmp_version)) . '</td>';
 	}
 
 	form_end_row();
@@ -1845,10 +1845,11 @@ function show_tech_summary() : void {
 	utilities_get_mysql_recommendations();
 
 	// Shareable diagnostics report (Feature: Copy Diagnostics).
-	// When the redact toggle is on, hostnames, IP addresses, the DB host,
-	// credentials, absolute paths and the full RSA fingerprint are masked so
-	// the report is safe to paste into a public issue.
-	$snmp_line     = trim(explode("\n", strip_tags($snmp_version))[0]);
+	// When the redact toggle is on, hostnames/IPs embedded in the SNMP version
+	// line and web server string are masked via support_redact(), and the RSA
+	// fingerprint is truncated. The report does not include the DB host,
+	// credentials or absolute paths.
+	$snmp_line     = $snmp_installed ? trim(explode("\n", $snmp_version)[0]) : trim(strip_tags($snmp_version));
 	$web_server    = (string) ($_SERVER['SERVER_SOFTWARE'] ?? __('Unknown'));
 	$poller_report = $poller_options[read_config_option('poller_type')] ?? __('Unknown');
 
@@ -2031,13 +2032,6 @@ function support_redact(string $value) : string {
 		return $value;
 	}
 
-	// Replace this host's own node name wherever it appears (php_uname, SNMP banner, etc.).
-	$node = function_exists('php_uname') ? php_uname('n') : '';
-
-	if ($node != '' && strlen($node) > 1) {
-		$value = str_ireplace($node, '<host>', $value);
-	}
-
 	// IPv6 before IPv4 so the longer pattern wins. The candidate pattern is
 	// deliberately loose (it also matches "::" compression and would catch
 	// non-addresses like MACs or "1:2:3"); filter_var() gates the replacement
@@ -2048,8 +2042,19 @@ function support_redact(string $value) : string {
 	$value = preg_replace('/\b(?:\d{1,3}\.){3}\d{1,3}\b/', '<ipv4>', $value);
 
 	// FQDNs (foo.bar.example).  The alphabetic TLD requirement leaves version
-	// numbers such as 1.7.2 untouched.
+	// numbers such as 1.7.2 untouched.  This must run before the node-name
+	// replacement below: if the node name is a prefix of the FQDN (e.g. "db01"
+	// in "db01.local"), masking the node name first would strip the prefix and
+	// leave a bare suffix ("local") that no longer looks like an FQDN, leaking
+	// part of the domain.
 	$value = preg_replace('/\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\b/', '<host>', $value);
+
+	// Replace this host's own node name wherever it appears (php_uname, SNMP banner, etc.).
+	$node = function_exists('php_uname') ? php_uname('n') : '';
+
+	if ($node != '' && strlen($node) > 1) {
+		$value = str_ireplace($node, '<host>', $value);
+	}
 
 	// /home/<user>/ and /Users/<user>/ path segments.
 	$value = preg_replace('#/(?:home|Users)/[^/\s]+#', '/home/<redacted>', $value);

--- a/support.php
+++ b/support.php
@@ -2036,8 +2036,13 @@ function support_redact(string $value) : string {
 		$value = str_ireplace($node, '<host>', $value);
 	}
 
-	// IPv6 before IPv4 so the longer pattern wins.
-	$value = preg_replace('/\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b/', '<ipv6>', $value);
+	// IPv6 before IPv4 so the longer pattern wins. The candidate pattern is
+	// deliberately loose (it also matches "::" compression and would catch
+	// non-addresses like MACs or "1:2:3"); filter_var() gates the replacement
+	// so only strings that are genuinely IPv6 get masked.
+	$value = preg_replace_callback('/(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}/', function ($m) {
+		return filter_var($m[0], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false ? '<ipv6>' : $m[0];
+	}, $value);
 	$value = preg_replace('/\b(?:\d{1,3}\.){3}\d{1,3}\b/', '<ipv4>', $value);
 
 	// FQDNs (foo.bar.example).  The alphabetic TLD requirement leaves version

--- a/support.php
+++ b/support.php
@@ -1309,7 +1309,7 @@ function show_tech_summary() : void {
 
 	form_alternate_row();
 	print '<td>' . __('RSA Fingerprint') . '</td>';
-	print '<td>' . $rsa_fingerprint . '</td>';
+	print '<td>' . html_escape($rsa_fingerprint) . '</td>';
 	form_end_row();
 
 	form_alternate_row();
@@ -1848,7 +1848,7 @@ function show_tech_summary() : void {
 	// the report is safe to paste into a public issue.
 	$snmp_line     = trim(explode("\n", strip_tags($snmp_version))[0]);
 	$web_server    = (string) ($_SERVER['SERVER_SOFTWARE'] ?? __('Unknown'));
-	$poller_report = $poller_options[read_config_option('poller_type')];
+	$poller_report = $poller_options[read_config_option('poller_type')] ?? __('Unknown');
 
 	if ($redact) {
 		$snmp_line  = support_redact($snmp_line);

--- a/support.php
+++ b/support.php
@@ -185,7 +185,7 @@ function support_view_tech() : void {
 	}
 
 	// Display tech information
-	if (!isset($tabs[$current_tab]['header']) || $tabs[$current_tab]['header'] === true) {
+	if ($tabs[$current_tab]['header'] === true) {
 		html_start_box($header_label, '100%', false, 3, 'center', '');
 	}
 
@@ -240,7 +240,7 @@ function support_view_tech() : void {
 			break;
 	}
 
-	if (!isset($tabs[$current_tab]['header']) || $tabs[$current_tab]['header'] === true) {
+	if ($tabs[$current_tab]['header'] === true) {
 		html_end_box();
 	}
 

--- a/support.php
+++ b/support.php
@@ -1383,14 +1383,16 @@ function show_tech_summary() : void {
 	print '<td>' . __('Interval') . '</td>';
 	print '<td>' . read_config_option('poller_interval') . '</td>';
 
-	if (file_exists(read_config_option('path_spine')) && $poller_options[read_config_option('poller_type')] == 'spine') {
+	$poller_type_name = $poller_options[read_config_option('poller_type')] ?? __('Unknown');
+
+	if (file_exists(read_config_option('path_spine')) && $poller_type_name == 'spine') {
 		$type = $spine_version;
 
 		if (!strpos($spine_version, CACTI_VERSION)) {
 			$type .= '<span class="textError"> (' . __('Different version of Cacti and Spine!') . ')</span>';
 		}
 	} else {
-		$type = $poller_options[read_config_option('poller_type')];
+		$type = $poller_type_name;
 	}
 	form_end_row();
 
@@ -1960,12 +1962,12 @@ function show_tech_environment() : void {
 	html_section_header(__('Required Binaries'), 2);
 
 	foreach ($binaries as $option => $arg) {
-		$path = read_config_option($option);
+		$path = (string) read_config_option($option);
 
 		form_alternate_row();
 		print '<td>' . html_escape($option) . '</td>';
 
-		if ($path != '' && !str_contains($path, chr(0)) && file_exists($path) && function_exists('is_executable') && is_executable($path)) {
+		if ($path !== '' && !str_contains($path, chr(0)) && is_file($path) && function_exists('is_executable') && is_executable($path)) {
 			$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
 			$version = ($out != '' ? trim(explode("\n", $out)[0]) : __('Unknown version'));
 
@@ -2070,13 +2072,16 @@ function support_redact(string $value) : string {
  * @return array<int,string>
  */
 function support_tail_severity(string $file, int $max_lines, int $cap_bytes) : array {
-	$size = filesize($file);
+	// The path is checked by the caller, but the file can still vanish or
+	// become unreadable between that check and here; suppress the warning
+	// PHP would otherwise emit into the rendered page and fail closed.
+	$size = @filesize($file);
 
 	if ($size === false || $size == 0) {
 		return [];
 	}
 
-	$fp = fopen($file, 'rb');
+	$fp = @fopen($file, 'rb');
 
 	if ($fp === false) {
 		return [];

--- a/support.php
+++ b/support.php
@@ -1220,8 +1220,10 @@ function show_tech_summary() : void {
 	// Get SNMP cli version.  $snmp_installed distinguishes raw tool output
 	// (must be escaped when printed) from the pre-built status span below
 	// (already markup, must not be escaped).
-	if ((file_exists(read_config_option('path_snmpget'))) && ((function_exists('is_executable')) && (is_executable(read_config_option('path_snmpget'))))) {
-		$snmp_version   = (string) shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+	$snmpget_path = (string) read_config_option('path_snmpget');
+
+	if ($snmpget_path !== '' && !str_contains($snmpget_path, "\0") && is_file($snmpget_path) && is_executable($snmpget_path)) {
+		$snmp_version   = (string) shell_exec(cacti_escapeshellcmd($snmpget_path) . ' -V 2>&1');
 		$snmp_installed = true;
 	} else {
 		$snmp_version   = "<span class='deviceDown'>" . __('NET-SNMP Not Installed or its paths are not set.  Please install if you wish to monitor SNMP enabled devices.') . '</span>';

--- a/support.php
+++ b/support.php
@@ -22,6 +22,15 @@
  +-------------------------------------------------------------------------+
 */
 
+// A test bootstrap includes this file only to reach the function definitions
+// below; it cannot satisfy the auth and database dispatch that follows. Return
+// before that runs. Top-level function declarations are hoisted at compile time
+// so they stay callable after this early return. The predicate matches
+// include/global.php's test-bootstrap gate, so production always falls through.
+if (defined('PHP_TESTING') && getenv('CACTI_TEST_BOOTSTRAP', true) === '1') {
+	return;
+}
+
 require('./include/auth.php');
 require_once(CACTI_PATH_LIBRARY . '/api_data_source.php');
 require_once(CACTI_PATH_LIBRARY . '/boost.php');

--- a/support.php
+++ b/support.php
@@ -71,12 +71,18 @@ function support_view_tech() : void {
 
 	// ================= input validation =================
 	gfrv('tab', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => '/^([a-z_A-Z]+)$/']]);
+	// redact is a display-only toggle; coerce to a strict 0/1 and never fail on bad input
+	set_request_var('redact', gnrv('redact') == 1 ? 1 : 0);
 	// ====================================================
 
 	// present a tabbed interface
 	$tabs = [
 		'summary' => [
 			'display' => __('Summary'),
+			'header'  => true
+		],
+		'environment' => [
+			'display' => __('Environment'),
 			'header'  => true
 		],
 		'database' => [
@@ -111,6 +117,10 @@ function support_view_tech() : void {
 			'display' => __('PHP Info'),
 			'header'  => true
 		],
+		'log' => [
+			'display' => __('Recent Log'),
+			'header'  => true
+		],
 		'changelog' => [
 			'display' => __('ChangeLog'),
 			'header'  => true
@@ -120,6 +130,16 @@ function support_view_tech() : void {
 	// set the default tab
 	load_current_session_value('tab', 'sess_ts_tabs', 'summary');
 	$current_tab = gnrv('tab');
+
+	// the regex above only guarantees the shape of the value; fall back to the
+	// default when it is not one of the tabs this page actually renders
+	if (!isset($tabs[$current_tab])) {
+		$current_tab = 'summary';
+		set_request_var('tab', $current_tab);
+	}
+
+	// carried on the tab links so redaction stays in effect while navigating
+	$redact = (grv('redact') == 1);
 
 	// the processes and background will set their own timeouts
 	$page = 'support.php?tab=' . $current_tab;
@@ -146,7 +166,7 @@ function support_view_tech() : void {
 			print "<li class='subTab'><a class='tab pic " . ($id == $current_tab ? " selected'" : "'") .
 				" href='" . htmle(CACTI_PATH_URL .
 				'support.php?' .
-				'tab=' . $id) .
+				'tab=' . $id . ($redact ? '&redact=1' : '')) .
 				"'>" . $name['display'] . '</a></li>';
 		}
 
@@ -163,6 +183,10 @@ function support_view_tech() : void {
 	switch (grv('tab')) {
 		case 'summary':
 			show_tech_summary();
+
+			break;
+		case 'environment':
+			show_tech_environment();
 
 			break;
 		case 'dbstatus':
@@ -191,6 +215,10 @@ function support_view_tech() : void {
 			break;
 		case 'phpinfo':
 			show_php_modules();
+
+			break;
+		case 'log':
+			show_tech_log();
 
 			break;
 		case 'processes':
@@ -223,8 +251,39 @@ function support_view_tech() : void {
 		$('#lockout').click(function() {
 			loadUrl({ url: 'support.php?action=lockout' });
 		});
+
+		$('#redact_toggle').change(function() {
+			loadUrl({ url: 'support.php?tab=summary&redact=' + ($(this).is(':checked') ? 1 : 0) });
+		});
+
+		$('#copy_diag').click(function() {
+			var report = $('#diag_report').val();
+			var done   = <?php print json_encode(__('Copied to clipboard')); ?>;
+			var failed = <?php print json_encode(__('Copy failed, select the text manually')); ?>;
+
+			if (navigator.clipboard && navigator.clipboard.writeText) {
+				navigator.clipboard.writeText(report).then(function() {
+					$('#copy_diag_status').text(done);
+				}, function() {
+					$('#copy_diag_status').text(failed);
+				});
+			} else {
+				var el = document.getElementById('diag_report');
+				el.style.display = 'block';
+				el.select();
+
+				try {
+					document.execCommand('copy');
+					$('#copy_diag_status').text(done);
+				} catch (e) {
+					$('#copy_diag_status').text(failed);
+				}
+
+				el.style.display = 'none';
+			}
+		});
 	});
-	</script>
+</script>
 	<?php
 
 	bottom_footer();
@@ -1107,6 +1166,9 @@ function show_database_status() : void {
 function show_tech_summary() : void {
 	global $database_hostname, $poller_options, $input_types, $local_db_cnn_id;
 
+	// When on, identifying values on this tab and in the copied report are masked.
+	$redact = (grv('redact') == 1);
+
 	// Get poller stats
 	$poller_item = db_fetch_assoc('SELECT action, count(action) AS total
 		FROM poller_item
@@ -1146,11 +1208,15 @@ function show_tech_summary() : void {
 		}
 	}
 
-	// Get SNMP cli version
+	// Get SNMP cli version.  $snmp_installed distinguishes raw tool output
+	// (must be escaped when printed) from the pre-built status span below
+	// (already markup, must not be escaped).
 	if ((file_exists(read_config_option('path_snmpget'))) && ((function_exists('is_executable')) && (is_executable(read_config_option('path_snmpget'))))) {
-		$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+		$snmp_version   = (string) shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+		$snmp_installed = true;
 	} else {
-		$snmp_version = "<span class='deviceDown'>" . __('NET-SNMP Not Installed or its paths are not set.  Please install if you wish to monitor SNMP enabled devices.') . '</span>';
+		$snmp_version   = "<span class='deviceDown'>" . __('NET-SNMP Not Installed or its paths are not set.  Please install if you wish to monitor SNMP enabled devices.') . '</span>';
+		$snmp_installed = false;
 	}
 
 	// Check RRDtool issues
@@ -1179,6 +1245,12 @@ function show_tech_summary() : void {
 	}
 
 	html_section_header(__('General Information'), 2);
+
+	form_alternate_row();
+	print '<td>' . __('Diagnostics Export') . '</td>';
+	print '<td><button type="button" id="copy_diag" title="' . __esc('Copy a diagnostics report to the clipboard.  Enable the redact toggle to mask identifying details before sharing.') . '">' . __('Copy Diagnostics') . '</button> <span id="copy_diag_status" class="deviceUp"></span>' .
+		'<label style="margin-left:12px"><input type="checkbox" id="redact_toggle"' . ($redact ? ' checked="checked"' : '') . '> ' . __('Redact for sharing') . '</label></td>';
+	form_end_row();
 
 	$lockout = read_config_option('cacti_lockout_status', true);
 	$enabled = read_config_option('auth_maint_lockout_type', true);
@@ -1220,14 +1292,27 @@ function show_tech_summary() : void {
 	print '<td>' . CACTI_SERVER_OS . '</td>';
 	form_end_row();
 
+	$rsa_fingerprint = read_config_option('rsa_fingerprint');
+
+	if ($redact && $rsa_fingerprint != '') {
+		$rsa_fingerprint = substr($rsa_fingerprint, 0, 8) . '… (' . __('masked') . ')';
+	}
+
 	form_alternate_row();
 	print '<td>' . __('RSA Fingerprint') . '</td>';
-	print '<td>' . read_config_option('rsa_fingerprint') . '</td>';
+	print '<td>' . $rsa_fingerprint . '</td>';
 	form_end_row();
 
 	form_alternate_row();
 	print '<td>' . __('NET-SNMP Version') . '</td>';
-	print '<td>' . $snmp_version . '</td>';
+
+	if (!$snmp_installed) {
+		// Pre-built status span; already markup, render as-is.
+		print '<td>' . $snmp_version . '</td>';
+	} else {
+		print '<td>' . ($redact ? html_escape(support_redact(strip_tags($snmp_version))) : html_escape($snmp_version)) . '</td>';
+	}
+
 	form_end_row();
 
 	form_alternate_row();
@@ -1683,7 +1768,7 @@ function show_tech_summary() : void {
 	print '<td>';
 
 	if (function_exists('php_uname')) {
-		print php_uname();
+		print $redact ? html_escape(support_redact(php_uname())) : php_uname();
 	} else {
 		print __('N/A');
 	}
@@ -1747,4 +1832,320 @@ function show_tech_summary() : void {
 	form_end_row();
 
 	utilities_get_mysql_recommendations();
+
+	// Shareable diagnostics report (Feature: Copy Diagnostics).
+	// When the redact toggle is on, hostnames, IP addresses, the DB host,
+	// credentials, absolute paths and the full RSA fingerprint are masked so
+	// the report is safe to paste into a public issue.
+	$snmp_line     = trim(explode("\n", strip_tags($snmp_version))[0]);
+	$web_server    = (string) ($_SERVER['SERVER_SOFTWARE'] ?? __('Unknown'));
+	$poller_report = $poller_options[read_config_option('poller_type')];
+
+	if ($redact) {
+		$snmp_line  = support_redact($snmp_line);
+		$web_server = support_redact($web_server);
+	}
+
+	if ($poller_report == 'spine' && $spine_version != 'Unknown') {
+		$poller_report = $spine_version;
+	}
+
+	$rsa = read_config_option('rsa_fingerprint');
+
+	if ($rsa == '') {
+		$rsa_report = __('N/A');
+	} elseif ($redact) {
+		$rsa_report = substr($rsa, 0, 8) . '… (' . __('masked') . ')';
+	} else {
+		$rsa_report = $rsa;
+	}
+
+	$report  = "### Cacti Diagnostics\n";
+	$report .= '- ' . __('Cacti Version') . ': ' . CACTI_VERSION . "\n";
+	$report .= '- ' . __('Cacti OS') . ': ' . CACTI_SERVER_OS . "\n";
+	$report .= '- ' . __('Web Server') . ': ' . $web_server . "\n";
+	$report .= '- ' . __('PHP Version') . ': ' . PHP_VERSION . "\n";
+	$report .= '- ' . __('PHP OS') . ': ' . PHP_OS . "\n";
+	$report .= '- ' . __('Database') . ': ' . trim($database . ' ' . $version) . "\n";
+	$report .= '- ' . __('RRDtool Version Configured') . ': ' . get_rrdtool_version() . "+\n";
+	$report .= '- ' . __('RRDtool Version Found') . ': ' . $rrdtool_release . "\n";
+	$report .= '- ' . __('NET-SNMP Version') . ': ' . $snmp_line . "\n";
+	$report .= '- ' . __('Poller Interval') . ': ' . read_config_option('poller_interval') . "\n";
+	$report .= '- ' . __('Poller Type') . ': ' . $poller_report . "\n";
+	$report .= '- ' . __('Last Run Statistics') . ': ' . read_config_option('stats_poller') . "\n";
+	$report .= '- ' . 'memory_limit: ' . ini_get('memory_limit') . "\n";
+	$report .= '- ' . 'max_execution_time: ' . ini_get('max_execution_time') . "\n";
+	$report .= '- ' . __('System Memory') . ': ' . ($total_memory > 0 ? number_format_i18n($total_memory, 2, 1000) . ' GB' : __('N/A')) . "\n";
+	$report .= '- ' . __('RSA Fingerprint') . ': ' . $rsa_report . "\n";
+
+	form_alternate_row();
+	print "<td colspan='2'><textarea id='diag_report' style='display:none' readonly='readonly'>" . html_escape($report) . '</textarea></td>';
+	form_end_row();
+}
+
+function show_tech_environment() : void {
+	// Required PHP extensions, cross-checked against install/cli_check.php.
+	$extensions = false;
+	utility_php_verify_extensions($extensions, 'web');
+
+	html_section_header(__('Required PHP Extensions'), 2);
+
+	foreach ($extensions as $name => $extension) {
+		$loaded = !empty($extension['web']);
+
+		form_alternate_row();
+		print '<td>' . html_escape($name) . '</td>';
+		print '<td>' . tech_env_status($loaded ? DB_STATUS_SUCCESS : DB_STATUS_ERROR, $loaded ? __('Installed') : __('Missing')) . '</td>';
+		form_end_row();
+	}
+
+	// Recommended (optional) extensions such as php-snmp.
+	$optionals = false;
+	utility_php_verify_optionals($optionals, 'web');
+
+	html_section_header(__('Recommended PHP Extensions'), 2);
+
+	foreach ($optionals as $name => $optional) {
+		$loaded = !empty($optional['web']);
+
+		form_alternate_row();
+		print '<td>' . html_escape($name) . '</td>';
+		print '<td>' . tech_env_status($loaded ? DB_STATUS_SUCCESS : DB_STATUS_WARNING, $loaded ? __('Installed') : __('Not installed')) . '</td>';
+		form_end_row();
+	}
+
+	// Key php.ini values and thresholds (reuses the installer's recommendations).
+	$recommends = false;
+	utility_php_verify_recommends($recommends, 'web');
+
+	html_section_header(__('PHP Configuration'), 2);
+
+	foreach ($recommends as $recommend) {
+		if ($recommend['name'] == 'location' || $recommend['name'] == 'version') {
+			continue;
+		}
+
+		form_alternate_row();
+		print '<td>' . html_escape($recommend['name']) . '</td>';
+		print '<td>' . tech_env_status((int) $recommend['status'], __('Current: %s, Recommended: %s', $recommend['current'], $recommend['value'])) . '</td>';
+		form_end_row();
+	}
+
+	$file_uploads = (bool) ini_get('file_uploads');
+
+	form_alternate_row();
+	print '<td>file_uploads</td>';
+	print '<td>' . tech_env_status($file_uploads ? DB_STATUS_SUCCESS : DB_STATUS_ERROR, $file_uploads ? __('On') : __('Off')) . '</td>';
+	form_end_row();
+
+	// Required binaries: existence + version.
+	$binaries = [
+		'path_php_binary' => '-v',
+		'path_rrdtool'    => '--version',
+		'path_snmpget'    => '-V',
+	];
+
+	html_section_header(__('Required Binaries'), 2);
+
+	foreach ($binaries as $option => $arg) {
+		$path = read_config_option($option);
+
+		form_alternate_row();
+		print '<td>' . html_escape($option) . '</td>';
+
+		if ($path != '' && !str_contains($path, chr(0)) && file_exists($path) && function_exists('is_executable') && is_executable($path)) {
+			$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
+			$version = ($out != '' ? trim(explode("\n", $out)[0]) : __('Unknown version'));
+
+			print '<td>' . tech_env_status(DB_STATUS_SUCCESS, $version) . '</td>';
+		} else {
+			print '<td>' . tech_env_status(DB_STATUS_ERROR, __('Not found or not executable: %s', $path)) . '</td>';
+		}
+
+		form_end_row();
+	}
+
+	// Writable directories.  cache/rra/log must be writable; scripts/resource
+	// are usually read-only so a non-writable result is only a warning.
+	$directories = [
+		CACTI_PATH_CACHE    => true,
+		CACTI_PATH_RRA      => true,
+		CACTI_PATH_LOG      => true,
+		CACTI_PATH_SCRIPTS  => false,
+		CACTI_PATH_RESOURCE => false,
+	];
+
+	html_section_header(__('Writable Directories'), 2);
+
+	foreach ($directories as $directory => $required) {
+		$writable = is_writable($directory);
+
+		if ($writable) {
+			$status = DB_STATUS_SUCCESS;
+			$text   = __('Writable');
+		} else {
+			$status = ($required ? DB_STATUS_ERROR : DB_STATUS_WARNING);
+			$text   = __('Not writable');
+		}
+
+		form_alternate_row();
+		print '<td>' . html_escape($directory) . '</td>';
+		print '<td>' . tech_env_status($status, $text) . '</td>';
+		form_end_row();
+	}
+}
+
+/**
+ * tech_env_status - render a status badge for the technical support report.
+ * $text is treated as plain text and escaped here, so callers pass raw values
+ * and must not pre-escape (doing so would double-encode).
+ */
+function tech_env_status(int $status, string $text) : string {
+	[$class, $icon] = match ($status) {
+		DB_STATUS_SUCCESS => ['deviceUp', 'fa-check-circle'],
+		DB_STATUS_ERROR   => ['deviceDown', 'fa-times-circle'],
+		default           => ['deviceRecovering', 'fa-exclamation-triangle'],
+	};
+
+	return "<span class='$class'><i class='fa $icon'></i> " . html_escape($text) . '</span>';
+}
+
+/**
+ * support_redact - mask identifying details in a display string so a support
+ * report can be shared publicly.  Display-only and deliberately conservative:
+ * it prefers to over-mask rather than leak.  Not applied to version numbers.
+ */
+function support_redact(string $value) : string {
+	if ($value === '') {
+		return $value;
+	}
+
+	// Replace this host's own node name wherever it appears (php_uname, SNMP banner, etc.).
+	$node = function_exists('php_uname') ? php_uname('n') : '';
+
+	if ($node != '' && strlen($node) > 1) {
+		$value = str_ireplace($node, '<host>', $value);
+	}
+
+	// IPv6 before IPv4 so the longer pattern wins.
+	$value = preg_replace('/\b(?:[0-9a-fA-F]{1,4}:){2,7}[0-9a-fA-F]{1,4}\b/', '<ipv6>', $value);
+	$value = preg_replace('/\b(?:\d{1,3}\.){3}\d{1,3}\b/', '<ipv4>', $value);
+
+	// FQDNs (foo.bar.example).  The alphabetic TLD requirement leaves version
+	// numbers such as 1.7.2 untouched.
+	$value = preg_replace('/\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\b/', '<host>', $value);
+
+	// /home/<user>/ and /Users/<user>/ path segments.
+	$value = preg_replace('#/(?:home|Users)/[^/\s]+#', '/home/<redacted>', $value);
+
+	return $value;
+}
+
+/**
+ * support_tail_severity - read the last WARN/ERROR/SECURITY lines from a log
+ * file without loading the whole file.  Seeks to the end and reads at most
+ * $cap_bytes so a multi-gigabyte log cannot exhaust memory.
+ *
+ * @return array<int,string>
+ */
+function support_tail_severity(string $file, int $max_lines, int $cap_bytes) : array {
+	$size = filesize($file);
+
+	if ($size === false || $size == 0) {
+		return [];
+	}
+
+	$fp = fopen($file, 'rb');
+
+	if ($fp === false) {
+		return [];
+	}
+
+	$read = ($size < $cap_bytes ? $size : $cap_bytes);
+
+	if (fseek($fp, -$read, SEEK_END) !== 0) {
+		fclose($fp);
+
+		return [];
+	}
+
+	$buffer = fread($fp, $read);
+	fclose($fp);
+
+	if ($buffer === false) {
+		return [];
+	}
+
+	$all = explode("\n", $buffer);
+
+	// The byte cap can slice through the first line; drop that partial fragment,
+	// but only when the file was actually larger than the cap.
+	if ($size > $cap_bytes) {
+		array_shift($all);
+	}
+
+	$matched = [];
+
+	foreach ($all as $line) {
+		$line = rtrim($line, "\r");
+
+		if ($line === '') {
+			continue;
+		}
+
+		if (str_contains($line, 'WARN') || str_contains($line, 'ERROR') || str_contains($line, 'SECURITY')) {
+			$matched[] = $line;
+		}
+	}
+
+	if (cacti_sizeof($matched) > $max_lines) {
+		$matched = array_slice($matched, -$max_lines);
+	}
+
+	return $matched;
+}
+
+function show_tech_log() : void {
+	$redact    = (grv('redact') == 1);
+	$max_lines = 100;
+	$cap_bytes = 256 * 1024;
+
+	// Only ever the configured Cacti log is read.  The path comes from
+	// read_config_option('path_cactilog'); no request variable can influence it.
+	$logfile = read_config_option('path_cactilog');
+
+	html_section_header(__('Recent Log (WARN / ERROR / SECURITY)'), 2);
+
+	if ($logfile == '' || str_contains($logfile, chr(0)) || !file_exists($logfile) || !is_file($logfile) || !is_readable($logfile)) {
+		form_alternate_row();
+		print "<td colspan='2'>" . __('Log not available.') . '</td>';
+		form_end_row();
+
+		return;
+	}
+
+	$lines = support_tail_severity($logfile, $max_lines, $cap_bytes);
+
+	if (!cacti_sizeof($lines)) {
+		form_alternate_row();
+		print "<td colspan='2'>" . __('No recent WARN, ERROR or SECURITY log entries found.') . '</td>';
+		form_end_row();
+
+		return;
+	}
+
+	form_alternate_row();
+	print "<td colspan='2' class='left'>";
+	print "<pre style='white-space:pre-wrap;margin:0'>";
+
+	foreach ($lines as $line) {
+		if ($redact) {
+			$line = support_redact($line);
+		}
+
+		print html_escape($line) . "\n";
+	}
+
+	print '</pre></td>';
+	form_end_row();
 }

--- a/tests/Unit/SupportSafeTriageTest.php
+++ b/tests/Unit/SupportSafeTriageTest.php
@@ -1,0 +1,334 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 2) . '/include/global.php';
+require_once dirname(__DIR__, 2) . '/lib/utility.php';
+
+// support.php returns early under the test-bootstrap gate, so only its function
+// declarations load here. That skips the auth + dispatch path a unit test cannot
+// satisfy while leaving the triage helpers callable.
+require_once dirname(__DIR__, 2) . '/support.php';
+
+beforeEach(function () {
+	global $_CACTI_REQUEST;
+
+	// get_request_var() caches validated values in these; clear them so the
+	// redact toggle from one test cannot leak into the next.
+	$_CACTI_REQUEST = [];
+	unset($_REQUEST['redact'], $_REQUEST['tab']);
+});
+
+test('support_redact returns an empty string unchanged', function () {
+	expect(support_redact(''))->toBe('');
+});
+
+test('tech_env_status maps each status to its badge class and icon', function () {
+	expect(tech_env_status(DB_STATUS_SUCCESS, 'Installed'))
+		->toContain("class='deviceUp'")->toContain('fa-check-circle')->toContain('Installed');
+
+	expect(tech_env_status(DB_STATUS_ERROR, 'Missing'))
+		->toContain("class='deviceDown'")->toContain('fa-times-circle');
+
+	// tech_env_status escapes its text argument; angle brackets must not survive raw.
+	expect(tech_env_status(DB_STATUS_WARNING, '<x>'))
+		->toContain("class='deviceRecovering'")->toContain('fa-exclamation-triangle')->not->toContain('<x>');
+});
+
+test('show_tech_environment renders every section without a database', function () {
+	global $config;
+
+	$config[OPTIONS_CLI]['path_php_binary'] = PHP_BINARY;
+	$config[OPTIONS_CLI]['path_rrdtool']    = '/cacti-tests/missing-rrdtool';
+	$config[OPTIONS_CLI]['path_snmpget']    = PHP_BINARY;
+
+	ob_start();
+	show_tech_environment();
+	$html = ob_get_clean();
+
+	expect($html)->toContain(__('Required PHP Extensions'))
+		->and($html)->toContain(__('Required Binaries'))
+		->and($html)->toContain(__('Writable Directories'));
+});
+
+test('show_tech_environment flags a directory that is not writable', function () {
+	global $config;
+
+	$config[OPTIONS_CLI]['path_php_binary'] = PHP_BINARY;
+	$config[OPTIONS_CLI]['path_rrdtool']    = PHP_BINARY;
+	$config[OPTIONS_CLI]['path_snmpget']    = PHP_BINARY;
+
+	$dir  = CACTI_PATH_RESOURCE;
+	$mode = fileperms($dir) & 0777;
+
+	expect(chmod($dir, 0555))->toBeTrue();
+
+	try {
+		clearstatcache(true, $dir);
+
+		ob_start();
+		show_tech_environment();
+		$html = ob_get_clean();
+
+		expect($html)->toContain(__('Not writable'));
+	} finally {
+		chmod($dir, $mode);
+		clearstatcache(true, $dir);
+	}
+})->skip(posix_getuid() === 0, 'root bypasses directory write permissions');
+
+function safe_triage_seed_summary(): void {
+	global $config, $poller_options, $database_hostname;
+
+	$poller_options    = [1 => 'cactid', 2 => 'spine'];
+	$database_hostname = 'localhost';
+
+	$config[OPTIONS_CLI]['rsa_fingerprint'] = 'abcdef0123456789feedface';
+	$config[OPTIONS_CLI]['poller_interval'] = '60';
+	$config[OPTIONS_CLI]['stats_poller']    = '';
+}
+
+test('show_tech_summary masks and escapes an installed SNMP banner when redacting', function () {
+	global $config;
+
+	safe_triage_seed_summary();
+
+	// A real executable makes the SNMP tool count as installed, so the escaped
+	// and redacted output branch runs instead of the pre-built status span.
+	$config[OPTIONS_CLI]['path_snmpget'] = PHP_BINARY;
+
+	// An executable path_spine that emits output drives the spine poller branch.
+	$config[OPTIONS_CLI]['path_spine']   = '/bin/echo';
+	$config[OPTIONS_CLI]['poller_type']  = '2';
+
+	$_REQUEST['redact'] = '1';
+
+	ob_start();
+	show_tech_summary();
+	$html = ob_get_clean();
+
+	expect($html)->toContain('abcdef01')
+		->and($html)->not->toContain('abcdef0123456789feedface');
+});
+
+test('show_tech_summary shows the full fingerprint and raw SNMP status when not redacting', function () {
+	global $config;
+
+	safe_triage_seed_summary();
+
+	// Missing SNMP tool exercises the not-installed status-span branch.
+	$config[OPTIONS_CLI]['path_snmpget'] = '/cacti-tests/missing-snmpget';
+	$config[OPTIONS_CLI]['poller_type']  = '1';
+
+	ob_start();
+	show_tech_summary();
+	$html = ob_get_clean();
+
+	expect($html)->toContain('abcdef0123456789feedface');
+});
+
+test('show_tech_summary reports N/A when no RSA fingerprint is set', function () {
+	global $config;
+
+	safe_triage_seed_summary();
+
+	$config[OPTIONS_CLI]['rsa_fingerprint'] = '';
+	$config[OPTIONS_CLI]['path_snmpget']    = PHP_BINARY;
+	$config[OPTIONS_CLI]['poller_type']     = '1';
+
+	ob_start();
+	show_tech_summary();
+	$html = ob_get_clean();
+
+	expect($html)->toContain(__('N/A'));
+});
+
+test('show_tech_log reports when the log is not available', function () {
+	global $config;
+
+	$config[OPTIONS_CLI]['path_cactilog'] = '';
+
+	ob_start();
+	show_tech_log();
+	$html = ob_get_clean();
+
+	expect($html)->toContain(__('Log not available.'));
+});
+
+test('show_tech_log reports when no severity lines are present', function () {
+	global $config;
+
+	$file = tempnam(sys_get_temp_dir(), 'triagelog');
+	file_put_contents($file, "2026-01-01 INFO nothing interesting here\n");
+	$config[OPTIONS_CLI]['path_cactilog'] = $file;
+
+	try {
+		ob_start();
+		show_tech_log();
+		$html = ob_get_clean();
+
+		expect($html)->toContain(__('No recent WARN, ERROR or SECURITY log entries found.'));
+	} finally {
+		unlink($file);
+	}
+});
+
+test('show_tech_log prints recent severity lines and redacts on request', function () {
+	global $config;
+
+	$file = tempnam(sys_get_temp_dir(), 'triagelog');
+	file_put_contents($file, "2026-01-01 WARN failure on 192.168.5.5\n");
+	$config[OPTIONS_CLI]['path_cactilog'] = $file;
+
+	$_REQUEST['redact'] = '1';
+
+	try {
+		ob_start();
+		show_tech_log();
+		$html = ob_get_clean();
+
+		expect($html)->toContain('WARN')
+			->and($html)->toContain('&lt;ipv4&gt;')
+			->and($html)->not->toContain('192.168.5.5');
+	} finally {
+		unset($_REQUEST['redact']);
+		unlink($file);
+	}
+});
+
+test('support_redact masks IPv4, IPv6 and FQDN but leaves version numbers', function () {
+	$out = support_redact('host db01.corp.example at 192.168.10.5 and fe80:0:0:0:0:0:0:1 running 1.7.2');
+
+	expect($out)->toContain('<ipv4>')
+		->and($out)->toContain('<ipv6>')
+		->and($out)->toContain('<host>')
+		->and($out)->toContain('1.7.2')
+		->and($out)->not->toContain('192.168.10.5')
+		->and($out)->not->toContain('fe80:0:0:0:0:0:0:1')
+		->and($out)->not->toContain('db01.corp.example');
+});
+
+test('support_redact masks home directory path segments', function () {
+	expect(support_redact('/home/alice/scripts'))->toContain('/home/<redacted>')
+		->and(support_redact('/Users/bob/rra'))->toContain('/home/<redacted>');
+});
+
+test('support_redact masks this hosts own node name', function () {
+	$node = php_uname('n');
+
+	// Only exercised when the running host has a usable node name.
+	if ($node == '' || strlen($node) <= 1) {
+		expect(true)->toBeTrue();
+
+		return;
+	}
+
+	expect(support_redact("logged in on $node now"))->toContain('<host>')
+		->and(support_redact("logged in on $node now"))->not->toContain($node);
+});
+
+test('support_tail_severity returns nothing for an empty file', function () {
+	$file = tempnam(sys_get_temp_dir(), 'triagelog');
+
+	try {
+		expect(support_tail_severity($file, 100, 4096))->toBe([]);
+	} finally {
+		unlink($file);
+	}
+});
+
+test('support_tail_severity returns only WARN, ERROR and SECURITY lines', function () {
+	$file = tempnam(sys_get_temp_dir(), 'triagelog');
+
+	file_put_contents($file, implode("\n", [
+		'2026-01-01 INFO normal line',
+		'2026-01-01 WARN something odd',
+		'2026-01-01 DEBUG noise',
+		'2026-01-01 ERROR broke',
+		'2026-01-01 SECURITY denied',
+		'',
+	]));
+
+	try {
+		$lines = support_tail_severity($file, 100, 65536);
+
+		expect($lines)->toHaveCount(3)
+			->and($lines[0])->toContain('WARN')
+			->and($lines[1])->toContain('ERROR')
+			->and($lines[2])->toContain('SECURITY');
+	} finally {
+		unlink($file);
+	}
+});
+
+test('support_tail_severity caps the byte window and drops the partial first line', function () {
+	$file = tempnam(sys_get_temp_dir(), 'triagelog');
+
+	// Pad past the cap so the seek lands mid-line; the sliced fragment must be
+	// discarded and only the trailing matches returned.
+	$pad = str_repeat("2026-01-01 INFO padding line to grow the file\n", 200);
+	file_put_contents($file, $pad . "2026-01-01 WARN near the end\n2026-01-01 ERROR last one\n");
+
+	try {
+		$lines = support_tail_severity($file, 100, 512);
+
+		expect($lines)->toContain('2026-01-01 WARN near the end')
+			->and($lines)->toContain('2026-01-01 ERROR last one');
+	} finally {
+		unlink($file);
+	}
+});
+
+test('support_tail_severity limits the number of returned lines', function () {
+	$file = tempnam(sys_get_temp_dir(), 'triagelog');
+
+	$many = '';
+	for ($i = 0; $i < 20; $i++) {
+		$many .= "2026-01-01 WARN entry $i\n";
+	}
+	file_put_contents($file, $many);
+
+	try {
+		$lines = support_tail_severity($file, 5, 65536);
+
+		expect($lines)->toHaveCount(5)
+			->and($lines[4])->toContain('entry 19');
+	} finally {
+		unlink($file);
+	}
+});
+
+test('support_tail_severity returns nothing when the file cannot be opened', function () {
+	$file = tempnam(sys_get_temp_dir(), 'triagelog');
+	file_put_contents($file, "2026-01-01 WARN unreadable\n");
+	chmod($file, 0000);
+
+	try {
+		clearstatcache(true, $file);
+		expect(support_tail_severity($file, 100, 4096))->toBe([]);
+	} finally {
+		chmod($file, 0644);
+		unlink($file);
+	}
+})->skip(posix_getuid() === 0, 'root bypasses file read permissions');

--- a/tests/Unit/SupportSafeTriageTest.php
+++ b/tests/Unit/SupportSafeTriageTest.php
@@ -96,7 +96,7 @@ test('show_tech_environment flags a directory that is not writable', function ()
 		chmod($dir, $mode);
 		clearstatcache(true, $dir);
 	}
-})->skip(posix_getuid() === 0, 'root bypasses directory write permissions');
+})->skip(function_exists('posix_getuid') && posix_getuid() === 0, 'root bypasses directory write permissions');
 
 function safe_triage_seed_summary(): void {
 	global $config, $poller_options, $database_hostname;
@@ -331,4 +331,4 @@ test('support_tail_severity returns nothing when the file cannot be opened', fun
 		chmod($file, 0644);
 		unlink($file);
 	}
-})->skip(posix_getuid() === 0, 'root bypasses file read permissions');
+})->skip(function_exists('posix_getuid') && posix_getuid() === 0, 'root bypasses file read permissions');

--- a/tests/e2e/support_triage_docker.sh
+++ b/tests/e2e/support_triage_docker.sh
@@ -13,7 +13,8 @@
 # End-to-end check for the safe-triage redaction flow (#7358). Boots the Cacti
 # Docker stack, then runs support_triage_probe.php inside the web container to
 # confirm the redacted diagnostics report masks the RSA fingerprint and never
-# leaks the database host or password, while the unredacted report shows them.
+# leaks the database host or password (when non-default), while the
+# unredacted report contains the full RSA fingerprint.
 #
 # Requires Docker. Run from a checkout: tests/e2e/support_triage_docker.sh
 set -euo pipefail

--- a/tests/e2e/support_triage_docker.sh
+++ b/tests/e2e/support_triage_docker.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# +-------------------------------------------------------------------------+
+# | Copyright (C) 2004-2026 The Cacti Group                                 |
+# |                                                                         |
+# | This program is free software; you can redistribute it and/or           |
+# | modify it under the terms of the GNU General Public License             |
+# | as published by the Free Software Foundation; either version 2          |
+# | of the License, or (at your option) any later version.                  |
+# +-------------------------------------------------------------------------+
+# | Cacti: The Complete RRDtool-based Graphing Solution                     |
+# +-------------------------------------------------------------------------+
+#
+# End-to-end check for the safe-triage redaction flow (#7358). Boots the Cacti
+# Docker stack, then runs support_triage_probe.php inside the web container to
+# confirm the redacted diagnostics report masks the RSA fingerprint and never
+# leaks the database host or password, while the unredacted report shows them.
+#
+# Requires Docker. Run from a checkout: tests/e2e/support_triage_docker.sh
+set -euo pipefail
+
+COMPOSE_PROJECT="cacti_support_triage_e2e_$$"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ENV_FILE="$REPO_DIR/.env.support-triage-e2e"
+WEB_PORT=18085
+DB_PORT=13311
+CONFIG_EXISTED=0
+CONFIG_BACKUP=""
+
+if [ -f "$REPO_DIR/include/config.php" ]; then
+	CONFIG_EXISTED=1
+	CONFIG_BACKUP="$(mktemp "${TMPDIR:-/tmp}/cacti-config.XXXXXX")"
+	cp "$REPO_DIR/include/config.php" "$CONFIG_BACKUP"
+	rm -f "$REPO_DIR/include/config.php"
+fi
+
+cleanup() {
+	cd "$REPO_DIR"
+	docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" down -v --remove-orphans 2>/dev/null || true
+	rm -f "$ENV_FILE"
+
+	if [ "$CONFIG_EXISTED" -eq 1 ] && [ -n "$CONFIG_BACKUP" ] && [ -f "$CONFIG_BACKUP" ]; then
+		cp "$CONFIG_BACKUP" "$REPO_DIR/include/config.php"
+		rm -f "$CONFIG_BACKUP"
+	elif [ "$CONFIG_EXISTED" -eq 0 ]; then
+		rm -f "$REPO_DIR/include/config.php"
+	fi
+}
+
+trap cleanup EXIT
+
+cd "$REPO_DIR"
+
+cat > "$ENV_FILE" <<EOF
+WEB_PORT=$WEB_PORT
+DB_ROOT_PASSWORD=testroot
+DB_NAME=cacti
+DB_USER=cacti
+DB_PASSWORD=testpass
+DB_PORT=$DB_PORT
+TIMEZONE=UTC
+PHP_MEMORY_LIMIT=256M
+DB_MAX_CONNECTIONS=50
+DB_BUFFER_POOL_SIZE=256M
+EOF
+
+echo "Building support triage Docker test image..."
+docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" build --quiet
+
+echo "Starting support triage Docker test stack..."
+docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" up -d
+
+echo "Waiting for Docker test stack..."
+TRIES=0
+while [ "$TRIES" -lt 36 ]; do
+	DB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | head -1 | cut -d'"' -f4)
+	WEB_HEALTH=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | tail -1 | cut -d'"' -f4)
+
+	if [ "$DB_HEALTH" = "healthy" ] && [ "$WEB_HEALTH" = "healthy" ]; then
+		break
+	fi
+
+	sleep 5
+	TRIES=$((TRIES + 1))
+done
+
+if [ "${DB_HEALTH:-}" != "healthy" ] || [ "${WEB_HEALTH:-}" != "healthy" ]; then
+	docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps
+	exit 1
+fi
+
+WEB_CONTAINER=$(docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" ps -q web)
+
+docker exec "$WEB_CONTAINER" php -l /var/www/html/cacti/support.php
+docker exec "$WEB_CONTAINER" php -l /var/www/html/cacti/tests/e2e/support_triage_probe.php
+PROBE_OUTPUT=$(docker exec -e BASE_URL=http://localhost/cacti "$WEB_CONTAINER" php /var/www/html/cacti/tests/e2e/support_triage_probe.php)
+echo "$PROBE_OUTPUT"
+grep -q 'PASS support triage docker probe' <<<"$PROBE_OUTPUT"

--- a/tests/e2e/support_triage_probe.php
+++ b/tests/e2e/support_triage_probe.php
@@ -21,8 +21,8 @@
  * Runs inside the Cacti web container. Drives the safe-triage redaction flow
  * (support.php, #7358) over real HTTP: with redact=1 the rendered Summary tab
  * must mask the RSA fingerprint and must not contain the live database host or
- * password, and the Recent Log tab must render. Without the flag the same
- * values appear unmasked.
+ * password (when non-default), and the Recent Log tab must render. Without
+ * the flag, the report contains the full RSA fingerprint.
  *
  * Usage (inside the container):
  *   BASE_URL=http://localhost/cacti php support_triage_probe.php

--- a/tests/e2e/support_triage_probe.php
+++ b/tests/e2e/support_triage_probe.php
@@ -1,0 +1,144 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Runs inside the Cacti web container. Drives the safe-triage redaction flow
+ * (support.php, #7358) over real HTTP: with redact=1 the rendered Summary tab
+ * must mask the RSA fingerprint and must not contain the live database host or
+ * password, and the Recent Log tab must render. Without the flag the same
+ * values appear unmasked.
+ *
+ * Usage (inside the container):
+ *   BASE_URL=http://localhost/cacti php support_triage_probe.php
+ */
+
+chdir(dirname(__DIR__, 2));
+
+require_once __DIR__ . '/../../include/global.php';
+
+$base = rtrim(getenv('BASE_URL') ?: 'http://localhost/cacti', '/');
+$user = getenv('CACTI_USER') ?: 'admin';
+$pass = getenv('CACTI_PASS') ?: 'admin';
+$jar  = tempnam(sys_get_temp_dir(), 'cacticookie');
+
+function triage_probe_fail(string $message): void {
+	fwrite(STDERR, "FAIL: $message\n");
+	exit(1);
+}
+
+function triage_probe_request(string $url, string $jar, ?array $post = null): string {
+	$ch = curl_init($url);
+
+	curl_setopt_array($ch, [
+		CURLOPT_RETURNTRANSFER => true,
+		CURLOPT_FOLLOWLOCATION => true,
+		CURLOPT_COOKIEJAR      => $jar,
+		CURLOPT_COOKIEFILE     => $jar,
+		CURLOPT_TIMEOUT        => 20,
+	]);
+
+	if ($post !== null) {
+		curl_setopt($ch, CURLOPT_POST, true);
+		curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($post));
+	}
+
+	$body = curl_exec($ch);
+	curl_close($ch);
+
+	return (string) $body;
+}
+
+function triage_probe_csrf(string $html): string {
+	if (preg_match('/name="__csrf_magic"\s+value="([^"]+)"/', $html, $m)) {
+		return $m[1];
+	}
+
+	if (preg_match("/csrfMagicToken\s*=\s*\"([^\"]+)\"/", $html, $m)) {
+		return $m[1];
+	}
+
+	return '';
+}
+
+function triage_probe_report(string $html): string {
+	// The shareable report lives in a hidden textarea.
+	if (preg_match('/<textarea id=.diag_report.[^>]*>(.*?)<\/textarea>/s', $html, $m)) {
+		return html_entity_decode($m[1], ENT_QUOTES, 'UTF-8');
+	}
+
+	return '';
+}
+
+// Authenticate.
+$loginHtml = triage_probe_request("$base/index.php", $jar);
+$token     = triage_probe_csrf($loginHtml);
+triage_probe_request("$base/index.php", $jar, [
+	'__csrf_magic'   => $token,
+	'action'         => 'login',
+	'login_username' => $user,
+	'login_password' => $pass,
+]);
+
+// Seed an RSA fingerprint so there is an identifying value to redact.
+$fingerprint = 'abcdef0123456789cafebabefeedface';
+set_config_option('rsa_fingerprint', $fingerprint);
+
+global $database_hostname, $database_password;
+
+// Redacted render: the report must mask the fingerprint and hide infra values.
+$redacted = triage_probe_report(triage_probe_request("$base/support.php?tab=summary&redact=1", $jar));
+
+if ($redacted === '') {
+	triage_probe_fail('redacted Summary tab returned no diagnostics report');
+}
+
+if (strpos($redacted, $fingerprint) !== false) {
+	triage_probe_fail('redacted report leaked the full RSA fingerprint');
+}
+
+if (strpos($redacted, substr($fingerprint, 0, 8)) === false) {
+	triage_probe_fail('redacted report dropped the masked fingerprint prefix');
+}
+
+if (!empty($database_password) && strpos($redacted, $database_password) !== false) {
+	triage_probe_fail('redacted report leaked the database password');
+}
+
+if (!empty($database_hostname) && !in_array($database_hostname, ['localhost', '127.0.0.1'], true)
+	&& strpos($redacted, $database_hostname) !== false) {
+	triage_probe_fail('redacted report leaked the database hostname');
+}
+
+// Unredacted render: the fingerprint appears in full.
+$plain = triage_probe_report(triage_probe_request("$base/support.php?tab=summary", $jar));
+
+if (strpos($plain, $fingerprint) === false) {
+	triage_probe_fail('unredacted report did not contain the RSA fingerprint');
+}
+
+// The Recent Log tab must render.
+$log = triage_probe_request("$base/support.php?tab=log&redact=1", $jar);
+
+if (strpos($log, 'Recent Log') === false) {
+	triage_probe_fail('Recent Log tab did not render');
+}
+
+@unlink($jar);
+
+print "PASS support triage docker probe\n";

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -108,10 +108,10 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1188				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1208			$snmp_version   = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1233			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-cmd_exec	./support.php:1943				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1204				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1224			$snmp_version   = (string) shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1249			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1966				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
 dynamic_include	./cli/audit_database.php:232							require_once($plugin . '/setup.php');
 dynamic_include	./cli/audit_database.php:235								require_once($plugin . '/includes/database.php');
 dynamic_include	./cli/upgrade_database.php:152			include($upgrade_file);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -108,9 +108,10 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1133				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1151			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1174			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1188				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1208			$snmp_version   = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1233			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1943				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
 dynamic_include	./cli/audit_database.php:232							require_once($plugin . '/setup.php');
 dynamic_include	./cli/audit_database.php:235								require_once($plugin . '/includes/database.php');
 dynamic_include	./cli/upgrade_database.php:152			include($upgrade_file);

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -109,9 +109,9 @@ cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B 
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
 cmd_exec	./support.php:1204				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1224			$snmp_version   = (string) shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1249			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-cmd_exec	./support.php:1966				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1226			$snmp_version   = (string) shell_exec(cacti_escapeshellcmd($snmpget_path) . ' -V 2>&1');
+cmd_exec	./support.php:1251			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1968				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
 dynamic_include	./cli/audit_database.php:232							require_once($plugin . '/setup.php');
 dynamic_include	./cli/audit_database.php:235								require_once($plugin . '/includes/database.php');
 dynamic_include	./cli/upgrade_database.php:152			include($upgrade_file);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -211,7 +211,7 @@ fs_write	./scripts/ss_net_snmp_disk_bytes.php:288				file_put_contents("$tmpdir/
 fs_write	./scripts/ss_net_snmp_disk_io.php:289				file_put_contents("$tmpdir/$tmpfile", $data);
 fs_write	./snmpagent_mibcachechild.php:90		$lock = fopen($path_mibcache_lock, 'w');
 fs_write	./snmpagent_mibcachechild.php:94			file_put_contents($path_mibcache, '<?php $cache = ' . var_export($cache, true) . ';', LOCK_EX);
-fs_write	./support.php:2067		$fp = fopen($file, 'rb');
+fs_write	./support.php:2072		$fp = fopen($file, 'rb');
 fs_write	./templates_import.php:63				$fp       = fopen($_FILES['import_file']['tmp_name'],'r');
 fs_write	./utilities.php:191				$log_fh = fopen($logfile, 'w');
 header_redirect	./aggregate_graphs.php:1091			header('Location: ' . $referer);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -108,10 +108,10 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1188				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1208			$snmp_version   = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1233			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-cmd_exec	./support.php:1943				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1204				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1224			$snmp_version   = (string) shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1249			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1966				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
 deserialize	./lib/functions.php:5319				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:5359				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:9996		return unserialize($strobj, ['allowed_classes' => false]);
@@ -211,7 +211,7 @@ fs_write	./scripts/ss_net_snmp_disk_bytes.php:288				file_put_contents("$tmpdir/
 fs_write	./scripts/ss_net_snmp_disk_io.php:289				file_put_contents("$tmpdir/$tmpfile", $data);
 fs_write	./snmpagent_mibcachechild.php:90		$lock = fopen($path_mibcache_lock, 'w');
 fs_write	./snmpagent_mibcachechild.php:94			file_put_contents($path_mibcache, '<?php $cache = ' . var_export($cache, true) . ';', LOCK_EX);
-fs_write	./support.php:2049		$fp = fopen($file, 'rb');
+fs_write	./support.php:2067		$fp = fopen($file, 'rb');
 fs_write	./templates_import.php:63				$fp       = fopen($_FILES['import_file']['tmp_name'],'r');
 fs_write	./utilities.php:191				$log_fh = fopen($logfile, 'w');
 header_redirect	./aggregate_graphs.php:1091			header('Location: ' . $referer);
@@ -608,7 +608,7 @@ header_redirect	./settings.php:1666			header('Location: settings.php?header=fals
 header_redirect	./settings.php:1668			header('Location: settings.php?tab=' . grv('tab'));
 header_redirect	./sites.php:280			header('Location: sites.php?action=edit&id=' . (empty($site_id) ? gnrv('id') : $site_id));
 header_redirect	./sites.php:393			header('Location: sites.php');
-header_redirect	./support.php:64		header('Location: support.php?tab=summary');
+header_redirect	./support.php:73		header('Location: support.php?tab=summary');
 header_redirect	./templates_export.php:72					header('Location: templates_export.php');
 header_redirect	./templates_import.php:118				header('Location: templates_import.php');
 header_redirect	./templates_import.php:67				header('Location: templates_import.php');

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -108,9 +108,10 @@ cmd_exec	./snmpagent_mibcache.php:56			exec($php . ' ' . $extra_args . ' > /dev/
 cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B ' . $php . ' ' . $extra_args, 'r'));
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
-cmd_exec	./support.php:1133				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1151			$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1174			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1188				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
+cmd_exec	./support.php:1208			$snmp_version   = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
+cmd_exec	./support.php:1233			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1943				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
 deserialize	./lib/functions.php:5319				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:5359				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:9996		return unserialize($strobj, ['allowed_classes' => false]);
@@ -210,6 +211,7 @@ fs_write	./scripts/ss_net_snmp_disk_bytes.php:288				file_put_contents("$tmpdir/
 fs_write	./scripts/ss_net_snmp_disk_io.php:289				file_put_contents("$tmpdir/$tmpfile", $data);
 fs_write	./snmpagent_mibcachechild.php:90		$lock = fopen($path_mibcache_lock, 'w');
 fs_write	./snmpagent_mibcachechild.php:94			file_put_contents($path_mibcache, '<?php $cache = ' . var_export($cache, true) . ';', LOCK_EX);
+fs_write	./support.php:2049		$fp = fopen($file, 'rb');
 fs_write	./templates_import.php:63				$fp       = fopen($_FILES['import_file']['tmp_name'],'r');
 fs_write	./utilities.php:191				$log_fh = fopen($logfile, 'w');
 header_redirect	./aggregate_graphs.php:1091			header('Location: ' . $referer);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -109,9 +109,9 @@ cmd_exec	./snmpagent_persist.php:83		pclose(popen('start "CactiSNMPCache" /I /B 
 cmd_exec	./snmpagent_persist.php:85		exec('ps -ef | grep -v grep | grep -v "sh -c" | grep snmpagent_mibcache.php', $output);
 cmd_exec	./snmpagent_persist.php:88			exec($php . ' ' . $extra_args . ' > /dev/null &');
 cmd_exec	./support.php:1204				exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
-cmd_exec	./support.php:1224			$snmp_version   = (string) shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
-cmd_exec	./support.php:1249			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-cmd_exec	./support.php:1966				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
+cmd_exec	./support.php:1226			$snmp_version   = (string) shell_exec(cacti_escapeshellcmd($snmpget_path) . ' -V 2>&1');
+cmd_exec	./support.php:1251			exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
+cmd_exec	./support.php:1968				$out     = shell_exec(cacti_escapeshellcmd($path) . ' ' . $arg . ' 2>&1');
 deserialize	./lib/functions.php:5319				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:5359				$items = unserialize($unstripped, ['allowed_classes' => false]);
 deserialize	./lib/functions.php:9996		return unserialize($strobj, ['allowed_classes' => false]);
@@ -211,7 +211,7 @@ fs_write	./scripts/ss_net_snmp_disk_bytes.php:288				file_put_contents("$tmpdir/
 fs_write	./scripts/ss_net_snmp_disk_io.php:289				file_put_contents("$tmpdir/$tmpfile", $data);
 fs_write	./snmpagent_mibcachechild.php:90		$lock = fopen($path_mibcache_lock, 'w');
 fs_write	./snmpagent_mibcachechild.php:94			file_put_contents($path_mibcache, '<?php $cache = ' . var_export($cache, true) . ';', LOCK_EX);
-fs_write	./support.php:2072		$fp = fopen($file, 'rb');
+fs_write	./support.php:2074		$fp = fopen($file, 'rb');
 fs_write	./templates_import.php:63				$fp       = fopen($_FILES['import_file']['tmp_name'],'r');
 fs_write	./utilities.php:191				$log_fh = fopen($logfile, 'w');
 header_redirect	./aggregate_graphs.php:1091			header('Location: ' . $referer);

--- a/tests/tools/check_hardening_patterns.php
+++ b/tests/tools/check_hardening_patterns.php
@@ -63,6 +63,13 @@ foreach ($files as $file) {
 		continue;
 	}
 
+	/* The guard protects product code.  Test fixtures legitimately assign
+	   request superglobals and embed inline patterns to exercise the code
+	   under test, so the tests tree is out of scope. */
+	if (str_starts_with(preg_replace('#^\./#', '', $file), 'tests/')) {
+		continue;
+	}
+
 	$lines = file($file, FILE_IGNORE_NEW_LINES);
 
 	if ($lines === false) {


### PR DESCRIPTION
Stacked on #7349 (targets develop; until #7349 merges the diff carries its commits — the net-new change here is the final commit).

Two "safe triage" additions to the Technical Support page:

**Redact for sharing toggle** - a checkbox by the Copy Diagnostics control that masks identifying values on the Summary tab and in the copied report: this host's node name, IPv4/IPv6 addresses, FQDNs, the RSA fingerprint (truncated), and `/home|/Users/<user>/` path segments. Server-side via a `redact` request var carried on the tab links so it stays in effect across tabs. Unmasked mode is byte-for-byte unchanged. The masking is conservative (over-masks rather than leaks) and display-only.

**Recent Log tab** - the last 100 WARN/ERROR/SECURITY lines from the Cacti log. Reads only `read_config_option('path_cactilog')` (never a request-supplied path - no traversal), with a bounded tail (`fseek` to the last 256KB, single `fread`) so a multi-GB log never loads whole. Each line is `html_escape`'d; missing/empty logs show a clear message. Honors the redaction toggle.

Verified: php -l clean, php-cs-fixer 0 fixable, PHPStan level 6 no errors. Touches support.php plus its test coverage: tests/Unit/SupportSafeTriageTest.php, tests/e2e/support_triage_docker.sh, tests/e2e/support_triage_probe.php, and the security baseline/hardening-pattern files those additions require.

Part of #7370