### PR TITLE
ci: ignore mariadbd io_uring warning in page-crawl log check

### DIFF
--- a/tests/tools/check_all_pages.sh
+++ b/tests/tools/check_all_pages.sh
@@ -724,6 +724,7 @@ FILTERED_LOG="$(grep -v \
   -e "REINDEX Poller" \
   -e "DSDEBUG Bad Data" \
   -e "PUSHOUT Child Started" \
+  -e "io_uring_queue_init() failed" \
   "$CACTI_LOG")" || true
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The page-crawl e2e (`check_all_pages.sh`) fails when a GitHub runner has io_uring disabled: MariaDB logs `io_uring_queue_init() failed with EPERM`, Cacti copies it into cacti.log, and the log check treats it as unexpected output (exit 179). Added that warning to the existing `grep -v` allowlist so the environmental noise no longer fails the run.