### PR TITLE
ci: pin actions/setup-python to a commit SHA

### DIFF
--- a/.github/workflows/i18n-validation.yml
+++ b/.github/workflows/i18n-validation.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
setup-python was the only unpinned action in security.yml and i18n-validation.yml. Both now pin the v6.3.0 commit SHA (ece7cb06caefa5fff74198d8649806c4678c61a1) to match the other action pins in those files.

Resolves code-scanning alert #166 (mutable action tag).