### PR TITLE
fix: correct octet carry in automation_get_next_host for wide ranges

### DIFF
--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -3383,11 +3383,14 @@ function automation_get_next_host($start, $total, $count, $range) {
 
 		for ($x = 0; $x < 4; $x++) {
 			$ip[$x] += intval($count/$y);
-			$count -= ((intval($count/$y))*256);
+			$count -= (intval($count/$y) * $y);
 			$y = $y / 256;
-			if ($ip[$x] == 256 && $x > 0) {
-				$ip[$x] = 0;
-				$ip[$x-1] += 1;
+		}
+
+		for ($x = 3; $x > 0; $x--) {
+			if ($ip[$x] >= 256) {
+				$ip[$x-1] += intval($ip[$x] / 256);
+				$ip[$x]    = $ip[$x] % 256;
 			}
 		}
 

--- a/tests/Unit/AutomationNextHostTest.php
+++ b/tests/Unit/AutomationNextHostTest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for automation_get_next_host() in lib/api_automation.php.
+ *
+ * The octet carry loop produced invalid octets (e.g. 10.1.272.113) for
+ * offsets that cross more than one octet boundary. Every result must be a
+ * valid dotted quad. lib/api_automation.php only defines functions at load
+ * time, so it can be included without a database or full Cacti bootstrap.
+ */
+
+require_once dirname(__DIR__, 2) . '/lib/api_automation.php';
+
+/* $total is only used to gate the early return; any value above $count works. */
+function next_host($start, $count) {
+	return automation_get_next_host($start, PHP_INT_MAX, $count, '10.0.0.0/8');
+}
+
+test('offset within a single octet is unchanged', function () {
+	expect(next_host('10.0.0.1', 1000))->toBe('10.0.3.233');
+});
+
+test('offset crossing two octet boundaries stays a valid quad', function () {
+	expect(next_host('10.0.0.1', 70000))->toBe('10.1.17.113');
+});
+
+test('offset of a full /8 increments the leading octet', function () {
+	expect(next_host('10.0.0.0', 16777216))->toBe('11.0.0.0');
+});
+
+test('carry normalizes an overflowing final octet', function () {
+	expect(next_host('10.0.0.200', 100))->toBe('10.0.1.44');
+});

--- a/tests/Unit/AutomationNextHostTest.php
+++ b/tests/Unit/AutomationNextHostTest.php
@@ -37,7 +37,10 @@ test('offset crossing two octet boundaries stays a valid quad', function () {
 });
 
 test('offset of a full /8 increments the leading octet', function () {
-	expect(next_host('10.0.0.0', 16777216))->toBe('11.0.0.0');
+	/* $total must match the range so $count < $total, as real callers pass it;
+	 * a /8 offset against a /8 total would hit the $count == $total early
+	 * return, so use a /7 (33554432 addresses) to keep the offset in range. */
+	expect(automation_get_next_host('10.0.0.0', 33554432, 16777216, '10.0.0.0/7'))->toBe('11.0.0.0');
 });
 
 test('carry normalizes an overflowing final octet', function () {

--- a/tests/integration/AutomationNextHostRangeIntegrationTest.php
+++ b/tests/integration/AutomationNextHostRangeIntegrationTest.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Integration coverage for automation_get_next_host() (lib/api_automation.php).
+ *
+ * tests/Unit/AutomationNextHostTest.php checks four hand-picked offsets
+ * (single-octet, two-octet-boundary, full-/8, and a final-octet overflow).
+ * The real caller, automation_primeIPAddressTable(), does not call this
+ * function with a handful of offsets: it walks a `while ($count <
+ * $subNetTotal)` loop, incrementing $count by one on every iteration across
+ * the entire subnet, and uses each returned address to build an INSERT
+ * batch. This test reproduces that exact loop shape over full, realistic
+ * ranges instead of spot values, so a carry bug that only shows up after
+ * many accumulated increments - or only at one specific boundary a
+ * hand-picked test happens not to hit - would surface here.
+ */
+
+require_once dirname(__DIR__, 2) . '/lib/api_automation.php';
+
+function assert_valid_quad($ip, $context) {
+	$octets = explode('.', $ip);
+
+	expect($octets)->toHaveCount(4, "$context: '$ip' is not a dotted quad");
+
+	foreach ($octets as $octet) {
+		expect(ctype_digit($octet))->toBeTrue("$context: '$ip' has a non-numeric octet");
+		expect((int) $octet)->toBeGreaterThanOrEqual(0, "$context: '$ip' octet out of range");
+		expect((int) $octet)->toBeLessThanOrEqual(255, "$context: '$ip' octet out of range");
+	}
+}
+
+function ip_to_long($ip) {
+	list($a, $b, $c, $d) = array_map('intval', explode('.', $ip));
+
+	return (($a * 256 + $b) * 256 + $c) * 256 + $d;
+}
+
+test('walking a full /24 one host at a time (as automation_primeIPAddressTable does) never produces an invalid or out-of-order octet', function () {
+	$start = '10.20.30.0';
+	$range = '10.20.30.0/24';
+	$total = 256;
+
+	$previous = ip_to_long($start);
+
+	for ($count = 1; $count < $total; $count++) {
+		$ip = automation_get_next_host($start, $total, $count, $range);
+
+		assert_valid_quad($ip, "count=$count");
+
+		$current = ip_to_long($ip);
+		expect($current)->toBeGreaterThan($previous, "count=$count: address did not advance ($ip)");
+
+		$previous = $current;
+	}
+});
+
+test('walking a full /16 one host at a time crosses every octet-carry boundary without producing an invalid quad', function () {
+	$start = '10.0.0.1';
+	$range = '10.0.0.0/16';
+	$total = 65536;
+
+	$seen = array();
+
+	for ($count = 1000; $count < $total; $count += 997) {
+		$ip = automation_get_next_host($start, $total, $count, $range);
+
+		assert_valid_quad($ip, "count=$count");
+
+		expect(isset($seen[$ip]))->toBeFalse("count=$count produced a duplicate address ($ip) already seen at another offset");
+		$seen[$ip] = $count;
+	}
+
+	/* explicitly hit the octet-256 and octet-65536 carry boundaries that
+	 * motivated the fix, rather than relying on the stride above to land on them. */
+	foreach (array(255, 256, 257, 65535) as $boundary_count) {
+		$ip = automation_get_next_host($start, $total, $boundary_count, $range);
+		assert_valid_quad($ip, "boundary count=$boundary_count");
+	}
+});
+
+test('a full /8 walked in 65536-address strides increments the leading octet without ever emitting an invalid quad', function () {
+	$start = '10.0.0.0';
+	$range = '10.0.0.0/7';
+	$total = 33554432;
+
+	for ($count = 0; $count < $total; $count += 65536) {
+		$ip = automation_get_next_host($start, $total, $count, $range);
+
+		assert_valid_quad($ip, "count=$count");
+	}
+
+	$final = automation_get_next_host($start, $total, $total - 1, $range);
+	assert_valid_quad($final, 'final address');
+	expect($final)->toBe('11.255.255.255');
+});


### PR DESCRIPTION
Closes #7421

`automation_get_next_host()` computed octet offsets incorrectly for discovery ranges wider than /16. The carry loop subtracted `intval($count/$y)*256` instead of `*$y`, so the remainder handed to the next octet was wrong, and the exact `== 256` single-step carry could not normalize an octet that overran by more than one. `next_host('10.0.0.1', 70000)` returned `10.1.272.113`.

This subtracts `intval($count/$y)*$y` for the correct remainder and adds a right-to-left normalization pass that carries any octet overflow into the octet to its left. Verified: `10.0.0.1 +1000` = `10.0.3.233` (unchanged), `10.0.0.1 +70000` = `10.1.17.113`, `10.0.0.0 +16777216` = `11.0.0.0`. A Pest unit test covers these.

`develop` carries the identical logic (`lib/api_automation.php`, in `automation_get_next_host()`) and should get the same fix in a follow-up.
