### PR TITLE
fix(session): guard request URI reads on 1.2.x

### DIFF
--- a/include/global_session.php
+++ b/include/global_session.php
@@ -49,6 +49,8 @@ if (isset($_SESSION['clog_error']) && $_SESSION['clog_error'] != '') {
 }
 
 $script = basename($_SERVER['SCRIPT_NAME']);
+$request_uri = $_SERVER['REQUEST_URI'] ?? '';
+
 if ($script == 'graph_view.php' || $script == 'graph.php') {
 	if (isset($_SESSION['custom']) && $_SESSION['custom'] == true) {
 		$refreshIsLogout = 'true';
@@ -94,11 +96,11 @@ if (isset($_SESSION['refresh'])) {
 	$refreshIsLogout      = 'false';
 } elseif (isset($refresh)) {
 	$myrefresh['seconds'] = $refresh;
-	$myrefresh['page']    = sanitize_uri(appendHeaderSuppression($_SERVER['REQUEST_URI']));
+	$myrefresh['page']    = sanitize_uri(appendHeaderSuppression($request_uri));
 	$refreshIsLogout      = 'false';
 } elseif (read_config_option('auth_cache_enabled') == 'on' && isset($_SESSION['cacti_remembers']) && $_SESSION['cacti_remembers'] == true) {
 	$myrefresh['seconds'] = 99999999;
-	$myrefresh['page']    = sanitize_uri($_SERVER['REQUEST_URI']);
+	$myrefresh['page']    = sanitize_uri($request_uri);
 	$refreshIsLogout      = 'false';
 } elseif (read_user_setting('user_auto_logout_time') > 0 && is_realm_allowed(8)) {
 	$myrefresh['seconds'] = read_user_setting('user_auto_logout_time');
@@ -108,9 +110,9 @@ if (isset($_SESSION['refresh'])) {
 	$myrefresh['seconds'] = 99999999;
 	$myrefresh['page']    = 'index.php';
 	$refreshIsLogout      = 'false';
-} elseif (!isset($_SESSION['sess_user_id']) && isset($_SERVER['REQUEST_URL']) && strpos($_SERVER['REQUEST_URI'], 'index.php') !== false) {
+} elseif (!isset($_SESSION['sess_user_id']) && strpos($request_uri, 'index.php') !== false) {
 	$myrefresh['seconds'] = 99999999;
-	$myrefresh['page']    = sanitize_uri($_SERVER['REQUEST_URI']);
+	$myrefresh['page']    = sanitize_uri($request_uri);
 	$refreshIsLogout      = 'false';
 } else {
 	$myrefresh['seconds'] = ini_get('session.gc_maxlifetime');
@@ -121,14 +123,14 @@ if (isset($_SESSION['refresh'])) {
 /* guest account does not auto log off */
 if (isset($_SESSION['sess_user_id']) && $_SESSION['sess_user_id'] == read_config_option('guest_user')) {
 	$myrefresh['seconds'] = 99999999;
-	$myrefresh['page']    = sanitize_uri($_SERVER['REQUEST_URI']);
+	$myrefresh['page']    = sanitize_uri($request_uri);
 	$refreshIsLogout      = 'false';
 }
 
 /* basic auth times out when the auth provider times out */
 if (read_config_option('auth_method') == 2) {
 	$myrefresh['seconds'] = 99999999;
-	$myrefresh['page']    = sanitize_uri($_SERVER['REQUEST_URI']);
+	$myrefresh['page']    = sanitize_uri($request_uri);
 	$refreshIsLogout = 'false';
 }
 

--- a/tests/Unit/GlobalSessionRequestUriTest.php
+++ b/tests/Unit/GlobalSessionRequestUriTest.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+test('global session handles a missing request URI consistently', function () {
+	$source = file_get_contents(dirname(__DIR__, 2) . '/include/global_session.php');
+
+	expect($source)->not->toBeFalse()
+		->and($source)->toContain("\$request_uri = \$_SERVER['REQUEST_URI'] ?? '';")
+		->and(substr_count($source, "\$_SERVER['REQUEST_URI']"))->toBe(1)
+		->and($source)->not->toContain("\$_SERVER['REQUEST_URL']")
+		->and($source)->toContain("strpos(\$request_uri, 'index.php') !== false");
+});

--- a/tests/Unit/GlobalSessionRequestUriTest.php
+++ b/tests/Unit/GlobalSessionRequestUriTest.php
@@ -18,6 +18,8 @@ test('global session handles a missing request URI consistently', function () {
 	expect($source)->not->toBeFalse()
 		->and($source)->toContain("\$request_uri = \$_SERVER['REQUEST_URI'] ?? '';")
 		->and(substr_count($source, "\$_SERVER['REQUEST_URI']"))->toBe(1)
+		->and(substr_count($source, 'sanitize_uri($request_uri)'))->toBe(4)
+		->and(substr_count($source, 'sanitize_uri(appendHeaderSuppression($request_uri))'))->toBe(1)
 		->and($source)->not->toContain("\$_SERVER['REQUEST_URL']")
 		->and($source)->toContain("strpos(\$request_uri, 'index.php') !== false");
 });


### PR DESCRIPTION
## Summary

- read `REQUEST_URI` once with an empty-string fallback on `1.2.x`
- use the guarded value in every refresh/session branch
- fix the remaining `REQUEST_URL` typo reported in #7572
- add regression coverage for every changed URI site

## Root cause and impact

The original missing-key guard covered only one branch and misspelled the guarded key on `1.2.x`. Five refresh paths still dereferenced `REQUEST_URI` directly.

## Branch and duplicate audit

- target: `1.2.x`
- merged PR #7575 fixed only the typo on `develop`; it did not touch `1.2.x`
- PR #7592 covers the remaining reads on `develop`
- no other open or merged PR supplies this backport

## Test coverage and PHPDoc

- change coverage: 100% — the test asserts the sole guarded server read, four direct sanitized uses, the header-suppression sanitized use, the guarded `strpos()` condition, and complete removal of `REQUEST_URL`
- no functions, methods, classes, or public APIs are introduced, so no new PHPDoc surface is created

## Verification

- PHP lint on production and test files
- `tests/vendor/bin/pest tests/Unit/GlobalSessionRequestUriTest.php` (1 test, 7 assertions)

Completes the `1.2.x` fix for #7572 and #7583. GitHub does not auto-close issues from non-default branches.
