### PR TITLE
ci(security): refresh 1.2.x sink inventory baseline

### DIFF
--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -533,6 +533,7 @@ dynamic_include	./snmpagent_persist.php:165				include( $path_mibcache );
 dynamic_include	./spikekill.php:26	include_once($config['base_path'] . '/lib/spikekill.php');
 fs_write	./cactid.php:110		$STDERR = fopen('null', 'wb');
 fs_write	./cactid.php:99		$STDERR = fopen('/dev/null', 'wb');
+fs_write	./cli/change_device.php:987		$fh = fopen($file, 'r');
 fs_write	./cli/float_rrdfiles.php:342				$fp = fopen($tmp_file, 'w');
 fs_write	./cli/float_rrdfiles.php:345					$lf = fopen('/tmp/clearer.log', 'a');
 fs_write	./cli/import_package.php:159				$fp   = fopen($filename, 'r');


### PR DESCRIPTION
1.2.x itself is currently red on the sink inventory guard: #7382's CSV import in \`cli/change_device.php\` added an un-baselined \`fopen()\` call. This blocks the sink guard check on every open PR targeting 1.2.x regardless of that PR's own diff.

Refreshes \`tests/security/baselines/sink_inventory.baseline.tsv\` with the one new entry. No new architectural hotspots.