### PR TITLE
perf(database): batch db_update_table schema alters

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -1592,14 +1592,17 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 		return db_table_create($table, $data, $log, $db_conn);
 	}
 
-	if (isset($data['charset'])) {
-		$charset = ' DEFAULT CHARSET = ' . $data['charset'];
-		db_execute("ALTER TABLE `$table` " . $charset, $log, $db_conn);
-	}
+	$alter_clauses   = [];
+	$columns_changed = false;
 
-	if (isset($data['collate'])) {
-		$charset = ' COLLATE = ' . $data['collate'];
-		db_execute("ALTER TABLE `$table` " . $charset, $log, $db_conn);
+	if (isset($data['charset']) || isset($data['collate'])) {
+		$table_encoding = isset($data['charset']) ? 'DEFAULT CHARSET = ' . $data['charset'] : '';
+
+		if (isset($data['collate'])) {
+			$table_encoding .= ($table_encoding !== '' ? ' ' : 'DEFAULT ') . 'COLLATE = ' . $data['collate'];
+		}
+
+		$alter_clauses[] = $table_encoding;
 	}
 
 	$info = db_fetch_row("SELECT ENGINE, TABLE_COMMENT
@@ -1608,14 +1611,66 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 		AND TABLE_NAME = '$table'", $log, $db_conn);
 
 	if (isset($info['ENGINE']) && isset($data['type']) && cacti_strtolower($info['ENGINE']) != cacti_strtolower($data['type'])) {
-		if (!db_execute("ALTER TABLE `$table` ENGINE = " . $data['type'], $log, $db_conn)) {
-			return false;
-		}
+		$alter_clauses[] = 'ENGINE = ' . $data['type'];
 	}
 
 	if (isset($data['row_format']) && cacti_strtolower(db_get_global_variable('innodb_file_format', $db_conn)) == 'barracuda') {
-		db_execute("ALTER TABLE `$table` ROW_FORMAT = " . $data['row_format'], $log, $db_conn);
+		$alter_clauses[] = 'ROW_FORMAT = ' . $data['row_format'];
 	}
+
+	$column_definition = static function (array $column, bool $include_position = true) : string {
+		$sql = '`' . $column['name'] . '`';
+
+		if (isset($column['type'])) {
+			$sql .= ' ' . $column['type'];
+		}
+
+		if (isset($column['unsigned'])) {
+			$sql .= ' unsigned';
+		}
+
+		if (isset($column['NULL']) && $column['NULL'] === false) {
+			$sql .= ' NOT NULL';
+		}
+
+		if (isset($column['NULL']) && $column['NULL'] === true && !isset($column['default'])) {
+			$sql .= ' default NULL';
+		}
+
+		if (isset($column['default'])) {
+			$current_timestamp = $include_position
+				? in_array(cacti_strtolower($column['type']), ['timestamp', 'datetime', 'date'], true) && str_contains($column['default'], 'CURRENT_TIMESTAMP')
+				: cacti_strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP';
+
+			if ($current_timestamp) {
+				$sql .= ' default ' . $column['default'];
+			} else {
+				$sql .= ' default ' . (is_numeric($column['default']) ? $column['default'] : "'" . $column['default'] . "'");
+			}
+		}
+
+		if (isset($column['on_update'])) {
+			$sql .= ' ON UPDATE ' . $column['on_update'];
+		}
+
+		if (isset($column['auto_increment'])) {
+			$sql .= ' auto_increment';
+		}
+
+		if (isset($column['comment'])) {
+			$sql .= " COMMENT '" . $column['comment'] . "'";
+		}
+
+		if ($include_position) {
+			if (isset($column['after'])) {
+				$sql .= ' AFTER ' . $column['after'];
+			} elseif (isset($column['first'])) {
+				$sql .= ' FIRST';
+			}
+		}
+
+		return $sql;
+	};
 
 	$allcolumns  = [];
 	$prev_column = false;
@@ -1630,9 +1685,8 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 				$column['first'] = true;
 			}
 
-			if (!db_add_column($table, $column, $log, $db_conn)) {
-				return false;
-			}
+			$alter_clauses[] = 'ADD ' . $column_definition($column);
+			$columns_changed = true;
 		} else {
 			// Check that column is correct and fix it
 			// FIXME: Need to still check default value
@@ -1647,47 +1701,8 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 				|| (((!isset($column['unsigned']) || !$column['unsigned']) && isset($arr['unsigned']))
 					|| (isset($column['unsigned']) && $column['unsigned'] && !isset($arr['unsigned'])))
 				|| (isset($column['auto_increment']) && ($column['auto_increment'] ? 'auto_increment' : '') != $arr['Extra'])) {
-				$sql = 'ALTER TABLE `' . $table . '` CHANGE `' . $column['name'] . '` `' . $column['name'] . '`';
-
-				if (isset($column['type'])) {
-					$sql .= ' ' . $column['type'];
-				}
-
-				if (isset($column['unsigned'])) {
-					$sql .= ' unsigned';
-				}
-
-				if (isset($column['NULL']) && $column['NULL'] == false) {
-					$sql .= ' NOT NULL';
-				}
-
-				if (isset($column['NULL']) && $column['NULL'] == true && !isset($column['default'])) {
-					$sql .= ' default NULL';
-				}
-
-				if (isset($column['default'])) {
-					if (cacti_strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP') {
-						$sql .= ' default CURRENT_TIMESTAMP';
-					} else {
-						$sql .= ' default ' . (is_numeric($column['default']) ? $column['default'] : "'" . $column['default'] . "'");
-					}
-				}
-
-				if (isset($column['on_update'])) {
-					$sql .= ' ON UPDATE ' . $column['on_update'];
-				}
-
-				if (isset($column['auto_increment'])) {
-					$sql .= ' auto_increment';
-				}
-
-				if (isset($column['comment'])) {
-					$sql .= " COMMENT '" . $column['comment'] . "'";
-				}
-
-				if (!db_execute($sql, $log, $db_conn)) {
-					return false;
-				}
+				$alter_clauses[] = 'CHANGE `' . $column['name'] . '` ' . $column_definition($column, false);
+				$columns_changed = true;
 			}
 		}
 
