### PR TITLE
fix: correct unsigned reconstruction for negative disk sizes in ss_host_disk

### DIFF
--- a/scripts/ss_host_disk.php
+++ b/scripts/ss_host_disk.php
@@ -143,7 +143,7 @@ function ss_host_disk($hostname = '', $host_id = 0, $snmp_auth = '', $cmd = 'ind
 					$snmp_priv_protocol, $snmp_context, $snmp_port, $snmp_timeout, $ping_retries, SNMP_POLLER);
 
 				if ($snmp_data != '' && $snmp_data < 0) {
-					return (abs($snmp_data) + 2147483647) * $sau;
+					return ($snmp_data + 4294967296) * $sau;
 				} elseif (is_numeric($snmp_data) && is_numeric($sau)) {
 					return $snmp_data * $sau;
 				} elseif (is_numeric($snmp_data) && !$sau) {

--- a/scripts/ss_host_disk.php
+++ b/scripts/ss_host_disk.php
@@ -143,7 +143,11 @@ function ss_host_disk($hostname = '', $host_id = 0, $snmp_auth = '', $cmd = 'ind
 					$snmp_priv_protocol, $snmp_context, $snmp_port, $snmp_timeout, $ping_retries, SNMP_POLLER);
 
 				if ($snmp_data != '' && $snmp_data < 0) {
-					return ($snmp_data + 4294967296) * $sau;
+					if ($sau !== '' && is_numeric($sau)) {
+						return ($snmp_data + 4294967296) * $sau;
+					} else {
+						return 'U';
+					}
 				} elseif (is_numeric($snmp_data) && is_numeric($sau)) {
 					return $snmp_data * $sau;
 				} elseif (is_numeric($snmp_data) && !$sau) {


### PR DESCRIPTION
Closes #7419

`ss_host_disk` get returns the wrong value when an agent reports `hrStorageSize`/`hrStorageUsed` as a negative signed-32 integer (volumes whose block count exceeds 2^31). The negative branch reconstructed the unsigned value as `(abs($snmp_data) + 2147483647) * $sau`, which is never correct: raw `-1` yields `2147483648` when the true unsigned value is `4294967295`. The right reconstruction adds 2^32 to the raw signed value, so `-1` maps back to `4294967295`.

`develop` carries the identical formula at the same spot and needs the same fix in a follow-up.
