### PR TITLE
fix: update host status by id instead of hostname

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#7212: Address a few small memory leaks in realtime graphing
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
 -issue#7359: Undefined variables detected with legacy plugins
+-issue#7427: Update device status by host id instead of non-unique hostname
 -feature#7246: It should be possible to change the Device of a Graph if both Devices include the Data Query
 -feature#7364: Allow Users to Choose to Hide Graph Template on Site Trees
 -feature#7388: Allow admin to pass CSV file to change device script for bulk changes

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1836,7 +1836,7 @@ function update_host_status($status, $host_id, &$ping, $ping_availability, $prin
 		total_polls = ?,
 		failed_polls = ?,
 		availability = ?
-		WHERE hostname = ?
+		WHERE id = ?
 		AND deleted = ""',
 		array(
 			$host['status'],
@@ -1851,7 +1851,7 @@ function update_host_status($status, $host_id, &$ping, $ping_availability, $prin
 			$host['total_polls'],
 			$host['failed_polls'],
 			$host['availability'],
-			$host['hostname']
+			$host['id']
 		)
 
 	);

--- a/tests/Unit/Issue7416UpdateHostStatusByIdTest.php
+++ b/tests/Unit/Issue7416UpdateHostStatusByIdTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * update_host_status() looks the host up by id ($host_id) but the closing
+ * UPDATE previously matched WHERE hostname = ? using $host['hostname'].
+ * Hostnames are not unique in Cacti (multiple devices commonly share one),
+ * so the write could silently update every host sharing that hostname
+ * instead of just the polled one. The fix scopes the UPDATE to the same
+ * id the row was read with. Structural check: the WHERE clause and its
+ * bound value must both key off id, not hostname.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../lib/functions.php');
+
+test('update_host_status() UPDATE is scoped by WHERE id = ?', function () use ($source) {
+	$pos = strpos($source, "db_execute_prepared('UPDATE host SET");
+	expect($pos)->not->toBeFalse();
+
+	$fragment = substr($source, $pos, 700);
+
+	expect($fragment)->toContain('WHERE id = ?');
+	expect($fragment)->not->toContain('WHERE hostname = ?');
+});
+
+test('update_host_status() binds $host[\'id\'] as the WHERE parameter, not $host[\'hostname\']', function () use ($source) {
+	$pos = strpos($source, "db_execute_prepared('UPDATE host SET");
+	expect($pos)->not->toBeFalse();
+
+	$fragment = substr($source, $pos, 900);
+
+	expect($fragment)->toContain("\$host['id']\n\t\t)");
+	expect($fragment)->not->toContain("\$host['hostname']");
+});


### PR DESCRIPTION
Closes #7427

update_host_status() loads the device with SELECT * FROM host WHERE id = ? and computes every counter (status_event_count, total_polls, failed_polls, availability, cur/min/max/avg_time) from that row's prior values, but writes the result back with WHERE hostname = ?. host.hostname is a non-unique key and Cacti permits the same hostname on several devices (added twice with different SNMP settings, ports, etc). When that happens each device's poll overwrites its siblings' status and availability, producing spurious flapping. Key the write on the primary id so it updates only the polled row. Kept the AND deleted = "" guard from #2937. develop carries the same pattern.
