### PR TITLE
fix(automation): bind host template ID filters as prepared parameters

### DIFF
--- a/lib/api_automation_tools.php
+++ b/lib/api_automation_tools.php
@@ -42,6 +42,53 @@ function getHostTemplates() : array {
 }
 
 /**
+ * Normalizes database IDs and builds placeholders for a prepared IN clause.
+ *
+ * @param mixed $ids A positive integer ID, an array of positive integer IDs, or false/an empty array for no filter.
+ *
+ * @return array{placeholders: string, params: array<int, int>}|false Prepared placeholders and integer parameters,
+ *                                                                    or false when validation fails.
+ */
+function automation_prepare_id_list(mixed $ids) : array|false {
+	if ($ids === false || $ids === []) {
+		return [
+			'placeholders' => '',
+			'params'       => []
+		];
+	}
+
+	if (!is_array($ids)) {
+		$ids = [$ids];
+	}
+
+	$params = [];
+
+	foreach ($ids as $id) {
+		if (is_string($id) && ctype_digit($id)) {
+			$normalized_id = ltrim($id, '0');
+			$normalized_id = $normalized_id === '' ? '0' : $normalized_id;
+			$max_id        = (string) PHP_INT_MAX;
+
+			if (strlen($normalized_id) > strlen($max_id) ||
+				(strlen($normalized_id) === strlen($max_id) && strcmp($normalized_id, $max_id) > 0)) {
+				return false;
+			}
+		}
+
+		if (!(is_int($id) || (is_string($id) && ctype_digit($id))) || (int) $id < 1) {
+			return false;
+		}
+
+		$params[] = (int) $id;
+	}
+
+	return [
+		'placeholders' => implode(', ', array_fill(0, count($params), '?')),
+		'params'       => $params
+	];
+}
+
+/**
  * Retrieves hosts based on their description.
  *
  * @param mixed $hostTemplateIds An array of host template IDs to filter the hosts by, or false to retrieve all hosts.
@@ -49,32 +96,25 @@ function getHostTemplates() : array {
  * @return mixed - Returns an array of hosts that match the given description, or false on failure.
  */
 function getHostsByDescription(mixed $hostTemplateIds = false) : mixed {
-	$hosts = [];
+	$hosts  = [];
+	$filter = automation_prepare_id_list($hostTemplateIds);
 
-	if ($hostTemplateIds !== false) {
-		if (!is_array($hostTemplateIds)) {
-			$hostTemplateIds = [$hostTemplateIds];
-		}
+	if ($filter === false) {
+		return false;
 	}
 
-	if ($hostTemplateIds !== false && cacti_sizeof($hostTemplateIds)) {
-		foreach ($hostTemplateIds as $id) {
-			if (!is_numeric($id)) {
-				return false;
-			}
-		}
-
-		$sql_where = 'WHERE ht.id IN (' . implode(',', $hostTemplateIds) . ')';
+	if ($filter['placeholders'] !== '') {
+		$sql_where = 'WHERE ht.id IN (' . $filter['placeholders'] . ')';
 	} else {
 		$sql_where = '';
 	}
 
-	$tmpArray = db_fetch_assoc("SELECT h.id, h.description
+	$tmpArray = db_fetch_assoc_prepared("SELECT h.id, h.description
 		FROM host AS h
 		INNER JOIN host_template AS ht
 		ON h.host_template_id = ht.id
 		$sql_where
-		ORDER BY h.description");
+		ORDER BY h.description", $filter['params']);
 
 	if ($tmpArray !== false && cacti_sizeof($tmpArray)) {
 		foreach ($tmpArray as $tmp) {
@@ -112,32 +152,25 @@ function getSites() : array {
  * @return mixed - Returns an array of hosts if successful, or false on failure.
  */
 function getHosts(mixed $hostTemplateIds = false) : mixed {
-	$hosts = [];
+	$hosts  = [];
+	$filter = automation_prepare_id_list($hostTemplateIds);
 
-	if ($hostTemplateIds !== false) {
-		if (!is_array($hostTemplateIds)) {
-			$hostTemplateIds = [$hostTemplateIds];
-		}
+	if ($filter === false) {
+		return false;
 	}
 
-	if ($hostTemplateIds !== false && cacti_sizeof($hostTemplateIds)) {
-		foreach ($hostTemplateIds as $id) {
-			if (!is_numeric($id)) {
-				return false;
-			}
-		}
-
-		$sql_where = 'WHERE ht.id IN (' . implode(',', $hostTemplateIds) . ')';
+	if ($filter['placeholders'] !== '') {
+		$sql_where = 'WHERE ht.id IN (' . $filter['placeholders'] . ')';
 	} else {
 		$sql_where = '';
 	}
 
-	$tmpArray = db_fetch_assoc("SELECT h.id, h.hostname, h.description, h.host_template_id
+	$tmpArray = db_fetch_assoc_prepared("SELECT h.id, h.hostname, h.description, h.host_template_id
 		FROM host AS h
 		LEFT JOIN host_template AS ht
 		ON h.host_template_id = ht.id
 		$sql_where
-		ORDER BY h.id");
+		ORDER BY h.id", $filter['params']);
 
 	if ($tmpArray !== false && cacti_sizeof($tmpArray)) {
 		foreach ($tmpArray as $host) {
@@ -359,21 +392,14 @@ function getGraphTemplates() : array {
  */
 function getGraphTemplatesByHostTemplate(mixed $host_template_ids = false) : mixed {
 	$graph_templates = [];
+	$filter          = automation_prepare_id_list($host_template_ids);
 
-	if ($host_template_ids !== false) {
-		if (!is_array($host_template_ids)) {
-			$host_template_ids = [$host_template_ids];
-		}
+	if ($filter === false) {
+		return false;
 	}
 
-	if ($host_template_ids !== false && cacti_sizeof($host_template_ids)) {
-		foreach ($host_template_ids as $id) {
-			if (!is_numeric($id)) {
-				return false;
-			}
-		}
-
-		$sql_where = 'WHERE htg.host_template_id IN (' . implode(',', $host_template_ids) . ')';
+	if ($filter['placeholders'] !== '') {
+		$sql_where = 'WHERE htg.host_template_id IN (' . $filter['placeholders'] . ')';
 	} else {
 		$sql_where = '';
 	}
@@ -383,7 +409,7 @@ function getGraphTemplatesByHostTemplate(mixed $host_template_ids = false) : mix
 		LEFT JOIN graph_templates AS gt
 		ON htg.graph_template_id = gt.id
 		$sql_where
-		ORDER by gt.name ASC");
+		ORDER by gt.name ASC", $filter['params']);
 
 	if (cacti_sizeof($tmpArray)) {
 		foreach ($tmpArray as $t) {

--- a/tests/Unit/AutomationPreparedInClauseTest.php
+++ b/tests/Unit/AutomationPreparedInClauseTest.php
@@ -2,6 +2,11 @@
 /*
  +-------------------------------------------------------------------------+
  | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
  +-------------------------------------------------------------------------+
  | Cacti: The Complete RRDtool-based Graphing Solution                     |
  +-------------------------------------------------------------------------+

--- a/tests/Unit/AutomationPreparedInClauseTest.php
+++ b/tests/Unit/AutomationPreparedInClauseTest.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+if (!function_exists('cacti_sizeof')) {
+	/**
+	 * Returns the size of a countable test value.
+	 *
+	 * @param mixed $value Value to count.
+	 *
+	 * @return int Number of elements.
+	 */
+	function cacti_sizeof(mixed $value) : int {
+		return is_countable($value) ? count($value) : 0;
+	}
+}
+
+require_once dirname(__DIR__, 2) . '/lib/api_automation_tools.php';
+require_once dirname(__DIR__) . '/Helpers/IsolatedProbe.php';
+
+test('ID list normalization is strict and fail closed', function () : void {
+	expect(automation_prepare_id_list(false))->toBe(['placeholders' => '', 'params' => []])
+		->and(automation_prepare_id_list([]))->toBe(['placeholders' => '', 'params' => []])
+		->and(automation_prepare_id_list('7'))->toBe(['placeholders' => '?', 'params' => [7]])
+		->and(automation_prepare_id_list([2, '9']))->toBe(['placeholders' => '?, ?', 'params' => [2, 9]])
+		->and(automation_prepare_id_list('1e3'))->toBeFalse()
+		->and(automation_prepare_id_list('1 OR 1=1'))->toBeFalse()
+		->and(automation_prepare_id_list((string) PHP_INT_MAX))->toBe(['placeholders' => '?', 'params' => [PHP_INT_MAX]])
+		->and(automation_prepare_id_list((string) PHP_INT_MAX . '0'))->toBeFalse()
+		->and(automation_prepare_id_list(str_repeat('9', strlen((string) PHP_INT_MAX) + 1)))->toBeFalse()
+		->and(automation_prepare_id_list(0))->toBeFalse()
+		->and(automation_prepare_id_list(-1))->toBeFalse()
+		->and(automation_prepare_id_list(1.5))->toBeFalse();
+});
+
+test('all three host-template filters bind dynamic IN clause values', function () : void {
+	$verdict = cacti_test_isolated_probe(dirname(__DIR__) . '/fixtures/automation_prepared_in_clause_probe.php');
+	$queries = $verdict['queries'];
+
+	expect($queries)->toHaveCount(3)
+		->and($queries[0][0])->toContain('ht.id IN (?, ?)')
+		->and($queries[0][1])->toBe([1, 2])
+		->and($queries[1][0])->toContain('ht.id IN (?)')
+		->and($queries[1][1])->toBe([3])
+		->and($queries[2][0])->toContain('htg.host_template_id IN (?, ?)')
+		->and($queries[2][1])->toBe([4, 5]);
+});
+
+test('invalid ID lists never reach the database', function () : void {
+	$verdict = cacti_test_isolated_probe(dirname(__DIR__) . '/fixtures/automation_prepared_in_clause_probe.php');
+
+	expect($verdict['invalid_results'])->toBe([false, false, false])
+		->and($verdict['invalid_query_count'])->toBe(0);
+});

--- a/tests/Unit/AutomationPreparedInClauseTest.php
+++ b/tests/Unit/AutomationPreparedInClauseTest.php
@@ -9,14 +9,14 @@
 
 if (!function_exists('cacti_sizeof')) {
 	/**
-	 * Returns the size of a countable test value.
+	 * Returns the size of an array test value.
 	 *
 	 * @param mixed $value Value to count.
 	 *
 	 * @return int Number of elements.
 	 */
 	function cacti_sizeof(mixed $value) : int {
-		return is_countable($value) ? count($value) : 0;
+		return is_array($value) ? count($value) : 0;
 	}
 }
 
@@ -24,7 +24,8 @@ require_once dirname(__DIR__, 2) . '/lib/api_automation_tools.php';
 require_once dirname(__DIR__) . '/Helpers/IsolatedProbe.php';
 
 test('ID list normalization is strict and fail closed', function () : void {
-	expect(automation_prepare_id_list(false))->toBe(['placeholders' => '', 'params' => []])
+	expect(cacti_sizeof(new ArrayObject([1])))->toBe(0)
+		->and(automation_prepare_id_list(false))->toBe(['placeholders' => '', 'params' => []])
 		->and(automation_prepare_id_list([]))->toBe(['placeholders' => '', 'params' => []])
 		->and(automation_prepare_id_list('7'))->toBe(['placeholders' => '?', 'params' => [7]])
 		->and(automation_prepare_id_list([2, '9']))->toBe(['placeholders' => '?, ?', 'params' => [2, 9]])

--- a/tests/fixtures/automation_prepared_in_clause_probe.php
+++ b/tests/fixtures/automation_prepared_in_clause_probe.php
@@ -2,6 +2,11 @@
 /*
  +-------------------------------------------------------------------------+
  | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
  +-------------------------------------------------------------------------+
  | Cacti: The Complete RRDtool-based Graphing Solution                     |
  +-------------------------------------------------------------------------+

--- a/tests/fixtures/automation_prepared_in_clause_probe.php
+++ b/tests/fixtures/automation_prepared_in_clause_probe.php
@@ -26,14 +26,14 @@ function db_fetch_assoc_prepared(string $sql, array $params = []) : array {
 }
 
 /**
- * Returns the size of a countable probe value.
+ * Returns the size of an array probe value.
  *
  * @param mixed $value Value to count.
  *
  * @return int Number of elements.
  */
 function cacti_sizeof(mixed $value) : int {
-	return is_countable($value) ? count($value) : 0;
+	return is_array($value) ? count($value) : 0;
 }
 
 require_once dirname(__DIR__, 2) . '/lib/api_automation_tools.php';

--- a/tests/fixtures/automation_prepared_in_clause_probe.php
+++ b/tests/fixtures/automation_prepared_in_clause_probe.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$queries = [];
+
+/**
+ * Captures a prepared automation query without requiring a database.
+ *
+ * @param string $sql    Prepared SQL text.
+ * @param array  $params Bound query parameters.
+ *
+ * @return array Empty result set.
+ */
+function db_fetch_assoc_prepared(string $sql, array $params = []) : array {
+	global $queries;
+
+	$queries[] = [$sql, $params];
+
+	return [];
+}
+
+/**
+ * Returns the size of a countable probe value.
+ *
+ * @param mixed $value Value to count.
+ *
+ * @return int Number of elements.
+ */
+function cacti_sizeof(mixed $value) : int {
+	return is_countable($value) ? count($value) : 0;
+}
+
+require_once dirname(__DIR__, 2) . '/lib/api_automation_tools.php';
+
+getHostsByDescription([1, '2']);
+getHosts(3);
+getGraphTemplatesByHostTemplate(['4', 5]);
+
+$valid_queries = $queries;
+$queries       = [];
+
+$invalid_results = [
+	getHostsByDescription([1, 'bad']),
+	getHosts('1e3'),
+	getGraphTemplatesByHostTemplate('1 OR 1=1'),
+];
+
+print json_encode([
+	'queries'             => $valid_queries,
+	'invalid_results'     => $invalid_results,
+	'invalid_query_count' => count($queries),
+], JSON_THROW_ON_ERROR);


### PR DESCRIPTION
## Summary

- normalize automation host-template IDs with a strict positive-integer contract
- bind dynamic `IN` clause values through `db_fetch_assoc_prepared()` at all three affected query sites
- reject malformed lists before a database call

## Security assessment

The previous `is_numeric()` checks prevented direct SQL syntax from reaching these queries, so this is defense-in-depth rather than confirmation of an exploitable SQL injection. Prepared placeholders remove the implicit interpolation contract and reject permissive numeric forms such as scientific notation.

This is the `develop` counterpart to #7598.

## Tests

- `include/vendor/bin/pest tests/Unit/AutomationPreparedInClauseTest.php`
- 3 tests, 20 assertions
- 100% of changed behavior is exercised: valid scalar/list normalization, all three prepared queries, empty filters, and invalid-input rejection before database access

## Documentation

The new typed shared helper and test doubles include complete PHPDoc for inputs and return behavior.