### PR TITLE
fix(poller): drop the E_STRICT entry from the poller error handlers

### DIFF
--- a/lib/boost.php
+++ b/lib/boost.php
@@ -138,8 +138,7 @@ function boost_error_handler(int $errno, string $errmsg, string $filename, int $
 			E_COMPILE_WARNING   => 'Compile Warning',
 			E_USER_ERROR        => 'User Error',
 			E_USER_WARNING      => 'User Warning',
-			E_USER_NOTICE       => 'User Notice',
-			E_STRICT            => 'Runtime Notice'
+			E_USER_NOTICE       => 'User Notice'
 		];
 
 		if (defined('E_RECOVERABLE_ERROR')) {

--- a/lib/dsdebug.php
+++ b/lib/dsdebug.php
@@ -89,8 +89,7 @@ function dsdebug_error_handler(int $errno, string $errmsg, string $filename, int
 			E_COMPILE_WARNING   => 'Compile Warning',
 			E_USER_ERROR        => 'User Error',
 			E_USER_WARNING      => 'User Warning',
-			E_USER_NOTICE       => 'User Notice',
-			E_STRICT            => 'Runtime Notice'
+			E_USER_NOTICE       => 'User Notice'
 		];
 
 		if (defined('E_RECOVERABLE_ERROR')) {

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -774,8 +774,7 @@ function dsstats_error_handler(int $errno, string $errmsg, string $filename, int
 			E_COMPILE_WARNING   => 'Compile Warning',
 			E_USER_ERROR        => 'User Error',
 			E_USER_WARNING      => 'User Warning',
-			E_USER_NOTICE       => 'User Notice',
-			E_STRICT            => 'Runtime Notice'
+			E_USER_NOTICE       => 'User Notice'
 		];
 
 		if (defined('E_RECOVERABLE_ERROR')) {

--- a/tests/Unit/Php84EStrictPollerTest.php
+++ b/tests/Unit/Php84EStrictPollerTest.php
@@ -31,11 +31,14 @@ test('lib/dsdebug.php names no E_STRICT constant', function () use ($basePath) {
 	expect(file_get_contents($basePath . '/lib/dsdebug.php'))->not->toContain('E_STRICT');
 });
 
-test('userland can not raise E_STRICT, so the removed key is unreachable', function () {
+test('userland cannot raise E_STRICT, so the removed key is unreachable', function () {
+	/* 2048 is the E_STRICT level, spelled numerically because naming the
+	   constant is itself deprecated on PHP 8.4 */
+	$strict = 2048;
 	$raised = false;
 
 	try {
-		trigger_error('probe', 2048);
+		trigger_error('probe', $strict);
 	} catch (\ValueError $e) {
 		$raised = true;
 	}

--- a/tests/Unit/Php84EStrictPollerTest.php
+++ b/tests/Unit/Php84EStrictPollerTest.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ |                                                                         |
+ | The poller error handlers each carried an E_STRICT entry.  Nothing can  |
+ | raise that level as of PHP 8.0 and reading the constant is deprecated   |
+ | as of PHP 8.4, so every handled error emitted a second deprecation.     |
+ +-------------------------------------------------------------------------+
+*/
+
+$basePath = dirname(__DIR__, 2);
+
+test('lib/boost.php names no E_STRICT constant', function () use ($basePath) {
+	expect(file_get_contents($basePath . '/lib/boost.php'))->not->toContain('E_STRICT');
+});
+
+test('lib/dsstats.php names no E_STRICT constant', function () use ($basePath) {
+	expect(file_get_contents($basePath . '/lib/dsstats.php'))->not->toContain('E_STRICT');
+});
+
+test('lib/dsdebug.php names no E_STRICT constant', function () use ($basePath) {
+	expect(file_get_contents($basePath . '/lib/dsdebug.php'))->not->toContain('E_STRICT');
+});
+
+test('userland can not raise E_STRICT, so the removed key is unreachable', function () {
+	$raised = false;
+
+	try {
+		trigger_error('probe', 2048);
+	} catch (\ValueError $e) {
+		$raised = true;
+	}
+
+	expect($raised)->toBeTrue();
+});


### PR DESCRIPTION
Follow-up to #7546, which removed the same dead entry from the core error paths but left the three poller handlers alone to avoid colliding with other work in those files.

Nothing has been able to raise E_STRICT since PHP 8.0, and `trigger_error()` rejects it outright with a ValueError (only E_USER_* are accepted), so the key is unreachable against the `^8.1` floor. Reading the constant is deprecated as of 8.4, so every handled error in boost, dsstats and dsdebug emitted a second, spurious deprecation.

Each of the three does a bare `$errortype[$errno]` lookup with no isset() guard, so removing a key that could still arrive would introduce an undefined-key warning. It cannot: $errno reaches these handlers only from the engine or trigger_error(), and neither can produce 2048 on any supported version.

The `E_RECOVERABLE_ERROR` guards in lib/aggregate.php and lib/rrdcheck.php are dead for the same reason (the constant has existed since 5.2), but both files are already touched by #7546, so they are left for a follow-up rather than creating a conflict.