### PR TITLE
fix: #7026 verify package signatures with SHA-256 only

### DIFF
--- a/lib/import.php
+++ b/lib/import.php
@@ -464,11 +464,9 @@ function import_read_package_data($xmlfile, &$public_key) {
 		return false;
 	}
 
-	if (strlen($public_key) < 200) {
-		$ok = openssl_verify($xml, $binary_signature, $public_key, OPENSSL_ALGO_SHA1);
-	} else {
-		$ok = openssl_verify($xml, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
-	}
+	/* SECURITY: SHA-256 only. SHA-1 is vulnerable to chosen-prefix collisions and is
+	 * no longer accepted for package signature verification (#7026). */
+	$ok = openssl_verify($xml, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
 
 	if ($ok == 1) {
 		cacti_log('NOTE: File is Signed Correctly', false, 'IMPORT', POLLER_VERBOSITY_MEDIUM);
@@ -571,11 +569,8 @@ function import_package($xmlfile, $profile_id = 1, $remove_orphans = false, $rep
 		$binary_signature = base64_decode($f['filesignature']);
 		$fdata = base64_decode($f['data']);
 
-		if (strlen($public_key) < 200) {
-			$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA1);
-		} else {
-			$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
-		}
+		/* SECURITY: SHA-256 only (#7026). */
+		$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
 
 		if ($ok == 1) {
 			cacti_log('NOTE: File OK: ' . $f['name'], false, 'IMPORT', POLLER_VERBOSITY_MEDIUM);

--- a/tests/Unit/Issue7026Sha1SignatureRegressionTest.php
+++ b/tests/Unit/Issue7026Sha1SignatureRegressionTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression tests for issue #7026.
+ *
+ * Fix: drop the key-length conditional in import_read_package_data() and
+ *      import_package() that selected OPENSSL_ALGO_SHA1 for short keys.
+ *      Package signatures are now verified with SHA-256 unconditionally.
+ *
+ * Source-scan invariants plus a behavioural check that a SHA-1 signature no
+ * longer verifies through the SHA-256 path.
+ */
+
+$importSource = file_get_contents(__DIR__ . '/../../lib/import.php');
+
+test('#7026: SHA-1 is no longer referenced in the signature verification code', function () use ($importSource) {
+	expect($importSource)->not->toContain('OPENSSL_ALGO_SHA1');
+});
+
+test('#7026: the key-length fallback conditional is gone', function () use ($importSource) {
+	expect($importSource)->not->toContain('strlen($public_key) < 200');
+});
+
+test('#7026: both verify sites use OPENSSL_ALGO_SHA256', function () use ($importSource) {
+	// Two call sites remain: the XML signature and the per-file signature.
+	$count = substr_count($importSource, 'OPENSSL_ALGO_SHA256');
+	expect($count)->toBeGreaterThanOrEqual(2);
+});
+
+test('#7026: a SHA-256 signature verifies and a SHA-1 signature is rejected', function () {
+	$res = openssl_pkey_new([
+		'private_key_bits' => 2048,
+		'private_key_type' => OPENSSL_KEYTYPE_RSA,
+	]);
+
+	expect($res)->not->toBeFalse();
+
+	$details = openssl_pkey_get_details($res);
+	$public  = $details['key'];
+	$data    = 'cacti package payload';
+
+	$sha256_sig = '';
+	openssl_sign($data, $sha256_sig, $res, OPENSSL_ALGO_SHA256);
+
+	$sha1_sig = '';
+	openssl_sign($data, $sha1_sig, $res, OPENSSL_ALGO_SHA1);
+
+	// The verification path now uses SHA-256 only.
+	expect(openssl_verify($data, $sha256_sig, $public, OPENSSL_ALGO_SHA256))->toBe(1);
+	expect(openssl_verify($data, $sha1_sig, $public, OPENSSL_ALGO_SHA256))->toBe(0);
+});


### PR DESCRIPTION
Package import selected the OpenSSL hash by public-key string length, falling back to SHA-1 for short keys. SHA-1 is vulnerable to chosen-prefix collisions, so both verify sites in lib/import.php now use OPENSSL_ALGO_SHA256 unconditionally.

This does not break any importable package. Cacti signs with SHA-256, and the only key short enough to trigger the old SHA-1 branch is the legacy 512-bit key, which the 2048-bit minimum gate (GHSA-8w9r-xmpr-5q3v) already rejects before verification. A regression test confirms a SHA-256 signature still verifies and a SHA-1 signature is rejected.

Closes #7026