### PR TITLE
fix: monthly automation schedules corrupt next_start to 1970 and run every cycle

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Cacti CHANGELOG
 -issue#7212: Address a few small memory leaks in realtime graphing
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
 -issue#7359: Undefined variables detected with legacy plugins
+-issue#7429: Prevent monthly automation schedules from resetting next_start to 1970
 -feature#7246: It should be possible to change the Device of a Graph if both Devices include the Data Query
 -feature#7364: Allow Users to Choose to Hide Graph Template on Site Trees
 -feature#7388: Allow admin to pass CSV file to change device script for bulk changes

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -3802,10 +3802,10 @@ function calculateNextStart($net) {
 	/* Evaluate this year first; when every selected date has already passed,
 	   roll over to the next year so a valid monthly schedule never resolves to
 	   false (which the caller would otherwise store as a 1970 next_start). */
-	$next = calculateNextStartForYear($net, (int) date('Y'), $now);
+	$next = calculateNextStartForYear($net, (int) date('Y', $now), $now);
 
 	if ($next === false) {
-		$next = calculateNextStartForYear($net, (int) date('Y') + 1, $now);
+		$next = calculateNextStartForYear($net, (int) date('Y', $now) + 1, $now);
 	}
 
 	return $next;

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -3766,7 +3766,14 @@ function api_automation_is_time_to_start($network_id) {
 		break;
 	case '4':
 	case '5':
-		$next = calculateNextStart($net, $now);
+		$next = calculateNextStart($net);
+
+		/* No schedulable date was found (e.g. an incomplete schedule). Leave
+		   next_start untouched instead of writing a 1970 timestamp, which the
+		   run check below would then treat as due every poller cycle. */
+		if (empty($next)) {
+			return false;
+		}
 
 		db_execute_prepared('UPDATE automation_networks
 			SET next_start = ?
@@ -3790,8 +3797,22 @@ function api_automation_is_time_to_start($network_id) {
 }
 
 function calculateNextStart($net) {
-	$now    = time();
-	$dates  = array();
+	$now = time();
+
+	/* Evaluate this year first; when every selected date has already passed,
+	   roll over to the next year so a valid monthly schedule never resolves to
+	   false (which the caller would otherwise store as a 1970 next_start). */
+	$next = calculateNextStartForYear($net, (int) date('Y'), $now);
+
+	if ($next === false) {
+		$next = calculateNextStartForYear($net, (int) date('Y') + 1, $now);
+	}
+
+	return $next;
+}
+
+function calculateNextStartForYear($net, $year, $now) {
+	$dates = array();
 
 	switch($net['sched_type']) {
 	case '4':
@@ -3840,9 +3861,9 @@ function calculateNextStart($net) {
 				}
 
 				if ($day == '32') {
-					$dates[] = strtotime('last day of ' . $smonth);;
+					$dates[] = strtotime("last day of $smonth $year");
 				} else {
-					$dates[] = strtotime("$smonth $day");
+					$dates[] = strtotime("$smonth $day $year");
 				}
 			}
 		}
@@ -3852,8 +3873,6 @@ function calculateNextStart($net) {
 		$months = explode(',', $net['month']);
 		$weeks  = explode(',', $net['monthly_week']);
 		$days   = explode(',', $net['monthly_day']);
-		$now    = time();
-		$dates  = array();
 
 		foreach($months as $month) {
 			foreach($weeks as $week) {
@@ -3908,7 +3927,7 @@ function calculateNextStart($net) {
 						$sweek = 'third';
 						break;
 					case '4':
-						$sweek = 'forth';
+						$sweek = 'fourth';
 						break;
 					case '32':
 						$sweek = 'last';
@@ -3939,7 +3958,7 @@ function calculateNextStart($net) {
 						break;
 					}
 
-					$dates[] = strtotime("$sweek $sday of $smonth", strtotime($net['start_at']));
+					$dates[] = strtotime("$sweek $sday of $smonth $year");
 				}
 			}
 		}
@@ -3952,6 +3971,10 @@ function calculateNextStart($net) {
 	$newdates = array();
 
 	foreach($dates as $date) {
+		if ($date === false) {
+			continue;
+		}
+
 		$ndate = date('Y-m-d', $date) . ' ' . date('H:i:s', strtotime($net['start_at']));
 		$ntime = strtotime($ndate);
 

--- a/tests/Unit/AutomationMonthlyScheduleTest.php
+++ b/tests/Unit/AutomationMonthlyScheduleTest.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * calculateNextStart() built monthly candidate dates with the current year
+ * only and returned false once every selected date had passed. The caller
+ * then wrote date('Y-m-d H:i', false) = '1970-01-01', which the run check
+ * read as long overdue and fired discovery every poller cycle. Two smaller
+ * defects fed the same failure: the fourth-week label was misspelled 'forth'
+ * (strtotime() returns false), and the false return was stored verbatim.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../lib/api_automation.php');
+
+test('lib/api_automation.php spells the fourth week correctly', function () use ($source) {
+	expect($source)->toContain("\$sweek = 'fourth';");
+	expect(strpos($source, "\$sweek = 'forth';"))
+		->toBeFalse('the misspelled "forth" label must be gone');
+});
+
+test('monthly candidates are built for an explicit year', function () use ($source) {
+	expect($source)->toContain('strtotime("$smonth $day $year")');
+	expect($source)->toContain('strtotime("last day of $smonth $year")');
+	expect($source)->toContain('strtotime("$sweek $sday of $smonth $year")');
+});
+
+test('calculateNextStart guards against a false next_start', function () use ($source) {
+	expect($source)->toContain('function calculateNextStartForYear($net, $year, $now)');
+	expect($source)->toContain('if (empty($next)) {');
+});
+
+/* Local mirror of the fixed scan. calculateNextStart() cannot be included
+ * here without the full Cacti bootstrap, so this reproduces the year-rollover
+ * logic to prove behavior. */
+if (!function_exists('_test_next_start')) {
+	function _test_next_start($month_name, $day, $start_at, $now) {
+		foreach (array((int) date('Y', $now), (int) date('Y', $now) + 1) as $year) {
+			$dates = array(strtotime("$month_name $day $year"));
+
+			asort($dates);
+
+			foreach ($dates as $date) {
+				if ($date === false) {
+					continue;
+				}
+
+				$ntime = strtotime(date('Y-m-d', $date) . ' ' . date('H:i:s', strtotime($start_at)));
+
+				if ($ntime > $now) {
+					return $ntime;
+				}
+			}
+		}
+
+		return false;
+	}
+}
+
+test('a monthly schedule whose date already passed rolls into next year', function () {
+	$now = mktime(12, 0, 0, 7, 27, 2026);
+
+	$next = _test_next_start('January', 15, '2026-01-15 09:00:00', $now);
+
+	expect($next)->not->toBeFalse();
+	expect(date('Y', $next))->toBe('2027');
+});
+
+test('strtotime resolves the fourth weekday only with the corrected spelling', function () {
+	expect(strtotime('fourth Sunday of January 2027'))->not->toBeFalse();
+	expect((int) date('N', strtotime('fourth Sunday of January 2027')))->toBe(7);
+	expect(strtotime('forth Sunday of January 2027'))->toBeFalse();
+});

--- a/tests/integration/AutomationMonthlyScheduleIntegrationTest.php
+++ b/tests/integration/AutomationMonthlyScheduleIntegrationTest.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Integration coverage for calculateNextStart() / calculateNextStartForYear()
+ * (lib/api_automation.php).
+ *
+ * tests/Unit/AutomationMonthlyScheduleTest.php checks the fix's source
+ * fragments and re-implements the year-rollover scan in a local mirror
+ * function, because it assumed the real function "cannot be included ...
+ * without the full Cacti bootstrap". That is not the case: neither function
+ * touches the database or a Cacti global, so this test requires the real
+ * lib/api_automation.php and calls the real functions directly.
+ *
+ * The original bug was specifically about repeated/cumulative corruption:
+ * calculateNextStart() only scanned the current year, so once every date in
+ * a monthly schedule had passed for the year it returned false every single
+ * poller cycle, and the caller stored date('Y-m-d H:i', false) as
+ * '1970-01-01 00:00', which the run check then treated as perpetually due.
+ * A single-call unit test cannot show that "every cycle" failure mode; this
+ * test drives calculateNextStartForYear() across a simulated sequence of
+ * poller cycles (each cycle's $now taken from the previous cycle's computed
+ * next_start) and asserts the schedule keeps resolving to a real future date
+ * instead of ever collapsing to false/1970.
+ */
+
+require_once dirname(__DIR__, 2) . '/lib/api_automation.php';
+
+if (!isset($GLOBALS['config'])) {
+	/* automation_debug() prints to stdout when $config['is_web'] is falsy;
+	 * keep test output clean since we don't care about that log line here. */
+	$GLOBALS['config'] = array('is_web' => true);
+}
+
+function automation_next_start_for($net, $now) {
+	$next = calculateNextStartForYear($net, (int) date('Y', $now), $now);
+
+	if ($next === false) {
+		$next = calculateNextStartForYear($net, (int) date('Y', $now) + 1, $now);
+	}
+
+	return $next;
+}
+
+test('a day-of-month schedule never collapses to false/1970 across five simulated poller cycles', function () {
+	$net = array(
+		'sched_type'   => '4',
+		'month'        => '3',
+		'day_of_month' => '15',
+		'start_at'     => '09:00:00',
+	);
+
+	$now = mktime(12, 0, 0, 1, 1, 2026);
+
+	for ($cycle = 0; $cycle < 5; $cycle++) {
+		$next = automation_next_start_for($net, $now);
+
+		expect($next)->not->toBeFalse("cycle $cycle collapsed to false");
+		expect($next)->toBeGreaterThan($now);
+		expect(date('Y', $next))->not->toBe('1970');
+
+		/* advance "now" past the computed next_start, as the poller would
+		 * on its following run once the schedule fires. */
+		$now = $next + 86400;
+	}
+});
+
+test('a last-day-of-month schedule (day 32) never collapses to false/1970 across cycles', function () {
+	$net = array(
+		'sched_type'   => '4',
+		'month'        => '2',
+		'day_of_month' => '32',
+		'start_at'     => '23:00:00',
+	);
+
+	$now = mktime(0, 0, 0, 1, 1, 2026);
+
+	for ($cycle = 0; $cycle < 4; $cycle++) {
+		$next = automation_next_start_for($net, $now);
+
+		expect($next)->not->toBeFalse("cycle $cycle collapsed to false");
+		expect(date('Y', $next))->not->toBe('1970');
+
+		$now = $next + 86400;
+	}
+});
+
+test('a fourth-week-of-month schedule (sched_type 5) never collapses to false/1970 across cycles', function () {
+	$net = array(
+		'sched_type'   => '5',
+		'month'        => '6',
+		'monthly_week' => '4',
+		'monthly_day'  => '1',
+		'start_at'     => '06:00:00',
+	);
+
+	$now = mktime(0, 0, 0, 1, 1, 2026);
+
+	for ($cycle = 0; $cycle < 4; $cycle++) {
+		$next = automation_next_start_for($net, $now);
+
+		expect($next)->not->toBeFalse("cycle $cycle collapsed to false (the 'forth' misspelling regression would show up here)");
+		expect(date('Y', $next))->not->toBe('1970');
+
+		$now = $next + 86400;
+	}
+});
+
+test('once every date in the current year has passed, the schedule rolls to next year instead of failing', function () {
+	$net = array(
+		'sched_type'   => '4',
+		'month'        => '1',
+		'day_of_month' => '15',
+		'start_at'     => '09:00:00',
+	);
+
+	/* simulate "now" already past January 15th of the schedule's year */
+	$now = mktime(12, 0, 0, 6, 1, 2026);
+
+	$next = automation_next_start_for($net, $now);
+
+	expect($next)->not->toBeFalse();
+	expect((int) date('Y', $next))->toBe(2027);
+	expect((int) date('n', $next))->toBe(1);
+	expect((int) date('j', $next))->toBe(15);
+});


### PR DESCRIPTION
Closes #7429

Monthly network-discovery schedules (sched_type 4/5) build candidate dates for the current year only. When every selected date has passed, `calculateNextStart()` returned `false`, which the caller wrote as `date('Y-m-d H:i', false)` = `1970-01-01`; the run check then treats that as due every poller cycle.

- Split into `calculateNextStart()` (this year, then next year) + `calculateNextStartForYear($net, $year, $now)` so a valid schedule never resolves to false.
- Fix `$sweek = 'forth'` typo (`strtotime('forth Sunday of ...')` is false) -> `'fourth'`.
- Guard the caller so a false result leaves `next_start` untouched instead of writing 1970.

1.2.x only (develop uses a different scheduler). Includes `tests/Unit/AutomationMonthlyScheduleTest.php`.
