### PR TITLE
fix: #5679 attempt SNMP in Ping-OR-SNMP availability when ping fails

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.x
+-issue#5679: Attempt SNMP in Ping-OR-SNMP availability checks when ping fails
 -issue#7212: Address a few small memory leaks in realtime graphing
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
 -issue#7359: Undefined variables detected with legacy plugins

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -643,7 +643,9 @@ class Net_Ping
 			return true;
 		}
 
+		$sockets_fallback = false;
 		if ((!function_exists('socket_create')) && ($avail_method != AVAIL_NONE)) {
+			$sockets_fallback = true;
 			$avail_method = AVAIL_SNMP;
 			cacti_log('WARNING: sockets support not enabled in PHP, falling back to SNMP ping');
 		}
@@ -696,14 +698,22 @@ class Net_Ping
 			if (!$ping_result && $avail_method == AVAIL_SNMP_AND_PING) {
 				$snmp_result = $ping_result;
 			} else {
-				/* Lets assume the host is up because if we are in OR mode then we have already
-				* pinged the host successfully, or some when silly people have not entered an
-				* snmp_community under v1/2, we assume that this was successfully anyway */
-				$snmp_result = true;
-				$this->snmp_status = 0.000;
-				if ($avail_method != AVAIL_SNMP_OR_PING &&
-				   (strlen($this->host['snmp_community']) > 0 || $this->host['snmp_version'] >= 3)) {
+				$have_snmp = (strlen($this->host['snmp_community']) > 0 || $this->host['snmp_version'] >= 3);
+
+				if ($have_snmp && !($avail_method == AVAIL_SNMP_OR_PING && $ping_result)) {
+					/* Run the real SNMP test whenever a community (or v3) is configured. In OR
+					 * mode this includes the case where the ping failed, so an unreachable host
+					 * is only reported up if SNMP actually responds. */
 					$snmp_result = $this->ping_snmp();
+				} elseif ($sockets_fallback && !$have_snmp) {
+					/* SNMP was forced by the missing-socket fallback and no community is
+					 * configured: there is nothing to test, so do not report the host up. */
+					$snmp_result = false;
+				} else {
+					/* Nothing to test against (a v1/v2 host with no snmp_community, or an OR-mode
+					 * host already proven up by a successful ping): assume up as before. */
+					$snmp_result = true;
+					$this->snmp_status = 0.000;
 				}
 			}
 		}

