### PR TITLE
ci: compare sink guard on line-agnostic signatures

### DIFF
--- a/tests/security/verify_architectural_hotspots.sh
+++ b/tests/security/verify_architectural_hotspots.sh
@@ -38,5 +38,5 @@ cat "$TMP_NEW"
 echo
 echo "Line-number-only drift no longer fails here; refresh only when a genuine"
 echo "new hotspot is intentional and reviewed:"
-printf '%s\n' "  tests/security/build_architectural_helper_report.sh --hotspots | tr -d '\\r' | LC_ALL=C sort -u > tests/security/baselines/architectural_hotspots.baseline.tsv"
+printf '%s\n' "  tests/security/build_architectural_helper_report.sh --hotspots | tr -d '\\r' | LC_ALL=C sort > tests/security/baselines/architectural_hotspots.baseline.tsv"
 exit 1

--- a/tests/security/verify_architectural_hotspots.sh
+++ b/tests/security/verify_architectural_hotspots.sh
@@ -13,8 +13,17 @@ if [ ! -f "$BASELINE" ]; then
 	exit 1
 fi
 
-tr -d '\r' < "$BASELINE" | LC_ALL=C sort -u > "$TMP_BASELINE"
-"${ROOT_DIR}/tests/security/build_architectural_helper_report.sh" --hotspots | tr -d '\r' | LC_ALL=C sort -u > "$TMP_CUR"
+# Compare on the line-agnostic signature (class + file + code): strip the
+# trailing :LINE from field 2 (location) so pure line-number drift from an
+# unrelated edit or a develop merge no longer trips the gate. Sort without -u
+# so identical signatures are kept as a multiset; an added same-signature
+# hotspot still changes the comparison and is caught.
+strip_line_numbers() {
+	awk -F'\t' 'BEGIN{OFS="\t"} {sub(/:[0-9]+$/,"",$2); print}'
+}
+
+tr -d '\r' < "$BASELINE" | strip_line_numbers | LC_ALL=C sort > "$TMP_BASELINE"
+"${ROOT_DIR}/tests/security/build_architectural_helper_report.sh" --hotspots | tr -d '\r' | strip_line_numbers | LC_ALL=C sort > "$TMP_CUR"
 
 # Detect only newly introduced hotspots (existing baseline debt is tolerated).
 comm -13 "$TMP_BASELINE" "$TMP_CUR" > "$TMP_NEW" || true
@@ -27,6 +36,7 @@ fi
 echo "ERROR: new architectural hotspots detected:"
 cat "$TMP_NEW"
 echo
-echo "If this is intentional and reviewed, refresh baseline:"
+echo "Line-number-only drift no longer fails here; refresh only when a genuine"
+echo "new hotspot is intentional and reviewed:"
 printf '%s\n' "  tests/security/build_architectural_helper_report.sh --hotspots | tr -d '\\r' | LC_ALL=C sort -u > tests/security/baselines/architectural_hotspots.baseline.tsv"
 exit 1

--- a/tests/security/verify_architectural_hotspots.sh
+++ b/tests/security/verify_architectural_hotspots.sh
@@ -19,7 +19,7 @@ fi
 # so identical signatures are kept as a multiset; an added same-signature
 # hotspot still changes the comparison and is caught.
 strip_line_numbers() {
-	awk -F'\t' 'BEGIN{OFS="\t"} {sub(/:[0-9]+$/,"",$2); print}'
+	awk 'BEGIN{FS="\t";OFS="\t"} {sub(/:[0-9]+$/,"",$2); print}'
 }
 
 tr -d '\r' < "$BASELINE" | strip_line_numbers | LC_ALL=C sort > "$TMP_BASELINE"

