### PR TITLE
fix: #7245 raise execution time limit for bulk graph creation

### DIFF
--- a/graphs_new.php
+++ b/graphs_new.php
@@ -35,6 +35,8 @@ include_once('./lib/poller.php');
 include_once('./lib/template.php');
 include_once('./lib/utility.php');
 
+ini_set('max_execution_time', '0');
+
 /* set default action */
 set_default_action();
 switch (get_request_var('action')) {

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -793,9 +793,9 @@ header_redirect	./graphs_items.php:238				header('Location: graphs.php?header=fa
 header_redirect	./graphs_items.php:42			header('Location: graphs.php?header=false&action=graph_edit&id=' . get_request_var('local_graph_id'));
 header_redirect	./graphs_items.php:56			header('Location: graphs.php?header=false&action=graph_edit&id=' . get_request_var('local_graph_id'));
 header_redirect	./graphs_items.php:63			header('Location: graphs.php?header=false&action=graph_edit&id=' . get_request_var('local_graph_id'));
-header_redirect	./graphs_new.php:168			header('Location: graphs_new.php?host_id=' . $host_id . '&header=false');
-header_redirect	./graphs_new.php:174			header('Location: graphs_new.php?host_id=' . get_filter_request_var('host_id') . '&header=false');
-header_redirect	./graphs_new.php:48			header('Location: graphs_new.php?host_id=' . get_request_var('host_id') . '&header=false');
+header_redirect	./graphs_new.php:170			header('Location: graphs_new.php?host_id=' . $host_id . '&header=false');
+header_redirect	./graphs_new.php:176			header('Location: graphs_new.php?host_id=' . get_filter_request_var('host_id') . '&header=false');
+header_redirect	./graphs_new.php:50			header('Location: graphs_new.php?host_id=' . get_request_var('host_id') . '&header=false');
 header_redirect	./host.php:106			header('Location: host.php?header=false&action=edit&id=' . get_request_var('host_id'));
 header_redirect	./host.php:114			header('Location: host.php?header=false&action=edit&id=' . get_request_var('host_id'));
 header_redirect	./host.php:123			header('Location: host.php?header=false&action=edit&id=' . get_request_var('host_id'));


### PR DESCRIPTION
Fixes #7245.

Creating many graphs at once in `graphs_new.php` runs the bulk create under PHP's default `max_execution_time` with no override, so a large selection (30+) times out client-side while the server keeps working and the graphs are actually created. This mirrors the existing pattern in `graph_templates.php` (which already clears `max_execution_time` at the top of the page) and `lib/import.php`.

php-fpm's `request_terminate_timeout` is a separate admin-tuned hard limit that PHP cannot override; this addresses the PHP-side default so the operation is not cut off under standard configurations.
