### PR TITLE
Fix condition for MIBs collection timing

### DIFF
--- a/poller.php
+++ b/poller.php
@@ -222,7 +222,7 @@ $poller_lastrun  = intval(read_config_option('poller_lastrun_' . $poller_id));
 $boost_enabled   = read_config_option('boost_rrd_update_enable') == 'on' ? true : false;
 
 // collect the system mibs every 4 hours
-if ($poller_lastrun % 14440 < $current_time % 14440 || empty($poller_lastrun)) {
+if ($poller_lastrun % 14440 > $current_time % 14440 || empty($poller_lastrun)) {
 	$mibs = true;
 }
 

--- a/poller.php
+++ b/poller.php
@@ -222,7 +222,7 @@ $poller_lastrun  = intval(read_config_option('poller_lastrun_' . $poller_id));
 $boost_enabled   = read_config_option('boost_rrd_update_enable') == 'on' ? true : false;
 
 // collect the system mibs every 4 hours
-if ($poller_lastrun % 14440 > $current_time % 14440 || empty($poller_lastrun)) {
+if (intdiv($current_time, 14400) !== intdiv($poller_lastrun, 14400)) {
 	$mibs = true;
 }
 


### PR DESCRIPTION
## Summary

This change fixes the system MIB collection interval check in `poller.php`.

The current logic uses:

```php
if ($poller_lastrun % 14440 < $current_time % 14440 || empty($poller_lastrun)) {
    $mibs = true;
}
```

With a regularly running poller (e.g. every 1 or 5 minutes), this condition evaluates to true on almost every poller execution, except when the modulo value wraps around.

As a result, system MIB collection is performed far more frequently than the comment suggests:
```php
// collect the system mibs every 4 hours
```

## Problem

For example:
```
poller_lastrun % 14440 = 1000
current_time % 14440   = 1060
```

The condition:
```
1000 < 1060
```

is true, causing $mibs to be enabled on nearly every poller run.
This behavior does not match the documented intention of collecting system MIBs once per interval.

Additionally, the constant 14440 represents 4 hours and 40 seconds rather than exactly 4 hours. Other four-hour intervals throughout the codebase use 14400.

## Fix
Replace the modulo wrap detection logic with an interval boundary check:
```
if (
    intdiv($current_time, 14400) !== intdiv($poller_lastrun, 14400)
) {
    $mibs = true;
}
```
This triggers system MIB collection only when execution crosses into a new four-hour interval and also correctly handles situations where the poller has been stopped for longer than one interval.

## Additional Impact

The $mibs flag also controls execution of bad_index_check() later in the poller cycle.

Currently, due to the bug, bad_index_check() is executed on nearly every poller run. After this change it will execute once per four-hour collection interval, which significantly reduces unnecessary database activity.

As a result, bad SNMP index warnings may be delayed by up to four hours compared with current behavior. This is considered an acceptable trade-off because it aligns execution frequency with the documented intent and substantially reduces unnecessary processing.

## Benefits

- Aligns implementation with the code comment.
- Corrects the interval constant from 14440 to 14400.
- Ensures collection occurs once per four-hour interval.
- Correctly handles poller downtime exceeding a single interval.
- Reduces unnecessary execution of get_system_information().
- Reduces unnecessary execution of bad_index_check().
- Lowers database activity caused by repeated data_local and data_template_data lookups.
- Reduces additional SNMP requests to monitored devices.