--- a/tests/security/verify_sink_inventory.sh
+++ b/tests/security/verify_sink_inventory.sh
@@ -19,7 +19,7 @@ fi
 # so identical signatures are kept as a multiset; adding or removing one of
 # several same-signature sinks still changes the comparison and is caught.
 strip_line_numbers() {
-	awk -F'\t' 'BEGIN{OFS="\t"} {sub(/:[0-9]+$/,"",$2); print}'
+	awk 'BEGIN{FS="\t";OFS="\t"} {sub(/:[0-9]+$/,"",$2); print}'
 }
 
 tr -d '\r' < "$BASELINE" | strip_line_numbers | LC_ALL=C sort > "$TMP_BASELINE"

--- a/tests/security/verify_sink_inventory.sh
+++ b/tests/security/verify_sink_inventory.sh
@@ -36,5 +36,5 @@ echo "ERROR: sink inventory drift detected."
 echo "See: $TMP_DIFF"
 echo "Line-number-only drift no longer fails here; refresh only for a genuine"
 echo "sink add, remove, or code change:"
-printf '%s\n' "  tests/security/build_sink_inventory.sh | tr -d '\\r' | LC_ALL=C sort -u > tests/security/baselines/sink_inventory.baseline.tsv"
+printf '%s\n' "  tests/security/build_sink_inventory.sh | tr -d '\\r' | LC_ALL=C sort > tests/security/baselines/sink_inventory.baseline.tsv"
 exit 1

--- a/tests/security/verify_sink_inventory.sh
+++ b/tests/security/verify_sink_inventory.sh
@@ -13,8 +13,17 @@ if [ ! -f "$BASELINE" ]; then
 	exit 1
 fi
 
-tr -d '\r' < "$BASELINE" | LC_ALL=C sort -u > "$TMP_BASELINE"
-"${ROOT_DIR}/tests/security/build_sink_inventory.sh" | tr -d '\r' | LC_ALL=C sort -u > "$TMP_CUR"
+# Compare on the line-agnostic signature (type + file + code): strip the
+# trailing :LINE from field 2 (location) so pure line-number drift from an
+# unrelated edit or a develop merge no longer trips the gate. Sort without -u
+# so identical signatures are kept as a multiset; adding or removing one of
+# several same-signature sinks still changes the comparison and is caught.
+strip_line_numbers() {
+	awk -F'\t' 'BEGIN{OFS="\t"} {sub(/:[0-9]+$/,"",$2); print}'
+}
+
+tr -d '\r' < "$BASELINE" | strip_line_numbers | LC_ALL=C sort > "$TMP_BASELINE"
+"${ROOT_DIR}/tests/security/build_sink_inventory.sh" | tr -d '\r' | strip_line_numbers | LC_ALL=C sort > "$TMP_CUR"
 
 if diff -u "$TMP_BASELINE" "$TMP_CUR" > "$TMP_DIFF"; then
 	rm -f "$TMP_DIFF"
@@ -25,6 +34,7 @@ fi
 # $TMP_DIFF is deliberately left behind on failure so the drift can be inspected.
 echo "ERROR: sink inventory drift detected."
 echo "See: $TMP_DIFF"
-echo "If intentional, review and refresh baseline:"
+echo "Line-number-only drift no longer fails here; refresh only for a genuine"
+echo "sink add, remove, or code change:"
 printf '%s\n' "  tests/security/build_sink_inventory.sh | tr -d '\\r' | LC_ALL=C sort -u > tests/security/baselines/sink_inventory.baseline.tsv"
 exit 1


### PR DESCRIPTION
The security-sink and architectural-hotspot guards pinned each row to an exact `:LINE`, so any commit that shifted line numbers, or a develop merge, re-drifted the baseline and failed CI even when no sink changed.

The comparison now matches on the sink signature (type + file + code) and strips the trailing `:LINE` from both the baseline and the freshly built inventory. It sorts without `-u` so identical signatures are kept as a multiset, meaning add, remove, and modify are still caught (including adding or removing one of several same-signature sinks).

Baselines keep their line numbers for human reference; only the comparison is line-agnostic. This ends the recurring baseline-refresh churn across open PRs.

Verified on develop: unmodified tree passes; a pure line move passes; new, removed, modified, and duplicate-count changes all fail.