### PR TITLE
fix(docker): scope build context to docker/ so it builds standalone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@
 services:
   web:
     build:
-      context: .
-      dockerfile: docker/Dockerfile
+      context: ./docker
+      dockerfile: Dockerfile
     container_name: cacti_web
     ports:
       - "${WEB_PORT:-8080}:80"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN a2enmod rewrite headers proxy proxy_fcgi setenvif \
     && a2dismod mpm_prefork \
     && a2enmod mpm_event
 
-COPY docker/apache.conf /etc/apache2/sites-available/cacti.conf
+COPY apache.conf /etc/apache2/sites-available/cacti.conf
 RUN a2dissite 000-default && a2ensite cacti
 
 # Static PHP settings (runtime-tunable values are set in entrypoint.sh)
@@ -72,7 +72,7 @@ RUN mkdir -p /var/www/html/cacti/cache \
              /var/www/html/cacti/log \
     && chown -R www-data:www-data /var/www/html/cacti
 
-COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # App code comes from the docker-compose bind mount, not from this image.


### PR DESCRIPTION
## Summary
`docker build .` run from inside `docker/` fails because `COPY docker/apache.conf` and `COPY docker/entrypoint.sh` only resolve when the build context is the repo root. Neither COPY needs anything outside `docker/`, so this narrows the build context instead of requiring root.

Verified locally:
- `cd docker && docker build .` (the reported repro) — now builds
- `docker compose build web` from repo root — still builds

Fixes #7512