### PR TITLE
fix(headers): stop overriding no-store with a one year max-age

### DIFF
--- a/include/global.php
+++ b/include/global.php
@@ -641,8 +641,9 @@ if ($config['is_web']) {
 
 	// prevent IE from silently rejects cookies sent from third party sites.
 	header('P3P: CP="CAO PSA OUR"');
+	// header() replaces by default, so a second Cache-Control here would drop
+	// no-store and leave every authenticated page cacheable
 	header('Cache-Control: no-store, no-cache, must-revalidate');
-	header('Cache-Control: max-age=31536000');
 
 	cacti_session_start();
 

--- a/tests/Unit/CacheControlNoStoreTest.php
+++ b/tests/Unit/CacheControlNoStoreTest.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * include/global.php sent two Cache-Control headers in a row:
+ *
+ *   header('Cache-Control: no-store, no-cache, must-revalidate');
+ *   header('Cache-Control: max-age=31536000');
+ *
+ * header() replaces by default, so only the second one reached the browser and
+ * every authenticated page advertised itself as cacheable for a year, three
+ * lines below a comment saying we do not want these pages cached. The max-age
+ * arrived with a Lighthouse performance change (ced9f430f4) that was aimed at
+ * static content but landed on the path every page takes.
+ */
+
+$globalSource = file_get_contents(dirname(__DIR__, 2) . '/include/global.php');
+
+test('the page headers keep no-store', function () use ($globalSource) {
+	expect($globalSource)->toContain("header('Cache-Control: no-store, no-cache, must-revalidate');");
+});
+
+test('no second Cache-Control header overrides it', function () use ($globalSource) {
+	expect(substr_count($globalSource, 'Cache-Control:'))->toBe(1);
+	expect($globalSource)->not->toContain('max-age=31536000');
+});
+
+test('the surviving directive forbids storing the response', function () use ($globalSource) {
+	preg_match_all("/header\('Cache-Control: ([^']+)'\);/", $globalSource, $matches);
+
+	expect($matches[1])->toHaveCount(1);
+	expect($matches[1][0])->toContain('no-store');
+});


### PR DESCRIPTION
## Summary

- drop the `max-age=31536000` that was silently replacing `no-store` on every page

## Why

`include/global.php` sent two `Cache-Control` headers in a row:

```php
header('Cache-Control: no-store, no-cache, must-revalidate');
header('Cache-Control: max-age=31536000');
```

`header()` replaces by default, so only the second one reached the browser. Every authenticated page therefore advertised itself as cacheable for a year, three lines below a comment saying we do not want these pages cached. On a shared or proxy cache that is session-scoped content offered for reuse.

The `max-age` arrived in ced9f430f4, a Lighthouse performance change whose own message describes it as caching for static content and RRDtool generated graphics. It landed on the path every page takes instead. Static assets are served by the web server rather than through `global.php`, so the directive was never doing the job it was added for.

`1.2.x` is unaffected. It sends only the `no-store` form, from `lib/headers_secure.php`.

## Validation

- `tests/Unit/CacheControlNoStoreTest.php`: 3 tests, 2 of which fail against the unpatched source
- the third asserts the surviving directive still forbids storing the response, so a future edit that keeps one header but weakens it is also caught
- `tests/security/verify_sink_inventory.sh` and `verify_architectural_hotspots.sh` both report OK
- `php -l` clean