@@ -1699,17 +1714,14 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 
 		foreach ($result as $arr) {
 			if (!in_array($arr['Field'], $allcolumns, true)) {
-				if (!db_remove_column($table, $arr['Field'], $log, $db_conn)) {
-					return false;
-				}
+				$alter_clauses[] = 'DROP COLUMN `' . $arr['Field'] . '`';
+				$columns_changed = true;
 			}
 		}
 	}
 
 	if (isset($info['TABLE_COMMENT']) && isset($data['comment']) && str_replace("'", '', $info['TABLE_COMMENT']) != str_replace("'", '', $data['comment'])) {
-		if (!db_execute("ALTER TABLE `$table` COMMENT '" . str_replace("'", '', $data['comment']) . "'", $log, $db_conn)) {
-			return false;
-		}
+		$alter_clauses[] = "COMMENT '" . str_replace("'", '', $data['comment']) . "'";
 	}
 
 	// Correct any indexes
@@ -1731,10 +1743,8 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 					$del         = array_diff($index, $k['columns']);
 
 					if (!empty($add) || !empty($del)) {
-						if (!db_execute("ALTER TABLE `$table` DROP INDEX `$n`", $log, $db_conn) ||
-							!db_execute("ALTER TABLE `$table` ADD" . (isset($k['unique']) ? ' UNIQUE' : '') . " INDEX `$n` (" . $k['name'] . '` (' . db_format_index_create($k['columns']) . ')', $log, $db_conn)) {
-							return false;
-						}
+						$alter_clauses[] = "DROP INDEX `$n`";
+						$alter_clauses[] = 'ADD' . (isset($k['unique']) ? ' UNIQUE' : '') . ' INDEX `' . $k['name'] . '` (' . db_format_index_create($k['columns']) . ')';
 					}
 
 					break;
@@ -1742,9 +1752,7 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 			}
 
 			if ($removeindex) {
-				if (!db_execute("ALTER TABLE `$table` DROP INDEX `$n`", $log, $db_conn)) {
-					return false;
-				}
+				$alter_clauses[] = "DROP INDEX `$n`";
 			}
 		}
 	}
@@ -1753,9 +1761,7 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 	if (isset($data['keys'])) {
 		foreach ($data['keys'] as $k) {
 			if (!isset($allindexes[$k['name']])) {
-				if (!db_execute("ALTER TABLE `$table` ADD" . (isset($k['unique']) ? ' UNIQUE' : '') . ' INDEX `' . $k['name'] . '` (' . db_format_index_create($k['columns']) . ')', $log, $db_conn)) {
-					return false;
-				}
+				$alter_clauses[] = 'ADD' . (isset($k['unique']) ? ' UNIQUE' : '') . ' INDEX `' . $k['name'] . '` (' . db_format_index_create($k['columns']) . ')';
 			}
 		}
 	}
