### PR TITLE
fix: correct KILL CONNECTION typo in db_close

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -480,7 +480,7 @@ function db_close(mixed &$db_conn = false) : bool {
 
 	// forcibly close connection if not persistent
 	if (!$database_persist) {
-		db_execute('KILL CONNECTION CONNECTIION_ID()', false, $db_conn);
+		db_execute('KILL CONNECTION CONNECTION_ID()', false, $db_conn);
 	}
 
 	// unset the variables which should do the same

--- a/tests/Unit/Issue7432DbCloseKillConnectionTest.php
+++ b/tests/Unit/Issue7432DbCloseKillConnectionTest.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * db_close() forcibly disconnects non-persistent connections by issuing
+ * 'KILL CONNECTION CONNECTION_ID()'. The old code called the nonexistent
+ * MySQL function CONNECTIION_ID() (extra "I"), so every non-persistent
+ * db_close() emitted a SQL error. Structural check: the file must contain
+ * the corrected function name and must not contain the typo'd one.
+ */
+
+$repoRoot = __DIR__ . '/../..';
+
+test('db_close() issues the corrected KILL CONNECTION statement', function () use ($repoRoot) {
+	$src = file_get_contents("$repoRoot/lib/database.php");
+
+	expect($src)->toContain("db_execute('KILL CONNECTION CONNECTION_ID()', false, \$db_conn)");
+});
+
+test('db_close() no longer contains the CONNECTIION_ID typo', function () use ($repoRoot) {
+	$src = file_get_contents("$repoRoot/lib/database.php");
+
+	expect($src)->not->toContain('CONNECTIION_ID');
+});


### PR DESCRIPTION
Closes #7433

`db_close()` runs `KILL CONNECTION CONNECTIION_ID()` (double-I) to force-close non-persistent connections at teardown. `CONNECTIION_ID` is not a function, so with `$log=false` the statement errors silently and the forced close never happens. Correcting it to `CONNECTION_ID()` restores the intended behaviour; the `!$database_persist` guard already exempts persistent connections and it only runs at teardown.
