### PR TITLE
fix(installer): tolerate a microtime string with no fractional part

### DIFF
--- a/lib/installer.php
+++ b/lib/installer.php
@@ -3321,7 +3321,7 @@ class Installer implements JsonSerializable {
 		if (!$backgroundNeeded) {
 			log_install_debug('background', PHP_EOL . '----------------' . PHP_EOL . 'Check Expire' . PHP_EOL . '----------------');
 
-			$backgroundDateStarted = DateTime::createFromFormat('U.u', $backgroundTime);
+			$backgroundDateStarted = Installer::dateFromMicrotime($backgroundTime);
 			$backgroundLast        = read_config_option('install_updated', true);
 
 			log_install_debug('background', 'backgroundDateStarted = ' . $backgroundDateStarted->format('Y-m-d H:i:s') . PHP_EOL);
@@ -4167,6 +4167,23 @@ class Installer implements JsonSerializable {
 		return $failure;
 	}
 
+	/*
+	 * Installer timestamps are stored as (string) microtime(true), which has no
+	 * fractional part whenever the float lands on a whole second, and an install
+	 * carried over from an older release may hold a bare integer.  'U.u' rejects
+	 * both, so fall back to whole seconds rather than let a log message abort the
+	 * install with a format() call on false.
+	 */
+	public static function dateFromMicrotime(mixed $value) : DateTime {
+		$date = DateTime::createFromFormat('U.u', (string) $value);
+
+		if ($date === false && is_numeric($value)) {
+			$date = DateTime::createFromFormat('U', (string) (int) $value);
+		}
+
+		return $date === false ? new DateTime() : $date;
+	}
+
 	public static function beginInstall(string $backgroundArg, mixed $installer = null) : bool {
 		$eula = read_config_option('install_eula', true);
 
@@ -4185,17 +4202,8 @@ class Installer implements JsonSerializable {
 		log_install_high('', "beginInstall(): '$backgroundTime' (time) != '$backgroundArg' (arg) && '-b' != '$backgroundArg' (arg)");
 
 		if ("$backgroundTime" != "$backgroundArg" && "$backgroundArg" != '-b') {
-			$dateTime = DateTime::createFromFormat('U.u', $backgroundTime);
-
-			if ($dateTime === false) {
-				$dateTime = new DateTime();
-			}
-
-			$dateArg = DateTime::createFromFormat('U.u', $backgroundArg);
-
-			if ($dateArg === false) {
-				$dateArg = new DateTime();
-			}
+			$dateTime = Installer::dateFromMicrotime($backgroundTime);
+			$dateArg  = Installer::dateFromMicrotime($backgroundArg);
 
 			$background_error = __(
 				'Background was already started at %s, this attempt at %s was skipped',
@@ -4238,8 +4246,8 @@ class Installer implements JsonSerializable {
 
 		$backgroundDone = (string) microtime(true);
 
-		$dateBack = DateTime::createFromFormat('U.u', $backgroundTime);
-		$dateTime = DateTime::createFromFormat('U.u', $backgroundDone);
+		$dateBack = Installer::dateFromMicrotime($backgroundTime);
+		$dateTime = Installer::dateFromMicrotime($backgroundDone);
 
 		if ($completed) {
 			set_install_config_option('install_complete', $backgroundDone);

--- a/tests/Unit/InstallerMicrotimeDateTest.php
+++ b/tests/Unit/InstallerMicrotimeDateTest.php
@@ -37,7 +37,7 @@ test('installer preserves microseconds when the value carries them', function ()
 	$date = Installer::dateFromMicrotime('1785703138.123456');
 
 	expect($date->getTimestamp())->toBe(1785703138)
-		->and($date->format('Y-m-d H:i:s.u'))->toBe('2026-08-02 20:38:58.123456');
+		->and($date->format('u'))->toBe('123456');
 });
 
 test('both timestamps of the completion message survive fraction-less values', function () {
@@ -51,8 +51,10 @@ test('both timestamps of the completion message survive fraction-less values', f
 
 	$message = __('Installation was started at %s, completed at %s', $started->format('Y-m-d H:i:s'), $completed->format('Y-m-d H:i:s'));
 
-	expect($message)->toContain('2026-08-02 20:38:58')
-		->and($message)->toContain('2026-08-02 20:40:00');
+	expect($started->getTimestamp())->toBe(1785703138)
+		->and($completed->getTimestamp())->toBe(1785703200)
+		->and($message)->toContain($started->format('Y-m-d H:i:s'))
+		->and($message)->toContain($completed->format('Y-m-d H:i:s'));
 });
 
 test('installer falls back to now for values it cannot parse', function () {

--- a/tests/Unit/InstallerMicrotimeDateTest.php
+++ b/tests/Unit/InstallerMicrotimeDateTest.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 2) . '/include/global.php';
+require_once dirname(__DIR__, 2) . '/lib/installer.php';
+
+test('a microtime value without a fractional part is not parseable as U.u', function () {
+	/*
+	 * Root cause. (string) microtime(true) drops the fraction whenever the
+	 * float lands on a whole second, and 'U.u' rejects the result. Calling
+	 * format() on that false is what aborted the CLI install.
+	 */
+	expect(DateTime::createFromFormat('U.u', '1785703138'))->toBeFalse();
+});
+
+test('installer parses whole-second microtime values instead of returning false', function () {
+	$date = Installer::dateFromMicrotime('1785703138');
+
+	expect($date)->toBeInstanceOf(DateTime::class)
+		->and($date->getTimestamp())->toBe(1785703138)
+		->and($date->format('u'))->toBe('000000');
+});
+
+test('installer preserves microseconds when the value carries them', function () {
+	$date = Installer::dateFromMicrotime('1785703138.123456');
+
+	expect($date->getTimestamp())->toBe(1785703138)
+		->and($date->format('Y-m-d H:i:s.u'))->toBe('2026-08-02 20:38:58.123456');
+});
+
+test('both timestamps of the completion message survive fraction-less values', function () {
+	/*
+	 * beginInstall() formats a start and a finish timestamp into one message.
+	 * Either can arrive without a fraction, so exercise the worst case where
+	 * neither is parseable as U.u.
+	 */
+	$started   = Installer::dateFromMicrotime('1785703138');
+	$completed = Installer::dateFromMicrotime('1785703200');
+
+	$message = __('Installation was started at %s, completed at %s', $started->format('Y-m-d H:i:s'), $completed->format('Y-m-d H:i:s'));
+
+	expect($message)->toContain('2026-08-02 20:38:58')
+		->and($message)->toContain('2026-08-02 20:40:00');
+});
+
+test('installer falls back to now for values it cannot parse', function () {
+	/*
+	 * install_started reads as an empty string on a fresh config and as false
+	 * once beginInstall() normalises it. Neither is a timestamp, but the log
+	 * line still has to render.
+	 */
+	$before = time();
+
+	foreach (['', false, null, 'garbage'] as $value) {
+		$date = Installer::dateFromMicrotime($value);
+
+		expect($date)->toBeInstanceOf(DateTime::class)
+			->and($date->getTimestamp())->toBeGreaterThanOrEqual($before);
+	}
+});
+
+test('a float landing on a whole second stringifies without a fraction', function () {
+	// Confirms the failure is reachable from the producer, not just from stored values.
+	expect((string) 1785703138.0)->toBe('1785703138')
+		->and(Installer::dateFromMicrotime(1785703138.0)->getTimestamp())->toBe(1785703138);
+});
+
+test('no installer code path formats a raw U.u parse result', function () {
+	// Every caller must route through the guard, or the fatal comes back.
+	$installer = file_get_contents(dirname(__DIR__, 2) . '/lib/installer.php');
+
+	expect(substr_count($installer, "DateTime::createFromFormat('U.u'"))->toBe(1)
+		->and($installer)->toContain('Installer::dateFromMicrotime(');
+});


### PR DESCRIPTION
`DateTime::createFromFormat('U.u', $t)` returns false when $t has no microsecond part, and `(string) microtime(true)` produces a bare integer whenever the float lands on a whole second. The next line dereferences the result:

```
PHP Fatal error: Uncaught Error: Call to a member function format() on bool in lib/installer.php:4247
#0 cli/install_cacti.php(255): Installer::beginInstall()
```

That aborts the install with exit 255. It is timing dependent, so it reds an unrelated PR at random on the "Install Cacti through the CLI" step and passes on a re-run.

Two more call sites had the same shape: the failure-path log four lines below, and a `log_install_debug()` argument in processStepInstall() reachable from the web installer when `install_started` holds a whole second.

All five 'U.u' parses now go through one tolerant helper that retries as 'U' and falls back to now. 'U' is behaviour identical for the whole-second case. This is a log message only, so a parse failure must never abort the installer.

The producer is left alone deliberately: the stored microtime string is compared with string equality in the background-process dedupe (installer.php:3356 and :4187), so reformatting it would trade this fatal for duplicate installer processes. Existing installs already hold bare-integer values, so the reader has to tolerate them regardless.