### PR TITLE
fix: backport remote agent timeout options

### DIFF
--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -1275,7 +1275,9 @@ $settings = array(
 				5 => __('%d Seconds', 5),
 				10 => __('%d Seconds', 10),
 				15 => __('%d Seconds', 15),
-				20 => __('%d Seconds', 20)
+				20 => __('%d Seconds', 20),
+				30 => __('%d Seconds', 30),
+				60 => __('%d Seconds', 60)
 			)
 		),
 		'snmp_bulk_walk_size' => array(
@@ -2949,4 +2951,3 @@ if (!$config['is_web'] || is_realm_allowed(8)) {
 }
 
 api_plugin_hook('config_settings');
-

--- a/tests/Unit/Issue6545RemoteAgentTimeoutTest.php
+++ b/tests/Unit/Issue6545RemoteAgentTimeoutTest.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$globalSettings = file_get_contents(__DIR__ . '/../../include/global_settings.php');
+
+test('remote agent timeout dropdown includes long WAN-safe values', function () use ($globalSettings) {
+	expect($globalSettings)->not->toBeFalse();
+
+	foreach (array(5, 10, 15, 20, 30, 60) as $timeout) {
+		expect($globalSettings)->toContain($timeout . " => __('%d Seconds', " . $timeout . ')');
+	}
+});


### PR DESCRIPTION
## Summary
- backports the missing 30 and 60 second remote agent timeout options to the 1.2.x settings UI
- adds a source-contract unit test for the expected timeout dropdown values

## Issues
- Fixes #6545 for the 1.2.x branch

## Validation
- php -l include/global_settings.php
- php -l tests/Unit/Issue6545RemoteAgentTimeoutTest.php
- source contract checked locally with rg for 5/10/15/20/30/60 second entries

Note: the scoped Pest 1.x runner in tests/ is not runnable on local PHP 8.5 because its Collision dependency treats PHP 8.5 deprecations as fatal before test execution.