### PR TITLE
fix: guard process registration against pid reuse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#7212: Address a few small memory leaks in realtime graphing
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
 -issue#7359: Undefined variables detected with legacy plugins
+-issue#7425: Guard process registration and cleanup against PID reuse
 -feature#7246: It should be possible to change the Device of a Graph if both Devices include the Data Query
 -feature#7364: Allow Users to Choose to Hide Graph Template on Site Trees
 -feature#7388: Allow admin to pass CSV file to change device script for bulk changes

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -1203,7 +1203,7 @@ function dsstats_kill_running_processes() {
 	if (cacti_sizeof($processes)) {
 		foreach($processes as $p) {
 			if (cacti_process_still_running($p['pid'])) {
-				cacti_log(sprintf('WARNING: Killing DSStats %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'BOOST');
+				cacti_log(sprintf('WARNING: Killing DSStats %s PID %d due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'BOOST');
 				posix_kill($p['pid'], SIGTERM);
 			}
 

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -1202,8 +1202,10 @@ function dsstats_kill_running_processes() {
 
 	if (cacti_sizeof($processes)) {
 		foreach($processes as $p) {
-			cacti_log(sprintf('WARNING: Killing DSStats %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'BOOST');
-			posix_kill($p['pid'], SIGTERM);
+			if (cacti_process_still_running($p['pid'])) {
+				cacti_log(sprintf('WARNING: Killing DSStats %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'BOOST');
+				posix_kill($p['pid'], SIGTERM);
+			}
 
 			unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], $p['pid']);
 		}

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2369,6 +2369,41 @@ function get_remote_poller_ids_from_devices(&$devices) {
 }
 
 /**
+ * cacti_process_still_running - determine whether a registered pid is still
+ *   alive and still belongs to the process that registered it.
+ *
+ *   A bare posix_kill($pid, 0) only proves that *some* process owns the pid.
+ *   After a registered process dies without unregistering, the OS can recycle
+ *   its pid for an unrelated program; trusting the bare pid then blocks a
+ *   legitimate task from starting or sends SIGTERM to the wrong process.  On
+ *   Linux we compare /proc/<pid>/comm against our own command name as a
+ *   no-schema identity check (the processes table stores no start-time).  When
+ *   /proc is unavailable (non-Linux or restricted) we fall back to the bare
+ *   existence test, preserving prior behaviour.
+ *
+ * @param  (int)  $pid - the pid recorded in the processes table
+ *
+ * @return (bool) true if the pid is running and cannot be shown to be a reused
+ *                pid belonging to a different program
+ */
+function cacti_process_still_running($pid) {
+	$pid = intval($pid);
+
+	if ($pid <= 0 || !function_exists('posix_kill') || !posix_kill($pid, 0)) {
+		return false;
+	}
+
+	$self  = @file_get_contents('/proc/' . getmypid() . '/comm');
+	$other = @file_get_contents('/proc/' . $pid . '/comm');
+
+	if ($self !== false && $other !== false) {
+		return trim($self) === trim($other);
+	}
+
+	return true;
+}
+
+/**
  * register_process_start - public function to register a process
  *   in Cacti's process table
  *
@@ -2397,34 +2432,36 @@ function register_process_start($tasktype, $taskname, $taskid = 0, $timeout = 30
 		AND taskid = ?',
 		array($tasktype, $taskname, $taskid));
 
-	if (!cacti_sizeof($r)) {
-		cacti_log(sprintf('NOTE: Registering process! (%s, %s, %s, %s)', $tasktype, $taskname, $taskid, $pid), false, 'POLLER', POLLER_VERBOSITY_MEDIUM);
+		if (!cacti_sizeof($r)) {
+			cacti_log(sprintf('NOTE: Registering process! (%s, %s, %s, %s)', $tasktype, $taskname, $taskid, $pid), false, 'POLLER', POLLER_VERBOSITY_MEDIUM);
 
-		register_process($tasktype, $taskname, $taskid, $pid, $timeout);
-	} elseif ($r['timeout_exceeded']) {
-		$timeout_pid = (int) $r['pid'];
-
-		if (is_system_pid($timeout_pid)) {
-			// mirror timeout_kill_registered_processes(): never signal a reserved
-			// system PID from the registry, but still clear and re-register
-			cacti_log(sprintf('WARNING: Refusing to kill registered process with a reserved system PID! (%s, %s, %s, %s)', $tasktype, $taskname, $taskid, $r['pid']), false, 'POLLER');
-
-			unregister_process($tasktype, $taskname, $taskid);
 			register_process($tasktype, $taskname, $taskid, $pid, $timeout);
-		} elseif ($timeout_pid > 0) {
-			cacti_log(sprintf('ERROR: Process being killed due to timeout! (%s, %s, %s, Process %s, Time %s, Timeout %s, Timestamp %s)', $tasktype, $taskname, $taskid, $r['pid'], $r['timeout_exceeded'], $r['timeout'], $r['current_timestamp']), false, 'POLLER');
+		} elseif ($r['timeout_exceeded']) {
+			$timeout_pid = (int) $r['pid'];
 
-			posix_kill($timeout_pid, SIGTERM);
+			if (is_system_pid($timeout_pid)) {
+				// mirror timeout_kill_registered_processes(): never signal a reserved
+				// system PID from the registry, but still clear and re-register
+				cacti_log(sprintf('WARNING: Refusing to kill registered process with a reserved system PID! (%s, %s, %s, %s)', $tasktype, $taskname, $taskid, $r['pid']), false, 'POLLER');
 
-			unregister_process($tasktype, $taskname, $taskid);
-			register_process($tasktype, $taskname, $taskid, $pid, $timeout);
+				unregister_process($tasktype, $taskname, $taskid);
+				register_process($tasktype, $taskname, $taskid, $pid, $timeout);
+			} elseif ($timeout_pid > 0) {
+				if (cacti_process_still_running($timeout_pid)) {
+					cacti_log(sprintf('ERROR: Process being killed due to timeout! (%s, %s, %s, Process %s, Time %s, Timeout %s, Timestamp %s)', $tasktype, $taskname, $taskid, $r['pid'], $r['timeout_exceeded'], $r['timeout'], $r['current_timestamp']), false, 'POLLER');
+
+					posix_kill($timeout_pid, SIGTERM);
+				}
+
+				unregister_process($tasktype, $taskname, $taskid);
+				register_process($tasktype, $taskname, $taskid, $pid, $timeout);
 		} else {
 			// Should never be reached
 			cacti_log(sprintf('ERROR: Failed registering process.  Invalid pid found.  Unable to kill! (%s, %s, %s, %s)', $tasktype, $taskname, $taskid, $r['pid']), false, 'POLLER');
 
 			return false;
 		}
-	} elseif ($r['pid'] > 0 && posix_kill($r['pid'], 0)) {
+	} elseif (cacti_process_still_running($r['pid'])) {
 		cacti_log(sprintf('NOTE: Failed registering process.  Old process still running and has not timed out! (%s, %s, %s, %s)', $tasktype, $taskname, $taskid, $pid), false, 'POLLER', POLLER_VERBOSITY_MEDIUM);
 
 		return false;
@@ -2575,7 +2612,7 @@ function timeout_kill_registered_processes($tasktype = '', $taskname = '', $task
 
 			if (is_system_pid($pid)) {
 				cacti_log(sprintf('WARNING: Refusing to kill registered process with a reserved system PID! (%s, %s, %s, %s)', $r['tasktype'], $r['taskname'], $r['taskid'], $r['pid']), false, 'POLLER');
-			} elseif (posix_kill($pid, 0)) {
+			} elseif (cacti_process_still_running($pid)) {
 				cacti_log(sprintf('ERROR: Process killed due to timeout! (%s, %s, %s, %s)', $r['tasktype'], $r['taskname'], $r['taskid'], $r['pid']), false, 'POLLER');
 				posix_kill($pid, SIGTERM);
 			} else {
@@ -2586,4 +2623,3 @@ function timeout_kill_registered_processes($tasktype = '', $taskname = '', $task
 		}
 	}
 }
-

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2400,7 +2400,11 @@ function cacti_process_still_running($pid) {
 		return trim($self) === trim($other);
 	}
 
-	return true;
+	/* /proc is unavailable (non-Linux or restricted): fall back to the bare
+	 * existence test, but re-check it here rather than trusting the result
+	 * from the top of the function, which can now be stale if the pid exited
+	 * in the window between that check and these file reads. */
+	return posix_kill($pid, 0);
 }
 
 /**

--- a/tests/Unit/Issue7414ProcessPidReuseGuardTest.php
+++ b/tests/Unit/Issue7414ProcessPidReuseGuardTest.php
@@ -1,0 +1,119 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * register_process_start(), timeout_kill_registered_processes(), and
+ * dsstats_kill_running_processes() used to trust a registered pid with a
+ * bare `posix_kill($pid, 0)`. If the registered process died without
+ * unregistering and the OS recycled its pid for an unrelated program, the
+ * bare check couldn't tell the difference: it would refuse to start a
+ * legitimate new task, or SIGTERM a process that never had anything to do
+ * with Cacti. The fix adds cacti_process_still_running(), which layers a
+ * /proc/<pid>/comm identity check on Linux, and routes all three call
+ * sites through it instead of the bare posix_kill($pid, 0).
+ */
+
+require_once dirname(__DIR__, 2) . '/lib/poller.php';
+
+/*
+ * On hosts without /proc (macOS/BSD test runners), cacti_process_still_running()
+ * hits its own @file_get_contents() fallback path, which is intentionally
+ * suppressed in the fix itself. PHPUnit's error handler intercepts E_WARNING
+ * regardless of the "@" operator, so calls that can reach that path are
+ * wrapped here to keep the suppression the fix already declared.
+ */
+$stillRunning = function ($pid) {
+	set_error_handler(function () {
+		return true;
+	});
+
+	try {
+		return cacti_process_still_running($pid);
+	} finally {
+		restore_error_handler();
+	}
+};
+
+test('rejects non-positive pids outright', function () use ($stillRunning) {
+	expect($stillRunning(0))->toBeFalse();
+	expect($stillRunning(-1))->toBeFalse();
+});
+
+test('returns false for a pid that is not running', function () use ($stillRunning) {
+	// PID_MAX_LIMIT on Linux is 4194304; on macOS/BSD pids are 16-bit.
+	// 999999999 is not an assignable pid on any of these, so posix_kill
+	// with signal 0 must fail with ESRCH.
+	expect($stillRunning(999999999))->toBeFalse();
+});
+
+test('returns true for the currently running process (self)', function () use ($stillRunning) {
+	// Comparing /proc/self/comm to /proc/<pid>/comm (or falling back to
+	// the bare existence check when /proc is unavailable) must agree
+	// that our own pid is both alive and not a reused identity.
+	expect($stillRunning(getmypid()))->toBeTrue();
+});
+
+test('tracks a real child process through its start/exit lifecycle', function () use ($stillRunning) {
+	$descriptors = array(1 => array('pipe', 'w'), 2 => array('pipe', 'w'));
+	$proc        = proc_open('sleep 5', $descriptors, $pipes);
+
+	expect($proc)->not->toBeFalse();
+
+	$status = proc_get_status($proc);
+	$pid    = $status['pid'];
+
+	expect($stillRunning($pid))->toBeTrue();
+
+	posix_kill($pid, SIGKILL);
+
+	foreach ($pipes as $pipe) {
+		fclose($pipe);
+	}
+
+	proc_close($proc);
+
+	// Give the OS a moment to reap the pid before asserting it is gone.
+	$deadline = microtime(true) + 2;
+
+	while (posix_kill($pid, 0) && microtime(true) < $deadline) {
+		usleep(50000);
+	}
+
+	expect($stillRunning($pid))->toBeFalse();
+});
+
+test('falls back to the bare existence check when /proc is unavailable', function () use ($stillRunning) {
+	if (is_dir('/proc')) {
+		test()->markTestSkipped('This host has /proc; the Linux comm-comparison path is exercised instead.');
+	}
+
+	// On non-Linux hosts (e.g. macOS/BSD) file_get_contents() on
+	// /proc/<pid>/comm always fails, so the function must fall back to
+	// treating a live pid as "still running" rather than defaulting to
+	// false and starving legitimate registrations.
+	expect($stillRunning(getmypid()))->toBeTrue();
+});
+
+test('register_process_start() and timeout_kill_registered_processes() route through the guard, not a bare posix_kill(pid, 0)', function () {
+	$src = file_get_contents(dirname(__DIR__, 2) . '/lib/poller.php');
+
+	expect(substr_count($src, 'cacti_process_still_running($r[\'pid\'])'))->toBe(3);
+	expect($src)->not->toContain('$r[\'pid\'] > 0 && posix_kill($r[\'pid\'], 0)');
+});
+
+test('dsstats_kill_running_processes() guards its SIGTERM with the same check', function () {
+	$src = file_get_contents(dirname(__DIR__, 2) . '/lib/dsstats.php');
+
+	$pos = strpos($src, 'function dsstats_kill_running_processes()');
+	expect($pos)->not->toBeFalse();
+
+	$fragment = substr($src, $pos, 700);
+
+	expect($fragment)->toContain('if (cacti_process_still_running($p[\'pid\'])) {');
+});


### PR DESCRIPTION
Closes #7425

`register_process_start()`, `timeout_kill_registered_processes()` and `dsstats_kill_running_processes()` trust a bare stored pid via `posix_kill(pid, 0)`. If a registered process dies without unregistering and the OS recycles its pid, the code either refuses to start the legitimate task ("Old process still running") or SIGTERMs an unrelated process.

Adds `cacti_process_still_running()`, which confirms the pid still shares this process's `/proc/<pid>/comm` before trusting it. If identity can't be confirmed it never signals: a reused pid now lets the new task start and is skipped for SIGTERM.

Limitation: the `processes` table has no start-time column, so identity uses comm-name only (no schema change here). The check is Linux-only; on non-`/proc` platforms it falls back to the prior existence test.
