### PR TITLE
docs(config): expose HTMLPurifier cache path

### DIFF
--- a/include/config.php.dist
+++ b/include/config.php.dist
@@ -106,6 +106,14 @@ $disable_log_rotation = false;
 //$resource_path = '/var/www/html/cacti/resource/';
 
 /**
+ * Optional parameter to define the HTMLPurifier definition cache path.
+ * The directory must already exist and be writable by the web server user.
+ * If unset, Cacti uses cache/purifier below the Cacti installation path.
+ */
+
+//$config['purifier_cache_path'] = '/var/cache/cacti/purifier';
+
+/**
  * Optional parameter to define a data input whitelist command string. This
  * whitelist file will help protect cacti from unauthorized changes to Cacti
  * data input command string.

--- a/tests/Unit/HtmlPurifyCachePathTest.php
+++ b/tests/Unit/HtmlPurifyCachePathTest.php
@@ -127,7 +127,8 @@ test('the alternate cache path is documented in the distributed config', functio
 
 	expect($config)->not->toBeFalse()
 		->and($config)->toContain("\$config['purifier_cache_path'] = '/var/cache/cacti/purifier';")
-		->and($config)->toContain('The directory must already exist and be writable');
+		->and($config)->toContain('The directory must already exist and be writable')
+		->and($config)->toContain('If unset, Cacti uses cache/purifier');
 });
 
 test('the definition cache lands in the configured path, not the library tree', function () {

--- a/tests/Unit/HtmlPurifyCachePathTest.php
+++ b/tests/Unit/HtmlPurifyCachePathTest.php
@@ -122,6 +122,14 @@ function _html_purify_count($dir) {
 	));
 }
 
+test('the alternate cache path is documented in the distributed config', function () {
+	$config = file_get_contents(dirname(__DIR__, 2) . '/include/config.php.dist');
+
+	expect($config)->not->toBeFalse()
+		->and($config)->toContain("\$config['purifier_cache_path'] = '/var/cache/cacti/purifier';")
+		->and($config)->toContain('The directory must already exist and be writable');
+});
+
 test('the definition cache lands in the configured path, not the library tree', function () {
 	$cache  = _html_purify_tmpdir();
 	$before = _html_purify_count(_html_purify_library_cache());


### PR DESCRIPTION
## Summary

- document the `purifier_cache_path` override added by merged PR #7555
- show a package-friendly `/var/cache/cacti/purifier` example
- document the writable-directory requirement and built-in fallback path
- extend the existing purifier cache regression suite

## Root cause and impact

PR #7555 implemented the safe serializer path and packager override, but `include/config.php.dist` did not expose it. Packagers could only discover the setting by reading `lib/html.php`.

## Branch and duplicate audit

- target: `1.2.x`
- merged PR #7555 covers runtime behavior but not configuration documentation
- `develop` does not depend on HTMLPurifier and has no equivalent setting to document
- no other open or merged PR covers the remaining documentation gap

## Test coverage and PHPDoc

- change coverage: 100% — the test asserts the exact configuration key/example, writable-directory requirement, and fallback-path statement added by this PR
- the existing runtime tests cover configured, unwritable, and sanitization behavior
- no functions, methods, classes, or public APIs are introduced, so no new PHPDoc surface is created

## Verification

- `php -l include/config.php.dist`
- `php -l tests/Unit/HtmlPurifyCachePathTest.php`
- `tests/vendor/bin/pest tests/Unit/HtmlPurifyCachePathTest.php` (4 tests, 12 assertions)

Together with merged PR #7555, resolves #7552 on `1.2.x`. GitHub does not auto-close issues from non-default branches.
