### PR TITLE
docs(auth): document group token invalidation

### DIFF
--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4393,8 +4393,8 @@ function rsa_check_keypair() : void {
 }
 
 /**
- * Expires persistent authentication tokens and sets a flag for all users of a
- * group logged in that their permissions need to be reloaded from the database.
+ * Expires persistent authentication tokens for all group members and sets a
+ * flag so logged-in members reload their permissions from the database.
  *
  * @param int $group_id The ID of the group whose users' permissions need to be reset.
  *

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -4393,8 +4393,8 @@ function rsa_check_keypair() : void {
 }
 
 /**
- * Sets a flag for all users of a group logged in that their perms
- * need to be reloaded from the database
+ * Expires persistent authentication tokens and sets a flag for all users of a
+ * group logged in that their permissions need to be reloaded from the database.
  *
  * @param int $group_id The ID of the group whose users' permissions need to be reset.
  *


### PR DESCRIPTION
## What changed

Updates the `reset_group_perms()` PHPDoc to state that group permission resets expire persistent authentication tokens as well as forcing permission reloads.

## Why

PR #7601 added token invalidation and was merged before this review follow-up landed. The old description documented only the permission-reset side effect.

## Validation

- PHP CS Fixer dry run on `lib/auth.php`
- Existing `AuthCachePermissionInvalidationTest` suite: 4 tests, 15 assertions