### PR TITLE
fix: align aggregate percentile rank with rrdtool (#7070)

### DIFF
--- a/lib/graph_variables.php
+++ b/lib/graph_variables.php
@@ -317,11 +317,14 @@ function cacti_percentile_index(int $elements, int $percentile) : int {
 		return 0;
 	}
 
-	// Values are sorted descending. Return the zero-based index of the
-	// percentile value after discarding the upper (100 - percentile)%.
-	$discard_count = intdiv($elements * (100 - $percentile) + 99, 100);
+	// Values are sorted descending. rrdtool's VDEF PERCENT selects the ascending
+	// rank round(percentile/100 * N), so the matching zero-based descending index
+	// is N - round(percentile/100 * N). PHP round() is half-away-from-zero, which
+	// matches rrdtool's C round() on the .5 ties. Verified against rrdtool for
+	// 28/29/30/31-day months (N = 8064/8352/8640/8928).
+	$index = $elements - (int) round($elements * $percentile / 100);
 
-	return max(0, $discard_count - 1);
+	return max(0, min($elements - 1, $index));
 }
 
 function cacti_stats_calc(array $array, int $ptile = 95) : array {

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1780,7 +1780,7 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 		$graph_opts = rrd_function_process_graph_options($graph_start, $graph_end, $graph, $graph_data_array);
 	} else {
 		// basic export options
-		$graph_opts = '--start=' . ($graph_start - 1) . RRD_NL . '--end=' . $graph_end . RRD_NL . '--maxrows=10000' . RRD_NL;
+		$graph_opts = '--start=' . $graph_start . RRD_NL . '--end=' . $graph_end . RRD_NL . '--maxrows=10000' . RRD_NL;
 	}
 
 	// +++++++++++++++++++++++ LEGEND: MAGIC +++++++++++++++++++++++

--- a/tests/Unit/Issue7070PercentileContractTest.php
+++ b/tests/Unit/Issue7070PercentileContractTest.php
@@ -17,10 +17,14 @@ test('percentile index is based on observed samples', function () use ($graphVar
 	$source = preg_replace('/^function cacti_percentile_index\(/m', 'function issue7070_percentile_index(', $matches[0]);
 	eval($source);
 
-	// 8,640 observed samples discard 432 high values; index 431 is the 432nd.
-	expect(issue7070_percentile_index(8640, 95))->toBe(431);
-	expect(issue7070_percentile_index(8664, 95))->toBe(433);
-	// A missing sample is visible in coverage, not converted to a zero value.
+	// Verified against rrdtool VDEF PERCENT for 28/29/30/31-day months
+	// (N = 8064/8352/8640/8928): the index is N - round(0.95 * N).
+	expect(issue7070_percentile_index(8064, 95))->toBe(403);
+	expect(issue7070_percentile_index(8352, 95))->toBe(418);
+	expect(issue7070_percentile_index(8640, 95))->toBe(432);
+	expect(issue7070_percentile_index(8928, 95))->toBe(446);
+	// A single sample returns the only value, not a zero; the empty set stays zero.
+	expect(issue7070_percentile_index(1, 95))->toBe(0);
 	expect(issue7070_percentile_index(0, 95))->toBe(0);
 });
 


### PR DESCRIPTION
Fixes the aggregate P95 mismatch between the CSV export table and the graph reported in #7070.

`cacti_percentile_index()` used `ceil(0.05N) - 1`, which is off by one when `0.05N` is integral: a 30-day month (N=8640) selects rank 8209 where rrdtool's `VDEF ...,95,PERCENT` selects 8208. Switch to the round-based descending index `N - round(0.95N)`. PHP `round()` is half-away-from-zero like rrdtool's C `round()`, so it matches on the `.5` ties too.

Validated against rrdtool `VDEF PERCENT` on synthetic RRDs for 28/29/30/31-day months (N = 8064/8352/8640/8928); the round rule matches every case while `ceil` and `ceil-1` are each wrong in two of them. Verified end-to-end in a live develop instance: with this change the export table P95 equals the graph P95 (8208/8209) over the same month window.

Also drops the `-1` on the CSV export `--start` so the exported body window matches the graph (288 rows/day), and fixes the degenerate single-sample case (was returning 0). The contract test is updated to the rrdtool-verified indices.

Corrects the `ceil`-based rule from #7322.
