### PR TITLE
Harden report image conversion

### DIFF
--- a/lib/reports.php
+++ b/lib/reports.php
@@ -1867,15 +1867,9 @@ function png2jpeg(string $png_data) : string {
 	$ImageData = '';
 
 	if ($png_data != '') {
-		$fn = '/tmp/' . time() . '.png';
-
-		// write rrdtool's png file to scratch dir
-		$f = fopen($fn, 'wb');
-		fwrite($f, $png_data);
-		fclose($f);
-
-		// create php-gd image object from file
-		$im = imagecreatefrompng($fn);
+		// Decode the in-memory graph directly.  A predictable temporary file
+		// can collide with concurrent reports and is vulnerable to symlink races.
+		$im = imagecreatefromstring($png_data);
 
 		if (!$im) {								// check for errors
 			$im  = imagecreate(150, 30);		// create an empty image
@@ -1883,7 +1877,7 @@ function png2jpeg(string $png_data) : string {
 			$tc  = imagecolorallocate($im, 0, 0, 0);
 			imagefilledrectangle($im, 0, 0, 150, 30, $bgc);
 			// print error message
-			imagestring($im, 1, 5, 5, "Error while opening: $fn", $tc);
+			imagestring($im, 1, 5, 5, 'Error while decoding PNG data', $tc);
 		}
 
 		ob_start(); // start a new output buffer to capture jpeg image stream
@@ -1891,8 +1885,6 @@ function png2jpeg(string $png_data) : string {
 		$ImageData       = ob_get_contents(); // fetch image from buffer
 		$ImageDataLength = ob_get_length();
 		ob_end_clean(); // stop this output buffer
-
-		unlink($fn); // delete scratch file
 	}
 
 	return $ImageData;
@@ -1909,15 +1901,9 @@ function png2gif(string $png_data) : string {
 	$ImageData = '';
 
 	if ($png_data != '') {
-		$fn = '/tmp/' . time() . '.png';
-
-		// write rrdtool's png file to scratch dir
-		$f = fopen($fn, 'wb');
-		fwrite($f, $png_data);
-		fclose($f);
-
-		// create php-gd image object from file
-		$im = imagecreatefrompng($fn);
+		// Decode the in-memory graph directly.  A predictable temporary file
+		// can collide with concurrent reports and is vulnerable to symlink races.
+		$im = imagecreatefromstring($png_data);
 
 		if (!$im) {								// check for errors
 			$im  = imagecreate(150, 30);		// create an empty image
@@ -1925,7 +1911,7 @@ function png2gif(string $png_data) : string {
 			$tc  = imagecolorallocate($im, 0, 0, 0);
 			imagefilledrectangle($im, 0, 0, 150, 30, $bgc);
 			// print error message
-			imagestring($im, 1, 5, 5, "Error while opening: $fn", $tc);
+			imagestring($im, 1, 5, 5, 'Error while decoding PNG data', $tc);
 		}
 
 		ob_start(); // start a new output buffer to capture gif image stream
@@ -1933,8 +1919,6 @@ function png2gif(string $png_data) : string {
 		$ImageData       = ob_get_contents(); // fetch image from buffer
 		$ImageDataLength = ob_get_length();
 		ob_end_clean(); // stop this output buffer
-
-		unlink($fn); // delete scratch file
 	}
 
 	return $ImageData;

--- a/lib/reports.php
+++ b/lib/reports.php
@@ -1869,7 +1869,14 @@ function png2jpeg(string $png_data) : string {
 	if ($png_data != '') {
 		// Decode the in-memory graph directly.  A predictable temporary file
 		// can collide with concurrent reports and is vulnerable to symlink races.
-		$im = imagecreatefromstring($png_data);
+		// Only accept real PNG data here; imagecreatefromstring() would also
+		// happily decode a JPEG/GIF/WebP payload if GD supports it, and the
+		// fallback image below is meant to run for anything that isn't PNG.
+		$im = false;
+
+		if (substr($png_data, 0, 8) === "\x89PNG\r\n\x1a\n") {
+			$im = imagecreatefromstring($png_data);
+		}
 
 		if (!$im) {								// check for errors
 			$im  = imagecreate(150, 30);		// create an empty image
@@ -1903,7 +1910,14 @@ function png2gif(string $png_data) : string {
 	if ($png_data != '') {
 		// Decode the in-memory graph directly.  A predictable temporary file
 		// can collide with concurrent reports and is vulnerable to symlink races.
-		$im = imagecreatefromstring($png_data);
+		// Only accept real PNG data here; imagecreatefromstring() would also
+		// happily decode a JPEG/GIF/WebP payload if GD supports it, and the
+		// fallback image below is meant to run for anything that isn't PNG.
+		$im = false;
+
+		if (substr($png_data, 0, 8) === "\x89PNG\r\n\x1a\n") {
+			$im = imagecreatefromstring($png_data);
+		}
 
 		if (!$im) {								// check for errors
 			$im  = imagecreate(150, 30);		// create an empty image

--- a/tests/Unit/ReportImageConversionHardeningTest.php
+++ b/tests/Unit/ReportImageConversionHardeningTest.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * png2jpeg()/png2gif() used to write each report graph to a predictable
+ * /tmp/<timestamp>.png before decoding it with imagecreatefrompng(). Two
+ * concurrent reports could collide on the same filename, and the shared,
+ * predictable path was vulnerable to symlink races. The fix decodes the PNG
+ * directly from memory with imagecreatefromstring() and drops the temp file
+ * entirely.
+ */
+
+$reportsPath = dirname(__DIR__, 2) . '/lib/reports.php';
+
+beforeEach(function () use ($reportsPath) {
+	require_once $reportsPath;
+});
+
+test('reports.php decodes PNG data in memory via imagecreatefromstring', function () use ($reportsPath) {
+	$src = file_get_contents($reportsPath);
+
+	expect($src)->toContain('imagecreatefromstring($png_data)');
+});
+
+test('png2jpeg no longer writes a predictable temp file', function () use ($reportsPath) {
+	$src = file_get_contents($reportsPath);
+
+	expect($src)->not->toContain("'/tmp/' . time() . '.png'")
+		->and($src)->not->toMatch('/\bfopen\s*\(\s*\$fn\b/')
+		->and($src)->not->toContain('imagecreatefrompng($fn)');
+});
+
+test('reports.php contains no fopen or predictable-path file writes', function () use ($reportsPath) {
+	$src = file_get_contents($reportsPath);
+
+	expect($src)->not->toMatch('/\bfopen\s*\(/')
+		->and($src)->not->toMatch('/\bfile_put_contents\s*\(\s*[\'"]\/tmp\//');
+});
+
+test('png2jpeg round-trips a minimal valid PNG without touching disk', function () {
+	$im = imagecreate(1, 1);
+	imagecolorallocate($im, 255, 0, 0);
+	ob_start();
+	imagepng($im);
+	$png = ob_get_clean();
+
+	$before = glob(sys_get_temp_dir() . '/*.png');
+	$jpeg   = png2jpeg($png);
+	$after  = glob(sys_get_temp_dir() . '/*.png');
+
+	expect($jpeg)->toBeString()
+		->and($jpeg)->not->toBe('')
+		->and(substr($jpeg, 0, 2))->toBe("\xFF\xD8")
+		->and($after)->toBe($before);
+});
+
+test('png2gif round-trips a minimal valid PNG without touching disk', function () {
+	$im = imagecreate(1, 1);
+	imagecolorallocate($im, 255, 0, 0);
+	ob_start();
+	imagepng($im);
+	$png = ob_get_clean();
+
+	$before = glob(sys_get_temp_dir() . '/*.png');
+	$gif    = png2gif($png);
+	$after  = glob(sys_get_temp_dir() . '/*.png');
+
+	expect($gif)->toBeString()
+		->and($gif)->not->toBe('')
+		->and(substr($gif, 0, 6))->toMatch('/^GIF8[79]a/')
+		->and($after)->toBe($before);
+});

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -191,8 +191,6 @@ fs_write	./lib/plugins.php:2325				$fh = fopen($file, 'w');
 fs_write	./lib/poller.php:1316									if (file_put_contents($tmpfile, $contents) !== false) {
 fs_write	./lib/poller.php:1323												file_put_contents($mypath, $contents);
 fs_write	./lib/poller.php:1352								file_put_contents($mypath, $contents);
-fs_write	./lib/reports.php:1873			$f = fopen($fn, 'wb');
-fs_write	./lib/reports.php:1915			$f = fopen($fn, 'wb');
 fs_write	./lib/rrd.php:2914					if ($fp = fopen($graph_data_array['export_realtime'], 'w')) {
 fs_write	./lib/spikekill.php:806			return file_put_contents($xmlfile, $output);
 fs_write	./package_import.php:226							file_put_contents($xmlfile, $data);


### PR DESCRIPTION
## What changed

- Decode report PNG data directly from memory for JPEG and GIF conversion.
- Remove predictable timestamp-based files from `/tmp`.
- Preserve the existing fallback image behavior when PNG decoding fails.

## Why

The previous conversion path wrote each report graph to `/tmp/<timestamp>.png`. Concurrent reports could collide on the same filename, and predictable shared temporary paths are susceptible to symlink races. In-memory decoding removes both risks and avoids unnecessary filesystem I/O.

## Impact

Report JPEG/GIF attachments keep the same output behavior while conversion no longer depends on a writable shared temporary directory.

## Validation

- `php -l lib/reports.php`
- Direct GD smoke test confirmed valid JPEG and GIF signatures from a generated PNG.
- `git diff --check`

The repository test dependencies could not be installed on the local PHP 8.5.8 runtime because the current Pest/ParaTest constraints do not resolve for that PHP version.
