### PR TITLE
fix: #7070 align percentile rank with observed export samples

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -86,6 +86,7 @@ Cacti CHANGELOG
 -issue#6606: When using SpikeKill, actions would not always lead to expected results
 -issue#6706: Some hosts may show as down incorrectly by xmacan
 -issue#6945: Improve PHP 8.5 support
+-issue#7070: Align percentile rank with observed samples and expose missing export rows
 -issue#7121: When using data input methods, unexpected log entries may appear
 -issue#7133: When attempting to push out items, offline data sources can have unexpected results
 -issue#7135: Fix issue with locally scoped OID/Script path not being correctly cleared

--- a/graph_xport.php
+++ b/graph_xport.php
@@ -116,6 +116,22 @@ if (isset_request_var('format') && get_nfilter_request_var('format') == 'table')
 }
 
 if (is_array($xport_array) && isset($xport_array['meta']['start'])) {
+	/* Percentile summaries use the observed finite samples. Expose the expected
+	 * row count so sparse periods are visible instead of being mistaken for zero. */
+	$xport_array['meta']['expected_rows'] = 0;
+	$xport_array['meta']['missing_rows']  = 0;
+
+	if ($xport_array['meta']['step'] > 0) {
+		$effective_end = $xport_array['meta']['end'];
+
+		if ($effective_end == $xport_array['meta']['start'] && $xport_array['meta']['rows'] > 0) {
+			$effective_end = $xport_array['meta']['start'] + $xport_array['meta']['step'] * ($xport_array['meta']['rows'] - 1);
+		}
+
+		$xport_array['meta']['expected_rows'] = (int) floor(($effective_end - $xport_array['meta']['start']) / $xport_array['meta']['step']) + 1;
+		$xport_array['meta']['missing_rows']  = max(0, $xport_array['meta']['expected_rows'] - $xport_array['meta']['rows']);
+	}
+
 	if (!$html) {
 		$output  = '"' . __('Title') . '","'          . $xport_array['meta']['title_cache']    . '"' . "\n";
 		$output .= '"' . __('Vertical Label') . '","' . $xport_array['meta']['vertical_label'] . '"' . "\n";
@@ -124,6 +140,8 @@ if (is_array($xport_array) && isset($xport_array['meta']['start'])) {
 		$output .= '"' . __('End Date') . '","'       . date('Y-m-d H:i:s', ($xport_array['meta']['end'] == $xport_array['meta']['start']) ? $xport_array['meta']['start'] + $xport_array['meta']['step']*($xport_array['meta']['rows']-1) : $xport_array['meta']['end']) . '"' . "\n";
 		$output .= '"' . __('Step') . '","'           . $xport_array['meta']['step']                       . '"' . "\n";
 		$output .= '"' . __('Total Rows') . '","'     . $xport_array['meta']['rows']                       . '"' . "\n";
+		$output .= '"' . __('Expected Rows') . '","'  . $xport_array['meta']['expected_rows']              . '"' . "\n";
+		$output .= '"' . __('Missing Rows') . '","'   . $xport_array['meta']['missing_rows']               . '"' . "\n";
 		$output .= '"' . __('Graph ID') . '","'       . $xport_array['meta']['local_graph_id']             . '"' . "\n";
 		$output .= '"' . __('Host ID') . '","'        . $xport_array['meta']['host_id']                    . '"' . "\n";
 
@@ -186,6 +204,16 @@ if (is_array($xport_array) && isset($xport_array['meta']['start'])) {
 		print "<tr class='odd'>
 			<td class='left'>" . __('Total Rows') . "</td>
 			<td class='right'>" . $xport_array['meta']['rows'] . "</td>
+		</tr>\n";
+
+		print "<tr class='even'>
+			<td class='left'>" . __('Expected Rows') . "</td>
+			<td class='right'>" . $xport_array['meta']['expected_rows'] . "</td>
+		</tr>\n";
+
+		print "<tr class='odd'>
+			<td class='left'>" . __('Missing Rows') . "</td>
+			<td class='right'>" . $xport_array['meta']['missing_rows'] . "</td>
 		</tr>\n";
 
 		print "<tr class='even'>

--- a/lib/graph_variables.php
+++ b/lib/graph_variables.php
@@ -253,6 +253,21 @@ function nth_percentile_fetch_statistics($percentile, &$local_data_ids, &$fetch_
 	return($stats);
 }
 
+function cacti_percentile_index($elements, $percentile) {
+	if ($elements <= 0 || $percentile <= 0 || $percentile >= 100) {
+		return 0;
+	}
+
+	// Values are sorted descending. rrdtool's VDEF PERCENT selects the ascending
+	// rank round(percentile/100 * N), so the matching zero-based descending index
+	// is N - round(percentile/100 * N). PHP round() is half-away-from-zero, which
+	// matches rrdtool's C round() on the .5 ties. Verified against rrdtool for
+	// 28/29/30/31-day months (N = 8064/8352/8640/8928).
+	$index = $elements - (int) round($elements * $percentile / 100);
+
+	return max(0, min($elements - 1, $index));
+}
+
 function cacti_stats_calc($array, $ptile = 95) {
 	rsort($array, SORT_NUMERIC);
 
@@ -290,12 +305,12 @@ function cacti_stats_calc($array, $ptile = 95) {
 		$variance += pow(abs($number - $average), 2);
 	}
 
-	$ptile_index = ceil($elements * (1 - ($ptile/100)));
-	$p95n_index  = ceil($elements * 0.05);
-	$p90n_index  = ceil($elements * 0.1);
-	$p75n_index  = ceil($elements * 0.25);
-	$p50n_index  = ceil($elements * 0.50);
-	$p25n_index  = ceil($elements * 0.75);
+	$ptile_index = cacti_percentile_index($elements, $ptile);
+	$p95n_index  = cacti_percentile_index($elements, 95);
+	$p90n_index  = cacti_percentile_index($elements, 90);
+	$p75n_index  = cacti_percentile_index($elements, 75);
+	$p50n_index  = cacti_percentile_index($elements, 50);
+	$p25n_index  = cacti_percentile_index($elements, 25);
 
 	$results = array(
 		'p95n'     => (isset($array[$p95n_index]) ? $array[$p95n_index] : 0),

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1547,7 +1547,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 	} else {
 		/* basic export options */
 		$graph_opts =
-			'--start=' . cacti_escapeshellarg($graph_start-1) . RRD_NL .
+			'--start=' . cacti_escapeshellarg($graph_start) . RRD_NL .
 			'--end=' . cacti_escapeshellarg($graph_end) . RRD_NL .
 			'--maxrows=10000' . RRD_NL;
 	}

--- a/tests/Unit/Issue7070PercentileContractTest.php
+++ b/tests/Unit/Issue7070PercentileContractTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$graphVariables = file_get_contents(__DIR__ . '/../../lib/graph_variables.php');
+$graphXport     = file_get_contents(__DIR__ . '/../../graph_xport.php');
+
+test('percentile index is based on observed samples', function () use ($graphVariables) {
+	preg_match('/^function cacti_percentile_index\([^)]*\).*?\{.*?^\}/sm', $graphVariables, $matches);
+	expect($matches)->not->toBeEmpty();
+
+	$source = preg_replace('/^function cacti_percentile_index\(/m', 'function issue7070_percentile_index(', $matches[0]);
+	eval($source);
+
+	// Verified against rrdtool VDEF PERCENT for 28/29/30/31-day months
+	// (N = 8064/8352/8640/8928): the index is N - round(0.95 * N).
+	expect(issue7070_percentile_index(8064, 95))->toBe(403);
+	expect(issue7070_percentile_index(8352, 95))->toBe(418);
+	expect(issue7070_percentile_index(8640, 95))->toBe(432);
+	expect(issue7070_percentile_index(8928, 95))->toBe(446);
+	// A single sample returns the only value, not a zero; the empty set stays zero.
+	expect(issue7070_percentile_index(1, 95))->toBe(0);
+	expect(issue7070_percentile_index(0, 95))->toBe(0);
+});
+
+test('CSV export exposes sparse-period coverage', function () use ($graphXport) {
+	expect($graphXport)->toContain("__('Expected Rows')");
+	expect($graphXport)->toContain("__('Missing Rows')");
+	expect($graphXport)->toContain("['meta']['missing_rows']");
+});

--- a/tests/Unit/Issue7070PercentileContractTest.php
+++ b/tests/Unit/Issue7070PercentileContractTest.php
@@ -16,6 +16,8 @@ $graphVariables = file_get_contents(__DIR__ . '/../../lib/graph_variables.php');
 $graphXport     = file_get_contents(__DIR__ . '/../../graph_xport.php');
 
 test('percentile index is based on observed samples', function () use ($graphVariables) {
+	expect($graphVariables)->not->toBeFalse();
+
 	preg_match('/^function cacti_percentile_index\([^)]*\).*?\{.*?^\}/sm', $graphVariables, $matches);
 	expect($matches)->not->toBeEmpty();
 
@@ -34,6 +36,7 @@ test('percentile index is based on observed samples', function () use ($graphVar
 });
 
 test('CSV export exposes sparse-period coverage', function () use ($graphXport) {
+	expect($graphXport)->not->toBeFalse();
 	expect($graphXport)->toContain("__('Expected Rows')");
 	expect($graphXport)->toContain("__('Missing Rows')");
 	expect($graphXport)->toContain("['meta']['missing_rows']");


### PR DESCRIPTION
1.2.x backport of the #7070 percentile fix from develop (#7322 and its follow-up #7377). cacti_percentile_index() derives the descending index from the observed sample count using rrdtool's VDEF PERCENT rank, N - round(percentile/100 * N), replacing the ceil() indices in cacti_stats_calc(). The CSV and table export gain Expected Rows and Missing Rows so sparse periods stay visible instead of reading as zero, and the basic export no longer requests the extra leading row via --start=graph_start-1. The helper is untyped to match 1.2.x on PHP 7.4. Addresses #7070 on 1.2.x.