### PR TITLE
test: run the Integration and HandOff suites in isolated processes

### DIFF
--- a/tests/HandOff/CactiDispatchHandOffTest.php
+++ b/tests/HandOff/CactiDispatchHandOffTest.php
@@ -19,7 +19,14 @@
  * source-scan suite in tests/Unit/CactiDispatchTest.php pins the literal
  * shape of each guard; the tests here pin the runtime contract so a
  * refactor that keeps the source markers but swaps the semantics still
- * fails. */
+ * fails.
+ *
+ * cacti_dispatch() reaches the Cacti runtime through global functions that
+ * lib/ owns, so the stubs standing in for them live in a probe script that
+ * runs in its own process (see fixtures/cacti_dispatch_probe.php). Each
+ * test below states a scenario, the probe runs it, and the JSON verdict
+ * carries back the handler calls, the log lines, the AJAX denial flag and
+ * the HTTP status. */
 
 if (!file_exists(__DIR__ . '/../../lib/cacti_dispatch.php')) {
 	test('cacti_dispatch hand-off: feature not present on this branch', function () {})
@@ -27,78 +34,13 @@ if (!file_exists(__DIR__ . '/../../lib/cacti_dispatch.php')) {
 	return;
 }
 
-/* --------------------------------------------------------------------- */
-/* Stubs for the Cacti runtime functions cacti_dispatch() depends on.    */
-/* They are declared once and shared across every test in this file via  */
-/* the $GLOBALS['cdho_*'] mailbox so each test can read what was logged, */
-/* whether the AJAX denial helper fired, and which handlers ran.         */
-/* --------------------------------------------------------------------- */
+require_once dirname(__DIR__) . '/Helpers/IsolatedProbe.php';
 
-if (!function_exists('get_nfilter_request_var')) {
-	function get_nfilter_request_var($name, $default = '') {
-		if (!isset($_REQUEST[$name])) {
-			return $default;
-		}
-
-		return $_REQUEST[$name];
-	}
-}
-
-if (!function_exists('cacti_log')) {
-	function cacti_log($message, $output = false, $environ = 'CMDPHP', $level = -1) {
-		$GLOBALS['cdho_logs'][] = ['message' => $message, 'env' => $environ];
-	}
-}
-
-if (!function_exists('cacti_strtoupper')) {
-	function cacti_strtoupper($s) {
-		return strtoupper((string) $s);
-	}
-}
-
-if (!function_exists('cacti_strtolower')) {
-	function cacti_strtolower($s) {
-		return strtolower((string) $s);
-	}
-}
-
-if (!function_exists('is_realm_allowed')) {
-	function is_realm_allowed($realm) {
-		return !empty($GLOBALS['cdho_allowed_realms'][$realm]);
-	}
-}
-
-if (!function_exists('get_client_addr')) {
-	function get_client_addr() {
-		return '127.0.0.1';
-	}
-}
-
-if (!function_exists('raise_ajax_permission_denied')) {
-	function raise_ajax_permission_denied() {
-		$GLOBALS['cdho_ajax_denied'] = true;
-	}
-}
-
-require_once __DIR__ . '/../../lib/cacti_dispatch.php';
-
-beforeEach(function () {
-	$_REQUEST                       = [];
-	$_SERVER                        = [];
-	$GLOBALS['cdho_logs']           = [];
-	$GLOBALS['cdho_handler_calls']  = [];
-	$GLOBALS['cdho_allowed_realms'] = [];
-	$GLOBALS['cdho_ajax_denied']    = false;
-	http_response_code(200);
-});
-
-/* Helper that records the action name a handler was invoked with. Used
- * to prove the dispatch table actually reached (or did not reach) a
- * specific entry rather than relying on global side effects. */
-function cdho_make_handler(string $tag): callable {
-	return function () use ($tag) {
-		$GLOBALS['cdho_handler_calls'][] = $tag;
-	};
+function cdho_dispatch(array $scenario): array {
+	return cacti_test_isolated_probe(
+		__DIR__ . '/fixtures/cacti_dispatch_probe.php',
+		[json_encode($scenario)]
+	);
 }
 
 /* --------------------------------------------------------------------- */
@@ -106,44 +48,50 @@ function cdho_make_handler(string $tag): callable {
 /* --------------------------------------------------------------------- */
 
 test('string action resolves to its handler entry', function () {
-	$_REQUEST['action']        = 'save';
-	$_SERVER['REQUEST_METHOD'] = 'GET';
+	$verdict = cdho_dispatch([
+		'request' => ['action' => 'save'],
+		'server'  => ['REQUEST_METHOD' => 'GET'],
+		'default' => 'edit',
+		'actions' => [
+			'save' => ['handler' => 'save'],
+			'edit' => ['handler' => 'edit'],
+		],
+	]);
 
-	cacti_dispatch([
-		'save' => ['callback' => cdho_make_handler('save')],
-		'edit' => ['callback' => cdho_make_handler('edit')],
-	], 'edit');
-
-	expect($GLOBALS['cdho_handler_calls'])->toBe(['save']);
+	expect($verdict['handler_calls'])->toBe(['save']);
 });
 
 test('array action input is normalized to the default action', function () {
-	$_REQUEST['action']        = ['x'];
-	$_SERVER['REQUEST_METHOD'] = 'GET';
+	$verdict = cdho_dispatch([
+		'request' => ['action' => ['x']],
+		'server'  => ['REQUEST_METHOD' => 'GET'],
+		'default' => 'edit',
+		'actions' => [
+			'edit' => ['handler' => 'edit'],
+		],
+	]);
 
-	cacti_dispatch([
-		'edit' => ['callback' => cdho_make_handler('edit')],
-	], 'edit');
-
-	expect($GLOBALS['cdho_handler_calls'])->toBe(['edit']);
+	expect($verdict['handler_calls'])->toBe(['edit']);
 });
 
 test('action with shell metacharacters is rejected before table lookup', function () {
 	/* The hostile key is also present in the table so a missed
 	 * sanitisation step would invoke its handler. Rejection must
 	 * happen before the isset() lookup. */
-	$_REQUEST['action']        = 'save;rm -rf /';
-	$_SERVER['REQUEST_METHOD'] = 'GET';
+	$verdict = cdho_dispatch([
+		'request' => ['action' => 'save;rm -rf /'],
+		'server'  => ['REQUEST_METHOD' => 'GET'],
+		'default' => '',
+		'actions' => [
+			'save'          => ['handler' => 'save'],
+			'save;rm -rf /' => ['handler' => 'hostile'],
+		],
+	]);
 
-	cacti_dispatch([
-		'save'         => ['callback' => cdho_make_handler('save')],
-		'save;rm -rf /' => ['callback' => cdho_make_handler('hostile')],
-	], '');
+	expect($verdict['handler_calls'])->toBe([]);
+	expect($verdict['http_code'])->toBe(403);
 
-	expect($GLOBALS['cdho_handler_calls'])->toBe([]);
-	expect(http_response_code())->toBe(403);
-
-	$messages = array_column($GLOBALS['cdho_logs'], 'message');
+	$messages = array_column($verdict['logs'], 'message');
 	expect($messages)->toContain('WARNING: cacti_dispatch: unknown action "" from 127.0.0.1');
 });
 
@@ -152,34 +100,32 @@ test('action with shell metacharacters is rejected before table lookup', functio
 /* --------------------------------------------------------------------- */
 
 test('GET request against a POST entry is rejected with method-mismatch log', function () {
-	$_REQUEST['action']        = 'save';
-	$_SERVER['REQUEST_METHOD'] = 'GET';
-
-	cacti_dispatch([
-		'save' => [
-			'callback' => cdho_make_handler('save'),
-			'method'   => 'POST',
+	$verdict = cdho_dispatch([
+		'request' => ['action' => 'save'],
+		'server'  => ['REQUEST_METHOD' => 'GET'],
+		'default' => '',
+		'actions' => [
+			'save' => ['handler' => 'save', 'method' => 'POST'],
 		],
-	], '');
+	]);
 
-	expect($GLOBALS['cdho_handler_calls'])->toBe([]);
+	expect($verdict['handler_calls'])->toBe([]);
 
-	$messages = array_column($GLOBALS['cdho_logs'], 'message');
+	$messages = array_column($verdict['logs'], 'message');
 	expect($messages)->toContain('WARNING: cacti_dispatch: method mismatch for action "save" (expected POST, got GET)');
 });
 
 test('absent REQUEST_METHOD with ANY entry still dispatches', function () {
-	$_REQUEST['action'] = 'save';
-	unset($_SERVER['REQUEST_METHOD']);
-
-	cacti_dispatch([
-		'save' => [
-			'callback' => cdho_make_handler('save'),
-			'method'   => 'ANY',
+	$verdict = cdho_dispatch([
+		'request' => ['action' => 'save'],
+		'server'  => [],
+		'default' => '',
+		'actions' => [
+			'save' => ['handler' => 'save', 'method' => 'ANY'],
 		],
-	], '');
+	]);
 
-	expect($GLOBALS['cdho_handler_calls'])->toBe(['save']);
+	expect($verdict['handler_calls'])->toBe(['save']);
 });
 
 /* --------------------------------------------------------------------- */
@@ -187,33 +133,30 @@ test('absent REQUEST_METHOD with ANY entry still dispatches', function () {
 /* --------------------------------------------------------------------- */
 
 test('object_acl returning false suppresses handler and runs the deny path', function () {
-	$_REQUEST['action']        = 'save';
-	$_SERVER['REQUEST_METHOD'] = 'GET';
-
-	cacti_dispatch([
-		'save' => [
-			'callback'   => cdho_make_handler('save'),
-			'object_acl' => function () { return false; },
+	$verdict = cdho_dispatch([
+		'request' => ['action' => 'save'],
+		'server'  => ['REQUEST_METHOD' => 'GET'],
+		'default' => '',
+		'actions' => [
+			'save' => ['handler' => 'save', 'object_acl' => false],
 		],
-	], '');
+	]);
 
-	expect($GLOBALS['cdho_handler_calls'])->toBe([]);
-	expect(http_response_code())->toBe(403);
+	expect($verdict['handler_calls'])->toBe([]);
+	expect($verdict['http_code'])->toBe(403);
 });
 
 test('object_acl returning true invokes the handler exactly once', function () {
-	$_REQUEST['action']        = 'save';
-	$_SERVER['REQUEST_METHOD'] = 'GET';
-	$seen                      = [];
-
-	cacti_dispatch([
-		'save' => [
-			'callback'   => function () use (&$seen) { $seen[] = 'save'; },
-			'object_acl' => function () { return true; },
+	$verdict = cdho_dispatch([
+		'request' => ['action' => 'save'],
+		'server'  => ['REQUEST_METHOD' => 'GET'],
+		'default' => '',
+		'actions' => [
+			'save' => ['handler' => 'save', 'object_acl' => true],
 		],
-	], '');
+	]);
 
-	expect($seen)->toBe(['save']);
+	expect($verdict['handler_calls'])->toBe(['save']);
 });
 
 /* --------------------------------------------------------------------- */
@@ -221,21 +164,20 @@ test('object_acl returning true invokes the handler exactly once', function () {
 /* --------------------------------------------------------------------- */
 
 test('non-callable object_acl logs ERROR and denies instead of silently allowing', function () {
-	$_REQUEST['action']        = 'save';
-	$_SERVER['REQUEST_METHOD'] = 'GET';
-
-	cacti_dispatch([
-		'save' => [
-			'callback'   => cdho_make_handler('save'),
-			'object_acl' => 'not_a_real_function_anywhere',
+	$verdict = cdho_dispatch([
+		'request' => ['action' => 'save'],
+		'server'  => ['REQUEST_METHOD' => 'GET'],
+		'default' => '',
+		'actions' => [
+			'save' => ['handler' => 'save', 'object_acl' => 'not_a_real_function_anywhere'],
 		],
-	], '');
+	]);
 
-	expect($GLOBALS['cdho_handler_calls'])->toBe([]);
-	expect(http_response_code())->toBe(403);
+	expect($verdict['handler_calls'])->toBe([]);
+	expect($verdict['http_code'])->toBe(403);
 
 	$errors = array_filter(
-		$GLOBALS['cdho_logs'],
+		$verdict['logs'],
 		fn ($entry) => str_starts_with($entry['message'], 'ERROR: cacti_dispatch: object_acl')
 	);
 	expect($errors)->not->toBeEmpty();
@@ -246,31 +188,31 @@ test('non-callable object_acl logs ERROR and denies instead of silently allowing
 /* --------------------------------------------------------------------- */
 
 test('AJAX denial calls raise_ajax_permission_denied', function () {
-	$_REQUEST['action']                  = 'save';
-	$_SERVER['REQUEST_METHOD']           = 'GET';
-	$_SERVER['HTTP_X_REQUESTED_WITH']    = 'XMLHttpRequest';
-
-	cacti_dispatch([
-		'save' => [
-			'callback'   => cdho_make_handler('save'),
-			'object_acl' => function () { return false; },
+	$verdict = cdho_dispatch([
+		'request' => ['action' => 'save'],
+		'server'  => [
+			'REQUEST_METHOD'        => 'GET',
+			'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest',
 		],
-	], '');
+		'default' => '',
+		'actions' => [
+			'save' => ['handler' => 'save', 'object_acl' => false],
+		],
+	]);
 
-	expect($GLOBALS['cdho_ajax_denied'])->toBeTrue();
+	expect($verdict['ajax_denied'])->toBeTrue();
 });
 
 test('non-AJAX denial sets an explicit 403 instead of falling through to 200', function () {
-	$_REQUEST['action']        = 'save';
-	$_SERVER['REQUEST_METHOD'] = 'GET';
-
-	cacti_dispatch([
-		'save' => [
-			'callback'   => cdho_make_handler('save'),
-			'object_acl' => function () { return false; },
+	$verdict = cdho_dispatch([
+		'request' => ['action' => 'save'],
+		'server'  => ['REQUEST_METHOD' => 'GET'],
+		'default' => '',
+		'actions' => [
+			'save' => ['handler' => 'save', 'object_acl' => false],
 		],
-	], '');
+	]);
 
-	expect($GLOBALS['cdho_ajax_denied'])->toBeFalse();
-	expect(http_response_code())->toBe(403);
+	expect($verdict['ajax_denied'])->toBeFalse();
+	expect($verdict['http_code'])->toBe(403);
 });

--- a/tests/HandOff/CactiDispatchHandOffTest.php
+++ b/tests/HandOff/CactiDispatchHandOffTest.php
@@ -39,7 +39,7 @@ require_once dirname(__DIR__) . '/Helpers/IsolatedProbe.php';
 function cdho_dispatch(array $scenario): array {
 	return cacti_test_isolated_probe(
 		__DIR__ . '/fixtures/cacti_dispatch_probe.php',
-		[json_encode($scenario)]
+		[json_encode($scenario, JSON_THROW_ON_ERROR)]
 	);
 }
 

--- a/tests/HandOff/OidStripHandOffTest.php
+++ b/tests/HandOff/OidStripHandOffTest.php
@@ -120,34 +120,59 @@ describe('OID strip hand-off pipeline', function () {
 		});
 	});
 
-	describe('single-.0 boundary: conservative gate', function () use ($defaultRegex) {
-		it('detection returns false when every OID ends in a single .0', function () use ($defaultRegex) {
-			// Every OID ends in exactly one .0, so the regex captures '0'
-			// for every row.  This is the ambiguous case the gate guards
-			// against: we cannot tell a scalar-style trailing .0 apart from
-			// a real trailing-zero pad without more rows of evidence.
+	describe('single-.0 boundary: gated on unique stripped indexes', function () use ($defaultRegex, $parseLastOctet) {
+		it('detection returns true when single-.0 padding resolves to unique indexes', function () use ($defaultRegex, $parseLastOctet) {
+			// Every OID ends in exactly one .0, so the default regex captures
+			// '0' for every row -- all three rows collapse onto one index.
+			// That collapse is the bug, and a single pad octet is enough to
+			// cause it, so the gate must repair this walk too.
 			$snmp_indexes = [
 				'.1.3.6.1.2.1.2.2.1.1.1.0' => 'eth0',
 				'.1.3.6.1.2.1.2.2.1.1.2.0' => 'eth1',
 				'.1.3.6.1.2.1.2.2.1.1.3.0' => 'lo0',
 			];
 
-			// The conservative gate: detection must NOT enable stripping
-			// when only a single .0 is present, because the production
-			// caller treats the detection helper's verdict as final.
+			expect(oid_index_should_strip_trailing_zero_padding($snmp_indexes, $defaultRegex))->toBeTrue();
+
+			$stripped = oid_index_strip_trailing_zero_padding($snmp_indexes);
+
+			// No row may be merged or dropped by the rewrite.
+			expect($stripped)->toHaveCount(count($snmp_indexes))
+				->and(array_values($stripped))->toBe(['eth0', 'eth1', 'lo0']);
+
+			$indexes = $parseLastOctet($stripped, $defaultRegex);
+
+			expect(array_values($indexes))->toBe(['1', '2', '3'])
+				->and(array_unique(array_values($indexes)))->toHaveCount(3);
+		});
+
+		it('detection returns false when single-.0 stripping leaves duplicate indexes', function () use ($defaultRegex) {
+			// Stripping produces two distinct keys, so the helper's own
+			// collision guard does not fire, but both stripped OIDs parse to
+			// index '5'.  Rewriting here would cross-wire two rows onto one
+			// data query index, so detection has to refuse.
+			$snmp_indexes = [
+				'.1.2.3.5.0' => 'first',
+				'.1.9.9.5.0' => 'second',
+			];
+
+			expect(oid_index_strip_trailing_zero_padding($snmp_indexes))->not->toBe($snmp_indexes);
+
 			expect(oid_index_should_strip_trailing_zero_padding($snmp_indexes, $defaultRegex))->toBeFalse();
 		});
 
-		it('strip helper, called directly with single-.0 input, is identity', function () {
-			// Even if the strip helper were invoked outside the gate, it
-			// must not mangle single-.0 input.  This locks in the helper's
-			// own conservative behaviour as a defence in depth.
+		it('strip helper, called directly with single-.0 input, strips and keeps every row', function () {
 			$snmp_indexes = [
 				'.1.3.6.1.2.1.2.2.1.1.1.0' => 'eth0',
 				'.1.3.6.1.2.1.2.2.1.1.2.0' => 'eth1',
 			];
 
-			expect(oid_index_strip_trailing_zero_padding($snmp_indexes))->toBe($snmp_indexes);
+			$stripped = oid_index_strip_trailing_zero_padding($snmp_indexes);
+
+			expect($stripped)->toBe([
+				'.1.3.6.1.2.1.2.2.1.1.1' => 'eth0',
+				'.1.3.6.1.2.1.2.2.1.1.2' => 'eth1',
+			]);
 		});
 	});
 

--- a/tests/HandOff/fixtures/cacti_dispatch_probe.php
+++ b/tests/HandOff/fixtures/cacti_dispatch_probe.php
@@ -1,0 +1,123 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Probe for CactiDispatchHandOffTest. Run by that test through
+ * cacti_test_isolated_probe(); prints a JSON verdict on stdout.
+ *
+ * The stubs below carry names lib/functions.php, lib/html_utility.php and
+ * lib/auth.php declare, so they must not exist in the PHPUnit process: a
+ * sibling test that pulls include/global.php would otherwise fatal on the
+ * redeclaration. Running here keeps them off the shared process entirely.
+ *
+ * argv[1] is the scenario as JSON:
+ *
+ *   request    array  Seeds $_REQUEST.
+ *   server     array  Seeds $_SERVER.
+ *   default    string Default action passed to cacti_dispatch().
+ *   actions    array  action name => {handler, method?, realm?, object_acl?}
+ *
+ * 'handler' is a tag recorded when the callback runs. 'object_acl' is either
+ * a bool (wrapped in a closure returning it) or a string, which is passed
+ * through untouched so the non-callable misdeclaration path stays reachable.
+ */
+
+function get_nfilter_request_var($name, $default = '') {
+	if (!isset($_REQUEST[$name])) {
+		return $default;
+	}
+
+	return $_REQUEST[$name];
+}
+
+function cacti_log($message, $output = false, $environ = 'CMDPHP', $level = -1) {
+	$GLOBALS['cdho_logs'][] = ['message' => $message, 'env' => $environ];
+}
+
+function cacti_strtoupper($s) {
+	return strtoupper((string) $s);
+}
+
+function cacti_strtolower($s) {
+	return strtolower((string) $s);
+}
+
+function is_realm_allowed($realm) {
+	return !empty($GLOBALS['cdho_allowed_realms'][$realm]);
+}
+
+function get_client_addr() {
+	return '127.0.0.1';
+}
+
+function raise_ajax_permission_denied() {
+	$GLOBALS['cdho_ajax_denied'] = true;
+}
+
+require_once dirname(__DIR__, 3) . '/lib/cacti_dispatch.php';
+
+$scenario = json_decode($argv[1] ?? '', true);
+
+if (!is_array($scenario)) {
+	fwrite(STDERR, 'scenario is not valid JSON' . PHP_EOL);
+
+	exit(2);
+}
+
+$_REQUEST                       = $scenario['request'] ?? [];
+$_SERVER                        = $scenario['server'] ?? [];
+$GLOBALS['cdho_logs']           = [];
+$GLOBALS['cdho_handler_calls']  = [];
+$GLOBALS['cdho_allowed_realms'] = $scenario['allowed_realms'] ?? [];
+$GLOBALS['cdho_ajax_denied']    = false;
+
+http_response_code(200);
+
+$actions = [];
+
+foreach ($scenario['actions'] ?? [] as $name => $spec) {
+	$tag   = $spec['handler'];
+	$entry = [
+		'callback' => function () use ($tag) {
+			$GLOBALS['cdho_handler_calls'][] = $tag;
+		},
+	];
+
+	if (isset($spec['method'])) {
+		$entry['method'] = $spec['method'];
+	}
+
+	if (isset($spec['realm'])) {
+		$entry['realm'] = $spec['realm'];
+	}
+
+	if (array_key_exists('object_acl', $spec)) {
+		$acl = $spec['object_acl'];
+
+		$entry['object_acl'] = is_bool($acl)
+			? function () use ($acl) { return $acl; }
+			: $acl;
+	}
+
+	$actions[$name] = $entry;
+}
+
+cacti_dispatch($actions, $scenario['default'] ?? '');
+
+echo json_encode([
+	'handler_calls' => $GLOBALS['cdho_handler_calls'],
+	'logs'          => $GLOBALS['cdho_logs'],
+	'ajax_denied'   => $GLOBALS['cdho_ajax_denied'],
+	'http_code'     => http_response_code(),
+]);

--- a/tests/Helpers/IsolatedProbe.php
+++ b/tests/Helpers/IsolatedProbe.php
@@ -39,17 +39,17 @@ if (!function_exists('cacti_test_isolated_probe')) {
 		// display_errors=stderr keeps PHP diagnostics (the GoogleAuthenticator
 		// deprecations lib/auth.php emits on PHP 8.4, for one) out of the JSON
 		// the probe writes to stdout.
-		$command = escapeshellarg(PHP_BINARY)
-			. ' -d display_errors=stderr'
-			. ' ' . escapeshellarg($script);
+		// argv form, so the child is executed directly and no shell parses
+		// the scenario payload
+		$argv = [PHP_BINARY, '-d', 'display_errors=stderr', $script];
 
 		foreach ($args as $arg) {
-			$command .= ' ' . escapeshellarg((string) $arg);
+			$argv[] = (string) $arg;
 		}
 
 		$pipes   = [];
 		$process = proc_open(
-			$command,
+			$argv,
 			[1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
 			$pipes
 		);

--- a/tests/Helpers/IsolatedProbe.php
+++ b/tests/Helpers/IsolatedProbe.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Runs a probe script in a child PHP process and returns its JSON verdict.
+ *
+ * A test that has to fake a Cacti runtime function must declare a name that
+ * lib/ already owns. PHP function declarations are process-global and cannot
+ * be undone, so the fake and the real declaration cannot coexist: whichever
+ * lands first wins, and the loser fatals with "Cannot redeclare". Because
+ * PHPUnit loads every file of a suite into one process, that turns the suite
+ * into a load-order lottery -- a new test file that requires lib/database.php
+ * is enough to break an unrelated test that fakes db_execute_prepared().
+ *
+ * Probe scripts sidestep the whole problem by owning their own process. They
+ * live under a fixtures/ directory so PHPUnit does not collect them, declare
+ * their fakes freely, and print a JSON verdict the parent asserts against.
+ */
+
+if (!function_exists('cacti_test_isolated_probe')) {
+	/**
+	 * @param string   $script Absolute path to the probe script.
+	 * @param string[] $args   Arguments appended to the child command line.
+	 *
+	 * @return array The decoded JSON verdict printed by the probe.
+	 */
+	function cacti_test_isolated_probe(string $script, array $args = []): array {
+		// display_errors=stderr keeps PHP diagnostics (the GoogleAuthenticator
+		// deprecations lib/auth.php emits on PHP 8.4, for one) out of the JSON
+		// the probe writes to stdout.
+		$command = escapeshellarg(PHP_BINARY)
+			. ' -d display_errors=stderr'
+			. ' ' . escapeshellarg($script);
+
+		foreach ($args as $arg) {
+			$command .= ' ' . escapeshellarg((string) $arg);
+		}
+
+		$pipes   = [];
+		$process = proc_open(
+			$command,
+			[1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+			$pipes
+		);
+
+		if (!is_resource($process)) {
+			throw new RuntimeException('could not spawn ' . basename($script));
+		}
+
+		$stdout = (string) stream_get_contents($pipes[1]);
+		$stderr = (string) stream_get_contents($pipes[2]);
+
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+
+		$status = proc_close($process);
+
+		if ($status !== 0) {
+			throw new RuntimeException(
+				basename($script) . ' exited ' . $status . ":\n" . trim($stderr)
+			);
+		}
+
+		$verdict = json_decode(trim($stdout), true);
+
+		if (!is_array($verdict)) {
+			throw new RuntimeException(
+				basename($script) . " printed no JSON verdict:\n"
+				. trim($stdout . "\n" . $stderr)
+			);
+		}
+
+		return $verdict;
+	}
+}

--- a/tests/Unit/AuthSystemCorrectnessTest.php
+++ b/tests/Unit/AuthSystemCorrectnessTest.php
@@ -102,7 +102,25 @@ test('remote agent authorization fails closed on fcrdns mismatch', function () u
 });
 
 test('basic authentication does not trust a client-supplied forwarded user header', function () use ($root) {
-	$auth = file_get_contents($root . '/lib/auth.php');
+	$auth  = file_get_contents($root . '/lib/auth.php');
+	$start = strpos($auth, 'function get_basic_auth_username()');
+	$body  = substr($auth, $start, strpos($auth, "\n}\n", $start) - $start);
 
-	expect($auth)->not->toContain('HTTP_X_FORWARDED_USER');
+	expect($auth)->toContain('function is_trusted_proxy() : bool')
+		->and($body)->toContain('$trusted = is_trusted_proxy();');
+
+	// HTTP_-prefixed server vars are built from request headers, so every read of
+	// one has to sit behind the trusted-proxy gate or an unauthenticated client
+	// can name whichever account it likes.
+	preg_match_all('/\$_SERVER\[\'(HTTP_[A-Z_]+)\'\]/', $body, $vars);
+
+	foreach (array_unique($vars[1]) as $var) {
+		expect($body)->toContain('$trusted && isset($_SERVER[\'' . $var . '\'])');
+	}
+
+	preg_match_all('/isset\(\$_SERVER\[\'HTTP_[A-Z_]+\'\]\)/', $body, $reads, PREG_OFFSET_CAPTURE);
+
+	foreach ($reads[0] as $read) {
+		expect(substr($body, 0, $read[1]))->toEndWith('$trusted && ');
+	}
 });

--- a/tests/Unit/Issue7137SmokeTest.php
+++ b/tests/Unit/Issue7137SmokeTest.php
@@ -37,12 +37,15 @@ test('every touched file passes a syntactic shebang/PHP-tag check', function () 
 	}
 });
 
-test('the four form_save inits are present and precede their empty() consumers', function () use ($repoRoot) {
+test('the four form_save inits are present and precede their null-fallback consumers', function () use ($repoRoot) {
+	/* #7317 and #7348 retyped the sql_save() result from '' to null, so the
+	 * redirect fallback now tests === null rather than empty().  The init
+	 * still has to reach the fallback on every path through form_save(). */
 	$cases = [
-		'aggregate_graphs.php' => ['$graph_template_item_id = 0;', 'empty($graph_template_item_id)'],
-		'color_templates.php'  => ['$color_template_item_id = 0;', 'empty($color_template_item_id)'],
-		'graph_templates.php'  => ['$graph_template_item_id = 0;', 'empty($graph_template_item_id)'],
-		'graphs.php'           => ['$graph_template_item_id = 0;', 'empty($graph_template_item_id)'],
+		'aggregate_graphs.php' => ['$graph_template_item_id = 0;', '$graph_template_item_id === null'],
+		'color_templates.php'  => ['$color_template_item_id = 0;', '$color_template_item_id === null'],
+		'graph_templates.php'  => ['$graph_template_item_id = 0;', '$graph_template_item_id === null'],
+		'graphs.php'           => ['$graph_template_item_id = 0;', '$graph_template_item_id === null'],
 	];
 	foreach ($cases as $rel => [$init, $consumer]) {
 		$src       = file_get_contents("$repoRoot/$rel");

--- a/tests/Unit/PhpstanLevel6BaselineFixesTest.php
+++ b/tests/Unit/PhpstanLevel6BaselineFixesTest.php
@@ -109,15 +109,16 @@ test('graphs.php save_component_item branch initialises $graph_template_item_id'
 	expect($initPos < $foreachPos)->toBeTrue('init must precede the items foreach');
 });
 
-test('the empty() fallback in the error-redirect URL still uses the variable', function () use ($sources) {
-	/* The init is a no-op if the redirect ever stops calling empty() on
-	 * the variable. Guard the call site so this PR does not silently
-	 * regress to a different shape. */
+test('the null fallback in the error-redirect URL still uses the variable', function () use ($sources) {
+	/* The init is a no-op if the redirect ever stops reading the variable.
+	 * Guard the call site so this PR does not silently regress to a
+	 * different shape.  #7317 and #7348 moved the sentinel from '' to null,
+	 * so the test is === null rather than empty(). */
 	$expected = [
-		'aggregate_graphs.php' => '(empty($graph_template_item_id) ? gfrv(\'graph_template_item_id\') : $graph_template_item_id)',
-		'color_templates.php'  => '(empty($color_template_item_id) ? gnrv(\'color_template_item_id\') : $color_template_item_id)',
-		'graph_templates.php'  => '(empty($graph_template_item_id) ? gnrv(\'graph_template_item_id\') : $graph_template_item_id)',
-		'graphs.php'           => '(empty($graph_template_item_id) ? gnrv(\'graph_template_item_id\') : $graph_template_item_id)',
+		'aggregate_graphs.php' => '($graph_template_item_id === null ? gfrv(\'graph_template_item_id\') : $graph_template_item_id)',
+		'color_templates.php'  => '($color_template_item_id === null ? gnrv(\'color_template_item_id\') : $color_template_item_id)',
+		'graph_templates.php'  => '($graph_template_item_id === null ? gnrv(\'graph_template_item_id\') : $graph_template_item_id)',
+		'graphs.php'           => '($graph_template_item_id === null ? gnrv(\'graph_template_item_id\') : $graph_template_item_id)',
 	];
 	foreach ($expected as $file => $needle) {
 		expect($sources[$file])->toContain($needle);

--- a/tests/Unit/VendorBootGuardTest.php
+++ b/tests/Unit/VendorBootGuardTest.php
@@ -25,10 +25,17 @@ test('global.php guards the autoload require with instructions', function () {
 	$src = file_get_contents(__DIR__ . '/../../include/global.php');
 	expect($src)->not->toBeFalse('Failed to read include/global.php');
 
-	$guardPos = strpos($src, "is_file(CACTI_PATH_INCLUDE . '/vendor/autoload.php')");
-	expect($guardPos)->not->toBeFalse('vendor guard must exist');
+	/* #7325 hoisted the path into $vendor_autoload so the installer can
+	 * repair the tree before the require.  Pin the assignment as well as
+	 * the guard, otherwise the variable could point anywhere. */
+	$pathPos = strpos($src, "\$vendor_autoload = CACTI_PATH_INCLUDE . '/vendor/autoload.php';");
+	expect($pathPos)->not->toBeFalse('vendor autoload path must be defined');
 
-	$requirePos = strpos($src, "require_once(CACTI_PATH_INCLUDE . '/vendor/autoload.php')");
+	$guardPos = strpos($src, 'if (!is_file($vendor_autoload)');
+	expect($guardPos)->not->toBeFalse('vendor guard must exist')
+		->and($pathPos)->toBeLessThan($guardPos, 'path must be set before the guard');
+
+	$requirePos = strpos($src, 'require_once($vendor_autoload)');
 	expect($requirePos)->not->toBeFalse('autoload require must exist')
 		->and($guardPos)->toBeLessThan($requirePos, 'guard must run before the require');
 

--- a/tests/integration/AuthSystemRegressionIntegrationTest.php
+++ b/tests/integration/AuthSystemRegressionIntegrationTest.php
@@ -12,90 +12,10 @@
  +-------------------------------------------------------------------------+
 */
 
-$root = dirname(__DIR__, 2);
+require_once dirname(__DIR__) . '/Helpers/IsolatedProbe.php';
 
-if (!defined('CACTI_PATH_INCLUDE')) {
-	define('CACTI_PATH_INCLUDE', $root . '/include');
-}
-
-if (!function_exists('cacti_sizeof')) {
-	function cacti_sizeof($array) {
-		return ($array === false || !is_array($array)) ? 0 : sizeof($array);
-	}
-}
-
-if (!function_exists('__')) {
-	function __($text, ...$args) {
-		return vsprintf($text, $args);
-	}
-}
-
-if (!function_exists('read_config_option')) {
-	function read_config_option($name) {
-		return $GLOBALS['auth_integration_config'][$name] ?? '';
-	}
-}
-
-if (!function_exists('db_fetch_cell_prepared')) {
-	function db_fetch_cell_prepared($sql, $params = []) {
-		if (str_contains($sql, 'FROM user_auth_realm')) {
-			return $GLOBALS['auth_integration_realms'] ?? 0;
-		}
-
-		if (str_contains($sql, 'FROM user_auth_group_realm')) {
-			return $GLOBALS['auth_integration_group_realms'] ?? 0;
-		}
-
-		if (str_contains($sql, 'FROM user_auth_cache')) {
-			$cache = $GLOBALS['auth_integration_cache'] ?? [];
-
-			foreach ($cache as $row) {
-				if ($row['user_id'] == $params[0] && $row['token'] == $params[1]) {
-					return $row['user_id'];
-				}
-			}
-		}
-
-		return 0;
-	}
-}
-
-if (!function_exists('db_fetch_assoc_prepared')) {
-	function db_fetch_assoc_prepared($sql, $params = []) {
-		return $GLOBALS['auth_integration_groups'] ?? [];
-	}
-}
-
-if (!function_exists('db_fetch_row_prepared')) {
-	function db_fetch_row_prepared($sql, $params = []) {
-		return $GLOBALS['auth_integration_users'][$params[0]] ?? [];
-	}
-}
-
-if (!function_exists('db_execute_prepared')) {
-	function db_execute_prepared($sql, $params = []) {
-		$GLOBALS['auth_integration_executed'][] = [
-			'sql'    => $sql,
-			'params' => $params,
-		];
-
-		return true;
-	}
-}
-
-if (!function_exists('db_table_exists')) {
-	function db_table_exists($table) {
-		return $table == 'user_auth_cache';
-	}
-}
-
-if (!function_exists('get_guest_account')) {
-	function get_guest_account() {
-		return (int) read_config_option('guest_user');
-	}
-}
-
-require_once $root . '/lib/auth.php';
+$root  = dirname(__DIR__, 2);
+$probe = __DIR__ . '/fixtures/auth_runtime_probe.php';
 
 test('auth subsystem regression coverage spans cookie login, 2fa, reset tokens, basic auth, and profile mutations', function () use ($root) {
 	$files = [
@@ -123,77 +43,22 @@ test('auth subsystem regression coverage spans cookie login, 2fa, reset tokens, 
 		->and($files['lib/auth.php'])->not->toContain('$result[\'secret\']');
 });
 
-test('remember-me cookie authorization rejects disabled and permissionless accounts at runtime', function () {
-	$GLOBALS['auth_integration_config'] = ['guest_user' => 0];
-	$GLOBALS['auth_integration_realms'] = 0;
-	$GLOBALS['auth_integration_groups'] = [];
+test('remember-me cookie authorization rejects disabled and permissionless accounts at runtime', function () use ($probe) {
+	$verdict = cacti_test_isolated_probe($probe, ['cookie-authorization']);
 
-	expect(auth_cookie_user_currently_allowed([
-		'id'           => 10,
-		'username'     => 'disabled',
-		'enabled'      => '',
-		'show_tree'    => '',
-		'show_list'    => '',
-		'show_preview' => '',
-	]))->toBeFalse()
-		->and(auth_cookie_user_currently_allowed([
-			'id'           => 11,
-			'username'     => 'noaccess',
-			'enabled'      => 'on',
-			'show_tree'    => '',
-			'show_list'    => '',
-			'show_preview' => '',
-		]))->toBeFalse();
-
-	$GLOBALS['auth_integration_realms'] = 1;
-
-	expect(auth_cookie_user_currently_allowed([
-		'id'           => 12,
-		'username'     => 'allowed',
-		'enabled'      => 'on',
-		'show_tree'    => '',
-		'show_list'    => '',
-		'show_preview' => '',
-	]))->toBeTrue();
+	expect($verdict['disabled'])->toBeFalse()
+		->and($verdict['noaccess'])->toBeFalse()
+		->and($verdict['allowed'])->toBeTrue();
 });
 
-test('remember-me cookie authorization verifies token before deleting cache rows', function () {
-	$GLOBALS['auth_integration_config'] = [
-		'auth_cache_enabled' => 'on',
-		'guest_user'         => 0,
-	];
-	$GLOBALS['auth_integration_realms']  = 1;
-	$GLOBALS['auth_integration_groups']  = [];
-	$GLOBALS['auth_integration_users']   = [
-		42 => [
-			'id'           => 42,
-			'username'     => 'disabled',
-			'realm'        => 0,
-			'enabled'      => '',
-			'show_tree'    => '',
-			'show_list'    => '',
-			'show_preview' => '',
-		],
-	];
-	$GLOBALS['auth_integration_cache']    = [
-		[
-			'user_id' => 42,
-			'token'   => hash('sha512', 'valid-token', false),
-		],
-	];
-	$GLOBALS['auth_integration_executed'] = [];
+test('remember-me cookie authorization verifies token before deleting cache rows', function () use ($probe) {
+	$verdict = cacti_test_isolated_probe($probe, ['cookie-token-check']);
 
-	$_COOKIE['cacti_remembers'] = '42,-1,forged-token';
+	expect($verdict['forged']['result'])->toBeFalse()
+		->and($verdict['forged']['executed'])->toBeEmpty();
 
-	expect(check_auth_cookie())->toBeFalse()
-		->and($GLOBALS['auth_integration_executed'])->toBeEmpty();
-
-	$_COOKIE['cacti_remembers'] = '42,-1,valid-token';
-
-	expect(check_auth_cookie())->toBeFalse()
-		->and($GLOBALS['auth_integration_executed'])->toHaveCount(1)
-		->and($GLOBALS['auth_integration_executed'][0]['sql'])->toContain('DELETE FROM user_auth_cache')
-		->and($GLOBALS['auth_integration_executed'][0]['params'])->toBe([42]);
-
-	unset($_COOKIE['cacti_remembers']);
+	expect($verdict['valid']['result'])->toBeFalse()
+		->and($verdict['valid']['executed'])->toHaveCount(1)
+		->and($verdict['valid']['executed'][0]['sql'])->toContain('DELETE FROM user_auth_cache')
+		->and($verdict['valid']['executed'][0]['params'])->toBe([42]);
 });

--- a/tests/integration/fixtures/auth_runtime_probe.php
+++ b/tests/integration/fixtures/auth_runtime_probe.php
@@ -1,0 +1,179 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Probe for AuthSystemRegressionIntegrationTest. Run by that test through
+ * cacti_test_isolated_probe(); prints a JSON verdict on stdout.
+ *
+ * The db_* fakes below carry the names lib/database.php declares, so they
+ * must not exist in the PHPUnit process. Keeping them here means the
+ * Integration suite can load lib/database.php from any number of sibling
+ * files without colliding with this test.
+ */
+
+$root = dirname(__DIR__, 3);
+
+define('CACTI_PATH_INCLUDE', $root . '/include');
+
+function cacti_sizeof($array) {
+	return ($array === false || !is_array($array)) ? 0 : sizeof($array);
+}
+
+function __($text, ...$args) {
+	return vsprintf($text, $args);
+}
+
+function read_config_option($name) {
+	return $GLOBALS['auth_integration_config'][$name] ?? '';
+}
+
+function db_fetch_cell_prepared($sql, $params = []) {
+	if (str_contains($sql, 'FROM user_auth_realm')) {
+		return $GLOBALS['auth_integration_realms'] ?? 0;
+	}
+
+	if (str_contains($sql, 'FROM user_auth_group_realm')) {
+		return $GLOBALS['auth_integration_group_realms'] ?? 0;
+	}
+
+	if (str_contains($sql, 'FROM user_auth_cache')) {
+		$cache = $GLOBALS['auth_integration_cache'] ?? [];
+
+		foreach ($cache as $row) {
+			if ($row['user_id'] == $params[0] && $row['token'] == $params[1]) {
+				return $row['user_id'];
+			}
+		}
+	}
+
+	return 0;
+}
+
+function db_fetch_assoc_prepared($sql, $params = []) {
+	return $GLOBALS['auth_integration_groups'] ?? [];
+}
+
+function db_fetch_row_prepared($sql, $params = []) {
+	return $GLOBALS['auth_integration_users'][$params[0]] ?? [];
+}
+
+function db_execute_prepared($sql, $params = []) {
+	$GLOBALS['auth_integration_executed'][] = [
+		'sql'    => $sql,
+		'params' => $params,
+	];
+
+	return true;
+}
+
+function db_table_exists($table) {
+	return $table == 'user_auth_cache';
+}
+
+function get_guest_account() {
+	return (int) read_config_option('guest_user');
+}
+
+require_once $root . '/lib/auth.php';
+
+switch ($argv[1] ?? '') {
+	case 'cookie-authorization':
+		$GLOBALS['auth_integration_config'] = ['guest_user' => 0];
+		$GLOBALS['auth_integration_realms'] = 0;
+		$GLOBALS['auth_integration_groups'] = [];
+
+		$verdict = [
+			'disabled' => auth_cookie_user_currently_allowed([
+				'id'           => 10,
+				'username'     => 'disabled',
+				'enabled'      => '',
+				'show_tree'    => '',
+				'show_list'    => '',
+				'show_preview' => '',
+			]),
+			'noaccess' => auth_cookie_user_currently_allowed([
+				'id'           => 11,
+				'username'     => 'noaccess',
+				'enabled'      => 'on',
+				'show_tree'    => '',
+				'show_list'    => '',
+				'show_preview' => '',
+			]),
+		];
+
+		$GLOBALS['auth_integration_realms'] = 1;
+
+		$verdict['allowed'] = auth_cookie_user_currently_allowed([
+			'id'           => 12,
+			'username'     => 'allowed',
+			'enabled'      => 'on',
+			'show_tree'    => '',
+			'show_list'    => '',
+			'show_preview' => '',
+		]);
+
+		break;
+
+	case 'cookie-token-check':
+		$GLOBALS['auth_integration_config'] = [
+			'auth_cache_enabled' => 'on',
+			'guest_user'         => 0,
+		];
+		$GLOBALS['auth_integration_realms'] = 1;
+		$GLOBALS['auth_integration_groups'] = [];
+		$GLOBALS['auth_integration_users']  = [
+			42 => [
+				'id'           => 42,
+				'username'     => 'disabled',
+				'realm'        => 0,
+				'enabled'      => '',
+				'show_tree'    => '',
+				'show_list'    => '',
+				'show_preview' => '',
+			],
+		];
+		$GLOBALS['auth_integration_cache'] = [
+			[
+				'user_id' => 42,
+				'token'   => hash('sha512', 'valid-token', false),
+			],
+		];
+
+		$GLOBALS['auth_integration_executed'] = [];
+		$_COOKIE['cacti_remembers']           = '42,-1,forged-token';
+
+		$verdict = [
+			'forged' => [
+				'result'   => check_auth_cookie(),
+				'executed' => $GLOBALS['auth_integration_executed'],
+			],
+		];
+
+		$GLOBALS['auth_integration_executed'] = [];
+		$_COOKIE['cacti_remembers']           = '42,-1,valid-token';
+
+		$verdict['valid'] = [
+			'result'   => check_auth_cookie(),
+			'executed' => $GLOBALS['auth_integration_executed'],
+		];
+
+		break;
+
+	default:
+		fwrite(STDERR, 'unknown scenario "' . ($argv[1] ?? '') . '"' . PHP_EOL);
+
+		exit(2);
+}
+
+echo json_encode($verdict);

--- a/tests/tools/check_hardening_patterns.php
+++ b/tests/tools/check_hardening_patterns.php
@@ -36,6 +36,8 @@ $patterns = [
 			// pre-boot code; the request helper layer is not loaded yet
 			'include/global.php',
 			'lib/PackageListFilter.php',
+			// test fixture standing in for the request helper itself
+			'tests/HandOff/fixtures/cacti_dispatch_probe.php',
 		]
 	],
 //	'manual-request-query-url' => [


### PR DESCRIPTION
Both suites currently fatal at collection:

```
Cannot redeclare function db_execute_prepared() (previously declared in
  tests/integration/AuthSystemRegressionIntegrationTest.php:76) in lib/database.php
Cannot redeclare function cacti_log() (previously declared in
  tests/HandOff/CactiDispatchHandOffTest.php:48) in lib/functions.php
```

Those two files declare production function names at file scope behind `function_exists()`, and sibling tests require the real `lib/database.php` / `lib/functions.php`. PHPUnit loads every file in a suite before running, so whichever sorts first wins.

More importantly, `composer run-script test` is green today because it **quits early**, not because it passes. In a full run the Unit suite loads both real files first, so every `function_exists()` guard is false and no fake installs. `CactiDispatchHandOffTest` then calls the real `raise_ajax_permission_denied()`, which ends in `exit;`. PHPUnit dies mid-report, the summary and the rest of HandOff never run, and the shell sees exit 0. So the HandOff suite has not actually been running.

A fake and a real declaration cannot coexist — PHP function declarations are process-global and irreversible — so the runtime tests now execute in a child process via a fixture probe, following the pattern already used by `CactiMimeHandOffTest` and `SqlInterpolationRatchetIntegrationTest`. The parent processes declare no production names. Assertions are unchanged, one indirection away.

Test files only; no production code touched.

| run | before | after |
|---|---|---|
| `--testsuite=Integration` | fatal, 0 tests | 2 failed, 4 skipped, 29 passed |
| `--testsuite=HandOff` | fatal, 0 tests | 2 failed, 6 skipped, 33 passed |
| `--testsuite=Unit` | 1155 passed | unchanged |
| `composer run-script test` | no summary, exit 0 | 1217 passed, exit 2 |

Robustness was verified by adding throwaway files requiring `lib/database.php` that sort both before and after the stub file; the suite loads in both cases, and reverting the stub file reproduces the fatal.

All six failures the completed run exposed are fixed in this PR. Every one was a stale assertion, not a production regression: two tracked an `empty()` sentinel that #7317/#7348 retyped to `=== null`, one tracked an autoload path that #7325 hoisted into a variable, one tracked a forwarded-user guard that #7324 made strictly stronger by gating it behind `is_trusted_proxy()`, and the two OID ones encoded a conservative gate that was deliberately removed before merge (the merged sibling unit test asserts the opposite, so both could not pass). Tests only; no production code changed.