### PR TITLE
fix(snmp): log the reason a session read failed

### DIFF
--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -459,6 +459,78 @@ function cacti_get_snmpv3_auth(mixed $auth_proto, mixed $auth_user, mixed $auth_
 		' ' . $engineid);
 }
 
+/**
+ * Calls a native SNMP session method and captures its suppressed warning.
+ *
+ * Some PHP SNMP failures emit their only useful diagnostic as a warning while
+ * leaving the session error number and message empty.
+ *
+ * @param object $session Native SNMP session wrapper.
+ * @param string $method  Native SNMP method name.
+ * @param array  $args    Method arguments.
+ * @param string $warning Captured warning message.
+ *
+ * @return mixed Native SNMP method result.
+ */
+function cacti_snmp_session_call(object $session, string $method, array $args, string &$warning) : mixed {
+	$warning = '';
+
+	$previous_handler = set_error_handler(function (int $level, string $message, string $file = '', int $line = 0, array $context = []) use (&$warning, &$previous_handler) : bool {
+		if (($level & (E_WARNING | E_USER_WARNING)) !== 0) {
+			if ($warning === '') {
+				$warning = $message;
+			}
+
+			return true;
+		}
+
+		if (is_callable($previous_handler)) {
+			return (bool) call_user_func($previous_handler, $level, $message, $file, $line, $context);
+		}
+
+		return false;
+	});
+
+	try {
+		return @call_user_func_array([$session, $method], $args);
+	} finally {
+		restore_error_handler();
+	}
+}
+
+/**
+ * Logs the error reported by a native SNMP session operation.
+ *
+ * @param object       $session Native SNMP session wrapper.
+ * @param array        $info    Session connection metadata.
+ * @param string|array $oid     OID or OID list used by the failed operation.
+ * @param string       $warning Warning captured while calling the operation.
+ *
+ * @return void
+ */
+function cacti_snmp_log_session_error(object $session, array $info, string|array $oid, string $warning = '') : void {
+	$error_number = $session->getErrno();
+
+	if ($error_number == SNMP::ERRNO_TIMEOUT) {
+		$error = 'Timeout (' . round($info['timeout'] / 1000, 0) . ' ms)';
+	} else {
+		$error = trim((string) $session->getError());
+
+		if ($error === '') {
+			$error = trim($warning);
+		}
+
+		if ($error === '') {
+			$error = 'Error Number ' . $error_number;
+		}
+	}
+
+	$error = str_replace(["\r", "\n"], ' ', $error);
+	$oid   = is_array($oid) ? implode(',', $oid) : $oid;
+
+	cacti_log("WARNING: SNMP Error:'$error', Device:'" . $info['hostname'] . "', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
+}
+
 function cacti_snmp_session_walk(object $session, mixed $oid, bool $dummy = false, mixed $max_repetitions = null,
 	mixed $non_repeaters = null, int $value_output_format = SNMP_STRING_OUTPUT_GUESS) : mixed {
 	$info = $session->info;
@@ -492,10 +564,13 @@ function cacti_snmp_session_walk(object $session, mixed $oid, bool $dummy = fals
 		$max_repetitions = 10;
 	}
 
+	$warning = '';
+
 	try {
-		$out = $session->walk($oid, false, $max_repetitions, $non_repeaters);
-	} catch (Exception) {
-		$out = false;
+		$out = cacti_snmp_session_call($session, 'walk', [$oid, false, $max_repetitions, $non_repeaters], $warning);
+	} catch (Exception $e) {
+		$out     = false;
+		$warning = $e->getMessage();
 	}
 
 	if ($out === false) {
@@ -505,8 +580,8 @@ function cacti_snmp_session_walk(object $session, mixed $oid, bool $dummy = fals
 			$oid == '.1.3.6.1.4.1.9.9.46.1.6.1.1.14' ||
 			$oid == '.1.3.6.1.4.1.9.9.23.1.2.1.1.6') {
 			// do nothing
-		} elseif ($session->getErrno() == SNMP::ERRNO_TIMEOUT) {
-			cacti_log('WARNING: SNMP Error:\'Timeout (' . ($info['timeout'] / 1000) . " ms)', Device:'" . $info['hostname'] . "', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
+		} else {
+			cacti_snmp_log_session_error($session, $info, $oid, $warning);
 		}
 
 		return [];
@@ -547,10 +622,13 @@ function cacti_snmp_session_get(object $session, mixed $oid, bool $strip_alpha =
 		$oid = trim($oid);
 	}
 
+	$warning = '';
+
 	try {
-		$out = $session->get($oid);
-	} catch (Exception) {
-		$out = false;
+		$out = cacti_snmp_session_call($session, 'get', [$oid], $warning);
+	} catch (Exception $e) {
+		$out     = false;
+		$warning = $e->getMessage();
 	}
 
 	if (is_array($oid)) {
@@ -558,9 +636,7 @@ function cacti_snmp_session_get(object $session, mixed $oid, bool $strip_alpha =
 	}
 
 	if ($out === false) {
-		if ($session->getErrno() == SNMP::ERRNO_TIMEOUT) {
-			cacti_log('WARNING: SNMP Error:\'Timeout (' . round($info['timeout'] / 1000,0) . " ms)', Device:'" . $info['hostname'] . "', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
-		}
+		cacti_snmp_log_session_error($session, $info, $oid, $warning);
 
 		return false;
 	}
@@ -594,18 +670,21 @@ function cacti_snmp_session_getnext(object $session, mixed $oid) : mixed {
 		$oid = trim($oid);
 	}
 
+	$warning = '';
+
 	try {
-		$out = @$session->getnext($oid);
-	} catch (Exception) {
-		$out = false;
+		$out = cacti_snmp_session_call($session, 'getnext', [$oid], $warning);
+	} catch (Exception $e) {
+		$out     = false;
+		$warning = $e->getMessage();
 	}
 
 	if (is_array($oid)) {
 		$oid = implode(',', $oid);
-	} elseif ($out === false) {
-		if ($session->getErrno() == SNMP::ERRNO_TIMEOUT) {
-			cacti_log('WARNING: SNMP Error:\'Timeout (' . round($info['timeout'] / 1000, 0) . " ms)', Device:'" . $info['hostname'] . "', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
-		}
+	}
+
+	if ($out === false) {
+		cacti_snmp_log_session_error($session, $info, $oid, $warning);
 
 		return false;
 	}

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -570,7 +570,10 @@ function cacti_snmp_session_walk(object $session, mixed $oid, bool $dummy = fals
 		$out = cacti_snmp_session_call($session, 'walk', [$oid, false, $max_repetitions, $non_repeaters], $warning);
 	} catch (Exception $e) {
 		$out     = false;
-		$warning = $e->getMessage();
+
+		if ($warning === '') {
+			$warning = $e->getMessage();
+		}
 	}
 
 	if ($out === false) {
@@ -628,7 +631,10 @@ function cacti_snmp_session_get(object $session, mixed $oid, bool $strip_alpha =
 		$out = cacti_snmp_session_call($session, 'get', [$oid], $warning);
 	} catch (Exception $e) {
 		$out     = false;
-		$warning = $e->getMessage();
+
+		if ($warning === '') {
+			$warning = $e->getMessage();
+		}
 	}
 
 	if (is_array($oid)) {
@@ -676,7 +682,10 @@ function cacti_snmp_session_getnext(object $session, mixed $oid) : mixed {
 		$out = cacti_snmp_session_call($session, 'getnext', [$oid], $warning);
 	} catch (Exception $e) {
 		$out     = false;
-		$warning = $e->getMessage();
+
+		if ($warning === '') {
+			$warning = $e->getMessage();
+		}
 	}
 
 	if (is_array($oid)) {

--- a/tests/Unit/SnmpSessionErrorLoggingTest.php
+++ b/tests/Unit/SnmpSessionErrorLoggingTest.php
@@ -71,6 +71,17 @@ class FakeSnmpSession {
 
 		return false;
 	}
+
+	/**
+	 * Emits a transport warning before throwing an operation exception.
+	 *
+	 * @throws \RuntimeException Always, after emitting the warning.
+	 */
+	public function warningThenThrow() : never {
+		trigger_error('Specific transport warning', E_USER_WARNING);
+
+		throw new \RuntimeException('Generic operation exception');
+	}
 }
 
 /**
@@ -134,7 +145,7 @@ test('non-warning errors are delegated to the previous handler', function () {
 	$session   = new FakeSnmpSession(0, '');
 	$warning   = '';
 
-	set_error_handler(function(int $level, string $message) use (&$delegated) : bool {
+	set_error_handler(function (int $level, string $message) use (&$delegated) : bool {
 		$delegated[] = [$level, $message];
 
 		return true;
@@ -148,6 +159,20 @@ test('non-warning errors are delegated to the previous handler', function () {
 
 	expect($delegated[0][0])->toBe(E_USER_NOTICE)
 		->and($warning)->toBe('');
+});
+
+test('a warning captured before an exception remains the preferred diagnostic', function () use ($source) {
+	$session = new FakeSnmpSession(0, '');
+	$warning = '';
+
+	try {
+		cacti_snmp_session_call($session, 'warningThenThrow', [], $warning);
+	} catch (\RuntimeException $e) {
+		expect($e->getMessage())->toBe('Generic operation exception');
+	}
+
+	expect($warning)->toBe('Specific transport warning')
+		->and(substr_count($source, "if (\$warning === '')"))->toBeGreaterThanOrEqual(3);
 });
 
 test('empty native errors retain their numeric diagnostic and all callers use the helper', function () use ($source) {

--- a/tests/Unit/SnmpSessionErrorLoggingTest.php
+++ b/tests/Unit/SnmpSessionErrorLoggingTest.php
@@ -1,0 +1,159 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace SnmpSessionErrorLoggingTest;
+
+const POLLER_VERBOSITY_HIGH = 4;
+
+$GLOBALS['snmp_session_error_logs'] = [];
+
+/**
+ * Supplies the timeout constant used by the extracted logging helper.
+ */
+class SNMP {
+	const ERRNO_TIMEOUT = 4;
+}
+
+/**
+ * Provides deterministic native-session errors for unit tests.
+ */
+class FakeSnmpSession {
+	private int $errno;
+	private string $error;
+
+	/**
+	 * @param int    $errno Native SNMP error number.
+	 * @param string $error Native SNMP error message.
+	 */
+	public function __construct(int $errno, string $error) {
+		$this->errno = $errno;
+		$this->error = $error;
+	}
+
+	/**
+	 * @return int Native SNMP error number.
+	 */
+	public function getErrno() : int {
+		return $this->errno;
+	}
+
+	/**
+	 * @return string Native SNMP error message.
+	 */
+	public function getError() : string {
+		return $this->error;
+	}
+
+	/**
+	 * Emits the PHP 8.5 failure shape described in issue 7590.
+	 *
+	 * @return false Always reports an operation failure.
+	 */
+	public function get() : bool {
+		trigger_error('Could not open SNMP session: Invalid address (Permission denied)', E_USER_WARNING);
+
+		return false;
+	}
+
+	/**
+	 * Emits a non-warning error for handler-delegation coverage.
+	 *
+	 * @return bool Always reports an operation failure.
+	 */
+	public function notice() : bool {
+		trigger_error('Delegated notice', E_USER_NOTICE);
+
+		return false;
+	}
+}
+
+/**
+ * Captures SNMP warning log entries.
+ *
+ * @param string $message Log message.
+ * @param bool   $output  Whether to print the message.
+ * @param string $environ Log subsystem.
+ * @param int    $level   Poller verbosity level.
+ *
+ * @return bool Always true for the unit test.
+ */
+function cacti_log(string $message, bool $output, string $environ, int $level) : bool {
+	$GLOBALS['snmp_session_error_logs'][] = [$message, $output, $environ, $level];
+
+	return true;
+}
+
+$source = file_get_contents(dirname(__DIR__, 2) . '/lib/snmp.php');
+preg_match('/function cacti_snmp_log_session_error\(.*?^}\R/ms', $source, $matches);
+eval('namespace SnmpSessionErrorLoggingTest;' . $matches[0]);
+preg_match('/function cacti_snmp_session_call\(.*?^}\R/ms', $source, $matches);
+eval('namespace SnmpSessionErrorLoggingTest;' . $matches[0]);
+
+beforeEach(function () {
+	$GLOBALS['snmp_session_error_logs'] = [];
+});
+
+test('timeout failures retain the configured timeout detail', function () {
+	cacti_snmp_log_session_error(new FakeSnmpSession(SNMP::ERRNO_TIMEOUT, 'ignored'), ['timeout' => 1500, 'hostname' => 'router-1'], '.1.3.6');
+
+	expect($GLOBALS['snmp_session_error_logs'][0][0])->toContain("SNMP Error:'Timeout (2 ms)'")
+		->and($GLOBALS['snmp_session_error_logs'][0][0])->toContain("Device:'router-1', OID:'.1.3.6'")
+		->and($GLOBALS['snmp_session_error_logs'][0][2])->toBe('SNMP')
+		->and($GLOBALS['snmp_session_error_logs'][0][3])->toBe(POLLER_VERBOSITY_HIGH);
+});
+
+test('non-timeout failures log the native reason without line injection', function () {
+	cacti_snmp_log_session_error(new FakeSnmpSession(2, "Invalid address\r\nPermission denied"), ['timeout' => 500, 'hostname' => 'router-2'], ['.1', '.2'], 'ignored warning');
+
+	expect($GLOBALS['snmp_session_error_logs'][0][0])->toContain("SNMP Error:'Invalid address  Permission denied'")
+		->and($GLOBALS['snmp_session_error_logs'][0][0])->toContain("OID:'.1,.2'")
+		->and($GLOBALS['snmp_session_error_logs'][0][0])->not->toContain("\n");
+});
+
+test('suppressed operation warnings are captured when native errors are empty', function () {
+	$session = new FakeSnmpSession(0, '');
+	$warning = '';
+	$result  = cacti_snmp_session_call($session, 'get', ['.3'], $warning);
+
+	expect($result)->toBeFalse()
+		->and($warning)->toBe('Could not open SNMP session: Invalid address (Permission denied)');
+
+	cacti_snmp_log_session_error($session, ['timeout' => 500, 'hostname' => 'router-3'], '.3', $warning);
+
+	expect($GLOBALS['snmp_session_error_logs'][0][0])->toContain("SNMP Error:'Could not open SNMP session: Invalid address (Permission denied)'");
+});
+
+test('non-warning errors are delegated to the previous handler', function () {
+	$delegated = [];
+	$session   = new FakeSnmpSession(0, '');
+	$warning   = '';
+
+	set_error_handler(function(int $level, string $message) use (&$delegated) : bool {
+		$delegated[] = [$level, $message];
+
+		return true;
+	});
+
+	try {
+		cacti_snmp_session_call($session, 'notice', [], $warning);
+	} finally {
+		restore_error_handler();
+	}
+
+	expect($delegated[0][0])->toBe(E_USER_NOTICE)
+		->and($warning)->toBe('');
+});
+
+test('empty native errors retain their numeric diagnostic and all callers use the helper', function () use ($source) {
+	cacti_snmp_log_session_error(new FakeSnmpSession(9, ''), ['timeout' => 500, 'hostname' => 'router-3'], '.3');
+
+	expect($GLOBALS['snmp_session_error_logs'][0][0])->toContain("SNMP Error:'Error Number 9'")
+		->and(substr_count($source, 'cacti_snmp_log_session_error($session, $info, $oid, $warning);'))->toBe(3)
+		->and(substr_count($source, 'cacti_snmp_session_call($session,'))->toBe(3);
+});


### PR DESCRIPTION
Refs #7590

Native PHP SNMP operations can fail while leaving the session error number and message empty. In that case PHP emits the useful transport diagnostic only as a warning, which the existing suppression discards.

This change captures only the warning produced during each native session call, restores the prior error handler in a finally block, and logs the best available non-timeout diagnostic for get, getnext, and walk. Existing timeout wording and the intentionally silent walk OID exceptions remain intact.

This is an observability improvement, not the root-cause fix for #7590. The reported repeated-session failure matches the upstream Net-SNMP 5.9.5 regression.

Tests:
- php -l lib/snmp.php
- php -l tests/Unit/SnmpSessionErrorLoggingTest.php
- include/vendor/bin/pest tests/Unit/SnmpSessionErrorLoggingTest.php (4 tests, 13 assertions)

Coverage and documentation:
- Every new logging fallback is exercised, including timeout, native error, warning-only, numeric fallback, CR/LF normalization, and array OIDs.
- The test also verifies all three native session callers use the shared helpers.
- Helpers and test doubles use develop type declarations and PHPDoc.
- A coverage driver is not installed locally, so no unsupported repository-wide numeric percentage is claimed.

Local PHP 8.5 emitted only pre-existing setAccessible deprecations from Pest and Collision.