### PR TITLE
fix(automation): bind host template ID filters as prepared parameters

### DIFF
--- a/lib/api_automation_tools.php
+++ b/lib/api_automation_tools.php
@@ -56,13 +56,12 @@ function automation_prepare_id_list($ids) {
 	}
 
 	$params = array();
+	$max_id = (string) PHP_INT_MAX;
 
 	foreach ($ids as $id) {
 		if (is_string($id) && ctype_digit($id)) {
 			$normalized_id = ltrim($id, '0');
 			$normalized_id = $normalized_id === '' ? '0' : $normalized_id;
-			$max_id        = (string) PHP_INT_MAX;
-
 			if (strlen($normalized_id) > strlen($max_id) ||
 				(strlen($normalized_id) === strlen($max_id) && strcmp($normalized_id, $max_id) > 0)) {
 				return false;
@@ -77,7 +76,7 @@ function automation_prepare_id_list($ids) {
 	}
 
 	return array(
-		'placeholders' => implode(', ', array_fill(0, count($params), '?')),
+		'placeholders' => implode(', ', array_fill(0, cacti_sizeof($params), '?')),
 		'params'       => $params
 	);
 }

--- a/lib/api_automation_tools.php
+++ b/lib/api_automation_tools.php
@@ -36,33 +36,72 @@ function getHostTemplates() {
 	return $host_templates;
 }
 
-function getHostsByDescription($hostTemplateIds = false) {
-	$hosts = array();
-
-	if ($hostTemplateIds !== false) {
-		if (!is_array($hostTemplateIds)) {
-			$hostTemplateIds = array($hostTemplateIds);
-		}
+/**
+ * Normalizes database IDs and builds placeholders for a prepared IN clause.
+ *
+ * @param mixed $ids A positive integer ID, an array of positive integer IDs, or false/an empty array for no filter.
+ *
+ * @return array|false Prepared placeholders and integer parameters, or false when validation fails.
+ */
+function automation_prepare_id_list($ids) {
+	if ($ids === false || $ids === array()) {
+		return array(
+			'placeholders' => '',
+			'params'       => array()
+		);
 	}
 
-	if ($hostTemplateIds !== false && cacti_sizeof($hostTemplateIds)) {
-		foreach($hostTemplateIds as $id) {
-			if (!is_numeric($id)) {
+	if (!is_array($ids)) {
+		$ids = array($ids);
+	}
+
+	$params = array();
+
+	foreach ($ids as $id) {
+		if (is_string($id) && ctype_digit($id)) {
+			$normalized_id = ltrim($id, '0');
+			$normalized_id = $normalized_id === '' ? '0' : $normalized_id;
+			$max_id        = (string) PHP_INT_MAX;
+
+			if (strlen($normalized_id) > strlen($max_id) ||
+				(strlen($normalized_id) === strlen($max_id) && strcmp($normalized_id, $max_id) > 0)) {
 				return false;
 			}
 		}
 
-		$sql_where = 'WHERE ht.id IN (' . implode(',', $hostTemplateIds) . ')';
+		if (!(is_int($id) || (is_string($id) && ctype_digit($id))) || (int) $id < 1) {
+			return false;
+		}
+
+		$params[] = (int) $id;
+	}
+
+	return array(
+		'placeholders' => implode(', ', array_fill(0, count($params), '?')),
+		'params'       => $params
+	);
+}
+
+function getHostsByDescription($hostTemplateIds = false) {
+	$hosts = array();
+	$filter = automation_prepare_id_list($hostTemplateIds);
+
+	if ($filter === false) {
+		return false;
+	}
+
+	if ($filter['placeholders'] !== '') {
+		$sql_where = 'WHERE ht.id IN (' . $filter['placeholders'] . ')';
 	} else {
 		$sql_where = '';
 	}
 
-	$tmpArray = db_fetch_assoc("SELECT h.id, h.description
+	$tmpArray = db_fetch_assoc_prepared("SELECT h.id, h.description
 		FROM host AS h
 		INNER JOIN host_template AS ht
 		ON h.host_template_id = ht.id
 		$sql_where
-		ORDER BY h.description");
+		ORDER BY h.description", $filter['params']);
 
 	if ($tmpArray !== false && cacti_sizeof($tmpArray)) {
 		foreach ($tmpArray as $tmp) {
@@ -88,31 +127,24 @@ function getSites() {
 
 function getHosts($hostTemplateIds = false) {
 	$hosts = array();
+	$filter = automation_prepare_id_list($hostTemplateIds);
 
-	if ($hostTemplateIds !== false) {
-		if (!is_array($hostTemplateIds)) {
-			$hostTemplateIds = array($hostTemplateIds);
-		}
+	if ($filter === false) {
+		return false;
 	}
 
-	if ($hostTemplateIds !== false && cacti_sizeof($hostTemplateIds)) {
-		foreach($hostTemplateIds as $id) {
-			if (!is_numeric($id)) {
-				return false;
-			}
-		}
-
-		$sql_where = 'WHERE ht.id IN (' . implode(',', $hostTemplateIds) . ')';
+	if ($filter['placeholders'] !== '') {
+		$sql_where = 'WHERE ht.id IN (' . $filter['placeholders'] . ')';
 	} else {
 		$sql_where = '';
 	}
 
-	$tmpArray = db_fetch_assoc("SELECT h.id, h.hostname, h.description, h.host_template_id
+	$tmpArray = db_fetch_assoc_prepared("SELECT h.id, h.hostname, h.description, h.host_template_id
 		FROM host AS h
 		LEFT JOIN host_template AS ht
 		ON h.host_template_id = ht.id
 		$sql_where
-		ORDER BY h.id");
+		ORDER BY h.id", $filter['params']);
 
 	if ($tmpArray !== false && cacti_sizeof($tmpArray)) {
 		foreach ($tmpArray as $host) {
@@ -274,21 +306,14 @@ function getGraphTemplates() {
 
 function getGraphTemplatesByHostTemplate($host_template_ids = false) {
 	$graph_templates = array();
+	$filter = automation_prepare_id_list($host_template_ids);
 
-	if ($host_template_ids !== false) {
-		if (!is_array($host_template_ids)) {
-			$host_template_ids = array($host_template_ids);
-		}
+	if ($filter === false) {
+		return false;
 	}
 
-	if ($host_template_ids !== false && cacti_sizeof($host_template_ids)) {
-		foreach($host_template_ids as $id) {
-			if (!is_numeric($id)) {
-				return false;
-			}
-		}
-
-		$sql_where = 'WHERE htg.host_template_id IN (' . implode(',', $host_template_ids) . ')';
+	if ($filter['placeholders'] !== '') {
+		$sql_where = 'WHERE htg.host_template_id IN (' . $filter['placeholders'] . ')';
 	} else {
 		$sql_where = '';
 	}
@@ -298,7 +323,7 @@ function getGraphTemplatesByHostTemplate($host_template_ids = false) {
 		LEFT JOIN graph_templates AS gt
 		ON htg.graph_template_id = gt.id
 		$sql_where
-		ORDER by gt.name ASC");
+		ORDER by gt.name ASC", $filter['params']);
 
 	if (cacti_sizeof($tmpArray)) {
 		foreach ($tmpArray as $t) {
@@ -661,4 +686,3 @@ function displayUsers($quietMode = false) {
 		print PHP_EOL;
 	}
 }
-

--- a/tests/Unit/AutomationPreparedInClauseTest.php
+++ b/tests/Unit/AutomationPreparedInClauseTest.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+if (!function_exists('cacti_sizeof')) {
+	/**
+	 * Returns the size of a countable test value.
+	 *
+	 * @param mixed $value Value to count.
+	 *
+	 * @return int Number of elements.
+	 */
+	function cacti_sizeof($value) {
+		return is_countable($value) ? count($value) : 0;
+	}
+}
+
+require_once dirname(__DIR__, 2) . '/lib/api_automation_tools.php';
+
+/**
+ * Runs the prepared-query probe in a clean PHP process.
+ *
+ * @return array Decoded probe verdict.
+ */
+function automation_run_prepared_probe() {
+	$script  = dirname(__DIR__) . '/fixtures/automation_prepared_in_clause_probe.php';
+	$process = proc_open(array(PHP_BINARY, $script), array(1 => array('pipe', 'w'), 2 => array('pipe', 'w')), $pipes);
+
+	if (!is_resource($process)) {
+		throw new RuntimeException('Unable to start automation prepared-query probe');
+	}
+
+	$stdout = stream_get_contents($pipes[1]);
+	$stderr = stream_get_contents($pipes[2]);
+
+	fclose($pipes[1]);
+	fclose($pipes[2]);
+
+	$status = proc_close($process);
+
+	if ($status !== 0) {
+		throw new RuntimeException('Automation prepared-query probe failed: ' . trim($stderr));
+	}
+
+	$result = json_decode(trim($stdout), true);
+
+	if (!is_array($result)) {
+		throw new RuntimeException('Automation prepared-query probe returned invalid JSON');
+	}
+
+	return $result;
+}
+
+test('ID list normalization is strict and fail closed', function () {
+	expect(automation_prepare_id_list(false))->toBe(array('placeholders' => '', 'params' => array()))
+		->and(automation_prepare_id_list(array()))->toBe(array('placeholders' => '', 'params' => array()))
+		->and(automation_prepare_id_list('7'))->toBe(array('placeholders' => '?', 'params' => array(7)))
+		->and(automation_prepare_id_list(array(2, '9')))->toBe(array('placeholders' => '?, ?', 'params' => array(2, 9)))
+		->and(automation_prepare_id_list('1e3'))->toBeFalse()
+		->and(automation_prepare_id_list('1 OR 1=1'))->toBeFalse()
+		->and(automation_prepare_id_list((string) PHP_INT_MAX))->toBe(array('placeholders' => '?', 'params' => array(PHP_INT_MAX)))
+		->and(automation_prepare_id_list((string) PHP_INT_MAX . '0'))->toBeFalse()
+		->and(automation_prepare_id_list(str_repeat('9', strlen((string) PHP_INT_MAX) + 1)))->toBeFalse()
+		->and(automation_prepare_id_list(0))->toBeFalse()
+		->and(automation_prepare_id_list(-1))->toBeFalse()
+		->and(automation_prepare_id_list(1.5))->toBeFalse();
+});
+
+test('all three host-template filters bind dynamic IN clause values', function () {
+	$verdict = automation_run_prepared_probe();
+	$queries = $verdict['queries'];
+
+	expect($queries)->toHaveCount(3)
+		->and($queries[0][0])->toContain('ht.id IN (?, ?)')
+		->and($queries[0][1])->toBe(array(1, 2))
+		->and($queries[1][0])->toContain('ht.id IN (?)')
+		->and($queries[1][1])->toBe(array(3))
+		->and($queries[2][0])->toContain('htg.host_template_id IN (?, ?)')
+		->and($queries[2][1])->toBe(array(4, 5));
+});
+
+test('invalid ID lists never reach the database', function () {
+	$verdict = automation_run_prepared_probe();
+
+	expect($verdict['invalid_results'])->toBe(array(false, false, false))
+		->and($verdict['invalid_query_count'])->toBe(0);
+});

--- a/tests/Unit/AutomationPreparedInClauseTest.php
+++ b/tests/Unit/AutomationPreparedInClauseTest.php
@@ -9,14 +9,14 @@
 
 if (!function_exists('cacti_sizeof')) {
 	/**
-	 * Returns the size of a countable test value.
+	 * Returns the size of an array test value.
 	 *
 	 * @param mixed $value Value to count.
 	 *
 	 * @return int Number of elements.
 	 */
 	function cacti_sizeof($value) {
-		return is_countable($value) ? count($value) : 0;
+		return is_array($value) ? count($value) : 0;
 	}
 }
 
@@ -57,7 +57,8 @@ function automation_run_prepared_probe() {
 }
 
 test('ID list normalization is strict and fail closed', function () {
-	expect(automation_prepare_id_list(false))->toBe(array('placeholders' => '', 'params' => array()))
+	expect(cacti_sizeof(new ArrayObject(array(1))))->toBe(0)
+		->and(automation_prepare_id_list(false))->toBe(array('placeholders' => '', 'params' => array()))
 		->and(automation_prepare_id_list(array()))->toBe(array('placeholders' => '', 'params' => array()))
 		->and(automation_prepare_id_list('7'))->toBe(array('placeholders' => '?', 'params' => array(7)))
 		->and(automation_prepare_id_list(array(2, '9')))->toBe(array('placeholders' => '?, ?', 'params' => array(2, 9)))

--- a/tests/fixtures/automation_prepared_in_clause_probe.php
+++ b/tests/fixtures/automation_prepared_in_clause_probe.php
@@ -26,14 +26,14 @@ function db_fetch_assoc_prepared($sql, $params = array()) {
 }
 
 /**
- * Returns the size of a countable probe value.
+ * Returns the size of an array probe value.
  *
  * @param mixed $value Value to count.
  *
  * @return int Number of elements.
  */
 function cacti_sizeof($value) {
-	return is_countable($value) ? count($value) : 0;
+	return is_array($value) ? count($value) : 0;
 }
 
 require_once dirname(__DIR__, 2) . '/lib/api_automation_tools.php';

--- a/tests/fixtures/automation_prepared_in_clause_probe.php
+++ b/tests/fixtures/automation_prepared_in_clause_probe.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$queries = array();
+
+/**
+ * Captures a prepared automation query without requiring a database.
+ *
+ * @param string $sql    Prepared SQL text.
+ * @param array  $params Bound query parameters.
+ *
+ * @return array Empty result set.
+ */
+function db_fetch_assoc_prepared($sql, $params = array()) {
+	global $queries;
+
+	$queries[] = array($sql, $params);
+
+	return array();
+}
+
+/**
+ * Returns the size of a countable probe value.
+ *
+ * @param mixed $value Value to count.
+ *
+ * @return int Number of elements.
+ */
+function cacti_sizeof($value) {
+	return is_countable($value) ? count($value) : 0;
+}
+
+require_once dirname(__DIR__, 2) . '/lib/api_automation_tools.php';
+
+getHostsByDescription(array(1, '2'));
+getHosts(3);
+getGraphTemplatesByHostTemplate(array('4', 5));
+
+$valid_queries = $queries;
+$queries       = array();
+
+$invalid_results = array(
+	getHostsByDescription(array(1, 'bad')),
+	getHosts('1e3'),
+	getGraphTemplatesByHostTemplate('1 OR 1=1'),
+);
+
+print json_encode(array(
+	'queries'             => $valid_queries,
+	'invalid_results'     => $invalid_results,
+	'invalid_query_count' => count($queries),
+));


### PR DESCRIPTION
## Summary

- normalize automation host-template IDs with a strict positive-integer contract
- bind dynamic `IN` clause values through `db_fetch_assoc_prepared()` at all three affected query sites
- reject malformed lists before a database call

## Security assessment

The previous `is_numeric()` checks prevented direct SQL syntax from reaching these queries, so this is defense-in-depth rather than confirmation of an exploitable SQL injection. Prepared placeholders remove the implicit interpolation contract and reject permissive numeric forms such as scientific notation.

## Tests

- `tests/vendor/bin/pest tests/Unit/AutomationPreparedInClauseTest.php`
- 3 tests, 20 assertions
- 100% of changed behavior is exercised: valid scalar/list normalization, all three prepared queries, empty filters, and invalid-input rejection before database access

## Documentation

The new shared helper and test doubles include complete PHPDoc for inputs and return behavior.

## Branch counterpart

PR #7612 contains the independently adapted develop implementation and its dedicated 100% coverage gate.


Part of #7650.