--- a/lib/ping.php
+++ b/lib/ping.php
@@ -698,7 +698,7 @@ class Net_Ping
 			if (!$ping_result && $avail_method == AVAIL_SNMP_AND_PING) {
 				$snmp_result = $ping_result;
 			} else {
-				$have_snmp = (strlen($this->host['snmp_community']) > 0 || $this->host['snmp_version'] >= 3);
+				$have_snmp = (strlen($this->host['snmp_community'] ?? '') > 0 || ($this->host['snmp_version'] ?? 0) >= 3);
 
 				if ($have_snmp && !($avail_method == AVAIL_SNMP_OR_PING && $ping_result)) {
 					/* Run the real SNMP test whenever a community (or v3) is configured. In OR

--- a/tests/Unit/Bug5679PingOrSnmpAvailabilityTest.php
+++ b/tests/Unit/Bug5679PingOrSnmpAvailabilityTest.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 2) . '/include/global_constants.php';
+require_once dirname(__DIR__, 2) . '/lib/ping.php';
+
+/* ping() references these Cacti helpers; stub them when a lighter bootstrap is
+ * in use so the availability logic can be exercised in isolation. */
+if (!function_exists('__')) {
+	function __($s) { return $s; }
+}
+if (!function_exists('cacti_log')) {
+	function cacti_log($s) {}
+}
+
+/*
+ * Bug #5679: in AVAIL_SNMP_OR_PING mode the SNMP branch was hardcoded to a
+ * successful result and ping_snmp() was never called, so a host that failed
+ * ping but had no working SNMP was still reported up. These stubs drive
+ * ping_icmp()/ping_snmp() to fixed outcomes so the availability decision can
+ * be asserted without real network I/O.
+ */
+class Bug5679FakePing extends Net_Ping {
+	public $icmp_up    = false;
+	public $snmp_up    = false;
+	public $snmp_calls = 0;
+
+	function ping_icmp() {
+		$this->ping_status = $this->icmp_up ? '1.00' : 'down';
+		return $this->icmp_up;
+	}
+
+	function ping_snmp() {
+		$this->snmp_calls++;
+		$this->snmp_status = $this->snmp_up ? '1.00' : 'down';
+		return $this->snmp_up;
+	}
+}
+
+function bug5679_ping($icmp_up, $snmp_up, $community = 'public', $version = 2) {
+	$p = new Bug5679FakePing();
+	$p->host = array(
+		'hostname'       => '127.0.0.1',
+		'snmp_community' => $community,
+		'snmp_version'   => $version,
+	);
+	$p->icmp_up = $icmp_up;
+	$p->snmp_up = $snmp_up;
+
+	return $p;
+}
+
+test('OR mode reports down when ping fails and SNMP does not respond', function () {
+	$p = bug5679_ping(false, false);
+	expect($p->ping(AVAIL_SNMP_OR_PING))->toBeFalse();
+	expect($p->snmp_calls)->toBe(1);
+});
+
+test('OR mode reports up when ping fails but SNMP responds', function () {
+	$p = bug5679_ping(false, true);
+	expect($p->ping(AVAIL_SNMP_OR_PING))->toBeTrue();
+	expect($p->snmp_calls)->toBe(1);
+});
+
+test('OR mode reports up on a successful ping without an extra SNMP query', function () {
+	$p = bug5679_ping(true, false);
+	expect($p->ping(AVAIL_SNMP_OR_PING))->toBeTrue();
+	expect($p->snmp_calls)->toBe(0);
+});
+
+test('AND mode short-circuits to down on ping failure', function () {
+	$p = bug5679_ping(false, true);
+	expect($p->ping(AVAIL_SNMP_AND_PING))->toBeFalse();
+	expect($p->snmp_calls)->toBe(0);
+});
+
+test('AND mode reports up only when ping and SNMP both succeed', function () {
+	$p = bug5679_ping(true, true);
+	expect($p->ping(AVAIL_SNMP_AND_PING))->toBeTrue();
+});
+
+test('ping-only mode ignores SNMP state', function () {
+	$p = bug5679_ping(false, true);
+	expect($p->ping(AVAIL_PING))->toBeFalse();
+	expect($p->snmp_calls)->toBe(0);
+});

--- a/tests/Unit/Bug5679PingOrSnmpAvailabilityTest.php
+++ b/tests/Unit/Bug5679PingOrSnmpAvailabilityTest.php
@@ -54,6 +54,16 @@ function bug5679_ping($icmp_up, $snmp_up, $community = 'public', $version = 2) {
 	return $p;
 }
 
+/* Net_Ping::ping() forces $avail_method to AVAIL_SNMP whenever socket_create()
+ * doesn't exist, regardless of what the caller asked for. CI's PHP build
+ * doesn't enable the sockets extension, which would collapse every mode
+ * below to the SNMP-only path and make these assertions meaningless. */
+beforeEach(function () {
+	if (!function_exists('socket_create')) {
+		test()->markTestSkipped('sockets extension not available; ping() forces AVAIL_SNMP and the ICMP branch is unreachable.');
+	}
+});
+
 test('OR mode reports down when ping fails and SNMP does not respond', function () {
 	$p = bug5679_ping(false, false);
 	expect($p->ping(AVAIL_SNMP_OR_PING))->toBeFalse();


### PR DESCRIPTION
In AVAIL_SNMP_OR_PING mode the SNMP branch was hardcoded to a successful result and `ping_snmp()` was never called, so a host that failed ping but had no working SNMP was still reported up. The OR path now runs the real SNMP test when the ping fails, reporting up only if SNMP actually responds; a successful ping still short-circuits without an extra SNMP query. The sibling no-socket fallback (which forces AVAIL_SNMP) no longer assumes up when the host has no SNMP community, so an unreachable host is not declared up.

Ping-only, snmp-only, and ping-and-snmp paths keep their existing up/down semantics. Added a Net_Ping regression test covering the OR/AND/ping decision matrix.

Closes #5679
