### PR TITLE
fix: keep lib/html_utility.php PHP 8.0-parseable after DsstatsMeasure enum

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 Cacti CHANGELOG
 
 1.3.0-dev
--issue: Replace the DsstatsMeasure backed enum in lib/html_utility.php with plain const arrays so the file stays parseable on PHP 8.0 (stock Rocky Linux 9), fixing the weekly Rocky Linux compatibility check
 -issue#2205: Allow admins to disable RRDtool watermark
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
 -issue#3074: ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php do now report mmcblk data.
@@ -53,6 +52,7 @@ Cacti CHANGELOG
 -issue#7211: Correct the Nth percentile and bandwidth summation divisor on base-1024 graphs
 -issue#7214: Fix TypeError in boost_graph_set_file when sending reports
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
+-issue#7518: Replace the DsstatsMeasure enum in lib/html_utility.php with const arrays for PHP 8.0 compatibility
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-issue: Replace the DsstatsMeasure backed enum in lib/html_utility.php with plain const arrays so the file stays parseable on PHP 8.0 (stock Rocky Linux 9), fixing the weekly Rocky Linux compatibility check
 -issue#2205: Allow admins to disable RRDtool watermark
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
 -issue#3074: ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php do now report mmcblk data.

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1433,21 +1433,17 @@ function get_order_string() : string {
 }
 
 /**
- * Backing enum for the dsstats measure columns that get_dsstats_order_string()
- * is allowed to sort by. Cases are the single source of truth for both the
- * enum and the Assert\Choice constraint's `choices` list below, so a new
- * measure only needs to be added in one place.
+ * Whitelist of the dsstats measure columns that get_dsstats_order_string()
+ * is allowed to sort by. This is the single source of truth for both the
+ * Assert\Choice constraint's `choices` list below and the fallback default,
+ * so a new measure only needs to be added in one place.
+ *
+ * Kept as plain const arrays rather than a backed enum so this file stays
+ * parseable on PHP 8.0 (see .github/workflows/rocky-linux.yml, which lints
+ * against Rocky Linux 9's stock php-cli package).
  */
-enum DsstatsMeasure : string {
-	case Average = 'average';
-	case Peak    = 'peak';
-	case P25n    = 'p25n';
-	case P50n    = 'p50n';
-	case P75n    = 'p75n';
-	case P90n    = 'p90n';
-	case P95n    = 'p95n';
-	case Sum     = 'sum';
-}
+const DSSTATS_MEASURES        = ['average', 'peak', 'p25n', 'p50n', 'p75n', 'p90n', 'p95n', 'sum'];
+const DSSTATS_MEASURE_DEFAULT = 'average';
 
 /**
  * Builds the validated ORDER BY clause used by get_allowed_graphs() when
@@ -1463,11 +1459,9 @@ enum DsstatsMeasure : string {
  * @return string The 'ORDER BY rs.<measure> <ASC|DESC>' clause.
  */
 function get_dsstats_order_string(array $sql_order) : string {
-	$measure_choices = array_map(static fn (DsstatsMeasure $case) => $case->value, DsstatsMeasure::cases());
-
-	$measure = isset($sql_order['measure']) && is_scalar($sql_order['measure']) && CactiValidator::isValid($sql_order['measure'], [new Assert\Choice(choices: $measure_choices)])
+	$measure = isset($sql_order['measure']) && is_scalar($sql_order['measure']) && CactiValidator::isValid($sql_order['measure'], [new Assert\Choice(choices: DSSTATS_MEASURES)])
 		? $sql_order['measure']
-		: DsstatsMeasure::Average->value;
+		: DSSTATS_MEASURE_DEFAULT;
 
 	$order = isset($sql_order['order']) && is_scalar($sql_order['order']) ? strtoupper((string) $sql_order['order']) : '';
 


### PR DESCRIPTION
## Summary
#7438 (merged) added a PHP 8.1+ backed enum (`enum DsstatsMeasure : string`) to `lib/html_utility.php`. PHP 8.0 doesn't support the `enum` keyword at all, so this broke the weekly "Rocky Linux compatibility" check (`.github/workflows/rocky-linux.yml`), which lints every PHP file against Rocky Linux 9's stock `php-cli` package (currently PHP 8.0.30). Since this is a core file required by `include/global.php`, the regression would hard-break Cacti on any genuinely stock Rocky 9 install.

Replaces the enum with a plain top-level `const` array (`DSSTATS_MEASURES`) plus a separate default constant, preserving the exact same `CactiValidator`/`Assert\Choice` validation behavior — no logic change, just PHP-8.0-compatible syntax.

## Verification
- Real `rockylinux:9` container (`dnf install php-cli` → PHP 8.0.30, matching the CI failure): `php -l` passes on the fixed file, and a full repo-wide sweep replicating the workflow line-for-line passes on all 1287 PHP files
- Grepped for other PHP 8.1+ constructs in the file (readonly, never, first-class callables): none found
- Behavioral equivalence: ran the actual `CactiValidator`/`Assert\Choice` code path (not mocked) against both the original enum and the fixed const-array version across all 17 existing unit-test cases (valid measures, case-insensitive ASC/DESC, SQLi payloads, missing-key fallback) — output byte-for-byte identical

`DsstatsMeasure` wasn't referenced anywhere else in the repo (test files only pass string literals), so no other files needed changes.