@@ -1764,18 +1770,14 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 
 	// Check Primary Key
 	if (!isset($data['primary']) && isset($allindexes['PRIMARY'])) {
-		if (!db_execute("ALTER TABLE `$table` DROP PRIMARY KEY", $log, $db_conn)) {
-			return false;
-		}
+		$alter_clauses[] = 'DROP PRIMARY KEY';
 		unset($allindexes['PRIMARY']);
 	}
 
 	if (isset($data['primary'])) {
 		if (!isset($allindexes['PRIMARY'])) {
 			// No current primary key, so add it
-			if (!db_execute("ALTER TABLE `$table` ADD PRIMARY KEY(" . db_format_index_create($data['primary']) . ')', $log, $db_conn)) {
-				return false;
-			}
+			$alter_clauses[] = 'ADD PRIMARY KEY (' . db_format_index_create($data['primary']) . ')';
 		} else {
 			if (!is_array($data['primary'])) {
 				$data['primary'] = [$data['primary']];
@@ -1785,12 +1787,18 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 			$del = array_diff($allindexes['PRIMARY'], $data['primary']);
 
 			if (!empty($add) || !empty($del)) {
-				if (!db_execute("ALTER TABLE `$table` DROP PRIMARY KEY", $log, $db_conn) ||
-					!db_execute("ALTER TABLE `$table` ADD PRIMARY KEY(" . db_format_index_create($data['primary']) . ')', $log, $db_conn)) {
-					return false;
-				}
+				$alter_clauses[] = 'DROP PRIMARY KEY';
+				$alter_clauses[] = 'ADD PRIMARY KEY (' . db_format_index_create($data['primary']) . ')';
 			}
 		}
+	}
+
+	if (cacti_sizeof($alter_clauses) && !db_execute("ALTER TABLE `$table` " . implode(', ', $alter_clauses), $log, $db_conn)) {
+		return false;
+	}
+
+	if ($columns_changed) {
+		db_column_type_cache_reset();
 	}
 
 	return true;

--- a/lib/database.php
+++ b/lib/database.php
@@ -1599,7 +1599,7 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 		$table_encoding = isset($data['charset']) ? 'DEFAULT CHARSET = ' . $data['charset'] : '';
 
 		if (isset($data['collate'])) {
-			$table_encoding .= ($table_encoding !== '' ? ' ' : 'DEFAULT ') . 'COLLATE = ' . $data['collate'];
+			$table_encoding .= ($table_encoding !== '' ? ' ' : '') . 'COLLATE = ' . $data['collate'];
 		}
 
 		$alter_clauses[] = $table_encoding;
@@ -1638,9 +1638,8 @@ function db_update_table(string $table, array $data, bool $removecolumns = false
 		}
 
 		if (isset($column['default'])) {
-			$current_timestamp = $include_position
-				? in_array(cacti_strtolower($column['type']), ['timestamp', 'datetime', 'date'], true) && str_contains($column['default'], 'CURRENT_TIMESTAMP')
-				: cacti_strtolower($column['type']) == 'timestamp' && $column['default'] === 'CURRENT_TIMESTAMP';
+			$current_timestamp = in_array(cacti_strtolower($column['type']), ['timestamp', 'datetime', 'date'], true)
+				&& preg_match('/^CURRENT_TIMESTAMP(?:\(\d*\))?$/i', (string) $column['default']);
 
 			if ($current_timestamp) {
 				$sql .= ' default ' . $column['default'];

--- a/tests/Unit/DbUpdateTableBatchingTest.php
+++ b/tests/Unit/DbUpdateTableBatchingTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$source = file_get_contents(dirname(__DIR__, 2) . '/lib/database.php');
+expect($source)->not->toBeFalse('lib/database.php must be readable');
+
+$start = strpos($source, 'function db_update_table(');
+expect($start)->not->toBeFalse('db_update_table() must exist');
+
+$end = strpos($source, 'function db_format_index_create(', $start);
+expect($end)->not->toBeFalse('db_format_index_create() must follow db_update_table()');
+
+$body = substr($source, $start, $end - $start);
+
+test('db_update_table batches every schema change into one alter statement', function () use ($body) {
+	expect(substr_count($body, 'db_execute('))->toBe(1)
+		->and($body)->toContain("implode(', ', \$alter_clauses)")
+		->and($body)->toContain("'ADD ' . \$column_definition")
+		->and($body)->toContain("'CHANGE `'")
+		->and($body)->toContain("'DROP COLUMN `'")
+		->and($body)->toContain("'ADD' . (isset(\$k['unique'])")
+		->and($body)->toContain("'DROP PRIMARY KEY'")
+		->and($body)->not->toContain('db_add_column(')
+		->and($body)->not->toContain('db_remove_column(');
+});

--- a/tests/Unit/DbUpdateTableBatchingTest.php
+++ b/tests/Unit/DbUpdateTableBatchingTest.php
@@ -17,25 +17,47 @@
  +-------------------------------------------------------------------------+
 */
 
-$source = file_get_contents(dirname(__DIR__, 2) . '/lib/database.php');
-expect($source)->not->toBeFalse('lib/database.php must be readable');
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once dirname(__DIR__) . '/Helpers/FakeMySQLPDO.php';
+require_once dirname(__DIR__, 2) . '/include/vendor/autoload.php';
+require_once dirname(__DIR__, 2) . '/lib/database.php';
 
-$start = strpos($source, 'function db_update_table(');
-expect($start)->not->toBeFalse('db_update_table() must exist');
+class DbUpdateTableRecordingPDO extends FakeMySQLPDO {
+	public array $alterStatements = [];
 
-$end = strpos($source, 'function db_format_index_create(', $start);
-expect($end)->not->toBeFalse('db_format_index_create() must follow db_update_table()');
+	public function prepare(string $query, array $options = []): PDOStatement|false {
+		if (str_starts_with(ltrim($query), 'ALTER TABLE')) {
+			$this->alterStatements[] = $query;
 
-$body = substr($source, $start, $end - $start);
+			return parent::prepare('SELECT 1', $options);
+		}
 
-test('db_update_table batches every schema change into one alter statement', function () use ($body) {
-	expect(substr_count($body, 'db_execute('))->toBe(1)
-		->and($body)->toContain("implode(', ', \$alter_clauses)")
-		->and($body)->toContain("'ADD ' . \$column_definition")
-		->and($body)->toContain("'CHANGE `'")
-		->and($body)->toContain("'DROP COLUMN `'")
-		->and($body)->toContain("'ADD' . (isset(\$k['unique'])")
-		->and($body)->toContain("'DROP PRIMARY KEY'")
-		->and($body)->not->toContain('db_add_column(')
-		->and($body)->not->toContain('db_remove_column(');
+		if (str_contains($query, 'information_schema.TABLES')) {
+			return parent::prepare("SELECT 'InnoDB' AS ENGINE, '' AS TABLE_COMMENT", $options);
+		}
+
+		return parent::prepare($query, $options);
+	}
+}
+
+test('db_update_table batches schema changes and preserves timestamp expressions', function () {
+	$connection = new DbUpdateTableRecordingPDO();
+	$connection->exec('CREATE TABLE test_table (id INTEGER NOT NULL, changed TEXT, obsolete TEXT)');
+
+	$result = db_update_table('test_table', [
+		'collate' => 'utf8mb4_unicode_ci',
+		'columns' => [
+			['name' => 'id', 'type' => 'INTEGER', 'NULL' => false],
+			['name' => 'changed', 'type' => 'datetime', 'NULL' => false, 'default' => 'CURRENT_TIMESTAMP(6)'],
+			['name' => 'created_at', 'type' => 'timestamp', 'NULL' => false, 'default' => 'CURRENT_TIMESTAMP'],
+		],
+	], true, false, $connection);
+
+	expect($result)->toBeTrue()
+		->and($connection->alterStatements)->toHaveCount(1)
+		->and($connection->alterStatements[0])->toContain('COLLATE = utf8mb4_unicode_ci')
+		->and($connection->alterStatements[0])->not->toContain('DEFAULT COLLATE')
+		->and($connection->alterStatements[0])->toContain('CHANGE `changed` `changed` datetime NOT NULL default CURRENT_TIMESTAMP(6)')
+		->and($connection->alterStatements[0])->toContain('ADD `created_at` timestamp NOT NULL default CURRENT_TIMESTAMP')
+		->and($connection->alterStatements[0])->toContain('DROP COLUMN `obsolete`');
 });


### PR DESCRIPTION
## Summary
- collect db_update_table schema changes into one compound ALTER TABLE statement
- preserve column ordering, table options, index replacement, and primary-key updates
- reset column metadata only after the compound alter succeeds
- add a structural regression test that enforces the single-execution contract

This is the develop counterpart requested in review on #7235.

## Test
- php -l lib/database.php
- ./include/vendor/bin/pest tests/Unit/DbUpdateTableBatchingTest.php