### PR TITLE
fix(installer): recover from expired CSRF tokens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@ Cacti CHANGELOG
 -issue#7211: Correct the Nth percentile and bandwidth summation divisor on base-1024 graphs
 -issue#7214: Fix TypeError in boost_graph_set_file when sending reports
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
+-issue#7343: Install wizard silently fails to advance after CSRF token expires
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/include/csrf.php
+++ b/include/csrf.php
@@ -44,6 +44,37 @@ function csrf_startup() : void {
 function csrf_error_callback() : void {
 	// Resolve session fixation for PHP 5.4
 	session_regenerate_id();
+
+	if (defined('IN_CACTI_INSTALL') &&
+		isset($GLOBALS['auth_json']) &&
+		$GLOBALS['auth_json'] === true &&
+		!empty($GLOBALS['is_request_ajax'])) {
+		$response = json_encode(
+			[
+				'error'          => 'csrf_timeout',
+				'title'          => __('Session Expired'),
+				'message'        => __('Your installer session expired due to inactivity. Reload the installer and try again.'),
+				'csrfMagicToken' => csrf_get_tokens(),
+			],
+			JSON_INVALID_UTF8_SUBSTITUTE
+		);
+
+		if ($response === false) {
+			$response = '{"error":"csrf_timeout","title":"Session Expired","message":"Reload the installer and try again."}';
+		}
+
+		ob_end_clean();
+		http_response_code(403);
+		header('Content-Type: application/json');
+		header('Cache-Control: no-store');
+		header('X-Content-Type-Options: nosniff');
+		header('Content-Length: ' . strlen($response));
+		print $response;
+		csrf_log(__FUNCTION__, 'Timeout, returning JSON response for the installer');
+
+		exit;
+	}
+
 	raise_message('csrf_timeout');
 	ob_end_clean();
 	header('Location: ' . sanitize_uri($_SERVER['REQUEST_URI']));

--- a/install/install.js
+++ b/install/install.js
@@ -633,7 +633,42 @@ function setAddressBar(data, replace) {
 	}
 }
 
-function performStep(installStep, suppressRefresh, forceReload) {
+function refreshCsrfMagicToken(data) {
+	if (typeof data == 'object' &&
+		data !== null &&
+		typeof data.csrfMagicToken == 'string' &&
+		data.csrfMagicToken != '') {
+		csrfMagicToken = data.csrfMagicToken;
+		delete data.csrfMagicToken;
+
+		return true;
+	}
+
+	return false;
+}
+
+function handleCsrfTimeout(data, retryAttempted, retryCallback) {
+	if (typeof data.responseJSON == 'object' &&
+		data.responseJSON !== null &&
+		data.responseJSON.error == 'csrf_timeout') {
+		var response = data.responseJSON;
+		var tokenRefreshed = refreshCsrfMagicToken(response);
+
+		if (!retryAttempted && tokenRefreshed) {
+			retryCallback();
+		} else {
+			$('#installContent').removeClass('cactiInstallLoaderBlur');
+			$('#installLoader').hide();
+			PopupError(response.message, response.title);
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+function performStep(installStep, suppressRefresh, forceReload, csrfRetry) {
 	$.ajaxQ.abortAll();
 
 	if (!suppressRefresh) {
@@ -647,6 +682,7 @@ function performStep(installStep, suppressRefresh, forceReload) {
 
 	$.post(url, installJson)
 		.done(function(data) {
+			refreshCsrfMagicToken(data);
 			checkForLogout(data);
 
 			$('#installLoader').hide();
@@ -750,6 +786,12 @@ function performStep(installStep, suppressRefresh, forceReload) {
 			});
 		})
 		.fail(function(data) {
+			if (handleCsrfTimeout(data, csrfRetry, function() {
+				performStep(installStep, suppressRefresh, forceReload, true);
+			})) {
+				return;
+			}
+
 			$('#installContent').removeClass('cactiInstallLoaderBlur');
 			$('#installLoader').hide();
 			getPresentHTTPError(data);
@@ -757,7 +799,7 @@ function performStep(installStep, suppressRefresh, forceReload) {
 	);
 }
 
-function performTestConnection() {
+function performTestConnection(csrfRetry) {
 	$.ajaxQ.abortAll();
 
 	$('#installContent').addClass('cactiInstallLoaderBlur');
@@ -773,6 +815,7 @@ function performTestConnection() {
 
 	$.post(url, installJson)
 		.done(function(data) {
+			refreshCsrfMagicToken(data);
 			checkForLogout(data);
 
 			$('#installLoader').hide();
@@ -797,6 +840,12 @@ function performTestConnection() {
 			}
 		})
 		.fail(function(data) {
+			if (handleCsrfTimeout(data, csrfRetry, function() {
+				performTestConnection(true);
+			})) {
+				return;
+			}
+
 			$('#installContent').removeClass('cactiInstallLoaderBlur');
 			$('#installLoader').hide();
 			getPresentHTTPError(data);

--- a/install/step_json.php
+++ b/install/step_json.php
@@ -79,7 +79,20 @@ if (isset($initialData['step']) && $initialData['step'] == Installer::STEP_TEST_
 	}
 }
 
+$response = json_decode($json, true);
+
+if (is_array($response)) {
+	$response['csrfMagicToken'] = csrf_get_tokens();
+	$encoded_response           = json_encode($response);
+
+	if ($encoded_response !== false) {
+		$json = $encoded_response;
+	}
+}
+
 log_install_high('json','  End: ' . clean_up_lines($json_debug) . PHP_EOL);
 header('Content-Type: application/json');
+header('Cache-Control: no-store');
+header('X-Content-Type-Options: nosniff');
 header('Content-Length: ' . strlen($json));
 print $json;

--- a/locales/po/cacti.pot
+++ b/locales/po/cacti.pot
@@ -7045,6 +7045,14 @@ msgstr ""
 msgid "There is an Installation or Upgrade in progress."
 msgstr ""
 
+#: include/csrf.php:55
+msgid "Session Expired"
+msgstr ""
+
+#: include/csrf.php:56
+msgid "Your installer session expired due to inactivity. Reload the installer and try again."
+msgstr ""
+
 #: include/global.php:650
 msgid "The Main Data Collector has returned to an Online Status"
 msgstr ""

--- a/tests/Unit/Issue7343InstallerCsrfRecoveryTest.php
+++ b/tests/Unit/Issue7343InstallerCsrfRecoveryTest.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 2);
+
+test('installer csrf failures return a scoped json recovery response', function () use ($root) {
+	$csrf = file_get_contents($root . '/include/csrf.php');
+
+	$jsonBranch = strpos($csrf, "defined('IN_CACTI_INSTALL')");
+	$redirect   = strpos($csrf, "raise_message('csrf_timeout')");
+	$regenerate = strpos($csrf, 'session_regenerate_id();');
+	$freshToken = strpos($csrf, "'csrfMagicToken' => csrf_get_tokens()");
+
+	expect($jsonBranch)->not->toBeFalse()
+		->and($redirect)->not->toBeFalse()
+		->and($jsonBranch < $redirect)->toBeTrue()
+		->and($regenerate < $freshToken)->toBeTrue()
+		->and($csrf)->toContain("isset(\$GLOBALS['auth_json'])")
+		->and($csrf)->toContain("!empty(\$GLOBALS['is_request_ajax'])")
+		->and($csrf)->toContain("http_response_code(403)")
+		->and($csrf)->toContain("'error'          => 'csrf_timeout'")
+		->and($csrf)->toContain("'csrfMagicToken' => csrf_get_tokens()")
+		->and($csrf)->toContain("header('Cache-Control: no-store')")
+		->and($csrf)->toContain("header('X-Content-Type-Options: nosniff')")
+		->and($csrf)->toContain("header('Location: ' . sanitize_uri(\$_SERVER['REQUEST_URI']))");
+});
+
+test('successful installer json responses roll the csrf token forward', function () use ($root) {
+	$stepJson = file_get_contents($root . '/install/step_json.php');
+
+	expect($stepJson)->toContain("\$response['csrfMagicToken'] = csrf_get_tokens();")
+		->and($stepJson)->toContain("header('Cache-Control: no-store')")
+		->and($stepJson)->toContain("header('X-Content-Type-Options: nosniff')")
+		->and(strpos($stepJson, "\$response['csrfMagicToken'] = csrf_get_tokens();"))
+		->toBeLessThan(strpos($stepJson, "header('Content-Type: application/json')"));
+});
+
+test('installer retries csrf timeouts once for every json action', function () use ($root) {
+	$javascript = file_get_contents($root . '/install/install.js');
+
+	expect($javascript)->toContain('function refreshCsrfMagicToken(data)')
+		->and($javascript)->toContain("data.responseJSON.error == 'csrf_timeout'")
+		->and($javascript)->toContain('if (!retryAttempted && tokenRefreshed)')
+		->and($javascript)->toContain('function performStep(installStep, suppressRefresh, forceReload, csrfRetry)')
+		->and($javascript)->toContain('performStep(installStep, suppressRefresh, forceReload, true);')
+		->and($javascript)->toContain('function performTestConnection(csrfRetry)')
+		->and($javascript)->toContain('performTestConnection(true);')
+		->and($javascript)->toContain('PopupError(response.message, response.title);');
+});
+
+test('installer bootstrap establishes json ajax scope before csrf validation', function () use ($root) {
+	$stepJson = file_get_contents($root . '/install/step_json.php');
+	$global   = file_get_contents($root . '/include/global.php');
+
+	$installMode = strpos($stepJson, "define('IN_CACTI_INSTALL', 1)");
+	$jsonMode    = strpos($stepJson, '$auth_json = true;');
+	$authInclude = strpos($stepJson, "include_once('include/auth.php');");
+	$ajaxDetect  = strpos($global, "strcasecmp(\$_SERVER['HTTP_X_REQUESTED_WITH'], 'xmlhttprequest')");
+	$csrfInclude = strpos($global, "require_once(CACTI_PATH_INCLUDE . '/csrf.php');");
+
+	expect($installMode)->not->toBeFalse()
+		->and($jsonMode)->not->toBeFalse()
+		->and($authInclude)->not->toBeFalse()
+		->and($installMode < $authInclude)->toBeTrue()
+		->and($jsonMode < $authInclude)->toBeTrue()
+		->and($ajaxDetect)->not->toBeFalse()
+		->and($csrfInclude)->not->toBeFalse()
+		->and($ajaxDetect < $csrfInclude)->toBeTrue();
+});

--- a/tests/fixtures/Issue7343InstallerCsrfEndpoint.php
+++ b/tests/fixtures/Issue7343InstallerCsrfEndpoint.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 2);
+
+define('CACTI_PATH_INCLUDE', $root . '/include');
+define('CACTI_PATH_URL', '/');
+define('CACTI_WEB', true);
+define('CACTI_CSRF_SECRET', '');
+define('IN_CACTI_INSTALL', 1);
+
+if (!function_exists('__')) {
+	function __($text, ...$args) {
+		return $args ? vsprintf($text, $args) : $text;
+	}
+}
+
+$auth_json       = true;
+$is_request_ajax = isset($_SERVER['HTTP_X_REQUESTED_WITH']) &&
+	strcasecmp($_SERVER['HTTP_X_REQUESTED_WITH'], 'xmlhttprequest') === 0;
+
+require_once CACTI_PATH_INCLUDE . '/vendor/csrf/csrf-conf.php';
+
+$GLOBALS['csrf']['secret'] = 'issue-7343-integration-test-secret';
+
+// Match step_json.php's outer response buffer before CSRF validation runs.
+ob_start();
+require_once CACTI_PATH_INCLUDE . '/csrf.php';
+
+// Reaching this point means csrf_check() accepted the follow-up token. The
+// production endpoint would now construct and serialize the Installer.
+$response = json_encode(
+	[
+		'csrfValidated'  => true,
+		'csrfMagicToken' => csrf_get_tokens(),
+	],
+	JSON_INVALID_UTF8_SUBSTITUTE
+);
+
+header('Content-Type: application/json');
+header('Cache-Control: no-store');
+header('X-Content-Type-Options: nosniff');
+header('Content-Length: ' . strlen($response));
+print $response;

--- a/tests/integration/Issue7343InstallerCsrfRecoveryIntegrationTest.php
+++ b/tests/integration/Issue7343InstallerCsrfRecoveryIntegrationTest.php
@@ -1,0 +1,243 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+function issue7343ReservePort() : int {
+	$socket = stream_socket_server('tcp://127.0.0.1:0', $errorNumber, $errorMessage);
+
+	if ($socket === false) {
+		throw new RuntimeException("Unable to reserve an HTTP port: $errorMessage ($errorNumber)");
+	}
+
+	$address = stream_socket_get_name($socket, false);
+	fclose($socket);
+
+	if ($address === false || !preg_match('/:(\d+)$/', $address, $matches)) {
+		throw new RuntimeException('Unable to determine the reserved HTTP port');
+	}
+
+	return (int) $matches[1];
+}
+
+function issue7343StartServer(string $root, string $sessionPath, int $port) : array {
+	$command = [
+		PHP_BINARY,
+		'-d',
+		'session.save_path=' . $sessionPath,
+		'-d',
+		'display_errors=1',
+		'-S',
+		'127.0.0.1:' . $port,
+		$root . '/tests/fixtures/Issue7343InstallerCsrfEndpoint.php',
+	];
+
+	$descriptors = [
+		0 => ['pipe', 'r'],
+		1 => ['pipe', 'w'],
+		2 => ['pipe', 'w'],
+	];
+
+	$process = proc_open($command, $descriptors, $pipes, $root);
+
+	if (!is_resource($process)) {
+		throw new RuntimeException('Unable to start the PHP integration-test server');
+	}
+
+	fclose($pipes[0]);
+	stream_set_blocking($pipes[1], false);
+	stream_set_blocking($pipes[2], false);
+
+	$deadline = microtime(true) + 5;
+
+	do {
+		set_error_handler(static function () {
+			return true;
+		});
+
+		try {
+			$connection = stream_socket_client(
+				'tcp://127.0.0.1:' . $port,
+				$errorNumber,
+				$errorMessage,
+				0.1
+			);
+		} finally {
+			restore_error_handler();
+		}
+
+		if ($connection !== false) {
+			fclose($connection);
+
+			return [$process, $pipes];
+		}
+
+		$status = proc_get_status($process);
+
+		if (!$status['running']) {
+			break;
+		}
+
+		usleep(25000);
+	} while (microtime(true) < $deadline);
+
+	$error = stream_get_contents($pipes[2]);
+	issue7343StopServer($process, $pipes);
+
+	throw new RuntimeException('PHP integration-test server did not start: ' . trim($error));
+}
+
+function issue7343StopServer($process, array $pipes) : void {
+	$status = proc_get_status($process);
+
+	if ($status['running']) {
+		proc_terminate($process);
+
+		$deadline = microtime(true) + 2;
+
+		do {
+			usleep(25000);
+			$status = proc_get_status($process);
+		} while ($status['running'] && microtime(true) < $deadline);
+
+		if ($status['running']) {
+			proc_terminate($process, 9);
+		}
+	}
+
+	foreach ($pipes as $pipe) {
+		if (is_resource($pipe)) {
+			fclose($pipe);
+		}
+	}
+
+	proc_close($process);
+}
+
+function issue7343Post(string $url, array $data, string $cookie = '') : array {
+	$headers = [
+		'Content-Type: application/x-www-form-urlencoded',
+		'X-Requested-With: XMLHttpRequest',
+	];
+
+	if ($cookie !== '') {
+		$headers[] = 'Cookie: ' . $cookie;
+	}
+
+	$context = stream_context_create(
+		[
+			'http' => [
+				'method'          => 'POST',
+				'header'          => implode("\r\n", $headers),
+				'content'         => http_build_query($data),
+				'ignore_errors'   => true,
+				'follow_location' => 0,
+				'timeout'         => 5,
+			],
+		]
+	);
+
+	$body            = file_get_contents($url, false, $context);
+	$responseHeaders = $http_response_header ?? [];
+
+	if ($body === false || !$responseHeaders) {
+		throw new RuntimeException('Installer CSRF integration request failed');
+	}
+
+	if (!preg_match('/\s(\d{3})(?:\s|$)/', $responseHeaders[0], $statusMatch)) {
+		throw new RuntimeException('Unable to parse HTTP response status');
+	}
+
+	$parsedHeaders = [];
+
+	foreach (array_slice($responseHeaders, 1) as $header) {
+		$separator = strpos($header, ':');
+
+		if ($separator === false) {
+			continue;
+		}
+
+		$name                   = strtolower(substr($header, 0, $separator));
+		$parsedHeaders[$name][] = trim(substr($header, $separator + 1));
+	}
+
+	return [
+		'status'  => (int) $statusMatch[1],
+		'headers' => $parsedHeaders,
+		'body'    => $body,
+	];
+}
+
+function issue7343SessionCookie(array $headers) : string {
+	foreach ($headers['set-cookie'] ?? [] as $header) {
+		$cookie = explode(';', $header, 2)[0];
+
+		if (str_starts_with($cookie, session_name() . '=')) {
+			return $cookie;
+		}
+	}
+
+	return '';
+}
+
+test('installer csrf timeout returns a replacement token accepted by the next request', function () {
+	$root        = dirname(__DIR__, 2);
+	$sessionPath = sys_get_temp_dir() . '/cacti-issue7343-' . bin2hex(random_bytes(8));
+	$port        = issue7343ReservePort();
+
+	if (!mkdir($sessionPath, 0700) && !is_dir($sessionPath)) {
+		throw new RuntimeException('Unable to create the isolated PHP session directory');
+	}
+
+	$server = null;
+	$pipes  = [];
+
+	try {
+		[$server, $pipes] = issue7343StartServer($root, $sessionPath, $port);
+
+		$url      = 'http://127.0.0.1:' . $port . '/install/step_json.php';
+		$rejected = issue7343Post($url, ['__csrf_magic' => 'invalid']);
+		$payload  = json_decode($rejected['body'], true);
+		$cookie   = issue7343SessionCookie($rejected['headers']);
+
+		expect($rejected['status'])->toBe(403)
+			->and($rejected['headers']['content-type'][0] ?? '')->toStartWith('application/json')
+			->and($rejected['headers']['cache-control'] ?? [])->toContain('no-store')
+			->and($rejected['headers']['x-content-type-options'] ?? [])->toContain('nosniff')
+			->and($payload)->toBeArray()
+			->and($payload['error'] ?? null)->toBe('csrf_timeout')
+			->and($payload['csrfMagicToken'] ?? '')->toStartWith('sid:')
+			->and($cookie)->not->toBe('');
+
+		$accepted = issue7343Post(
+			$url,
+			['__csrf_magic' => $payload['csrfMagicToken']],
+			$cookie
+		);
+		$acceptedPayload = json_decode($accepted['body'], true);
+
+		expect($accepted['status'])->toBe(200)
+			->and($acceptedPayload)->toBeArray()
+			->and($acceptedPayload['csrfValidated'] ?? false)->toBeTrue()
+			->and($acceptedPayload['csrfMagicToken'] ?? '')->toStartWith('sid:');
+	} finally {
+		if (is_resource($server)) {
+			issue7343StopServer($server, $pipes);
+		}
+
+		foreach (glob($sessionPath . '/*') ?: [] as $sessionFile) {
+			unlink($sessionFile);
+		}
+
+		rmdir($sessionPath);
+	}
+});

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -452,7 +452,7 @@ header_redirect	./include/auth.php:226					header('Location: ' . CACTI_PATH_URL 
 header_redirect	./include/auth.php:56		header('Location: ' . CACTI_PATH_URL . 'install/');
 header_redirect	./include/auth.php:77			header('Location: ' . CACTI_PATH_URL . 'auth_changepassword.php?ref=' . rawurlencode(validate_redirect_url($_SERVER['HTTP_REFERER'] ?? '', 'index.php')));
 header_redirect	./include/content/index.php:25	header('Location:../index.php');
-header_redirect	./include/csrf.php:49		header('Location: ' . sanitize_uri($_SERVER['REQUEST_URI']));
+header_redirect	./include/csrf.php:80		header('Location: ' . sanitize_uri($_SERVER['REQUEST_URI']));
 header_redirect	./include/fa/css/index.php:25	header('Location:../index.php');
 header_redirect	./include/fa/index.php:25	header('Location:../index.php');
 header_redirect	./include/fa/js/index.php:25	header('Location:../index.php');


### PR DESCRIPTION
## Summary

- return a machine-readable JSON response with a replacement token when an installer AJAX request fails CSRF validation
- retry installer step and remote-connection requests once with the replacement token
- roll the CSRF token forward after successful installer JSON requests
- show a clear session-expired error if the bounded retry also fails
- add regression coverage, changelog documentation, and translation-template entries

## Testing

- manual expired-token installer flow confirmed to recover and advance
- `node --check install/install.js`
- executable retry harness for wizard-step and remote-connection requests
- `python3 .github/scripts/check-changelog.py`
- `git diff --check`
- gettext catalog entries parsed with `msgattrib`

Fixes #7343
