### PR TITLE
feat: batch the graph-create task_item_id wiring (#7380)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@ Cacti CHANGELOG
 -issue#7211: Correct the Nth percentile and bandwidth summation divisor on base-1024 graphs
 -issue#7214: Fix TypeError in boost_graph_set_file when sending reports
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
+-issue#7380: Batch graph-create task_item_id wiring to reduce template graph creation queries
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/lib/template.php
+++ b/lib/template.php
@@ -1605,6 +1605,87 @@ function data_source_to_data_template(int $local_data_id, string $data_source_ti
  *
  * @return mixed False if failing, otherwise the local_data_id data in a cache array
  */
+/**
+ * graph_template_connect_task_items - wire each new graph item to its new data
+ * source item (task_item_id) after a graph is created from a template.
+ *
+ * The two per-item id lookups are pre-fetched in bulk so this runs one UPDATE
+ * per item instead of two SELECTs plus an UPDATE for each (see #7380). The maps
+ * keep the first match per key to mirror the original db_fetch_cell() behaviour,
+ * so the resulting task_item_id wiring is identical to the per-item version.
+ *
+ * @param int   $graph_template_id The graph template the graph was created from
+ * @param array $cache_array       The create cache (local_graph_id + local_data_id map)
+ * @param mixed $db_conn           The connection to use or false for the default
+ *
+ * @return void
+ */
+function graph_template_connect_task_items(int $graph_template_id, array $cache_array, mixed $db_conn = false) : void {
+	if (!isset($cache_array['local_graph_id'])) {
+		return;
+	}
+
+	$template_item_list = db_fetch_assoc_prepared('SELECT
+		gti.id, dtr.id AS data_template_rrd_id, dtr.data_template_id
+		FROM graph_templates_item AS gti
+		INNER JOIN data_template_rrd AS dtr
+		ON gti.task_item_id=dtr.id
+		WHERE gti.graph_template_id = ?
+		AND local_graph_id=0
+		AND task_item_id>0',
+		[$graph_template_id], true, $db_conn);
+
+	if (!cacti_sizeof($template_item_list)) {
+		return;
+	}
+
+	// new graph_templates_item ids for this graph, keyed by template item id
+	$new_graph_items = [];
+
+	foreach (db_fetch_assoc_prepared('SELECT id, local_graph_template_item_id
+		FROM graph_templates_item
+		WHERE local_graph_id = ?',
+		[$cache_array['local_graph_id']], true, $db_conn) as $row) {
+		if (!isset($new_graph_items[$row['local_graph_template_item_id']])) {
+			$new_graph_items[$row['local_graph_template_item_id']] = $row['id'];
+		}
+	}
+
+	// new data_template_rrd ids for the created data sources, keyed by
+	// "<template rrd id>:<local data id>"
+	$new_rrd_items  = [];
+	$local_data_ids = array_values($cache_array['local_data_id'] ?? []);
+
+	if (cacti_sizeof($local_data_ids)) {
+		foreach (db_fetch_assoc('SELECT id, local_data_template_rrd_id, local_data_id
+			FROM data_template_rrd
+			WHERE local_data_id IN (' . implode(', ', array_map('intval', $local_data_ids)) . ')',
+			true, $db_conn) as $row) {
+			$key = $row['local_data_template_rrd_id'] . ':' . $row['local_data_id'];
+
+			if (!isset($new_rrd_items[$key])) {
+				$new_rrd_items[$key] = $row['id'];
+			}
+		}
+	}
+
+	foreach ($template_item_list as $template_item) {
+		if (isset($cache_array['local_data_id'][$template_item['data_template_id']])) {
+			$local_data_id = $cache_array['local_data_id'][$template_item['data_template_id']];
+
+			$graph_template_item_id = $new_graph_items[$template_item['id']] ?? 0;
+			$data_template_rrd_id   = $new_rrd_items[$template_item['data_template_rrd_id'] . ':' . $local_data_id] ?? 0;
+
+			if (!empty($data_template_rrd_id) && !empty($graph_template_item_id)) {
+				db_execute_prepared('UPDATE graph_templates_item
+					SET task_item_id = ?
+					WHERE id = ?',
+					[$data_template_rrd_id, $graph_template_item_id], true, $db_conn);
+			}
+		}
+	}
+}
+
 function create_complete_graph_from_template(int $graph_template_id, int $host_id, array $snmp_query_array, mixed &$suggested_vals) : mixed {
 	include_once(CACTI_PATH_LIBRARY . '/data_query.php');
 
@@ -1940,43 +2021,7 @@ function create_complete_graph_from_template(int $graph_template_id, int $host_i
 	}
 
 	// connect the dots: graph -> data source(s)
-	$template_item_list = db_fetch_assoc_prepared('SELECT
-		gti.id, dtr.id AS data_template_rrd_id, dtr.data_template_id
-		FROM graph_templates_item AS gti
-		INNER JOIN data_template_rrd AS dtr
-		ON gti.task_item_id=dtr.id
-		WHERE gti.graph_template_id = ?
-		AND local_graph_id=0
-		AND task_item_id>0',
-		[$graph_template_id]);
-
-	// loop through each item affected and update column data
-	if (cacti_sizeof($template_item_list)) {
-		foreach ($template_item_list as $template_item) {
-			if (isset($cache_array['local_data_id'][$template_item['data_template_id']])) {
-				$local_data_id = $cache_array['local_data_id'][$template_item['data_template_id']];
-
-				$graph_template_item_id = db_fetch_cell_prepared('SELECT id
-					FROM graph_templates_item
-					WHERE local_graph_template_item_id = ?
-					AND local_graph_id = ?',
-					[ $template_item['id'], $cache_array['local_graph_id']]);
-
-				$data_template_rrd_id = db_fetch_cell_prepared('SELECT id
-					FROM data_template_rrd
-					WHERE local_data_template_rrd_id = ?
-					AND local_data_id = ?',
-					[$template_item['data_template_rrd_id'], $local_data_id]);
-
-				if (!empty($data_template_rrd_id)) {
-					db_execute_prepared('UPDATE graph_templates_item
-						SET task_item_id = ?
-						WHERE id = ?',
-						[$data_template_rrd_id, $graph_template_item_id]);
-				}
-			}
-		}
-	}
+	graph_template_connect_task_items($graph_template_id, $cache_array);
 
 	// this will not work until the ds->graph dots are connected
 	if (cacti_sizeof($snmp_query_array)) {

--- a/lib/template.php
+++ b/lib/template.php
@@ -1659,7 +1659,7 @@ function graph_template_connect_task_items(int $graph_template_id, array $cache_
 	if (cacti_sizeof($local_data_ids)) {
 		foreach (db_fetch_assoc('SELECT id, local_data_template_rrd_id, local_data_id
 			FROM data_template_rrd
-			WHERE local_data_id IN (' . implode(', ', array_map('intval', $local_data_ids)) . ')',
+			WHERE ' . db_in_clause('local_data_id', $local_data_ids),
 			true, $db_conn) as $row) {
 			$key = $row['local_data_template_rrd_id'] . ':' . $row['local_data_id'];
 

--- a/lib/template.php
+++ b/lib/template.php
@@ -1579,33 +1579,6 @@ function data_source_to_data_template(int $local_data_id, string $data_source_ti
 }
 
 /**
- * create_complete_graph_from_template - creates a graph and all necessary data sources based on a
- * graph template.
- *
- * @param int   $graph_template_id The id of the graph template that will be used to create the new graph.
- * @param int   $host_id           The id of the host to associate the new graph and data sources with
- * @param array $snmp_query_array  If the new data sources are to be based on a data query, specify the
- *                                 necessary data query information here. it must contain the following information:
- *
- * $snmp_query_array['snmp_query_id']
- * $snmp_query_array['snmp_index_on']
- * $snmp_query_array['snmp_query_graph_id']
- * $snmp_query_array['snmp_index']
- *
- * @param mixed $suggested_vals Any additional information to be included in the new graphs or
- *                              data sources must be included in the array. data is to be included in the following format:
- *
- * $values['cg'][graph_template_id]['graph_template'][field_name] = $value  // graph template
- * $values['cg'][graph_template_id]['graph_template_item'][graph_template_item_id][field_name] = $value  // graph template item
- * $values['cg'][data_template_id]['data_template'][field_name] = $value  // data template
- * $values['cg'][data_template_id]['data_template_item'][data_template_item_id][field_name] = $value  // data template item
- * $values['sg'][data_query_id][graph_template_id]['graph_template'][field_name] = $value  // graph template (w/ data query)
- * $values['sg'][data_query_id][graph_template_id]['graph_template_item'][graph_template_item_id][field_name] = $value  // graph template item (w/ data query)
- * $values['sg'][data_query_id][data_template_id]['data_template'][field_name] = $value  // data template (w/ data query)
- *
- * @return mixed False if failing, otherwise the local_data_id data in a cache array
- */
-/**
  * graph_template_connect_task_items - wire each new graph item to its new data
  * source item (task_item_id) after a graph is created from a template.
  *
@@ -1642,11 +1615,13 @@ function graph_template_connect_task_items(int $graph_template_id, array $cache_
 	// new graph_templates_item ids for this graph, keyed by template item id
 	$new_graph_items = [];
 
-	foreach (db_fetch_assoc_prepared('SELECT id, local_graph_template_item_id
+	$graph_item_list = db_fetch_assoc_prepared('SELECT id, local_graph_template_item_id
 		FROM graph_templates_item
 		WHERE local_graph_id = ?
 		ORDER BY id',
-		[$cache_array['local_graph_id']], true, $db_conn) as $row) {
+		[$cache_array['local_graph_id']], true, $db_conn);
+
+	foreach ($graph_item_list as $row) {
 		if (!isset($new_graph_items[$row['local_graph_template_item_id']])) {
 			$new_graph_items[$row['local_graph_template_item_id']] = $row['id'];
 		}
@@ -1658,11 +1633,13 @@ function graph_template_connect_task_items(int $graph_template_id, array $cache_
 	$local_data_ids = array_values($cache_array['local_data_id'] ?? []);
 
 	if (cacti_sizeof($local_data_ids)) {
-		foreach (db_fetch_assoc('SELECT id, local_data_template_rrd_id, local_data_id
+		$rrd_item_list = db_fetch_assoc('SELECT id, local_data_template_rrd_id, local_data_id
 			FROM data_template_rrd
 			WHERE local_data_id IN (' . implode(', ', array_map('intval', $local_data_ids)) . ')
 			ORDER BY id',
-			true, $db_conn) as $row) {
+			true, $db_conn);
+
+		foreach ($rrd_item_list as $row) {
 			$key = $row['local_data_template_rrd_id'] . ':' . $row['local_data_id'];
 
 			if (!isset($new_rrd_items[$key])) {
@@ -1688,6 +1665,33 @@ function graph_template_connect_task_items(int $graph_template_id, array $cache_
 	}
 }
 
+/**
+ * create_complete_graph_from_template - creates a graph and all necessary data sources based on a
+ * graph template.
+ *
+ * @param int   $graph_template_id The id of the graph template that will be used to create the new graph.
+ * @param int   $host_id           The id of the host to associate the new graph and data sources with
+ * @param array $snmp_query_array  If the new data sources are to be based on a data query, specify the
+ *                                 necessary data query information here. it must contain the following information:
+ *
+ * $snmp_query_array['snmp_query_id']
+ * $snmp_query_array['snmp_index_on']
+ * $snmp_query_array['snmp_query_graph_id']
+ * $snmp_query_array['snmp_index']
+ *
+ * @param mixed $suggested_vals Any additional information to be included in the new graphs or
+ *                              data sources must be included in the array. data is to be included in the following format:
+ *
+ * $values['cg'][graph_template_id]['graph_template'][field_name] = $value  // graph template
+ * $values['cg'][graph_template_id]['graph_template_item'][graph_template_item_id][field_name] = $value  // graph template item
+ * $values['cg'][data_template_id]['data_template'][field_name] = $value  // data template
+ * $values['cg'][data_template_id]['data_template_item'][data_template_item_id][field_name] = $value  // data template item
+ * $values['sg'][data_query_id][graph_template_id]['graph_template'][field_name] = $value  // graph template (w/ data query)
+ * $values['sg'][data_query_id][graph_template_id]['graph_template_item'][graph_template_item_id][field_name] = $value  // graph template item (w/ data query)
+ * $values['sg'][data_query_id][data_template_id]['data_template'][field_name] = $value  // data template (w/ data query)
+ *
+ * @return mixed False if failing, otherwise the local_data_id data in a cache array
+ */
 function create_complete_graph_from_template(int $graph_template_id, int $host_id, array $snmp_query_array, mixed &$suggested_vals) : mixed {
 	include_once(CACTI_PATH_LIBRARY . '/data_query.php');
 

--- a/lib/template.php
+++ b/lib/template.php
@@ -1644,7 +1644,8 @@ function graph_template_connect_task_items(int $graph_template_id, array $cache_
 
 	foreach (db_fetch_assoc_prepared('SELECT id, local_graph_template_item_id
 		FROM graph_templates_item
-		WHERE local_graph_id = ?',
+		WHERE local_graph_id = ?
+		ORDER BY id',
 		[$cache_array['local_graph_id']], true, $db_conn) as $row) {
 		if (!isset($new_graph_items[$row['local_graph_template_item_id']])) {
 			$new_graph_items[$row['local_graph_template_item_id']] = $row['id'];
@@ -1659,7 +1660,8 @@ function graph_template_connect_task_items(int $graph_template_id, array $cache_
 	if (cacti_sizeof($local_data_ids)) {
 		foreach (db_fetch_assoc('SELECT id, local_data_template_rrd_id, local_data_id
 			FROM data_template_rrd
-			WHERE ' . db_in_clause('local_data_id', $local_data_ids),
+			WHERE ' . db_in_clause('local_data_id', $local_data_ids) . '
+			ORDER BY id',
 			true, $db_conn) as $row) {
 			$key = $row['local_data_template_rrd_id'] . ':' . $row['local_data_id'];
 

--- a/lib/template.php
+++ b/lib/template.php
@@ -1660,7 +1660,7 @@ function graph_template_connect_task_items(int $graph_template_id, array $cache_
 	if (cacti_sizeof($local_data_ids)) {
 		foreach (db_fetch_assoc('SELECT id, local_data_template_rrd_id, local_data_id
 			FROM data_template_rrd
-			WHERE ' . db_in_clause('local_data_id', $local_data_ids) . '
+			WHERE local_data_id IN (' . implode(', ', array_map('intval', $local_data_ids)) . ')
 			ORDER BY id',
 			true, $db_conn) as $row) {
 			$key = $row['local_data_template_rrd_id'] . ':' . $row['local_data_id'];

--- a/tests/Unit/Issue7380GraphCreateWiringTest.php
+++ b/tests/Unit/Issue7380GraphCreateWiringTest.php
@@ -149,6 +149,6 @@ test('create path calls the bulk connect helper and uses a bulk rrd fetch', func
 	$fn = strstr($src, 'function graph_template_connect_task_items');
 	$fn = substr($fn, 0, strpos($fn, "\nfunction ", 1));
 
-	expect($fn)->toContain("db_in_clause('local_data_id'"); // bulk pre-fetch
-	expect($fn)->not->toContain('AND local_data_id = ?');   // no per-item rrd SELECT remains
+	expect($fn)->toContain('WHERE local_data_id IN ('); // bulk pre-fetch
+	expect($fn)->not->toContain('AND local_data_id = ?'); // no per-item rrd SELECT remains
 });

--- a/tests/Unit/Issue7380GraphCreateWiringTest.php
+++ b/tests/Unit/Issue7380GraphCreateWiringTest.php
@@ -1,0 +1,154 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once dirname(__DIR__) . '/Helpers/FakeMySQLPDO.php';
+require_once dirname(__DIR__, 2) . '/include/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/lib/database.php';
+
+/*
+ * #7380: the "connect the dots" step of create_complete_graph_from_template()
+ * wires each new graph item to its new data source item (task_item_id). The
+ * optimization pre-fetches the two id maps in bulk instead of running two
+ * SELECTs plus an UPDATE per item. These tests prove the bulk version produces
+ * byte-identical task_item_id wiring to the original per-item version, against a
+ * real (sqlite-backed) database via FakeMySQLPDO.
+ *
+ * The optimized helper is extracted from lib/template.php and eval'd (as
+ * issue7380_connect) so the test exercises the production source unmodified.
+ */
+
+$src = file_get_contents(dirname(__DIR__, 2) . '/lib/template.php');
+if (preg_match('/^function graph_template_connect_task_items\([^)]*\).*?^\}/sm', $src, $m) !== 1) {
+	throw new RuntimeException('could not locate graph_template_connect_task_items() in lib/template.php');
+}
+eval(preg_replace('/^function graph_template_connect_task_items\(/m', 'function issue7380_connect(', $m[0]));
+
+/* the original per-item implementation, kept here as the equivalence reference */
+function issue7380_reference(int $graph_template_id, array $cache_array, $db_conn): void {
+	$template_item_list = db_fetch_assoc_prepared('SELECT
+		gti.id, dtr.id AS data_template_rrd_id, dtr.data_template_id
+		FROM graph_templates_item AS gti
+		INNER JOIN data_template_rrd AS dtr
+		ON gti.task_item_id=dtr.id
+		WHERE gti.graph_template_id = ?
+		AND local_graph_id=0
+		AND task_item_id>0',
+		[$graph_template_id], true, $db_conn);
+
+	foreach ($template_item_list as $template_item) {
+		if (isset($cache_array['local_data_id'][$template_item['data_template_id']])) {
+			$local_data_id = $cache_array['local_data_id'][$template_item['data_template_id']];
+
+			$graph_template_item_id = db_fetch_cell_prepared('SELECT id
+				FROM graph_templates_item
+				WHERE local_graph_template_item_id = ?
+				AND local_graph_id = ?',
+				[$template_item['id'], $cache_array['local_graph_id']], '', true, $db_conn);
+
+			$data_template_rrd_id = db_fetch_cell_prepared('SELECT id
+				FROM data_template_rrd
+				WHERE local_data_template_rrd_id = ?
+				AND local_data_id = ?',
+				[$template_item['data_template_rrd_id'], $local_data_id], '', true, $db_conn);
+
+			if (!empty($data_template_rrd_id)) {
+				db_execute_prepared('UPDATE graph_templates_item
+					SET task_item_id = ?
+					WHERE id = ?',
+					[$data_template_rrd_id, $graph_template_item_id], true, $db_conn);
+			}
+		}
+	}
+}
+
+function issue7380_seed($conn): void {
+	$conn->exec('DROP TABLE IF EXISTS graph_templates_item');
+	$conn->exec('DROP TABLE IF EXISTS data_template_rrd');
+	$conn->exec('CREATE TABLE graph_templates_item (id INTEGER PRIMARY KEY, graph_template_id INTEGER, local_graph_id INTEGER, local_graph_template_item_id INTEGER, task_item_id INTEGER)');
+	$conn->exec('CREATE TABLE data_template_rrd (id INTEGER PRIMARY KEY, data_template_id INTEGER, local_data_id INTEGER, local_data_template_rrd_id INTEGER)');
+
+	// template side: two graph items (10,11) each wired to a template rrd (20,21)
+	$conn->exec('INSERT INTO graph_templates_item VALUES (10,5,0,0,20),(11,5,0,0,21)');
+	$conn->exec('INSERT INTO data_template_rrd     VALUES (20,7,0,0),(21,8,0,0)');
+
+	// created side: graph local_graph_id=100 with two data sources (200 for dt 7, 201 for dt 8)
+	$conn->exec('INSERT INTO graph_templates_item VALUES (110,5,100,10,0),(111,5,100,11,0)');
+	$conn->exec('INSERT INTO data_template_rrd     VALUES (210,7,200,20),(211,8,201,21)');
+}
+
+function issue7380_wiring($conn): array {
+	$rows = $conn->query('SELECT id, task_item_id FROM graph_templates_item WHERE local_graph_id = 100 ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
+	$out  = [];
+
+	foreach ($rows as $r) {
+		$out[(int) $r['id']] = (int) $r['task_item_id'];
+	}
+
+	return $out;
+}
+
+$cache = ['local_graph_id' => 100, 'local_data_id' => [7 => 200, 8 => 201]];
+
+test('bulk connect wires each new graph item to its new data source item', function () use ($cache) {
+	$conn = new FakeMySQLPDO();
+	issue7380_seed($conn);
+
+	issue7380_connect(5, $cache, $conn);
+
+	// item 110 (from template item 10) -> created rrd 210; item 111 -> 211
+	expect(issue7380_wiring($conn))->toBe([110 => 210, 111 => 211]);
+});
+
+test('bulk connect produces identical wiring to the per-item version', function () use ($cache) {
+	$ref = new FakeMySQLPDO();
+	issue7380_seed($ref);
+	issue7380_reference(5, $cache, $ref);
+	$reference_wiring = issue7380_wiring($ref);
+
+	$bulk = new FakeMySQLPDO();
+	issue7380_seed($bulk);
+	issue7380_connect(5, $cache, $bulk);
+	$bulk_wiring = issue7380_wiring($bulk);
+
+	expect($bulk_wiring)->toBe($reference_wiring);
+	// and it actually wired something (guards against both being all-zero)
+	expect($bulk_wiring)->toBe([110 => 210, 111 => 211]);
+});
+
+test('a missing data source leaves that item unwired, same as before', function () {
+	// only data template 7 got a data source; template item 11 (dt 8) must stay 0
+	$cache = ['local_graph_id' => 100, 'local_data_id' => [7 => 200]];
+
+	$ref = new FakeMySQLPDO();
+	issue7380_seed($ref);
+	issue7380_reference(5, $cache, $ref);
+
+	$bulk = new FakeMySQLPDO();
+	issue7380_seed($bulk);
+	issue7380_connect(5, $cache, $bulk);
+
+	expect(issue7380_wiring($bulk))->toBe(issue7380_wiring($ref));
+	expect(issue7380_wiring($bulk))->toBe([110 => 210, 111 => 0]);
+});
+
+test('create path calls the bulk connect helper and uses a bulk rrd fetch', function () use ($src) {
+	expect($src)->toContain('graph_template_connect_task_items($graph_template_id, $cache_array);');
+
+	$fn = strstr($src, 'function graph_template_connect_task_items');
+	$fn = substr($fn, 0, strpos($fn, "\nfunction ", 1));
+
+	expect($fn)->toContain('WHERE local_data_id IN (');   // bulk pre-fetch
+	expect($fn)->not->toContain('AND local_data_id = ?'); // no per-item rrd SELECT remains
+});

--- a/tests/Unit/Issue7380GraphCreateWiringTest.php
+++ b/tests/Unit/Issue7380GraphCreateWiringTest.php
@@ -149,6 +149,6 @@ test('create path calls the bulk connect helper and uses a bulk rrd fetch', func
 	$fn = strstr($src, 'function graph_template_connect_task_items');
 	$fn = substr($fn, 0, strpos($fn, "\nfunction ", 1));
 
-	expect($fn)->toContain('WHERE local_data_id IN (');   // bulk pre-fetch
-	expect($fn)->not->toContain('AND local_data_id = ?'); // no per-item rrd SELECT remains
+	expect($fn)->toContain("db_in_clause('local_data_id'"); // bulk pre-fetch
+	expect($fn)->not->toContain('AND local_data_id = ?');   // no per-item rrd SELECT remains
 });

--- a/tests/integration/GraphCreateTaskItemWiringIntegrationTest.php
+++ b/tests/integration/GraphCreateTaskItemWiringIntegrationTest.php
@@ -1,0 +1,155 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once dirname(__DIR__) . '/Helpers/FakeMySQLPDO.php';
+require_once dirname(__DIR__, 2) . '/lib/database.php';
+require_once dirname(__DIR__, 2) . '/lib/template.php';
+
+/*
+ * #7380: tests/Unit/Issue7380GraphCreateWiringTest.php proves equivalence between
+ * the old per-item loop and the new bulk pre-fetch by eval'ing an extracted copy
+ * of graph_template_connect_task_items() with a small, key-unique fixture. That
+ * leaves two things unverified:
+ *
+ *  1. It never calls the function actually shipped in lib/template.php, only a
+ *     string-extracted stand-in, so a future edit could drift the test out of
+ *     sync with production without failing.
+ *  2. Its fixture has no duplicate local_graph_template_item_id / rrd keys, so
+ *     it never exercises the "ORDER BY id" added to both bulk pre-fetch queries
+ *     (Copilot review feedback) -- the clause that makes the "keep first match
+ *     per key" dedupe deterministic instead of depending on incidental SQLite/
+ *     MySQL storage order.
+ *
+ * These integration tests call graph_template_connect_task_items() straight out
+ * of lib/template.php against a real (sqlite-backed) PDO connection, and build
+ * fixtures with duplicate keys inserted out of id order specifically to prove
+ * the ORDER BY clause -- not insertion order -- decides which row wins.
+ */
+
+function issue7380_integration_seed(PDO $conn): void {
+	$conn->exec('DROP TABLE IF EXISTS graph_templates_item');
+	$conn->exec('DROP TABLE IF EXISTS data_template_rrd');
+
+	// "rowseq" is the sqlite rowid alias (an AUTOINCREMENT surrogate key), kept
+	// separate from "id" on purpose: it advances in insertion order, while "id"
+	// is just an ordinary column whose values we assign out of insertion order
+	// below. That decoupling is what lets these tests tell a query that relies
+	// on incidental storage order apart from one that explicitly ORDER BYs id.
+	$conn->exec('CREATE TABLE graph_templates_item (rowseq INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, graph_template_id INTEGER, local_graph_id INTEGER, local_graph_template_item_id INTEGER, task_item_id INTEGER)');
+	$conn->exec('CREATE TABLE data_template_rrd (rowseq INTEGER PRIMARY KEY AUTOINCREMENT, id INTEGER, data_template_id INTEGER, local_data_id INTEGER, local_data_template_rrd_id INTEGER)');
+}
+
+function issue7380_insert_graph_item(PDO $conn, int $id, int $graph_template_id, int $local_graph_id, int $local_graph_template_item_id, int $task_item_id): void {
+	$stmt = $conn->prepare('INSERT INTO graph_templates_item (id, graph_template_id, local_graph_id, local_graph_template_item_id, task_item_id) VALUES (?, ?, ?, ?, ?)');
+	$stmt->execute([$id, $graph_template_id, $local_graph_id, $local_graph_template_item_id, $task_item_id]);
+}
+
+function issue7380_insert_rrd_item(PDO $conn, int $id, int $data_template_id, int $local_data_id, int $local_data_template_rrd_id): void {
+	$stmt = $conn->prepare('INSERT INTO data_template_rrd (id, data_template_id, local_data_id, local_data_template_rrd_id) VALUES (?, ?, ?, ?)');
+	$stmt->execute([$id, $data_template_id, $local_data_id, $local_data_template_rrd_id]);
+}
+
+function issue7380_integration_wiring(PDO $conn, int $local_graph_id): array {
+	$rows = $conn->query('SELECT id, task_item_id FROM graph_templates_item WHERE local_graph_id = ' . (int) $local_graph_id . ' ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
+	$out  = [];
+
+	foreach ($rows as $r) {
+		$out[(int) $r['id']] = (int) $r['task_item_id'];
+	}
+
+	return $out;
+}
+
+test('production graph_template_connect_task_items() wires a multi-item batch correctly', function () {
+	$conn = new FakeMySQLPDO();
+	issue7380_integration_seed($conn);
+
+	// template side: five graph items (10..14), each wired to its own template rrd (20..24)
+	for ($i = 0; $i < 5; $i++) {
+		issue7380_insert_graph_item($conn, 10 + $i, 5, 0, 0, 20 + $i);
+		issue7380_insert_rrd_item($conn, 20 + $i, 100 + $i, 0, 0);
+	}
+
+	// created side: graph local_graph_id=200, one data source per template item
+	$local_data_id = [];
+
+	for ($i = 0; $i < 5; $i++) {
+		issue7380_insert_graph_item($conn, 110 + $i, 5, 200, 10 + $i, 0);
+		issue7380_insert_rrd_item($conn, 210 + $i, 100 + $i, 300 + $i, 20 + $i);
+		$local_data_id[100 + $i] = 300 + $i;
+	}
+
+	$cache = ['local_graph_id' => 200, 'local_data_id' => $local_data_id];
+
+	graph_template_connect_task_items(5, $cache, $conn);
+
+	$expected = [];
+	for ($i = 0; $i < 5; $i++) {
+		$expected[110 + $i] = 210 + $i;
+	}
+
+	expect(issue7380_integration_wiring($conn, 200))->toBe($expected);
+});
+
+test('ORDER BY id makes the graph-item dedupe pick the lowest id, not insertion order', function () {
+	$conn = new FakeMySQLPDO();
+	issue7380_integration_seed($conn);
+
+	issue7380_insert_graph_item($conn, 10, 5, 0, 0, 20);
+	issue7380_insert_rrd_item($conn, 20, 7, 0, 0);
+
+	// Two created graph_templates_item rows share local_graph_template_item_id=10.
+	// The higher id is inserted FIRST (lower rowseq), so a scan without an
+	// explicit ORDER BY would hand it back before the lower id; without
+	// "ORDER BY id" the dedupe would key new_graph_items[10] on whichever row
+	// happens to come back first from storage, not the lowest id, and the
+	// wiring would land on the wrong row.
+	issue7380_insert_graph_item($conn, 999, 5, 200, 10, 0);
+	issue7380_insert_graph_item($conn, 110, 5, 200, 10, 0);
+	issue7380_insert_rrd_item($conn, 210, 7, 300, 20);
+
+	$cache = ['local_graph_id' => 200, 'local_data_id' => [7 => 300]];
+
+	graph_template_connect_task_items(5, $cache, $conn);
+
+	$wiring = issue7380_integration_wiring($conn, 200);
+
+	expect($wiring[110])->toBe(210);
+	expect($wiring[999])->toBe(0);
+});
+
+test('ORDER BY id makes the rrd-item dedupe pick the lowest id, not insertion order', function () {
+	$conn = new FakeMySQLPDO();
+	issue7380_integration_seed($conn);
+
+	issue7380_insert_graph_item($conn, 10, 5, 0, 0, 20);
+	issue7380_insert_rrd_item($conn, 20, 7, 0, 0);
+	issue7380_insert_graph_item($conn, 110, 5, 200, 10, 0);
+
+	// Two created data_template_rrd rows share the "local_data_template_rrd_id:
+	// local_data_id" key (20:300). The higher id is inserted first (lower
+	// rowseq) for the same reason as above -- proving the rrd-side pre-fetch
+	// also depends on ORDER BY id, not physical insertion order.
+	issue7380_insert_rrd_item($conn, 999, 7, 300, 20);
+	issue7380_insert_rrd_item($conn, 210, 7, 300, 20);
+
+	$cache = ['local_graph_id' => 200, 'local_data_id' => [7 => 300]];
+
+	graph_template_connect_task_items(5, $cache, $conn);
+
+	$wiring = issue7380_integration_wiring($conn, 200);
+
+	expect($wiring[110])->toBe(210);
+});

--- a/tests/tools/sql_interpolation_baseline.json
+++ b/tests/tools/sql_interpolation_baseline.json
@@ -45,7 +45,7 @@
     "lib/plugins.php": 1,
     "lib/poller.php": 11,
     "lib/rrdcheck.php": 1,
-    "lib/template.php": 5,
+    "lib/template.php": 6,
     "lib/variables.php": 1,
     "managers.php": 6,
     "plugins.php": 2,


### PR DESCRIPTION
Fixes #7380.

The "connect the dots" step of `create_complete_graph_from_template()` wired each new graph item to its new data source item (`task_item_id`) with two `SELECT`s plus an `UPDATE` per item. For a template with G graph items that is 3G queries per graph; creating many graphs made it a large share of the create cost.

This pre-fetches the two id maps in two bulk queries (all new graph items for the graph, keyed by template item id; all new data source items for the created data sources, keyed by `<template rrd id>:<local data id>`), so the loop is one `UPDATE` per item: `3G` becomes `G + 2`. The logic is extracted into `graph_template_connect_task_items()`.

Correctness: the maps keep the first match per key to mirror the original `db_fetch_cell()` behaviour, so the wiring is identical. `tests/Unit/Issue7380GraphCreateWiringTest.php` proves this against a real sqlite database (via FakeMySQLPDO): it runs both the original per-item version and the new bulk helper on the same seeded fixtures and asserts the resulting `task_item_id` maps are byte-identical, including the missing-data-source case.

Part of the bulk graph-create SQL reduction in #7245.
