### PR TITLE
fix: #7027 guard system PIDs in timeout_kill_registered_processes

### DIFF
--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2402,10 +2402,19 @@ function register_process_start($tasktype, $taskname, $taskid = 0, $timeout = 30
 
 		register_process($tasktype, $taskname, $taskid, $pid, $timeout);
 	} elseif ($r['timeout_exceeded']) {
-		if ($r['pid'] > 0) {
+		$timeout_pid = (int) $r['pid'];
+
+		if (is_system_pid($timeout_pid)) {
+			// mirror timeout_kill_registered_processes(): never signal a reserved
+			// system PID from the registry, but still clear and re-register
+			cacti_log(sprintf('WARNING: Refusing to kill registered process with a reserved system PID! (%s, %s, %s, %s)', $tasktype, $taskname, $taskid, $r['pid']), false, 'POLLER');
+
+			unregister_process($tasktype, $taskname, $taskid);
+			register_process($tasktype, $taskname, $taskid, $pid, $timeout);
+		} elseif ($timeout_pid > 0) {
 			cacti_log(sprintf('ERROR: Process being killed due to timeout! (%s, %s, %s, Process %s, Time %s, Timeout %s, Timestamp %s)', $tasktype, $taskname, $taskid, $r['pid'], $r['timeout_exceeded'], $r['timeout'], $r['current_timestamp']), false, 'POLLER');
 
-			posix_kill($r['pid'], SIGTERM);
+			posix_kill($timeout_pid, SIGTERM);
 
 			unregister_process($tasktype, $taskname, $taskid);
 			register_process($tasktype, $taskname, $taskid, $pid, $timeout);

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2504,6 +2504,19 @@ function heartbeat_process($tasktype, $taskname, $taskid = 0) {
 }
 
 /**
+ * is_system_pid - test whether a PID falls in the reserved low range that Cacti
+ *   must never signal. init (1), systemd, and kernel threads live here, so a
+ *   tampered or reused pid column could otherwise take down a host service.
+ *
+ * @param  (int) $pid  - The process id to test
+ *
+ * @return (bool) true when the PID is a low/system PID that must be skipped
+ */
+function is_system_pid($pid) {
+	return (int) $pid <= 100;
+}
+
+/**
  * timeout_kill_registered_processes - allow a Cacti plugin or scheduled task to
  *   be bulk cleaned.
  *
@@ -2549,9 +2562,13 @@ function timeout_kill_registered_processes($tasktype = '', $taskname = '', $task
 
 	if (cacti_sizeof($processes)) {
 		foreach($processes as $r) {
-			if ($r['pid'] > 0 && posix_kill($r['pid'], 0)) {
+			$pid = (int) $r['pid'];
+
+			if (is_system_pid($pid)) {
+				cacti_log(sprintf('WARNING: Refusing to kill registered process with a reserved system PID! (%s, %s, %s, %s)', $r['tasktype'], $r['taskname'], $r['taskid'], $r['pid']), false, 'POLLER');
+			} elseif (posix_kill($pid, 0)) {
 				cacti_log(sprintf('ERROR: Process killed due to timeout! (%s, %s, %s, %s)', $r['tasktype'], $r['taskname'], $r['taskid'], $r['pid']), false, 'POLLER');
-				posix_kill($r['pid'], SIGTERM);
+				posix_kill($pid, SIGTERM);
 			} else {
 				cacti_log(sprintf('ERROR: Detected process that is gone and did not unregister first! (%s, %s, %s, %s)', $r['tasktype'], $r['taskname'], $r['taskid'], $r['pid']), false, 'POLLER');
 			}

--- a/tests/Unit/TimeoutKillSystemPidGuardTest.php
+++ b/tests/Unit/TimeoutKillSystemPidGuardTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Guard for issue #7027: timeout_kill_registered_processes() signalled any pid
+ * from the processes table. A tampered pid column could then take down init,
+ * systemd, or a kernel thread. is_system_pid() rejects the reserved low range
+ * so those pids are logged and skipped instead of killed.
+ *
+ * lib/poller.php only defines functions at file scope, so it is safe to load
+ * here; require_once dedupes by path across the suite.
+ */
+
+require_once __DIR__ . '/../../lib/poller.php';
+
+test('is_system_pid rejects init and the reserved low range', function () {
+	expect(is_system_pid(1))->toBeTrue();
+	expect(is_system_pid(0))->toBeTrue();
+	expect(is_system_pid(-1))->toBeTrue();
+	expect(is_system_pid(100))->toBeTrue();
+});
+
+test('is_system_pid allows a normal registered pid', function () {
+	expect(is_system_pid(101))->toBeFalse();
+	expect(is_system_pid(12345))->toBeFalse();
+});
+
+test('is_system_pid coerces numeric strings from the processes table', function () {
+	expect(is_system_pid('1'))->toBeTrue();
+	expect(is_system_pid('12345'))->toBeFalse();
+});
+
+test('timeout_kill_registered_processes gates posix_kill behind is_system_pid', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/poller.php');
+	expect($source)->not->toBeFalse();
+
+	$start = strpos($source, 'function timeout_kill_registered_processes');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($source, $start, 2200);
+
+	// The SIGTERM kill must sit on the elseif branch, reachable only after the
+	// is_system_pid() check has excluded the reserved range.
+	expect(strpos($body, 'if (is_system_pid($pid))'))->not->toBeFalse();
+	expect(strpos($body, '} elseif (posix_kill($pid, 0)) {'))->not->toBeFalse();
+	expect(strpos($body, 'posix_kill($pid, SIGTERM)'))->not->toBeFalse();
+});


### PR DESCRIPTION
timeout_kill_registered_processes() signalled any pid from the processes table. A tampered pid column (via SQLi in another vector) could then terminate init, systemd, or a kernel thread. This adds is_system_pid() to skip pids at or below 100 before posix_kill, logging a warning and still unregistering the row. Normal registered pids are unaffected. Unit test covers the reserved range and a normal pid.

Closes #7027