### PR TITLE
fix: remove inert Automatically Trust Signer control from package import

### DIFF
--- a/package_import.php
+++ b/package_import.php
@@ -141,7 +141,7 @@ function form_save() {
 			}
 
 			raise_message('verify_warning', __('The package signature could not be verified against a trusted author.'), MESSAGE_LEVEL_ERROR);
-			header('Location: package_import?package_location=0');
+			header('Location: package_import.php?package_location=0');
 			exit;
 		}
 

--- a/package_import.php
+++ b/package_import.php
@@ -135,14 +135,12 @@ function form_save() {
 			exit;
 		}
 
-		if (isset_request_var('trust_signer') && get_request_var('trust_signer') == 'on') {
-			import_validate_public_key($xmlfile, true);
-		} elseif (!package_validate_signature($xmlfile)) {
+		if (!package_validate_signature($xmlfile)) {
 			if ($session_tmpfile) {
 				@unlink($xmlfile);
 			}
 
-			raise_message('verify_warning', __('You have not Trusted this Package Author.  If you wish to import, check the Automatically Trust Author checkbox'), MESSAGE_LEVEL_ERROR);
+			raise_message('verify_warning', __('The package signature could not be verified against a trusted author.'), MESSAGE_LEVEL_ERROR);
 			header('Location: package_import?package_location=0');
 			exit;
 		}
@@ -787,11 +785,6 @@ function validate_request_vars() {
 			'options' => array('options' => array('regexp' => '(on|true|false)')),
 			'default' => 'on'
 		),
-		'trust_signer' => array(
-			'filter' => FILTER_VALIDATE_REGEXP,
-			'options' => array('options' => array('regexp' => '(on|true|false)')),
-			'default' => 'on'
-		),
 		'data_source_profile' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'default' => $default_profile
@@ -837,12 +830,6 @@ function get_import_form($default_profile) {
 		$remove_orphans = '';
 	}
 
-	if (isset_request_var('trust_signer') && get_nfilter_request_var('trust_signer') == 'on') {
-		$trust_signer = 'on';
-	} else {
-		$trust_signer = '';
-	}
-
 	if (isset_request_var('image_format')) {
 		$image_format = get_filter_request_var('image_format');
 	} else {
@@ -867,13 +854,6 @@ function get_import_form($default_profile) {
 			'description' => __('The *.xml.gz file located on your Local machine to Upload and Import.'),
 			'accept' => '.xml.gz',
 			'method' => 'file'
-		),
-		'trust_signer' => array(
-			'friendly_name' => __('Automatically Trust Signer'),
-			'method' => 'hidden',
-			'description' => __('If checked, Cacti will automatically Trust the Signer for this and any future Packages by that author.'),
-			'value' => 'on',
-			'default' => ''
 		),
 	);
 
@@ -1014,10 +994,6 @@ function package_import() {
 
 			if ($('#replace_svalues').is(':checked')) {
 				formExtra += '&replace_svalues=on';
-			}
-
-			if ($('#trust_signer').is(':checked')) {
-				formExtra += '&trust_signer=on';
 			}
 
 			Pace.start();

--- a/tests/Unit/Issue7430PackageImportTrustSignerTest.php
+++ b/tests/Unit/Issue7430PackageImportTrustSignerTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * package_import.php previously let a request set trust_signer=on to skip
+ * package_validate_signature() entirely and call import_validate_public_key()
+ * with a forced-trust flag instead, so any request could bootstrap trust for
+ * an author it had never verified. The fix removes the control end to end
+ * (request var validation, the hidden form field, the JS that set it, and
+ * the form_save() branch that read it), leaving package_validate_signature()
+ * as the only gate. Structural check: none of those pieces may still exist.
+ */
+
+$repoRoot = __DIR__ . '/../..';
+
+test('form_save() always gates on package_validate_signature(), no bypass branch', function () use ($repoRoot) {
+	$src = file_get_contents("$repoRoot/package_import.php");
+
+	expect($src)->toContain('if (!package_validate_signature($xmlfile)) {');
+	expect($src)->not->toContain('isset_request_var(\'trust_signer\')');
+});
+
+test('trust_signer is gone from validate_request_vars(), the form, and the JS', function () use ($repoRoot) {
+	$src = file_get_contents("$repoRoot/package_import.php");
+
+	expect($src)->not->toContain('trust_signer');
+});

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -581,7 +581,7 @@ fs_write	./lib/reports.php:1704			$f = fopen($fn, 'wb');
 fs_write	./lib/reports.php:1745			$f = fopen($fn, 'wb');
 fs_write	./lib/rrd.php:2520					if ($fp = fopen($graph_data_array['export_realtime'], 'w')) {
 fs_write	./lib/spikekill.php:780			return file_put_contents($xmlfile, $output);
-fs_write	./package_import.php:385					file_put_contents($xmlfile, $data);
+fs_write	./package_import.php:383					file_put_contents($xmlfile, $data);
 fs_write	./package_import.php:96		if (file_put_contents($xmlfile, $_SESSION['sess_import_package']) === false) {
 fs_write	./script_server.php:49		define('STDIN', fopen('php://stdin', 'r'));
 fs_write	./script_server.php:50		define('STDOUT', fopen('php://stdout', 'w'));
@@ -903,8 +903,8 @@ header_redirect	./managers.php:995				header('Location: managers.php?action=edit
 header_redirect	./mibs/index.php:25	header("Location:../index.php");
 header_redirect	./package_import.php:128					header('Location: package_import.php');
 header_redirect	./package_import.php:134				header('Location: package_import.php');
-header_redirect	./package_import.php:146				header('Location: package_import?package_location=0');
-header_redirect	./package_import.php:251				header('Location: package_import.php');
+header_redirect	./package_import.php:144				header('Location: package_import.php?package_location=0');
+header_redirect	./package_import.php:249				header('Location: package_import.php');
 header_redirect	./plugins.php:100				header('Location: plugins.php' . ($option != '' ? '?' . $option:''));
 header_redirect	./plugins.php:111				header('Location: plugins.php' . ($option != '' ? '?' . $option:''));
 header_redirect	./plugins.php:124				header('Location: plugins.php' . ($option != '' ? '?' . $option:''));


### PR DESCRIPTION
Closes #7431

On 1.2.x the "Automatically Trust Signer" checkbox is a no-op: `import_validate_public_key()` ignores its `$accept` argument, so checking it records no trust and only skips the upfront `package_validate_signature()` call. The import still requires the official Cacti key downstream, so the box mainly misleads and suppresses the signature check.

Removes the checkbox, its request/form handling, and the JS, and updates the stale error message. Signature verification now always runs. No change to the signature/key logic; this does not backport develop's trust-key feature.
