### PR TITLE
fix(import): return a strict bool from import_validate_signature()

### DIFF
--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -703,12 +703,6 @@ $settings['general'] = [
 		'method'        => 'drop_array',
 		'array'         => []
 	],
-	'trust_signer' => [
-		'friendly_name' => __('Automatically Trust Signer'),
-		'description'   => __('If checked, Cacti will automatically Trust the Signer for this and any future Packages by that author.'),
-		'method'        => 'checkbox',
-		'default'       => ''
-	],
 	'remove_orphans' => [
 		'friendly_name' => __('Remove Orphaned Graph Items'),
 		'description'   => __('If checked, Cacti will delete any Graph Items from both the Graph Template and associated Graphs that are not included in the imported Graph Template.'),

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -105,6 +105,10 @@ function upgrade_to_1_3_0() : void {
 	// remove all the legacy debounce entries
 	db_install_execute('DELETE FROM settings WHERE name LIKE "debounce_%" AND value > 0');
 
+	// the Automatically Trust Signer control is gone; a Package key is only
+	// trusted through the accept action now
+	db_install_execute('DELETE FROM settings WHERE name = "trust_signer"');
+
 	$data               = [];
 	$data['columns'][]  = ['name' => 'plugin', 'type' => 'varchar(32)', 'NULL' => false, 'default' => ''];
 	$data['columns'][]  = ['name' => 'description', 'type' => 'varchar(128)', 'NULL' => false, 'default' => ''];

--- a/lib/import.php
+++ b/lib/import.php
@@ -408,28 +408,33 @@ function import_package_get_details(string $xmlfile) : array {
  *
  * @param string $xmlfile The Package to check
  *
- * @return bool True when the Package key is an official or an accepted key
+ * @return bool True when the Package carries an official or an accepted key
  */
 function import_validate_signature(string $xmlfile) : bool {
-	// Cacti public key first
-	$cacti_key1   = get_public_key_sha1();
-	$cacti_key2   = get_public_key_sha256();
-	$public_key   = import_package_get_public_key($xmlfile);
-
 	$info = import_get_package_info($xmlfile);
 
-	if ($info === false || !isset($info['pubkey'])) {
+	// The key the Package carries, not the one import_package_get_public_key()
+	// substitutes when the element is absent.  A Package that names no key
+	// names no signer, so there is nothing to trust.
+	if ($info === false || $info['pubkey'] == '') {
 		return false;
 	}
 
+	// A Package carries the PEM with its trailing newline, the built in keys
+	// are written without one, and package_public_keys stores whatever the
+	// accepted Package carried.
+	$public_key = trim($info['pubkey']);
+
+	// Cacti public key first
+	if (is_cacti_public_key($public_key)) {
+		return true;
+	}
+
 	// Other trusted keys next
-	$keys = array_rekey(
+	$keys = array_map('trim', array_rekey(
 		db_fetch_assoc('SELECT public_key FROM package_public_keys'),
 		'public_key', 'public_key'
-	);
-
-	$keys[$cacti_key1] = $cacti_key1;
-	$keys[$cacti_key2] = $cacti_key2;
+	));
 
 	return in_array($public_key, $keys, true);
 }

--- a/lib/import.php
+++ b/lib/import.php
@@ -400,7 +400,17 @@ function import_package_get_details(string $xmlfile) : array {
 	return $return;
 }
 
-function import_validate_signature(string $xmlfile) : mixed {
+/**
+ * import_validate_signature - Report whether a Package is signed by a key that
+ * Cacti trusts.  The verdict is the return value itself, so a caller can not
+ * treat a populated result as a pass.  Callers that need to name the failing
+ * Package take its details from import_get_package_info().
+ *
+ * @param string $xmlfile The Package to check
+ *
+ * @return bool True when the Package key is an official or an accepted key
+ */
+function import_validate_signature(string $xmlfile) : bool {
 	// Cacti public key first
 	$cacti_key1   = get_public_key_sha1();
 	$cacti_key2   = get_public_key_sha256();
@@ -408,30 +418,20 @@ function import_validate_signature(string $xmlfile) : mixed {
 
 	$info = import_get_package_info($xmlfile);
 
-	if ($info === false) {
+	if ($info === false || !isset($info['pubkey'])) {
 		return false;
-	} else {
-		if (!isset($info['pubkey'])) {
-			return false;
-		}
-
-		// Other trusted keys next
-		$keys = array_rekey(
-			db_fetch_assoc('SELECT public_key FROM package_public_keys'),
-			'public_key', 'public_key'
-		);
-
-		$keys[$cacti_key1] = $cacti_key1;
-		$keys[$cacti_key2] = $cacti_key2;
-
-		if (in_array($public_key, $keys, true)) {
-			$info['valid'] = true;
-		} else {
-			$info['valid'] = false;
-		}
-
-		return $info;
 	}
+
+	// Other trusted keys next
+	$keys = array_rekey(
+		db_fetch_assoc('SELECT public_key FROM package_public_keys'),
+		'public_key', 'public_key'
+	);
+
+	$keys[$cacti_key1] = $cacti_key1;
+	$keys[$cacti_key2] = $cacti_key2;
+
+	return in_array($public_key, $keys, true);
 }
 
 function import_get_package_info(string $xmlfile) : mixed {
@@ -496,7 +496,9 @@ function import_read_package_data(string $xmlfile, string &$public_key, bool $pr
 
 	$filename = "compress.zlib://$xmlfile";
 
-	if (!import_validate_signature($xmlfile) && !$preview) {
+	// A preview neither writes files nor touches the database, so an untrusted
+	// Package may still be inspected.  A real import may not.
+	if (!$preview && !import_validate_signature($xmlfile)) {
 		cacti_log('FATAL: Package Public Key is not Official Cacti Public Key for Package ' . $filename, true, 'IMPORT', POLLER_VERBOSITY_LOW);
 
 		return false;

--- a/lib/import.php
+++ b/lib/import.php
@@ -504,7 +504,7 @@ function import_read_package_data(string $xmlfile, string &$public_key, bool $pr
 	// A preview neither writes files nor touches the database, so an untrusted
 	// Package may still be inspected.  A real import may not.
 	if (!$preview && !import_validate_signature($xmlfile)) {
-		cacti_log('FATAL: Package Public Key is not Official Cacti Public Key for Package ' . $filename, true, 'IMPORT', POLLER_VERBOSITY_LOW);
+		cacti_log('FATAL: Package Public Key is not a Trusted Public Key for Package ' . $filename, true, 'IMPORT', POLLER_VERBOSITY_LOW);
 
 		return false;
 	}

--- a/package_import.php
+++ b/package_import.php
@@ -503,10 +503,6 @@ function form_save() : void {
 			exit;
 		}
 
-		if (isrv('trust_signer') && gnrv('trust_signer') == 'on') {
-			import_validate_public_key($xmlfile, true);
-		}
-
 		if (gfrv('data_source_profile') == '0') {
 			$import_as_new = true;
 			$profile_id    = db_fetch_cell('SELECT id FROM data_source_profiles ORDER BY `default` DESC LIMIT 1');
@@ -824,9 +820,13 @@ function package_verify_key() : void {
 
 					file_put_contents($xmlfile, $data);
 
-					$info = import_validate_signature($xmlfile);
+					if (!import_validate_signature($xmlfile)) {
+						$info = import_get_package_info($xmlfile);
 
-					if ($info === false || $info['valid'] === false) {
+						if ($info === false) {
+							$info = ['name' => $package_name, 'author' => '', 'email' => ''];
+						}
+
 						$failed[$package_name] = $info;
 					}
 
@@ -849,10 +849,15 @@ function package_verify_key() : void {
 		$xmlfile = sys_get_temp_dir() . '/package_import_' . rand();
 
 		file_put_contents($xmlfile, $_SESSION['sess_import_package']);
-		$vsig  = import_validate_signature($xmlfile);
 
-		if ($vsig === false || empty($vsig['valid'])) {
-			$failed[$vsig['name']] = $vsig;
+		if (!import_validate_signature($xmlfile)) {
+			$info = import_get_package_info($xmlfile);
+
+			if ($info === false) {
+				$info = ['name' => __('Unknown'), 'author' => '', 'email' => ''];
+			}
+
+			$failed[$info['name']] = $info;
 		}
 
 		unlink($xmlfile);
@@ -1367,11 +1372,6 @@ function validate_request_vars() : void {
 			'options' => ['options' => ['regexp' => '(on|true|false)']],
 			'default' => read_config_option('remove_orphans') ?? ''
 		],
-		'trust_signer' => [
-			'filter'  => FILTER_VALIDATE_REGEXP,
-			'options' => ['options' => ['regexp' => '(on|true|false)']],
-			'default' => read_config_option('trust_signer') ?? ''
-		],
 		'package_location' => [
 			'filter'  => FILTER_VALIDATE_INT,
 			'default' => read_config_option('package_location') ?? ''
@@ -1421,12 +1421,6 @@ function get_import_form(int $repo_id, int $default_profile) : array {
 		$remove_orphans = '';
 	}
 
-	if (isrv('trust_signer') && gnrv('trust_signer') == 'on') {
-		$trust_signer = 'on';
-	} else {
-		$trust_signer = '';
-	}
-
 	if (isrv('image_format')) {
 		$image_format = gfrv('image_format');
 	} else {
@@ -1451,18 +1445,6 @@ function get_import_form(int $repo_id, int $default_profile) : array {
 			'description'   => __('The *.xml.gz file located on your Local machine to Upload and Import.'),
 			'accept'        => '.xml.gz',
 			'method'        => 'file'
-		],
-		'trust_header' => [
-			'friendly_name' => __('Package Signature'),
-			'collapsible'   => 'true',
-			'method'        => 'spacer',
-		],
-		'trust_signer' => [
-			'friendly_name' => __('Automatically Trust Signer'),
-			'description'   => __('If checked, Cacti will automatically Trust the Signer for this and any future Packages by that author.'),
-			'method'        => 'checkbox',
-			'value'         => $trust_signer,
-			'default'       => ''
 		],
 	];
 
@@ -1899,12 +1881,6 @@ function package_import() : void {
 				formExtra += '&replace_svalues=on';
 			} else {
 				formExtra += '&replace_svalues=';
-			}
-
-			if ($('#trust_signer').is(':checked')) {
-				formExtra += '&trust_signer=on';
-			} else {
-				formExtra += '&trust_signer=';
 			}
 
 			Pace.start();

--- a/tests/Unit/ImportPackageSignatureTrustTest.php
+++ b/tests/Unit/ImportPackageSignatureTrustTest.php
@@ -1,0 +1,188 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression coverage for the Package signature gate on the import path.
+ *
+ * import_validate_signature() used to return the Package info array for both a
+ * trusted and an untrusted key, recording the real verdict in $info['valid'].
+ * The gate in import_read_package_data() tested the array itself, which is
+ * always truthy, so a Package self-signed with its author's own key was read
+ * and its scripts/ files written to disk.  The helper now returns a strict
+ * bool and the gate reads that.
+ *
+ * The 'Automatically Trust Signer' control was the other half of the hole:
+ * trust_signer=on inserted the Package's own key into package_public_keys
+ * before the gate ran, so even a corrected gate would have passed.  The
+ * control is gone; a key becomes trusted only through the accept action.
+ */
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__) . '/Helpers/FakeMySQLPDO.php';
+require_once dirname(__DIR__, 2) . '/include/global.php';
+require_once dirname(__DIR__, 2) . '/lib/import.php';
+
+/*
+ * Build a Package the way lib/package.php does, but signed with a throwaway
+ * key rather than the Cacti key.  Returns the .xml.gz path; $public_key
+ * receives the PEM that the Package carries.
+ */
+function selfSignedPackage(string &$public_key): string {
+	$key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+	openssl_pkey_export($key, $private_key);
+	$public_key = openssl_pkey_get_details($key)['key'];
+
+	$payload   = "<?php\n// planted by the package\n";
+	$file_sig  = '';
+	$base_sig  = '';
+
+	$xml  = "<xml>\n";
+	$xml .= "   <info>\n";
+	$xml .= "     <name>Untrusted Package</name>\n";
+	$xml .= "     <author>Mallory</author>\n";
+	$xml .= "     <homepage>http://example.invalid</homepage>\n";
+	$xml .= "     <email>mallory@example.invalid</email>\n";
+	$xml .= "   </info>\n";
+	$xml .= "   <directories>\n";
+	$xml .= "       <directory>scripts</directory>\n";
+	$xml .= "   </directories>\n";
+	$xml .= "   <files>\n";
+	$xml .= "       <file>\n";
+	$xml .= "           <name>scripts/planted.php</name>\n";
+
+	openssl_sign($payload, $file_sig, $private_key, OPENSSL_ALGO_SHA256);
+
+	$xml .= '           <data>' . base64_encode($payload) . "</data>\n";
+	$xml .= '           <filesignature>' . base64_encode($file_sig) . "</filesignature>\n";
+	$xml .= "       </file>\n";
+	$xml .= "   </files>\n";
+	$xml .= "   <publickeyname>Mallory</publickeyname>\n";
+	$xml .= '   <publickey>' . base64_encode($public_key) . "</publickey>\n";
+
+	openssl_sign($xml . "   <signature></signature>\n</xml>", $base_sig, $private_key, OPENSSL_ALGO_SHA256);
+
+	$xml .= '   <signature>' . base64_encode($base_sig) . "</signature>\n</xml>";
+
+	$path = sys_get_temp_dir() . '/cacti_pkg_trust_' . bin2hex(random_bytes(4)) . '.xml.gz';
+	$f    = fopen("compress.zlib://$path", 'wb');
+
+	fwrite($f, $xml, strlen($xml));
+	fclose($f);
+
+	return $path;
+}
+
+function importSourceFile(string $name): string {
+	$src = file_get_contents(dirname(__DIR__, 2) . "/$name");
+	expect($src)->not->toBeFalse("Failed to read $name");
+
+	return $src;
+}
+
+beforeEach(function () {
+	$this->package_key = '';
+	$this->package     = selfSignedPackage($this->package_key);
+});
+
+afterEach(function () {
+	if (file_exists($this->package)) {
+		unlink($this->package);
+	}
+});
+
+// --- the gate ---
+
+test('import_validate_signature returns a strict bool', function () {
+	// The array return was the defect: any populated result read as a pass.
+	expect((string) (new ReflectionFunction('import_validate_signature'))->getReturnType())->toBe('bool');
+});
+
+test('a package signed with its own key is not trusted', function () {
+	expect(import_validate_signature($this->package))->toBeFalse();
+});
+
+test('a real import of a self-signed package is refused', function () {
+	$public_key = '';
+
+	expect(import_read_package_data($this->package, $public_key, false))->toBeFalse();
+});
+
+test('a preview of an untrusted package is still readable', function () {
+	// A preview writes neither files nor rows, so it stays available to let an
+	// operator inspect a Package before deciding to trust its signer.
+	$public_key = '';
+	$data       = import_read_package_data($this->package, $public_key, true);
+
+	expect($data)->toBeArray();
+	expect($data['files']['file']['name'])->toBe('scripts/planted.php');
+});
+
+test('the gate no longer short circuits before it reads the verdict', function () {
+	expect(importSourceFile('lib/import.php'))
+		->not->toContain('!import_validate_signature($xmlfile) && !$preview');
+});
+
+// --- accepted keys, and why auto-accepting them was the second hole ---
+
+test('a key in package_public_keys makes the same package importable', function () {
+	global $database_sessions, $database_hostname, $database_port, $database_default;
+
+	$session = "$database_hostname:$database_port:$database_default";
+	$prior   = $database_sessions[$session] ?? null;
+	$conn    = new FakeMySQLPDO();
+
+	$conn->exec('CREATE TABLE package_public_keys (id INTEGER PRIMARY KEY AUTOINCREMENT, public_key TEXT)');
+
+	$insert = $conn->prepare('INSERT INTO package_public_keys (public_key) VALUES (?)');
+	$insert->execute([$this->package_key]);
+
+	$database_sessions[$session] = $conn;
+
+	try {
+		$public_key = '';
+
+		expect(import_validate_signature($this->package))->toBeTrue();
+		expect(import_read_package_data($this->package, $public_key, false))->toBeArray();
+	} finally {
+		if ($prior === null) {
+			unset($database_sessions[$session]);
+		} else {
+			$database_sessions[$session] = $prior;
+		}
+	}
+});
+
+test('trust_signer no longer reaches the import', function () {
+	expect(importSourceFile('package_import.php'))->not->toContain('trust_signer');
+	expect(importSourceFile('include/global_settings.php'))->not->toContain('trust_signer');
+});
+
+test('a key is force trusted only by the accept action', function () {
+	$src    = importSourceFile('package_import.php');
+	$accept = strpos($src, 'function package_accept_key(');
+
+	expect($accept)->not->toBeFalse();
+
+	$offset = 0;
+	$found  = 0;
+
+	while (($pos = strpos($src, 'import_validate_public_key($xmlfile, true)', $offset)) !== false) {
+		expect($pos)->toBeGreaterThan($accept);
+
+		$found++;
+		$offset = $pos + 1;
+	}
+
+	expect($found)->toBeGreaterThan(0);
+});

--- a/tests/Unit/ImportPackageSignatureTrustTest.php
+++ b/tests/Unit/ImportPackageSignatureTrustTest.php
@@ -26,19 +26,26 @@
  * trust_signer=on inserted the Package's own key into package_public_keys
  * before the gate ran, so even a corrected gate would have passed.  The
  * control is gone; a key becomes trusted only through the accept action.
+ *
+ * The gate compares PEM against PEM, and the two sides do not agree on the
+ * trailing newline: a Package carries the key as OpenSSL exported it, the
+ * built in keys are written into lib/import.php without one.  A strict compare
+ * of the raw bytes therefore rejects every Package Cacti signs itself, which is
+ * why the shipped Device Packages are exercised here too.
  */
 
 require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
 require_once dirname(__DIR__) . '/Helpers/FakeMySQLPDO.php';
 require_once dirname(__DIR__, 2) . '/include/global.php';
 require_once dirname(__DIR__, 2) . '/lib/import.php';
+require_once dirname(__DIR__, 2) . '/lib/xml.php';
 
 /*
  * Build a Package the way lib/package.php does, but signed with a throwaway
  * key rather than the Cacti key.  Returns the .xml.gz path; $public_key
  * receives the PEM that the Package carries.
  */
-function selfSignedPackage(string &$public_key): string {
+function selfSignedPackage(string &$public_key, bool $names_key = true): string {
 	$key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
 	openssl_pkey_export($key, $private_key);
 	$public_key = openssl_pkey_get_details($key)['key'];
@@ -68,7 +75,10 @@ function selfSignedPackage(string &$public_key): string {
 	$xml .= "       </file>\n";
 	$xml .= "   </files>\n";
 	$xml .= "   <publickeyname>Mallory</publickeyname>\n";
-	$xml .= '   <publickey>' . base64_encode($public_key) . "</publickey>\n";
+
+	if ($names_key) {
+		$xml .= '   <publickey>' . base64_encode($public_key) . "</publickey>\n";
+	}
 
 	openssl_sign($xml . "   <signature></signature>\n</xml>", $base_sig, $private_key, OPENSSL_ALGO_SHA256);
 
@@ -112,6 +122,42 @@ test('a package signed with its own key is not trusted', function () {
 	expect(import_validate_signature($this->package))->toBeFalse();
 });
 
+test('a package that names no key is not trusted', function () {
+	// import_package_get_public_key() substitutes the built in Cacti key when
+	// the element is absent, so the gate must not ask it for the verdict.
+	$key     = '';
+	$package = selfSignedPackage($key, false);
+
+	try {
+		expect(import_get_package_info($package)['pubkey'])->toBe('');
+		expect(import_validate_signature($package))->toBeFalse();
+	} finally {
+		unlink($package);
+	}
+});
+
+test('the shipped device packages pass the trust gate', function () {
+	// Every install/templates Package is signed with the Cacti key and is
+	// imported by cli/import_package.php on a fresh install.  Rejecting them
+	// breaks the install, so the whole set is checked rather than a sample.
+	$packages = glob(dirname(__DIR__, 2) . '/install/templates/*.xml.gz');
+
+	expect($packages)->not->toBeEmpty();
+
+	foreach ($packages as $package) {
+		expect(import_validate_signature($package))->toBeTrue(basename($package) . ' is not trusted');
+	}
+});
+
+test('a shipped package key differs from the built in key only in trailing whitespace', function () {
+	// This is what a strict compare of the raw bytes tripped over.
+	$package = dirname(__DIR__, 2) . '/install/templates/Local_Linux_Machine.xml.gz';
+	$pubkey  = import_get_package_info($package)['pubkey'];
+
+	expect($pubkey)->not->toBe(get_public_key_sha256());
+	expect(trim($pubkey))->toBe(get_public_key_sha256());
+});
+
 test('a real import of a self-signed package is refused', function () {
 	$public_key = '';
 
@@ -143,6 +189,10 @@ test('a key in package_public_keys makes the same package importable', function 
 	$conn    = new FakeMySQLPDO();
 
 	$conn->exec('CREATE TABLE package_public_keys (id INTEGER PRIMARY KEY AUTOINCREMENT, public_key TEXT)');
+
+	// import_validate_public_key() stores the pubkey off the Package verbatim,
+	// so an already accepted row carries the trailing newline.
+	expect(str_ends_with($this->package_key, "\n"))->toBeTrue();
 
 	$insert = $conn->prepare('INSERT INTO package_public_keys (public_key) VALUES (?)');
 	$insert->execute([$this->package_key]);


### PR DESCRIPTION
`import_validate_signature()` returned a populated array whether or not the key was trusted, recording the verdict in `$info['valid']`. The guard in `import_read_package_data()` never read that field, and since the array is truthy the `&& !$preview` half never evaluated either, so the check passed for any package carrying a key.

The function now returns `bool`, so the verdict is the return value and the truthiness cannot diverge from the meaning again. Callers needing the package name take it from `import_get_package_info()`. This restores the property `is_cacti_public_key()` had before 4cc779b26d.

Also drops Automatically Trust Signer, following 9ac0e2776a on 1.2.x. On develop it had additionally become a site-wide setting, so ticking it once would trust every future package's own signer with no prompt. The explicit verify/accept flow is unaffected.

Fixes a latent crash on the way past: `$failed[$vsig['name']]` indexed `false` when a package failed to parse.

Tests: generates a real 2048-bit key, builds a self-signed package and drives the real import path. Reverting fails 7 of 8.