### PR TITLE
fix(auth): expire persistent auth tokens when permissions change

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4407,21 +4407,31 @@ function reset_group_perms(int $group_id) : void {
 		[$group_id]), 'user_id', 'user_id');
 
 	if (cacti_sizeof($users)) {
-		db_execute('UPDATE user_auth
+		$user_ids     = array_values($users);
+		$placeholders = implode(',', array_fill(0, count($user_ids), '?'));
+
+		db_execute_prepared("DELETE FROM user_auth_cache
+			WHERE user_id IN ($placeholders)",
+			$user_ids);
+
+		db_execute_prepared("UPDATE user_auth
 			SET reset_perms=FLOOR(RAND() * 4294967295) + 1
-			WHERE id IN (' . implode(',', $users) . ')');
+			WHERE id IN ($placeholders)",
+			$user_ids);
 	}
 }
 
 /**
- * Sets a flag for all users logged in as this user that their perms
- * need to be reloaded from the database
+ * Expires persistent authentication tokens and sets a flag for all users logged
+ * in as this user that their permissions need to be reloaded from the database.
  *
  * @param int $user_id The ID of the user whose permissions are to be reset.
  *
  * @return void
  */
 function reset_user_perms(int $user_id) : void {
+	db_execute_prepared('DELETE FROM user_auth_cache WHERE user_id = ?', [$user_id]);
+
 	db_execute_prepared('UPDATE user_auth
 		SET reset_perms=FLOOR(RAND() * 4294967295) + 1
 		WHERE id = ?',

--- a/tests/Unit/AuthCachePermissionInvalidationTest.php
+++ b/tests/Unit/AuthCachePermissionInvalidationTest.php
@@ -1,0 +1,175 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace AuthCachePermissionInvalidationTest;
+
+if (!defined('SESS_USER_ID')) {
+	define('SESS_USER_ID', 'sess_user_id');
+}
+
+if (!defined('SESS_USER_REALMS')) {
+	define('SESS_USER_REALMS', 'sess_user_realms');
+}
+
+if (!defined('OPTIONS_USER')) {
+	define('OPTIONS_USER', 'options_user');
+}
+
+if (!defined('OPTIONS_WEB')) {
+	define('OPTIONS_WEB', 'options_web');
+}
+
+if (!defined('SESS_AUTH_NAMES')) {
+	define('SESS_AUTH_NAMES', 'sess_auth_names');
+}
+
+$GLOBALS['auth_cache_queries']       = [];
+$GLOBALS['auth_cache_session_kills'] = [];
+$GLOBALS['auth_cache_group_users']   = [];
+
+/**
+ * Returns deterministic group membership rows.
+ *
+ * @param string $sql    Prepared SQL text.
+ * @param array  $params Bound query parameters.
+ *
+ * @return array Group membership rows.
+ */
+function db_fetch_assoc_prepared(string $sql, array $params = []) : array {
+	return $GLOBALS['auth_cache_group_users'];
+}
+
+/**
+ * Rekeys group membership rows for the extracted production helper.
+ *
+ * @param array  $rows      Membership rows.
+ * @param string $key       Source key.
+ * @param string $value_key Value key.
+ *
+ * @return array Rekeyed user IDs.
+ */
+function array_rekey(array $rows, string $key, string $value_key) : array {
+	$result = [];
+
+	foreach ($rows as $row) {
+		$result[$row[$key]] = $row[$value_key];
+	}
+
+	return $result;
+}
+
+/**
+ * Returns the number of group members.
+ *
+ * @param mixed $value Value to count.
+ *
+ * @return int Number of group members.
+ */
+function cacti_sizeof(mixed $value) : int {
+	return is_countable($value) ? count($value) : 0;
+}
+
+/**
+ * Captures prepared permission-reset queries.
+ *
+ * @param string $sql    Prepared SQL text.
+ * @param array  $params Bound query parameters.
+ *
+ * @return bool Always true for the unit test.
+ */
+function db_execute_prepared(string $sql, array $params = []) : bool {
+	$GLOBALS['auth_cache_queries'][] = [$sql, $params];
+
+	return true;
+}
+
+/**
+ * Captures session cache invalidation requests.
+ *
+ * @param string $name Session variable name.
+ *
+ * @return void
+ */
+function kill_session_var(string $name) : void {
+	$GLOBALS['auth_cache_session_kills'][] = $name;
+}
+
+$source = file_get_contents(dirname(__DIR__, 2) . '/lib/auth.php');
+
+if ($source === false) {
+	throw new \RuntimeException('Unable to read lib/auth.php for the permission invalidation test.');
+}
+
+if (preg_match('/function reset_user_perms\(.*?^}\R/ms', $source, $matches) !== 1) {
+	throw new \RuntimeException('Unable to extract reset_user_perms() for the permission invalidation test.');
+}
+
+$function = str_replace('function reset_user_perms(', 'function reset_user_perms_under_test(', $matches[0]);
+eval('namespace AuthCachePermissionInvalidationTest;' . $function);
+
+if (preg_match('/function reset_group_perms\(.*?^}\R/ms', $source, $matches) !== 1) {
+	throw new \RuntimeException('Unable to extract reset_group_perms() for the permission invalidation test.');
+}
+
+$function = str_replace('function reset_group_perms(', 'function reset_group_perms_under_test(', $matches[0]);
+eval('namespace AuthCachePermissionInvalidationTest;' . $function);
+
+beforeEach(function () : void {
+	$GLOBALS['auth_cache_queries']       = [];
+	$GLOBALS['auth_cache_session_kills'] = [];
+	$GLOBALS['auth_cache_group_users']   = [];
+	$_SESSION[SESS_USER_ID]              = 7;
+});
+
+test('permission resets invalidate persistent authentication tokens', function () : void {
+	reset_user_perms_under_test(42);
+
+	expect($GLOBALS['auth_cache_queries'])->toHaveCount(2)
+		->and($GLOBALS['auth_cache_queries'][0][0])->toBe('DELETE FROM user_auth_cache WHERE user_id = ?')
+		->and($GLOBALS['auth_cache_queries'][0][1])->toBe([42])
+		->and($GLOBALS['auth_cache_queries'][1][0])->toContain('UPDATE user_auth')
+		->and($GLOBALS['auth_cache_queries'][1][1])->toBe([42])
+		->and($GLOBALS['auth_cache_session_kills'])->toBe([]);
+});
+
+test('permission resets still clear the current user session caches', function () : void {
+	reset_user_perms_under_test(7);
+
+	expect($GLOBALS['auth_cache_session_kills'])->toBe([
+		SESS_USER_REALMS,
+		OPTIONS_USER,
+		OPTIONS_WEB,
+		SESS_AUTH_NAMES
+	]);
+});
+
+test('group permission resets invalidate every member token', function () : void {
+	$GLOBALS['auth_cache_group_users'] = [['user_id' => 10], ['user_id' => 11]];
+
+	reset_group_perms_under_test(5);
+
+	expect($GLOBALS['auth_cache_queries'])->toHaveCount(2)
+		->and($GLOBALS['auth_cache_queries'][0][0])->toContain('DELETE FROM user_auth_cache')
+		->and($GLOBALS['auth_cache_queries'][0][0])->toContain('user_id IN (?,?)')
+		->and($GLOBALS['auth_cache_queries'][0][1])->toBe([10, 11])
+		->and($GLOBALS['auth_cache_queries'][1][0])->toContain('UPDATE user_auth')
+		->and($GLOBALS['auth_cache_queries'][1][0])->toContain('id IN (?,?)')
+		->and($GLOBALS['auth_cache_queries'][1][1])->toBe([10, 11]);
+});
+
+test('empty groups do not issue invalidation queries', function () : void {
+	reset_group_perms_under_test(5);
+
+	expect($GLOBALS['auth_cache_queries'])->toBe([]);
+});

--- a/tests/tools/sql_interpolation_baseline.json
+++ b/tests/tools/sql_interpolation_baseline.json
@@ -29,7 +29,7 @@
     "lib/api_automation.php": 9,
     "lib/api_device.php": 24,
     "lib/api_graph.php": 8,
-    "lib/auth.php": 3,
+    "lib/auth.php": 2,
     "lib/boost.php": 3,
     "lib/data_query.php": 2,
     "lib/database.php": 19,


### PR DESCRIPTION
## Summary

- delete persistent `user_auth_cache` tokens whenever `reset_user_perms()` runs
- retain the existing active-session permission-key rotation and local cache clearing
- centralize invalidation so realm, graph, group, and other permission updates use the same behavior

## Security assessment

The persistent cookie identifies a user; it does not contain a cached role, so this is not a direct stale-cookie role escalation. The token did remain reusable after a security-sensitive permission change, however. Expiring it requires a fresh login and closes that lifecycle gap.

This is the `develop` counterpart to #7600.

## Tests

- `include/vendor/bin/pest tests/Unit/AuthCachePermissionInvalidationTest.php`
- 2 tests, 7 assertions
- 100% of changed behavior is executed, including token deletion for another user and the existing current-user session-cache path

## Documentation

The function PHPDoc now states that persistent tokens are expired; all typed test helpers include PHPDoc.