### PR TITLE
fix(csp): honor alternate frame ancestors

### DIFF
--- a/lib/headers_secure.php
+++ b/lib/headers_secure.php
@@ -142,7 +142,7 @@ class CactiSecureHeaders {
 			. "font-src 'self' {$alternates}; "
 			. "connect-src 'self' {$alternates}; "
 			. "frame-src 'self' {$alternates}; "
-			. "frame-ancestors 'self'; "
+			. "frame-ancestors 'self' {$alternates}; "
 			. "worker-src 'self' {$alternates}; "
 			. "object-src 'none'; "
 			. "base-uri 'self'; "

--- a/tests/Unit/HeadersSecureTest.php
+++ b/tests/Unit/HeadersSecureTest.php
@@ -84,6 +84,15 @@ test('buildCspPolicy empty mode has unsafe-inline in script-src', function () {
 	expect($policy)->toContain("'unsafe-inline'");
 });
 
+test('buildCspPolicy allows configured alternate frame ancestors', function () {
+	$policy = CactiSecureHeaders::buildCspPolicy('', '', 'https://dashboard.example.com');
+	$start  = strpos($policy, 'frame-ancestors');
+	$end    = strpos($policy, ';', $start);
+
+	expect(substr($policy, $start, $end - $start))
+		->toContain("'self' https://dashboard.example.com");
+});
+
 test('buildCspPolicy nonce mode has nonce token and no unsafe-inline in script-src', function () {
 	$policy = CactiSecureHeaders::buildCspPolicy('nonce', 'XYZ', '');
 	expect($policy)->toContain("'nonce-XYZ'");


### PR DESCRIPTION
## Summary

- include configured alternate CSP sources in `frame-ancestors`
- add regression coverage for an external dashboard origin

## Root cause and impact

`CactiSecureHeaders::buildCspPolicy()` applied `content_security_alternate_sources` to the other relevant source-list directives but hard-coded `frame-ancestors` to `'self'`. Operators could configure a trusted dashboard origin without that dashboard being allowed to embed Cacti.

## Branch and duplicate audit

- target: `1.2.x`; this implementation exists only on that branch
- `develop` uses a separate CSP implementation and had the same omission; companion PR #7597 covers it
- no other open or merged PR implements this `1.2.x` change

## Test coverage and PHPDoc

- change coverage: 100% — the changed policy directive is executed and isolated by the regression test, which asserts both `'self'` and the configured external origin
- existing empty-alternate tests execute the same line without an alternate origin
- no functions, methods, classes, or public APIs are introduced; `buildCspPolicy()` already has complete PHPDoc

## Verification

- `php -l lib/headers_secure.php`
- `php -l tests/Unit/HeadersSecureTest.php`
- `tests/vendor/bin/pest tests/Unit/HeadersSecureTest.php` (18 tests, 26 assertions)

Resolves the `1.2.x` portion of #7585. GitHub does not auto-close issues from non-default branches.
