### PR TITLE
fix(rrdcheck): escape the RRDfile path in RRDtool commands

### DIFF
--- a/lib/rrdcheck.php
+++ b/lib/rrdcheck.php
@@ -167,7 +167,7 @@ function do_rrdcheck(int $thread_id = 1) : void {
 			$file = $rrdval['data_source_path'];
 
 			if ($use_proxy) {
-				$file_exists = rrdtool_execute("file_exists $file", true, RRDTOOL_OUTPUT_BOOLEAN, false, 'RRDCHECK');
+				$file_exists = rrdtool_execute('file_exists ' . cacti_escapeshellarg($file), true, RRDTOOL_OUTPUT_BOOLEAN, false, 'RRDCHECK');
 			} else {
 				clearstatcache();
 				$file_exists = file_exists($file);
@@ -218,9 +218,9 @@ function do_rrdcheck(int $thread_id = 1) : void {
 				}
 
 				if ($use_proxy) {
-					$output = rrdtool_execute("info $file", false, RRDTOOL_OUTPUT_STDOUT, false, 'RRDCHECK');
+					$output = rrdtool_execute('info ' . cacti_escapeshellarg($file), false, RRDTOOL_OUTPUT_STDOUT, false, 'RRDCHECK');
 				} else {
-					$output = rrdcheck_rrdtool_execute("info $file", $pipes);
+					$output = rrdcheck_rrdtool_execute(['info', $file], $pipes);
 				}
 
 				$matches     = [];
@@ -374,9 +374,9 @@ function do_rrdcheck(int $thread_id = 1) : void {
 				$one_hour_limit = ($duration - 3600) / $step;
 
 				if ($use_proxy) {
-					$info_array = rrdtool_execute("fetch $file LAST -s $pstart -e $pend ", false, RRDTOOL_OUTPUT_STDOUT, false, 'RRDCHECK');
+					$info_array = rrdtool_execute('fetch ' . cacti_escapeshellarg($file) . " LAST -s $pstart -e $pend", false, RRDTOOL_OUTPUT_STDOUT, false, 'RRDCHECK');
 				} else {
-					$info_array = rrdcheck_rrdtool_execute("fetch $file LAST -s $pstart -e $pend", $pipes);
+					$info_array = rrdcheck_rrdtool_execute(['fetch', $file, 'LAST', '-s', $pstart, '-e', $pend], $pipes);
 				}
 
 				// don't do anything if RRDfile did not return data
@@ -829,13 +829,25 @@ function rrdcheck_rrdtool_init() : array {
  * This may not be the best method and may be changed after I have a conversation with a few
  * developers.
  *
- * @param string $command The rrdtool command to execute
- * @param array  $pipes   An array of stdin and stdout pipes to read and write data from
+ * @param array|string $command The rrdtool command to execute.  When passed as an array
+ *                              the first element is the sub-command and the remaining
+ *                              elements are escaped before being joined
+ * @param array        $pipes   An array of stdin and stdout pipes to read and write data from
  *
  * @return mixed The output from RRDtool
  */
-function rrdcheck_rrdtool_execute(string $command, mixed &$pipes) : mixed {
+function rrdcheck_rrdtool_execute(array|string $command, mixed &$pipes) : mixed {
 	static $broken = false;
+
+	if (is_array($command)) {
+		// RRDtool needs the sub-command verbatim, so only its arguments are quoted
+		$args    = $command;
+		$command = (string) array_shift($args);
+
+		if (cacti_sizeof($args)) {
+			$command .= ' ' . implode(' ', array_map('cacti_escapeshellarg', $args));
+		}
+	}
 
 	$stdout = '';
 

--- a/tests/Unit/RrdcheckShellEscapeTest.php
+++ b/tests/Unit/RrdcheckShellEscapeTest.php
@@ -1,0 +1,98 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Tests for RRDtool argument escaping in lib/rrdcheck.php.
+ *
+ * do_rrdcheck() interpolated $file (data_template_data.data_source_path, a
+ * free form textbox that is also settable through XML template import) and the
+ * fetch window straight into the RRDtool command strings:
+ *
+ *   rrdtool_execute("file_exists $file", ...)
+ *   rrdcheck_rrdtool_execute("fetch $file LAST -s $pstart -e $pend", $pipes)
+ *
+ * The proxy calls now quote the path with cacti_escapeshellarg() and the pipe
+ * calls pass an argument array, which rrdcheck_rrdtool_execute() escapes one
+ * argument at a time.
+ */
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 2) . '/include/global.php';
+require_once dirname(__DIR__, 2) . '/lib/rrdcheck.php';
+
+$rrdcheckSource = file_get_contents(__DIR__ . '/../../lib/rrdcheck.php');
+
+// --- proxy calls quote the RRDfile path ---
+
+test('rrdcheck file_exists escapes the RRDfile path', function () use ($rrdcheckSource) {
+	expect($rrdcheckSource)->toContain("rrdtool_execute('file_exists ' . cacti_escapeshellarg(\$file)");
+	expect($rrdcheckSource)->not->toContain('rrdtool_execute("file_exists $file"');
+});
+
+test('rrdcheck proxy info escapes the RRDfile path', function () use ($rrdcheckSource) {
+	expect($rrdcheckSource)->toContain("rrdtool_execute('info ' . cacti_escapeshellarg(\$file)");
+	expect($rrdcheckSource)->not->toContain('rrdtool_execute("info $file"');
+});
+
+test('rrdcheck proxy fetch escapes the RRDfile path', function () use ($rrdcheckSource) {
+	expect($rrdcheckSource)->toContain("rrdtool_execute('fetch ' . cacti_escapeshellarg(\$file)");
+	expect($rrdcheckSource)->not->toMatch('/rrdtool_execute\("fetch \$file/');
+});
+
+// --- pipe calls hand RRDtool an argument array ---
+
+test('rrdcheck pipe info uses the argument array form', function () use ($rrdcheckSource) {
+	expect($rrdcheckSource)->toContain("rrdcheck_rrdtool_execute(['info', \$file], \$pipes)");
+	expect($rrdcheckSource)->not->toContain('rrdcheck_rrdtool_execute("info $file"');
+});
+
+test('rrdcheck pipe fetch uses the argument array form', function () use ($rrdcheckSource) {
+	expect($rrdcheckSource)->toContain("rrdcheck_rrdtool_execute(['fetch', \$file, 'LAST', '-s', \$pstart, '-e', \$pend], \$pipes)");
+	expect($rrdcheckSource)->not->toMatch('/rrdcheck_rrdtool_execute\("fetch \$file/');
+});
+
+// --- no RRDtool command in this file interpolates the path ---
+
+test('no rrdcheck RRDtool command interpolates $file', function () use ($rrdcheckSource) {
+	expect(preg_match('/rrd(check_)?(rrd)?tool_execute\(\s*"[^"]*\$file/', $rrdcheckSource))->toBe(0,
+		'RRDtool commands must not interpolate $file into a double quoted string'
+	);
+});
+
+// --- the array form reaches RRDtool with every argument quoted ---
+
+test('rrdcheck_rrdtool_execute quotes each argument after the sub-command', function () {
+	/*
+	 * Drive the real function with a pair of in-memory streams.  The 'OK'
+	 * already sitting in the read pipe ends the response loop, so what lands
+	 * in the write pipe is the exact command line RRDtool would receive.
+	 */
+	$stdin  = fopen('php://temp', 'r+');
+	$stdout = fopen('php://temp', 'r+');
+
+	fwrite($stdout, "OK\n");
+	rewind($stdout);
+
+	$pipes = [$stdin, $stdout];
+
+	rrdcheck_rrdtool_execute(['fetch', '/rra/x.rrd; touch /tmp/pwned', 'LAST', '-s', 100, '-e', 200], $pipes);
+
+	rewind($stdin);
+	$written = stream_get_contents($stdin);
+
+	fclose($stdin);
+	fclose($stdout);
+
+	expect($written)->toBe("fetch '/rra/x.rrd; touch /tmp/pwned' 'LAST' '-s' '100' '-e' '200'\r\n");
+});


### PR DESCRIPTION
`lib/rrdcheck.php` interpolates `$file` (from `data_template_data.data_source_path`) straight into five RRDtool command strings. 1.2.x already escapes all five; develop regressed.

Mirrors 1.2.x: `cacti_escapeshellarg()` on the concatenated proxy calls, array form on the pipe calls. `rrdcheck_rrdtool_execute()` had been narrowed to `string`, so the array-flattening block is restored alongside it.

The proxy fetch keeps the concat form because `__rrd_proxy_execute()` is string-typed on develop and an array would be a TypeError. It follows the shape already used at lib/rrd.php:1188.

Tests: reverting fails all 7, including a behavioural one asserting the exact bytes written to rrdtool's stdin.