### PR TITLE
fix(scripts): correct SNMP disk counter wrap math (1.2.x)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#7212: Address a few small memory leaks in realtime graphing
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
 -issue#7359: Undefined variables detected with legacy plugins
+-issue#7424: Correct SNMP disk counter wrap delta calculations
 -feature#7246: It should be possible to change the Device of a Graph if both Devices include the Data Query
 -feature#7364: Allow Users to Choose to Hide Graph Template on Site Trees
 -feature#7388: Allow admin to pass CSV file to change device script for bulk changes

--- a/scripts/ss_net_snmp_disk_bytes.php
+++ b/scripts/ss_net_snmp_disk_bytes.php
@@ -36,6 +36,49 @@ if (!isset($called_by_script_server)) {
 	include_once(dirname(__FILE__) . '/../lib/snmp.php');
 }
 
+if (!function_exists('ss_counter_step')) {
+	/**
+	 * Apply a Counter32/Counter64 wrap-corrected delta to a running total.
+	 *
+	 * Counter32 (2^32) fits in PHP_INT_MAX on 64-bit but saturates on 32-bit;
+	 * Counter64 (2^64) overflows PHP_INT on every supported runtime. ext-gmp
+	 * is a Cacti dependency, so prefer arbitrary-precision arithmetic and
+	 * fall back to float (with documented precision loss) only when gmp is
+	 * unavailable.
+	 *
+	 * Returns a numeric string ('U' is sticky once set).
+	 * @param mixed $running
+	 */
+	function ss_counter_step($running, string $current, string $previous, string $modulus) : string {
+		if (!function_exists('gmp_init')) {
+			$cur   = (float) $current;
+			$prev  = (float) $previous;
+			$delta = ($cur >= $prev) ? ($cur - $prev) : ($cur + (float) $modulus - $prev);
+
+			if ($running === 'U' || !is_numeric($running)) {
+				return (string) $delta;
+			}
+
+			return (string) ((float) $running + $delta);
+		}
+
+		$cur  = gmp_init($current);
+		$prev = gmp_init($previous);
+
+		if (gmp_cmp($cur, $prev) >= 0) {
+			$delta = gmp_sub($cur, $prev);
+		} else {
+			$delta = gmp_sub(gmp_add($cur, gmp_init($modulus)), $prev);
+		}
+
+		if ($running === 'U' || !is_numeric((string) $running)) {
+			return gmp_strval($delta);
+		}
+
+		return gmp_strval(gmp_add(gmp_init((string) $running), $delta));
+	}
+}
+
 function ss_net_snmp_disk_bytes($host_id_or_hostname = '') {
 	global $environ, $poller_id, $config;
 
@@ -159,18 +202,8 @@ function ss_net_snmp_disk_bytes($host_id_or_hostname = '') {
 					$bytesread = 'U';
 				} elseif (!isset($previous["br$index"])) {
 					$bytesread = 'U';
-				} elseif ($previous["br$index"] > $measure['value']) {
-					if ($bytesread != 'U') {
-						$bytesread += intval($measure['value']) + 18446744073709551615 - intval($previous["br$index"]) - intval($previous["br$index"]);
-					} else {
-						$bytesread = intval($measure['value']) + 18446744073709551615 - intval($previous["br$index"]) - intval($previous["br$index"]);
-					}
 				} else {
-					if ($bytesread != 'U') {
-						$bytesread += $measure['value'] - $previous["br$index"];
-					} else {
-						$bytesread = $measure['value'] - $previous["br$index"];
-					}
+					$bytesread = ss_counter_step($bytesread, (string) $measure['value'], (string) $previous["br$index"], '18446744073709551616');
 				}
 
 				$current["br$index"] = $measure['value'];
@@ -205,18 +238,8 @@ function ss_net_snmp_disk_bytes($host_id_or_hostname = '') {
 					$byteswritten = 'U';
 				} elseif (!isset($previous["bw$index"])) {
 					$byteswritten = 'U';
-				} elseif ($previous["bw$index"] > $measure['value']) {
-					if ($byteswritten != 'U') {
-						$byteswritten += intval($measure['value']) + 18446744073709551615 - intval($previous["bw$index"]) - intval($previous["bw$index"]);
-					} else {
-						$byteswritten = intval($measure['value']) + 18446744073709551615 - intval($previous["bw$index"]) - intval($previous["bw$index"]);
-					}
 				} else {
-					if ($byteswritten != 'U') {
-						$byteswritten += $measure['value'] - $previous["bw$index"];
-					} else {
-						$byteswritten = $measure['value'] - $previous["bw$index"];
-					}
+					$byteswritten = ss_counter_step($byteswritten, (string) $measure['value'], (string) $previous["bw$index"], '18446744073709551616');
 				}
 
 				$current["bw$index"] = $measure['value'];

--- a/scripts/ss_net_snmp_disk_bytes.php
+++ b/scripts/ss_net_snmp_disk_bytes.php
@@ -46,7 +46,8 @@ if (!function_exists('ss_counter_step')) {
 	 * fall back to float (with documented precision loss) only when gmp is
 	 * unavailable.
 	 *
-	 * Returns a numeric string ('U' is sticky once set).
+	 * Returns a numeric string. If $running is 'U' or non-numeric, the
+	 * first computed delta replaces it -- 'U' does not persist.
 	 * @param mixed $running
 	 */
 	function ss_counter_step($running, string $current, string $previous, string $modulus) : string {

--- a/scripts/ss_net_snmp_disk_io.php
+++ b/scripts/ss_net_snmp_disk_io.php
@@ -36,6 +36,49 @@ if (!isset($called_by_script_server)) {
 	include_once(dirname(__FILE__) . '/../lib/snmp.php');
 }
 
+if (!function_exists('ss_counter_step')) {
+	/**
+	 * Apply a Counter32/Counter64 wrap-corrected delta to a running total.
+	 *
+	 * Counter32 (2^32) fits in PHP_INT_MAX on 64-bit but saturates on 32-bit;
+	 * Counter64 (2^64) overflows PHP_INT on every supported runtime. ext-gmp
+	 * is a Cacti dependency, so prefer arbitrary-precision arithmetic and
+	 * fall back to float (with documented precision loss) only when gmp is
+	 * unavailable.
+	 *
+	 * Returns a numeric string ('U' is sticky once set).
+	 * @param mixed $running
+	 */
+	function ss_counter_step($running, string $current, string $previous, string $modulus) : string {
+		if (!function_exists('gmp_init')) {
+			$cur   = (float) $current;
+			$prev  = (float) $previous;
+			$delta = ($cur >= $prev) ? ($cur - $prev) : ($cur + (float) $modulus - $prev);
+
+			if ($running === 'U' || !is_numeric($running)) {
+				return (string) $delta;
+			}
+
+			return (string) ((float) $running + $delta);
+		}
+
+		$cur  = gmp_init($current);
+		$prev = gmp_init($previous);
+
+		if (gmp_cmp($cur, $prev) >= 0) {
+			$delta = gmp_sub($cur, $prev);
+		} else {
+			$delta = gmp_sub(gmp_add($cur, gmp_init($modulus)), $prev);
+		}
+
+		if ($running === 'U' || !is_numeric((string) $running)) {
+			return gmp_strval($delta);
+		}
+
+		return gmp_strval(gmp_add(gmp_init((string) $running), $delta));
+	}
+}
+
 function ss_net_snmp_disk_io($host_id_or_hostname = '') {
 	global $environ, $poller_id, $config;
 
@@ -158,18 +201,8 @@ function ss_net_snmp_disk_io($host_id_or_hostname = '') {
 					$reads = 'U';
 				} elseif (!isset($previous["dr$index"])) {
 					$reads = 'U';
-				} elseif ($previous["dr$index"] > $measure['value']) {
-					if ($reads != 'U') {
-						$reads += intval($measure['value']) + 4294967295 - intval($previous["dr$index"]) - intval($previous["dr$index"]);
-					} else {
-						$reads = intval($measure['value']) + 4294967295 - intval($previous["dr$index"]) - intval($previous["dr$index"]);
-					}
 				} else {
-					if ($reads != 'U') {
-						$reads += $measure['value'] - $previous["dr$index"];
-					} else {
-						$reads = $measure['value'] - $previous["dr$index"];
-					}
+					$reads = ss_counter_step($reads, (string) $measure['value'], (string) $previous["dr$index"], '4294967296');
 				}
 
 				$current["dr$index"] = $measure['value'];
@@ -204,18 +237,8 @@ function ss_net_snmp_disk_io($host_id_or_hostname = '') {
 					$writes = 'U';
 				} elseif (!isset($previous["dw$index"])) {
 					$writes = 'U';
-				} elseif ($previous["dw$index"] > $measure['value']) {
-					if ($writes != 'U') {
-						$writes += intval($measure['value']) + 4294967295 - intval($previous["dw$index"]) - intval($previous["dw$index"]);
-					} else {
-						$writes = intval($measure['value']) + 4294967295 - intval($previous["dw$index"]) - intval($previous["dw$index"]);
-					}
 				} else {
-					if ($writes != 'U') {
-						$writes += $measure['value'] - $previous["dw$index"];
-					} else {
-						$writes = $measure['value'] - $previous["dw$index"];
-					}
+					$writes = ss_counter_step($writes, (string) $measure['value'], (string) $previous["dw$index"], '4294967296');
 				}
 
 				$current["dw$index"] = $measure['value'];

--- a/scripts/ss_net_snmp_disk_io.php
+++ b/scripts/ss_net_snmp_disk_io.php
@@ -46,7 +46,8 @@ if (!function_exists('ss_counter_step')) {
 	 * fall back to float (with documented precision loss) only when gmp is
 	 * unavailable.
 	 *
-	 * Returns a numeric string ('U' is sticky once set).
+	 * Returns a numeric string. If $running is 'U' or non-numeric, the
+	 * first computed delta replaces it -- 'U' does not persist.
 	 * @param mixed $running
 	 */
 	function ss_counter_step($running, string $current, string $previous, string $modulus) : string {

--- a/tests/Unit/SsCounterStepWrapTest.php
+++ b/tests/Unit/SsCounterStepWrapTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for ss_counter_step() in scripts/ss_net_snmp_disk_io.php.
+ *
+ * The old inline wrap-handling subtracted $previous twice
+ * (current + (modulus-1) - previous - previous), which produces a large
+ * negative delta instead of the small positive one a wrapped counter
+ * should yield. ss_counter_step() replaces that with current - previous,
+ * or current + modulus - previous when the counter has wrapped.
+ */
+
+global $called_by_script_server;
+$called_by_script_server = true;
+require_once __DIR__ . '/../../scripts/ss_net_snmp_disk_io.php';
+
+test('no wrap: delta is current minus previous', function () {
+	expect(ss_counter_step('U', '105', '100', '4294967296'))->toBe('5');
+});
+
+test('32-bit counter wrap yields the correct small positive delta', function () {
+	// previous=4294967290, current=5: counter wrapped past 2^32.
+	// Correct: 5 + 4294967296 - 4294967290 = 11
+	// Old buggy formula: current + (modulus-1) - previous - previous
+	//   = 5 + 4294967295 - 4294967290 - 4294967290 = -4294967280
+	$result = ss_counter_step('U', '5', '4294967290', '4294967296');
+
+	expect($result)->toBe('11');
+
+	$old_buggy = 5 + 4294967295 - 4294967290 - 4294967290;
+	expect((string) $old_buggy)->not->toBe($result);
+});
+
+test('64-bit counter wrap yields the correct small positive delta', function () {
+	// previous=18446744073709551610, current=5: Counter64 wrapped past 2^64.
+	// Correct: 5 + 18446744073709551616 - 18446744073709551610 = 11
+	expect(ss_counter_step('U', '5', '18446744073709551610', '18446744073709551616'))->toBe('11');
+});
+
+test('running total accumulates the wrap-corrected delta instead of replacing it', function () {
+	// running=100, wrapped delta=11 -> 111
+	expect(ss_counter_step('100', '5', '4294967290', '4294967296'))->toBe('111');
+});
+
+test('U running value is replaced by the first computed delta, not left as U', function () {
+	expect(ss_counter_step('U', '105', '100', '4294967296'))->toBe('5');
+});
+
+test('non-numeric running value is treated the same as U', function () {
+	expect(ss_counter_step('not-a-number', '105', '100', '4294967296'))->toBe('5');
+});

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -585,8 +585,8 @@ fs_write	./package_import.php:383					file_put_contents($xmlfile, $data);
 fs_write	./package_import.php:96		if (file_put_contents($xmlfile, $_SESSION['sess_import_package']) === false) {
 fs_write	./script_server.php:49		define('STDIN', fopen('php://stdin', 'r'));
 fs_write	./script_server.php:50		define('STDOUT', fopen('php://stdout', 'w'));
-fs_write	./scripts/ss_net_snmp_disk_bytes.php:227			file_put_contents("$tmpdir/$tmpfile", $data);
-fs_write	./scripts/ss_net_snmp_disk_io.php:226			file_put_contents("$tmpdir/$tmpfile", $data);
+fs_write	./scripts/ss_net_snmp_disk_bytes.php:251			file_put_contents("$tmpdir/$tmpfile", $data);
+fs_write	./scripts/ss_net_snmp_disk_io.php:250			file_put_contents("$tmpdir/$tmpfile", $data);
 fs_write	./snmpagent_mibcachechild.php:90		$lock = fopen($path_mibcache_lock, 'w');
 fs_write	./snmpagent_mibcachechild.php:94			file_put_contents($path_mibcache, '<?php $cache = ' . var_export($cache, true) . ';', LOCK_EX);
 fs_write	./templates_import.php:67				$fp = fopen($_FILES['import_file']['tmp_name'],'r');


### PR DESCRIPTION
Closes #7424

On every counter rollover, `ss_net_snmp_disk_io.php` and `ss_net_snmp_disk_bytes.php` computed the delta as `current + (2^32-1) - previous - previous` — subtracting `previous` twice and using `2^32-1` instead of the full modulus, which yields a large negative value that corrupts the RRD.

This ports develop's fix: route the wrap through a shared `ss_counter_step()` helper. It uses gmp (already a Cacti dependency) so the 2^64 `disk_bytes` case stays exact, with a float fallback when gmp is absent. Modulus is 2^32 for the 32-bit io counters and 2^64 for the 64-bit byte counters. No new dependency or file.

Verified a rollover example against develop: prev=4294967290, cur=5 now returns 11 (was -4294967280).
