### PR TITLE
fix(auth): normalize trusted-proxy match with inet_pton

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -250,10 +250,14 @@ function is_template_account(null|int|string $user_id) : bool {
 /**
  * Whether the current request originates from a reverse proxy that config.php
  * lists in $trusted_proxies. Only such proxies may assert a pre-authenticated
- * user via forwarded HTTP headers. An exact REMOTE_ADDR match is required; an
- * empty or unset list trusts no proxy.
+ * user via forwarded HTTP headers. Matching is IP-normalized: when both
+ * REMOTE_ADDR and a trusted entry parse as IP addresses, they are compared by
+ * packed binary form, so equivalent spellings (for example ::1 and
+ * 0:0:0:0:0:0:0:1) match regardless of text representation. A malformed or
+ * non-IP entry falls back to exact string equality. An empty or unset list
+ * trusts no proxy.
  *
- * @return bool true when REMOTE_ADDR exactly matches a trusted proxy entry.
+ * @return bool true when REMOTE_ADDR matches a trusted proxy entry.
  */
 function is_trusted_proxy() : bool {
 	global $config;
@@ -268,7 +272,29 @@ function is_trusted_proxy() : bool {
 		return false;
 	}
 
-	return in_array($_SERVER['REMOTE_ADDR'], $trusted, true);
+	$remote        = (string) $_SERVER['REMOTE_ADDR'];
+	$remote_packed = @inet_pton($remote);
+
+	foreach ($trusted as $entry) {
+		$entry = (string) $entry;
+
+		/* Compare valid IPs by packed form so alternate spellings of the same
+		 * address match. inet_pton yields 4 bytes for IPv4 and 16 for IPv6, so
+		 * an IPv4-mapped entry never silently matches its bare IPv4 form. */
+		if ($remote_packed !== false) {
+			$entry_packed = @inet_pton($entry);
+
+			if ($entry_packed !== false && hash_equals($entry_packed, $remote_packed)) {
+				return true;
+			}
+		}
+
+		if (hash_equals($entry, $remote)) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /**

--- a/tests/Unit/TrustedProxyAuthTest.php
+++ b/tests/Unit/TrustedProxyAuthTest.php
@@ -67,9 +67,34 @@ test('is_trusted_proxy is false when REMOTE_ADDR is unset', function () {
 	expect(is_trusted_proxy())->toBeFalse();
 });
 
+test('is_trusted_proxy matches an IPv6 proxy across text representations', function () {
+	reset_identity_env(['REMOTE_ADDR' => '0:0:0:0:0:0:0:1'], ['::1']);
+	expect(is_trusted_proxy())->toBeTrue();
+});
+
+test('is_trusted_proxy matches when REMOTE_ADDR is the compact IPv6 form', function () {
+	reset_identity_env(['REMOTE_ADDR' => '::1'], ['0:0:0:0:0:0:0:1']);
+	expect(is_trusted_proxy())->toBeTrue();
+});
+
+test('is_trusted_proxy rejects a different IPv6 address', function () {
+	reset_identity_env(['REMOTE_ADDR' => '::2'], ['::1']);
+	expect(is_trusted_proxy())->toBeFalse();
+});
+
+test('is_trusted_proxy does not equate IPv4-mapped and bare IPv4 forms', function () {
+	reset_identity_env(['REMOTE_ADDR' => '::ffff:10.0.0.1'], ['10.0.0.1']);
+	expect(is_trusted_proxy())->toBeFalse();
+});
+
+test('is_trusted_proxy still matches a malformed non-IP entry by exact string', function () {
+	reset_identity_env(['REMOTE_ADDR' => 'not-an-ip'], ['not-an-ip']);
+	expect(is_trusted_proxy())->toBeTrue();
+});
+
 test('forwarded X-Forwarded-User is ignored from an untrusted client', function () {
 	reset_identity_env([
-		'REMOTE_ADDR'          => '203.0.113.9',
+		'REMOTE_ADDR'           => '203.0.113.9',
 		'HTTP_X_FORWARDED_USER' => 'admin',
 	], []);
 	expect(get_basic_auth_username())->toBeFalse();
@@ -77,7 +102,7 @@ test('forwarded X-Forwarded-User is ignored from an untrusted client', function 
 
 test('forwarded HTTP_REMOTE_USER is ignored from an untrusted client', function () {
 	reset_identity_env([
-		'REMOTE_ADDR'     => '203.0.113.9',
+		'REMOTE_ADDR'      => '203.0.113.9',
 		'HTTP_REMOTE_USER' => 'admin',
 	], ['10.0.0.1']);
 	expect(get_basic_auth_username())->toBeFalse();
@@ -85,7 +110,7 @@ test('forwarded HTTP_REMOTE_USER is ignored from an untrusted client', function 
 
 test('forwarded X-Forwarded-User is honored from a trusted proxy', function () {
 	reset_identity_env([
-		'REMOTE_ADDR'          => '10.0.0.1',
+		'REMOTE_ADDR'           => '10.0.0.1',
 		'HTTP_X_FORWARDED_USER' => 'admin',
 	], ['10.0.0.1']);
 	expect(get_basic_auth_username())->toBe('admin');
@@ -93,7 +118,7 @@ test('forwarded X-Forwarded-User is honored from a trusted proxy', function () {
 
 test('forwarded HTTP_REMOTE_USER is honored from a trusted proxy', function () {
 	reset_identity_env([
-		'REMOTE_ADDR'     => '10.0.0.1',
+		'REMOTE_ADDR'      => '10.0.0.1',
 		'HTTP_REMOTE_USER' => 'proxyuser',
 	], ['10.0.0.1']);
 	expect(get_basic_auth_username())->toBe('proxyuser');
@@ -109,8 +134,8 @@ test('web-server-set REMOTE_USER is honored regardless of proxy trust', function
 
 test('an untrusted client cannot override the web-server REMOTE_USER via a forwarded header', function () {
 	reset_identity_env([
-		'REMOTE_ADDR'          => '203.0.113.9',
-		'REMOTE_USER'          => 'svcaccount',
+		'REMOTE_ADDR'           => '203.0.113.9',
+		'REMOTE_USER'           => 'svcaccount',
 		'HTTP_X_FORWARDED_USER' => 'attacker',
 	], []);
 	expect(get_basic_auth_username())->toBe('svcaccount');


### PR DESCRIPTION
Follow-up to #7324 (merged). `is_trusted_proxy()` compared `$_SERVER['REMOTE_ADDR']` against the configured list with an exact string match, so an IPv6 proxy written as `::1` wouldn't match a request arriving as `0:0:0:0:0:0:0:1`.

This normalizes both sides with `inet_pton` and compares the packed forms with `hash_equals()` (constant-time), so alternate spellings of the same address match. An exact-string fallback (also `hash_equals`) preserves behavior for malformed/non-IP entries and never fatals. Every existing guard is kept (unset REMOTE_ADDR -> false; non-array/empty list -> false).

IPv4-mapped decision: `inet_pton` yields 4 bytes for IPv4 and 16 for IPv6, so `::ffff:10.0.0.1` does not silently match bare `10.0.0.1` — the fail-closed choice (an operator lists the exact family they expect; trust is never broadened across representations). Covered by a test.

Verified: TrustedProxyAuthTest 15 passed (incl. the new IPv6 representation cases), php -l clean, php-cs-fixer 0 fixable, PHPStan level 6 no new errors. Same normalization the FCRDNS path already uses.