### PR TITLE
hardening: guard system PIDs in timeout_kill_registered_processes

### DIFF
--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2402,10 +2402,19 @@ function register_process_start($tasktype, $taskname, $taskid = 0, $timeout = 30
 
 		register_process($tasktype, $taskname, $taskid, $pid, $timeout);
 	} elseif ($r['timeout_exceeded']) {
-		if ($r['pid'] > 0) {
+		$timeout_pid = (int) $r['pid'];
+
+		if (is_system_pid($timeout_pid)) {
+			// mirror timeout_kill_registered_processes(): never signal a reserved
+			// system PID from the registry, but still clear and re-register
+			cacti_log(sprintf('WARNING: Refusing to kill registered process with a reserved system PID! (%s, %s, %s, %s)', $tasktype, $taskname, $taskid, $r['pid']), false, 'POLLER');
+
+			unregister_process($tasktype, $taskname, $taskid);
+			register_process($tasktype, $taskname, $taskid, $pid, $timeout);
+		} elseif ($timeout_pid > 0) {
 			cacti_log(sprintf('ERROR: Process being killed due to timeout! (%s, %s, %s, Process %s, Time %s, Timeout %s, Timestamp %s)', $tasktype, $taskname, $taskid, $r['pid'], $r['timeout_exceeded'], $r['timeout'], $r['current_timestamp']), false, 'POLLER');
 
-			posix_kill($r['pid'], SIGTERM);
+			posix_kill($timeout_pid, SIGTERM);
 
 			unregister_process($tasktype, $taskname, $taskid);
 			register_process($tasktype, $taskname, $taskid, $pid, $timeout);

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2504,6 +2504,19 @@ function heartbeat_process($tasktype, $taskname, $taskid = 0) {
 }
 
 /**
+ * is_system_pid - test whether a PID falls in the reserved low range that Cacti
+ *   must never signal. init (1), systemd, and kernel threads live here, so a
+ *   tampered or reused pid column could otherwise take down a host service.
+ *
+ * @param  (int) $pid  - The process id to test
+ *
+ * @return (bool) true when the PID is a low/system PID that must be skipped
+ */
+function is_system_pid($pid) {
+	return (int) $pid <= 100;
+}
+
+/**
  * timeout_kill_registered_processes - allow a Cacti plugin or scheduled task to
  *   be bulk cleaned.
  *
@@ -2549,9 +2562,13 @@ function timeout_kill_registered_processes($tasktype = '', $taskname = '', $task
 
 	if (cacti_sizeof($processes)) {
 		foreach($processes as $r) {
-			if ($r['pid'] > 0 && posix_kill($r['pid'], 0)) {
+			$pid = (int) $r['pid'];
+
+			if (is_system_pid($pid)) {
+				cacti_log(sprintf('WARNING: Refusing to kill registered process with a reserved system PID! (%s, %s, %s, %s)', $r['tasktype'], $r['taskname'], $r['taskid'], $r['pid']), false, 'POLLER');
+			} elseif (posix_kill($pid, 0)) {
 				cacti_log(sprintf('ERROR: Process killed due to timeout! (%s, %s, %s, %s)', $r['tasktype'], $r['taskname'], $r['taskid'], $r['pid']), false, 'POLLER');
-				posix_kill($r['pid'], SIGTERM);
+				posix_kill($pid, SIGTERM);
 			} else {
 				cacti_log(sprintf('ERROR: Detected process that is gone and did not unregister first! (%s, %s, %s, %s)', $r['tasktype'], $r['taskname'], $r['taskid'], $r['pid']), false, 'POLLER');
 			}

--- a/tests/Unit/PollerSystemPidBranchesTest.php
+++ b/tests/Unit/PollerSystemPidBranchesTest.php
@@ -1,0 +1,148 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Branch coverage for issue #7027. register_process_start() and
+ * timeout_kill_registered_processes() decide whether to signal a pid read from
+ * the processes table. is_system_pid() gates the kill so a tampered pid column
+ * cannot take down init/systemd. The DB and posix_kill() are the only external
+ * boundaries; both are stubbed here so every branch of the guarded code runs
+ * without a live database and without signalling this process.
+ */
+
+if (!defined('POLLER_VERBOSITY_MEDIUM')) {
+	define('POLLER_VERBOSITY_MEDIUM', 2);
+}
+
+if (!function_exists('cacti_sizeof')) {
+	function cacti_sizeof($a) {
+		return is_array($a) ? count($a) : 0;
+	}
+}
+
+if (!function_exists('cacti_log')) {
+	function cacti_log($message, $stdout = false, $environ = 'CMDPHP', $level = 0) {
+		$GLOBALS['__poller_log'][] = $message;
+		return true;
+	}
+}
+
+if (!function_exists('db_table_exists')) {
+	function db_table_exists($table, $log = true, $force = false) {
+		return $GLOBALS['__poller_table_exists'] ?? true;
+	}
+}
+
+if (!function_exists('db_execute_prepared')) {
+	function db_execute_prepared($sql, $params = array(), $log = true) {
+		$GLOBALS['__poller_writes'][] = array($sql, $params);
+		return true;
+	}
+}
+
+if (!function_exists('db_fetch_row_prepared')) {
+	function db_fetch_row_prepared($sql, $params = array(), $log = true) {
+		return $GLOBALS['__poller_row'] ?? array();
+	}
+}
+
+if (!function_exists('db_fetch_assoc_prepared')) {
+	function db_fetch_assoc_prepared($sql, $params = array(), $log = true) {
+		return $GLOBALS['__poller_procs'] ?? array();
+	}
+}
+
+require_once __DIR__ . '/../../lib/poller.php';
+
+beforeEach(function () {
+	$GLOBALS['__poller_log']          = array();
+	$GLOBALS['__poller_writes']       = array();
+	$GLOBALS['__poller_table_exists'] = true;
+	$GLOBALS['__poller_row']          = array();
+	$GLOBALS['__poller_procs']        = array();
+});
+
+// A pid that never exists on this platform, so posix_kill() is a safe no-op.
+const POLLER_DEAD_PID = 999999;
+
+test('register_process_start refuses to kill a reserved system pid on timeout', function () {
+	$GLOBALS['__poller_row'] = array(
+		'pid'               => 1,
+		'timeout_exceeded'  => 1720000000,
+		'timeout'           => 300,
+		'current_timestamp' => 1720000600,
+	);
+
+	$result = register_process_start('poller', 'test', 0, 300);
+
+	expect($result)->toBeTrue();
+	$joined = implode("\n", $GLOBALS['__poller_log']);
+	expect($joined)->toContain('reserved system PID');
+	// Must have re-registered (unregister + register both write).
+	expect(count($GLOBALS['__poller_writes']))->toBeGreaterThanOrEqual(2);
+});
+
+test('register_process_start signals a normal timed-out pid', function () {
+	$GLOBALS['__poller_row'] = array(
+		'pid'               => POLLER_DEAD_PID,
+		'timeout_exceeded'  => 1720000000,
+		'timeout'           => 300,
+		'current_timestamp' => 1720000600,
+	);
+
+	$result = register_process_start('poller', 'test', 0, 300);
+
+	expect($result)->toBeTrue();
+	$joined = implode("\n", $GLOBALS['__poller_log']);
+	expect($joined)->toContain('being killed due to timeout');
+});
+
+test('register_process_start treats a zero pid as a reserved system pid', function () {
+	// is_system_pid(0) is true, so a zero pid takes the guarded branch rather
+	// than reaching posix_kill().
+	$GLOBALS['__poller_row'] = array(
+		'pid'               => 0,
+		'timeout_exceeded'  => 1720000000,
+		'timeout'           => 300,
+		'current_timestamp' => 1720000600,
+	);
+
+	$result = register_process_start('poller', 'test', 0, 300);
+
+	expect($result)->toBeTrue();
+	$joined = implode("\n", $GLOBALS['__poller_log']);
+	expect($joined)->toContain('reserved system PID');
+});
+
+test('timeout_kill_registered_processes skips a reserved system pid', function () {
+	$GLOBALS['__poller_procs'] = array(
+		array('pid' => 1, 'tasktype' => 'poller', 'taskname' => 'test', 'taskid' => 0),
+	);
+
+	timeout_kill_registered_processes();
+
+	$joined = implode("\n", $GLOBALS['__poller_log']);
+	expect($joined)->toContain('reserved system PID');
+});
+
+test('timeout_kill_registered_processes reports a stale gone pid', function () {
+	$GLOBALS['__poller_procs'] = array(
+		array('pid' => POLLER_DEAD_PID, 'tasktype' => 'poller', 'taskname' => 'test', 'taskid' => 0),
+	);
+
+	timeout_kill_registered_processes();
+
+	$joined = implode("\n", $GLOBALS['__poller_log']);
+	expect($joined)->toContain('did not unregister first');
+});

--- a/tests/Unit/PollerSystemPidBranchesTest.php
+++ b/tests/Unit/PollerSystemPidBranchesTest.php
@@ -73,8 +73,9 @@ beforeEach(function () {
 	$GLOBALS['__poller_procs']        = array();
 });
 
-// A pid that never exists on this platform, so posix_kill() is a safe no-op.
-const POLLER_DEAD_PID = 999999;
+// A pid beyond any platform's pid_max, so posix_kill() fails with ESRCH and
+// can never signal a real process (999999 is reachable where pid_max is high).
+const POLLER_DEAD_PID = PHP_INT_MAX;
 
 test('register_process_start refuses to kill a reserved system pid on timeout', function () {
 	$GLOBALS['__poller_row'] = array(

--- a/tests/Unit/TimeoutKillSystemPidGuardTest.php
+++ b/tests/Unit/TimeoutKillSystemPidGuardTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Guard for issue #7027: timeout_kill_registered_processes() signalled any pid
+ * from the processes table. A tampered pid column could then take down init,
+ * systemd, or a kernel thread. is_system_pid() rejects the reserved low range
+ * so those pids are logged and skipped instead of killed.
+ *
+ * lib/poller.php only defines functions at file scope, so it is safe to load
+ * here; require_once dedupes by path across the suite.
+ */
+
+require_once __DIR__ . '/../../lib/poller.php';
+
+test('is_system_pid rejects init and the reserved low range', function () {
+	expect(is_system_pid(1))->toBeTrue();
+	expect(is_system_pid(0))->toBeTrue();
+	expect(is_system_pid(-1))->toBeTrue();
+	expect(is_system_pid(100))->toBeTrue();
+});
+
+test('is_system_pid allows a normal registered pid', function () {
+	expect(is_system_pid(101))->toBeFalse();
+	expect(is_system_pid(12345))->toBeFalse();
+});
+
+test('is_system_pid coerces numeric strings from the processes table', function () {
+	expect(is_system_pid('1'))->toBeTrue();
+	expect(is_system_pid('12345'))->toBeFalse();
+});
+
+test('timeout_kill_registered_processes gates posix_kill behind is_system_pid', function () {
+	$source = file_get_contents(__DIR__ . '/../../lib/poller.php');
+	expect($source)->not->toBeFalse();
+
+	$start = strpos($source, 'function timeout_kill_registered_processes');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($source, $start, 2200);
+
+	// The SIGTERM kill must sit on the elseif branch, reachable only after the
+	// is_system_pid() check has excluded the reserved range.
+	expect(strpos($body, 'if (is_system_pid($pid))'))->not->toBeFalse();
+	expect(strpos($body, '} elseif (posix_kill($pid, 0)) {'))->not->toBeFalse();
+	expect(strpos($body, 'posix_kill($pid, SIGTERM)'))->not->toBeFalse();
+});

--- a/tests/Unit/TimeoutKillSystemPidGuardTest.php
+++ b/tests/Unit/TimeoutKillSystemPidGuardTest.php
@@ -53,6 +53,6 @@ test('timeout_kill_registered_processes gates posix_kill behind is_system_pid', 
 	// The SIGTERM kill must sit on the elseif branch, reachable only after the
 	// is_system_pid() check has excluded the reserved range.
 	expect(strpos($body, 'if (is_system_pid($pid))'))->not->toBeFalse();
-	expect(strpos($body, '} elseif (posix_kill($pid, 0)) {'))->not->toBeFalse();
+	expect(preg_match('/}\s*elseif\s*\(\s*posix_kill\s*\(\s*\$pid\s*,\s*0\s*\)\s*\)\s*{/', $body))->toBe(1);
 	expect(strpos($body, 'posix_kill($pid, SIGTERM)'))->not->toBeFalse();
 });

--- a/tests/integration/PollerTimeoutKillProcessIntegrationTest.php
+++ b/tests/integration/PollerTimeoutKillProcessIntegrationTest.php
@@ -67,8 +67,9 @@ test('timeout_kill_registered_processes delivers SIGTERM to a live child', funct
 	expect($pid)->not->toBe(-1);
 
 	if ($pid === 0) {
-		// Child: block until the parent signals us, fail loudly if it never does.
-		sleep(30);
+		// Child: block until the parent signals us. Short enough that a kill
+		// regression fails fast instead of stalling the suite for 30s.
+		sleep(5);
 		exit(0);
 	}
 

--- a/tests/integration/PollerTimeoutKillProcessIntegrationTest.php
+++ b/tests/integration/PollerTimeoutKillProcessIntegrationTest.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Issue #7027 across a real process boundary. timeout_kill_registered_processes()
+ * signals a genuinely running pid, so this forks a real sleeper child and checks
+ * two outcomes: a normal child pid is delivered SIGTERM, and a reserved system
+ * pid (init, pid 1) is never signalled. The DB is stubbed because the guard,
+ * not the query, is under test.
+ */
+
+if (!function_exists('cacti_sizeof')) {
+	function cacti_sizeof($a) {
+		return is_array($a) ? count($a) : 0;
+	}
+}
+
+if (!function_exists('cacti_log')) {
+	function cacti_log($message, $stdout = false, $environ = 'CMDPHP', $level = 0) {
+		$GLOBALS['__poller_log'][] = $message;
+		return true;
+	}
+}
+
+if (!function_exists('db_table_exists')) {
+	function db_table_exists($table, $log = true, $force = false) {
+		return true;
+	}
+}
+
+if (!function_exists('db_execute_prepared')) {
+	function db_execute_prepared($sql, $params = array(), $log = true) {
+		return true;
+	}
+}
+
+if (!function_exists('db_fetch_assoc_prepared')) {
+	function db_fetch_assoc_prepared($sql, $params = array(), $log = true) {
+		return $GLOBALS['__poller_procs'] ?? array();
+	}
+}
+
+require_once __DIR__ . '/../../lib/poller.php';
+
+beforeEach(function () {
+	if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+		$this->markTestSkipped('pcntl/posix extensions required for the process boundary test');
+	}
+
+	$GLOBALS['__poller_log']   = array();
+	$GLOBALS['__poller_procs'] = array();
+});
+
+test('timeout_kill_registered_processes delivers SIGTERM to a live child', function () {
+	$pid = pcntl_fork();
+	expect($pid)->not->toBe(-1);
+
+	if ($pid === 0) {
+		// Child: block until the parent signals us, fail loudly if it never does.
+		sleep(30);
+		exit(0);
+	}
+
+	// Give the child a moment to enter its sleep before we signal it.
+	usleep(200000);
+
+	$GLOBALS['__poller_procs'] = array(
+		array('pid' => $pid, 'tasktype' => 'poller', 'taskname' => 'integration', 'taskid' => 0),
+	);
+
+	timeout_kill_registered_processes();
+
+	$status = 0;
+	$waited = pcntl_waitpid($pid, $status);
+	expect($waited)->toBe($pid);
+	expect(pcntl_wifsignaled($status))->toBeTrue();
+	expect(pcntl_wtermsig($status))->toBe(SIGTERM);
+
+	$joined = implode("\n", $GLOBALS['__poller_log']);
+	expect($joined)->toContain('killed due to timeout');
+});
+
+test('timeout_kill_registered_processes never signals init when the pid column is tampered', function () {
+	// pid 1 is always running; without the guard posix_kill(1, SIGTERM) would fire.
+	$GLOBALS['__poller_procs'] = array(
+		array('pid' => 1, 'tasktype' => 'poller', 'taskname' => 'integration', 'taskid' => 0),
+	);
+
+	timeout_kill_registered_processes();
+
+	$joined = implode("\n", $GLOBALS['__poller_log']);
+	expect($joined)->toContain('reserved system PID');
+	expect($joined)->not->toContain('killed due to timeout');
+});


### PR DESCRIPTION
Closes #7027.

`timeout_kill_registered_processes` and `register_process_start` could signal PIDs at or below 100, which on most systems are kernel/init-owned. Adds `is_system_pid()` (`(int)$pid <= 100`) and gates both kill sites so a stale or recycled low PID in the process table can never target a system process.

Replaces #7397 (closed by a branch rename).