### PR TITLE
fix: memoize db_get_table_column_types to cut redundant SHOW COLUMNS (1.2.x backport)

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -946,7 +946,11 @@ function db_add_column($table, $column, $log = true, $db_conn = false) {
 			$sql .= ' AFTER ' . $column['after'];
 		}
 
-		return db_execute($sql, $log, $db_conn);
+		$result = db_execute($sql, $log, $db_conn);
+
+		db_column_type_cache_reset();
+
+		return $result;
 	}
 
 	return true;
@@ -982,7 +986,11 @@ function db_remove_column($table, $column, $log = true, $db_conn = false) {
 
 	if (isset($column) && in_array($column, $columns)) {
 		$sql = 'ALTER TABLE `' . $table . '` DROP `' . $column . '`';
-		return db_execute($sql, $log, $db_conn);
+		$result = db_execute($sql, $log, $db_conn);
+
+		db_column_type_cache_reset();
+
+		return $result;
 	}
 
 	return true;
@@ -1227,7 +1235,7 @@ function db_column_exists($table, $column, $log = true, $db_conn = false) {
  * @return (array) An array of column types indexed by the column names
  */
 function db_get_table_column_types($table, $db_conn = false) {
-	global $database_sessions, $database_default, $database_hostname, $database_port;
+	global $database_sessions, $database_default, $database_hostname, $database_port, $db_column_type_cache;
 
 	/* check for a connection being passed, if not use legacy behavior */
 	if (!is_object($db_conn)) {
@@ -1238,15 +1246,33 @@ function db_get_table_column_types($table, $db_conn = false) {
 		}
 	}
 
+	/* column metadata is invariant within a request, so memoize the SHOW COLUMNS
+	 * lookup. sql_save() calls this for every write, and a bulk operation (e.g.
+	 * creating many graphs) otherwise re-queries the same tables hundreds of
+	 * times. The cache is cleared by the DDL helpers whenever a column changes. */
+	$key = spl_object_id($db_conn) . ':' . $table;
+
+	if (isset($db_column_type_cache[$key])) {
+		return $db_column_type_cache[$key];
+	}
+
 	$columns = db_fetch_assoc("SHOW COLUMNS FROM $table", false, $db_conn);
 	$cols    = array();
 	if (cacti_sizeof($columns)) {
 		foreach($columns as $col) {
 			$cols[$col['Field']] = array('type' => $col['Type'], 'null' => $col['Null'], 'default' => $col['Default'], 'extra' => $col['Extra']);;
 		}
+
+		$db_column_type_cache[$key] = $cols;
 	}
 
 	return $cols;
+}
+
+function db_column_type_cache_reset() {
+	global $db_column_type_cache;
+
+	$db_column_type_cache = array();
 }
 
 /**

--- a/tests/Unit/DbColumnTypeCacheTest.php
+++ b/tests/Unit/DbColumnTypeCacheTest.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * #7379 (1.2.x backport): db_get_table_column_types() memoizes its SHOW COLUMNS
+ * lookup, and every column-mutating DDL helper clears the cache so sql_save()
+ * sees the new schema after an ALTER. 1.2.x has no sqlite-backed DB harness, so
+ * this is a source-contract test guarding that structure (the behavioural
+ * equivalence test runs on develop in #7381, where the code is byte-equivalent).
+ */
+
+$source = file_get_contents(__DIR__ . '/../../lib/database.php');
+
+function _db_col_cache_body(string $src, string $fn): string {
+	$start = strpos($src, 'function ' . $fn . '(');
+	if ($start === false) {
+		return '';
+	}
+
+	$end = strpos($src, "\nfunction ", $start + 1);
+
+	return substr($src, $start, $end !== false ? $end - $start : strlen($src) - $start);
+}
+
+test('db_get_table_column_types memoizes the SHOW COLUMNS lookup', function () use ($source) {
+	$body = _db_col_cache_body($source, 'db_get_table_column_types');
+
+	expect($body)->not->toBe('');
+	// it still issues the SHOW COLUMNS query when uncached
+	expect($body)->toContain('SHOW COLUMNS FROM $table');
+	// but reads from and writes to the request-scoped cache
+	expect($body)->toContain('global $database_sessions, $database_default, $database_hostname, $database_port, $db_column_type_cache');
+	expect($body)->toContain('if (isset($db_column_type_cache[$key])) {');
+	expect($body)->toContain('return $db_column_type_cache[$key];');
+	expect($body)->toContain('$db_column_type_cache[$key] = $cols;');
+});
+
+test('db_column_type_cache_reset clears the cache', function () use ($source) {
+	$body = _db_col_cache_body($source, 'db_column_type_cache_reset');
+
+	expect($body)->not->toBe('');
+	expect($body)->toContain('$db_column_type_cache = array();');
+});
+
+test('every column-mutating DDL helper clears the cache', function () use ($source) {
+	// db_add_column and db_remove_column are the column mutators on 1.2.x
+	foreach (array('db_add_column', 'db_remove_column') as $fn) {
+		$body = _db_col_cache_body($source, $fn);
+
+		expect($body)->not->toBe('');
+		expect($body)->toContain('db_column_type_cache_reset();');
+	}
+});

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -21,7 +21,7 @@ cmd_exec	./graph_realtime.php:219		shell_exec($php_binary . ' -q ' . $script_pat
 cmd_exec	./host.php:195		shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/poller_reindex_hosts.php') . ' --qid=all --id=' . cacti_escapeshellarg((string) $host_id));
 cmd_exec	./install/functions.php:538				$myinfo = @json_decode(shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/import_package.php') . ' --filename=' . cacti_escapeshellarg("/$path/$xmlfile") . ' --info'), true);
 cmd_exec	./install/install.php:125			print '<li>' . __('The shell_exec() and/or exec() functions are currently blocked.') . '<br>' . __('See the PHP Manual: <a href="http://php.net/manual/en/ini.core.php#ini.disable-functions">Disable Functions</a>.') .'</li>';
-cmd_exec	./lib/database.php:2291		$process = proc_open(trim($cmd_string), $descriptors, $pipes, null, $env);
+cmd_exec	./lib/database.php:2317		$process = proc_open(trim($cmd_string), $descriptors, $pipes, null, $env);
 cmd_exec	./lib/dsstats.php:1060		$process = proc_open($command, $fds, $pipes);
 cmd_exec	./lib/functions.php:2234					$output = shell_exec($script_path);
 cmd_exec	./lib/functions.php:2249						$output = shell_exec($php . ' -q ' . $script);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -20,7 +20,7 @@ cmd_exec	./graph_realtime.php:219		shell_exec($php_binary . ' -q ' . $script_pat
 cmd_exec	./host.php:195		shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/poller_reindex_hosts.php') . ' --qid=all --id=' . cacti_escapeshellarg((string) $host_id));
 cmd_exec	./install/functions.php:538				$myinfo = @json_decode(shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/import_package.php') . ' --filename=' . cacti_escapeshellarg("/$path/$xmlfile") . ' --info'), true);
 cmd_exec	./install/install.php:125			print '<li>' . __('The shell_exec() and/or exec() functions are currently blocked.') . '<br>' . __('See the PHP Manual: <a href="http://php.net/manual/en/ini.core.php#ini.disable-functions">Disable Functions</a>.') .'</li>';
-cmd_exec	./lib/database.php:2291		$process = proc_open(trim($cmd_string), $descriptors, $pipes, null, $env);
+cmd_exec	./lib/database.php:2317		$process = proc_open(trim($cmd_string), $descriptors, $pipes, null, $env);
 cmd_exec	./lib/dsstats.php:1060		$process = proc_open($command, $fds, $pipes);
 cmd_exec	./lib/functions.php:2234					$output = shell_exec($script_path);
 cmd_exec	./lib/functions.php:2249						$output = shell_exec($php . ' -q ' . $script);
@@ -559,7 +559,7 @@ fs_write	./lib/boost.php:572							if ($fileptr = fopen($cache_file, 'w')) {
 fs_write	./lib/clog_webapi.php:119					$log_fh = fopen($logfile, 'w');
 fs_write	./lib/csp_report_endpoint.php:176		$fh = @fopen($bucket, 'c+');
 fs_write	./lib/database.php:206					file_put_contents(sys_get_temp_dir() . '/cacti-option.log',
-fs_write	./lib/database.php:2136		file_put_contents(sys_get_temp_dir() . '/cacti-sql.log', get_debug_prefix() . $line, FILE_APPEND);
+fs_write	./lib/database.php:2162		file_put_contents(sys_get_temp_dir() . '/cacti-sql.log', get_debug_prefix() . $line, FILE_APPEND);
 fs_write	./lib/database.php:74					file_put_contents(sys_get_temp_dir() . '/cacti-option.log',
 fs_write	./lib/functions.php:1353			$fp = @fopen($logfile, 'a');
 fs_write	./lib/functions.php:1428		$fp = fopen($file_name, 'r');


### PR DESCRIPTION
Backport of #7381 to 1.2.x. Related: #7379, #7245.

`sql_save()` calls `db_get_table_column_types()` on every write, and it ran `SHOW COLUMNS` with no caching, so bulk operations (e.g. creating many graphs) re-query the same handful of tables hundreds of times. The lookup is memoized per request and the cache is cleared by `db_add_column`/`db_remove_column` (the column-mutating helpers on 1.2.x) so the upgrade path sees the new schema. Only non-empty results are cached.
