### PR TITLE
test: add regression coverage for #7407 and #7408 fixes

### DIFF
--- a/tests/Unit/SsHostDiskNegativeSizeTest.php
+++ b/tests/Unit/SsHostDiskNegativeSizeTest.php
@@ -32,6 +32,10 @@
 
 $source = file_get_contents(__DIR__ . '/../../scripts/ss_host_disk.php');
 
+if ($source === false) {
+	throw new RuntimeException('Unable to read scripts/ss_host_disk.php');
+}
+
 preg_match('/if \(\$snmp_data != \'\'.*?\n\t\t\t\t\}\n(?=\t\t\t\} else \{)/s', $source, $matches);
 
 test('the negative-size reconstruction chain is present in the source', function () use ($matches) {

--- a/tests/Unit/SsHostDiskNegativeSizeTest.php
+++ b/tests/Unit/SsHostDiskNegativeSizeTest.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for the negative-disk-size reconstruction in ss_host_disk()
+ * (scripts/ss_host_disk.php).
+ *
+ * hrStorageSize/hrStorageUsed are unsigned 32-bit SNMP counters. When the
+ * true value exceeds PHP_INT32_MAX, net-snmp/PHP hand it back as a negative
+ * signed 32-bit integer. The old code reconstructed it as
+ * `abs($snmp_data) + 2147483647`, which is wrong: the correct unsigned
+ * value is `$snmp_data + 4294967296` (2^32). abs()+2^31-1 produces a
+ * value roughly half of the real one. The fix also returns 'U' instead of
+ * silently multiplying by an empty/non-numeric allocation unit.
+ *
+ * The fixed if/elseif/else chain is pulled directly out of the real
+ * source file and wrapped in a throwaway function, following the
+ * extract-and-eval pattern used in Issue7070PercentileContractTest.php
+ * and DbFetchCellReturnGuardTest.php.
+ */
+
+$source = file_get_contents(__DIR__ . '/../../scripts/ss_host_disk.php');
+
+preg_match('/if \(\$snmp_data != \'\'.*?\n\t\t\t\t\}\n(?=\t\t\t\} else \{)/s', $source, $matches);
+
+test('the negative-size reconstruction chain is present in the source', function () use ($matches) {
+	expect($matches)->not->toBeEmpty();
+	expect($matches[0])->toContain('4294967296');
+});
+
+/**
+ * compute - runs the real disk-size reconstruction chain extracted from
+ * ss_host_disk() against the given SNMP counter and allocation unit
+ *
+ * @param  mixed $snmp_data Raw hrStorageSize/hrStorageUsed SNMP value
+ * @param  mixed $sau       Allocation unit to multiply the size by
+ *
+ * @return mixed Reconstructed unsigned size, or 'U' when sau is missing
+ */
+$compute = function (mixed $snmp_data, mixed $sau) use ($matches) {
+	// eval() here only wraps a chain regex-extracted from this repo's own
+	// scripts/ss_host_disk.php (not external/user input) into a throwaway
+	// named function. Test-only.
+	$name = 'ss_host_disk_get_' . str_replace('.', '_', uniqid('', true));
+	eval("function $name(\$snmp_data, \$sau) { {$matches[0]} }");
+
+	return $name($snmp_data, $sau);
+};
+
+test('reconstructs the correct unsigned value for a wrapped negative size', function () use ($compute) {
+	// True unsigned value 4294967200 appears as a signed 32-bit int as
+	// 4294967200 - 2^32 = -96.
+	$result = $compute(-96, 1);
+
+	expect($result)->toEqual(4294967200);
+
+	// The pre-fix formula: abs(-96) + 2147483647 = 2147483743 -- roughly
+	// half the correct value.
+	expect($result)->not->toEqual(2147483743);
+});
+
+test('multiplies the reconstructed size by the allocation unit', function () use ($compute) {
+	// unsigned value 4294967200, allocation unit 4096 (4K blocks)
+	$result = $compute(-96, 4096);
+
+	expect($result)->toEqual(4294967200 * 4096);
+});
+
+test('returns U instead of silently zeroing out a missing allocation unit', function () use ($compute) {
+	expect($compute(-96, ''))->toBe('U');
+	expect($compute(-96, null))->toBe('U');
+});
+
+test('non-negative values are unaffected and still multiply normally', function () use ($compute) {
+	expect($compute(500, 4096))->toEqual(500 * 4096);
+});

--- a/tests/Unit/TimeoutKillRegisteredProcessesFilterTest.php
+++ b/tests/Unit/TimeoutKillRegisteredProcessesFilterTest.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for the WHERE-clause construction in
+ * timeout_kill_registered_processes() (lib/poller.php).
+ *
+ * The "match any taskid/pid" defaults are $taskid = 0 and $pid = -1, but
+ * the old guards were `$taskid != ''` and `$pid != ''`. On PHP 8, comparing
+ * an int to a non-numeric string casts the int to string first, so
+ * `0 != ''` and `-1 != ''` both evaluate true -- the filter was added even
+ * for the un-filtered defaults, so every call constrained the query to
+ * taskid = 0 AND pid = -1, which no real row ever matches. The fix guards
+ * on the actual sentinel values: `$taskid != 0` and `$pid != -1`.
+ *
+ * The guard chain is pulled directly out of the real source file and
+ * wrapped in a throwaway function, following the extract-and-eval pattern
+ * used elsewhere in this suite (see Issue7070PercentileContractTest.php).
+ */
+
+$source = file_get_contents(__DIR__ . '/../../lib/poller.php');
+
+preg_match(
+	"/if \(\\\$tasktype != ''\).*?\n\t\}\n\n\tif \(\\\$taskname.*?\n\t\}\n\n\tif \(\\\$taskid.*?\n\t\}\n\n\tif \(\\\$pid.*?\n\t\}/s",
+	$source,
+	$matches
+);
+
+test('the taskid/pid sentinel guards are present in the source', function () use ($matches) {
+	expect($matches)->not->toBeEmpty();
+	expect($matches[0])->toContain('$taskid != 0');
+	expect($matches[0])->toContain('$pid != -1');
+});
+
+test('UNIX_TIMESTAMP(started), not FROM_UNIXTIME(started), is used in the timeout comparison', function () use ($source) {
+	expect($source)->toContain('UNIX_TIMESTAMP() > UNIX_TIMESTAMP(started) + timeout');
+	expect($source)->not->toContain('FROM_UNIXTIME(started) + timeout');
+});
+
+/**
+ * build_where - runs the real WHERE-clause guard chain extracted from
+ * timeout_kill_registered_processes() against the given filter values
+ *
+ * @param  string $tasktype Task type filter, empty string to skip
+ * @param  string $taskname Task name filter, empty string to skip
+ * @param  mixed  $taskid   Task id filter, 0 is the match-any sentinel
+ * @param  mixed  $pid      Process id filter, -1 is the match-any sentinel
+ *
+ * @return array  [$sql_where, $params] as constructed by the guard chain
+ */
+$build_where = function (string $tasktype, string $taskname, mixed $taskid, mixed $pid) use ($matches) {
+	// eval() here only wraps a guard chain regex-extracted from this
+	// repo's own lib/poller.php (not external/user input) into a
+	// throwaway named function. Test-only.
+	$name = 'timeout_kill_where_' . str_replace('.', '_', uniqid('', true));
+	eval("function $name(\$tasktype, \$taskname, \$taskid, \$pid) {
+		\$sql_where = '';
+		\$params    = array();
+		{$matches[0]}
+		return array(\$sql_where, \$params);
+	}");
+
+	return $name($tasktype, $taskname, $taskid, $pid);
+};
+
+test('default taskid/pid (match-any sentinels) add no WHERE filter', function () use ($build_where) {
+	list($sql_where, $params) = $build_where('', '', 0, -1);
+
+	expect($sql_where)->toBe('');
+	expect($params)->toBe(array());
+});
+
+test('an explicit taskid of 0 is impossible to request, matching the match-any sentinel', function () use ($build_where) {
+	// Documents the actual (intentional) contract: 0 is reserved as
+	// "don't filter on taskid", same as -1 for pid.
+	list($sql_where,) = $build_where('', '', 0, -1);
+	expect($sql_where)->not->toContain('taskid');
+});
+
+test('a real taskid and pid add their WHERE filters', function () use ($build_where) {
+	list($sql_where, $params) = $build_where('poller', 'spikekill', 42, 12345);
+
+	expect($sql_where)->toContain('AND tasktype = ?');
+	expect($sql_where)->toContain('AND taskname = ?');
+	expect($sql_where)->toContain('AND taskid = ?');
+	expect($sql_where)->toContain('AND pid = ?');
+	expect($params)->toBe(array('poller', 'spikekill', 42, 12345));
+});

--- a/tests/Unit/TimeoutKillRegisteredProcessesFilterTest.php
+++ b/tests/Unit/TimeoutKillRegisteredProcessesFilterTest.php
@@ -31,6 +31,10 @@
 
 $source = file_get_contents(__DIR__ . '/../../lib/poller.php');
 
+if ($source === false) {
+	throw new RuntimeException('Unable to read lib/poller.php');
+}
+
 preg_match(
 	"/if \(\\\$tasktype != ''\).*?\n\t\}\n\n\tif \(\\\$taskname.*?\n\t\}\n\n\tif \(\\\$taskid.*?\n\t\}\n\n\tif \(\\\$pid.*?\n\t\}/s",
 	$source,


### PR DESCRIPTION
Both #7407 and #7408 merged before their in-progress test coverage landed. Carrying the two test files forward here:

- \`TimeoutKillRegisteredProcessesFilterTest.php\` — covers the taskid/pid sentinel guard fix and the FROM_UNIXTIME→UNIX_TIMESTAMP correction from #7407.
- \`SsHostDiskNegativeSizeTest.php\` — covers the unsigned-reconstruction fix from #7408.

Verified both extraction regexes still match current 1.2.x source and \`php -l\` passes.