### PR TITLE
fix: timeout_kill_registered_processes never matched any row

### DIFF
--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2532,19 +2532,19 @@ function timeout_kill_registered_processes($tasktype = '', $taskname = '', $task
 		$params[] = $taskname;
 	}
 
-	if ($taskid != '') {
+	if ($taskid != 0) {
 		$sql_where .= ' AND taskid = ?';
 		$params[] = $taskid;
 	}
 
-	if ($pid != '') {
+	if ($pid != -1) {
 		$sql_where .= ' AND pid = ?';
 		$params[] = $pid;
 	}
 
 	$processes = db_fetch_assoc_prepared("SELECT *
 		FROM processes
-		WHERE UNIX_TIMESTAMP() > FROM_UNIXTIME(started) + timeout
+		WHERE UNIX_TIMESTAMP() > UNIX_TIMESTAMP(started) + timeout
 		$sql_where", $params);
 
 	if (cacti_sizeof($processes)) {


### PR DESCRIPTION
Closes #7418

`timeout_kill_registered_processes()` never reaped a timed-out process because of two defects. `processes.started` is a `timestamp` column, so `FROM_UNIXTIME(started)` coerces it as a number and returns NULL, making the selection query match zero rows. And the default-arg guards `if ($taskid != '')` / `if ($pid != '')` are true for the sentinel defaults (`0` and `-1`), so the default call path always appended `AND taskid = ?` / `AND pid = ?` against ids that never exist.

The query now uses `UNIX_TIMESTAMP(started)`, matching the idiom `register_process_start()` already uses, and the guards become `!= 0` / `!= -1` to match develop's already-fixed form. The same `FROM_UNIXTIME(started)` line still exists on develop and should get the same one-line change in a follow-up.
