### PR TITLE
Harden RRDtool proxy transport handling

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1001,8 +1001,11 @@ function __rrd_proxy_execute(string|array $command_line, bool $log_to_stdout, in
 		case RRDTOOL_OUTPUT_NULL:
 			return $response['success'] ? 'OK' : false;
 		case RRDTOOL_OUTPUT_STDOUT:
-		case RRDTOOL_OUTPUT_GRAPH_DATA:
 			return $response['success'] ? rtrim($response['output']) : false;
+		case RRDTOOL_OUTPUT_GRAPH_DATA:
+			// Graph output is binary. The proxy decoder has already removed the
+			// protocol terminator, so trimming here could corrupt valid image bytes.
+			return $response['success'] ? $response['output'] : false;
 		case RRDTOOL_OUTPUT_STDERR:
 			if (!$response['success']) {
 				print $response['raw'];

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -880,7 +880,7 @@ function rrdtool_trim_output(string &$output) : void {
 /**
  * Execute an RRDtool command through the remote proxy.
  *
- * @param string|array $command_line  RRDtool command string, or one argument per array element
+ * @param string|array $command_line  RRDtool command string, or one string argument per array element
  * @param bool         $log_to_stdout Whether to echo log output
  * @param int          $output_flag   Requested RRDTOOL_OUTPUT_* result mode
  * @param mixed        $rrdp          Existing proxy connection tuple, or an empty value
@@ -890,6 +890,12 @@ function rrdtool_trim_output(string &$output) : void {
  */
 function __rrd_proxy_execute(string|array $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdp = '', string $logopt = 'WEBLOG') : mixed {
 	if (is_array($command_line)) {
+		if ($command_line === [] || array_filter($command_line, 'is_string') !== $command_line) {
+			cacti_log('CACTI2RRDP ERROR: Invalid proxy command argument list.', $log_to_stdout, $logopt, POLLER_VERBOSITY_LOW);
+
+			return false;
+		}
+
 		$command_line = implode(' ', array_map('cacti_escapeshellarg', $command_line));
 	}
 

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -24,6 +24,11 @@
 
 define('RRD_NL', " \\\n");
 define('MAX_FETCH_CACHE_SIZE', 5);
+define('RRD_PROXY_END_OF_PACKET', "_EOP_\r\n");
+define('RRD_PROXY_END_OF_SEQUENCE', "_EOT_\r\n");
+define('RRD_PROXY_TIMEOUT_SECONDS', 10);
+define('RRD_PROXY_MAX_KEY_SIZE', 1048576);
+define('RRD_PROXY_MAX_RESPONSE_SIZE', 67108864);
 
 if (read_config_option('storage_location')) {
 	global $encryption;
@@ -97,9 +102,245 @@ function __rrd_init(bool $output_to_term = true) : mixed {
 	return $process;
 }
 
+/**
+ * Configure bounded blocking I/O for an RRDtool proxy socket.
+ *
+ * @param Socket $socket  Connected or unconnected proxy socket
+ * @param int    $seconds Read and write timeout in seconds
+ *
+ * @return bool Whether both socket options were applied
+ */
+function rrdtool_proxy_set_timeouts(Socket $socket, int $seconds = RRD_PROXY_TIMEOUT_SECONDS) : bool {
+	if ($seconds < 1) {
+		return false;
+	}
+
+	$timeout = ['sec' => $seconds, 'usec' => 0];
+
+	return @socket_set_option($socket, SOL_SOCKET, SO_RCVTIMEO, $timeout)
+		&& @socket_set_option($socket, SOL_SOCKET, SO_SNDTIMEO, $timeout);
+}
+
+/**
+ * Connect to an RRDtool proxy with an explicit deadline.
+ *
+ * @param Socket $socket  Proxy socket
+ * @param string $server  IPv4 or IPv6 address
+ * @param int    $port    TCP port
+ * @param int    $seconds Connection timeout in seconds
+ *
+ * @return bool Whether the connection completed successfully
+ */
+function rrdtool_proxy_connect(Socket $socket, string $server, int $port, int $seconds = RRD_PROXY_TIMEOUT_SECONDS) : bool {
+	if ($seconds < 1 || !@socket_set_nonblock($socket)) {
+		return false;
+	}
+
+	$connected = @socket_connect($socket, $server, $port);
+
+	if (!$connected) {
+		$error       = socket_last_error($socket);
+		$in_progress = [];
+
+		foreach (['SOCKET_EINPROGRESS', 'SOCKET_EALREADY', 'SOCKET_EWOULDBLOCK', 'SOCKET_EAGAIN'] as $constant) {
+			if (defined($constant)) {
+				$in_progress[] = constant($constant);
+			}
+		}
+
+		if (!in_array($error, array_unique($in_progress), true)) {
+			@socket_set_block($socket);
+
+			return false;
+		}
+
+		$read   = [];
+		$write  = [$socket];
+		$except = [$socket];
+		$ready  = @socket_select($read, $write, $except, $seconds, 0);
+
+		if ($ready !== 1 || $except !== []) {
+			@socket_set_block($socket);
+
+			return false;
+		}
+
+		$socket_error = @socket_get_option($socket, SOL_SOCKET, SO_ERROR);
+
+		if ($socket_error !== 0) {
+			@socket_set_block($socket);
+
+			return false;
+		}
+	}
+
+	return @socket_set_block($socket);
+}
+
+/**
+ * Write an entire RRDtool proxy frame.
+ *
+ * socket_write() may complete only part of a write.  This helper retries until
+ * all bytes are transferred, and treats zero-byte or failed writes as errors.
+ *
+ * @param Socket $socket Proxy socket
+ * @param string $data   Complete encoded frame
+ *
+ * @return bool Whether every byte was written
+ */
+function rrdtool_proxy_write(Socket $socket, string $data) : bool {
+	$length  = strlen($data);
+	$written = 0;
+
+	while ($written < $length) {
+		set_error_handler(static fn () : bool => true);
+
+		try {
+			$result = socket_write($socket, substr($data, $written));
+		} finally {
+			restore_error_handler();
+		}
+
+		if ($result === false || $result === 0) {
+			return false;
+		}
+
+		$written += $result;
+	}
+
+	return true;
+}
+
+/**
+ * Read one bounded, terminator-delimited RRDtool proxy frame.
+ *
+ * @param Socket $socket     Proxy socket
+ * @param string $terminator Protocol frame terminator
+ * @param int    $max_size   Maximum buffered frame size
+ *
+ * @return string|false Frame contents without the terminator, or false
+ */
+function rrdtool_proxy_read_frame(Socket $socket, string $terminator, int $max_size) : string|false {
+	if ($terminator === '' || $max_size < 1) {
+		return false;
+	}
+
+	$input = '';
+
+	while (true) {
+		$remaining = $max_size + strlen($terminator) - strlen($input);
+		$recv      = @socket_read($socket, min(100000, $remaining), PHP_BINARY_READ);
+
+		if ($recv === false || $recv === '') {
+			return false;
+		}
+
+		$input .= $recv;
+		$position = strpos($input, $terminator);
+
+		if ($position !== false) {
+			return substr($input, 0, $position);
+		}
+
+		if (strlen($input) > $max_size) {
+			return false;
+		}
+	}
+}
+
+/**
+ * Decode gzip data without leaking malformed-peer warnings into graph output.
+ *
+ * @param string $input    Compressed packet
+ * @param int    $max_size Maximum decoded size
+ *
+ * @return string|false Decoded packet, or false when invalid or oversized
+ */
+function rrdtool_proxy_gzdecode(string $input, int $max_size) : string|false {
+	if ($max_size < 1) {
+		return false;
+	}
+
+	set_error_handler(static fn () : bool => true);
+
+	try {
+		return gzdecode($input, $max_size);
+	} finally {
+		restore_error_handler();
+	}
+}
+
+/**
+ * Decode and validate a complete RRDtool proxy response.
+ *
+ * The terminal status must occur at the end of the final protocol packet.
+ * Status-like text in graph or xport payload data is therefore not treated as
+ * a protocol boundary.
+ *
+ * @param string $frame    Encoded frame without the sequence terminator
+ * @param int    $max_size Maximum decoded response size
+ *
+ * @return array{output:string,status:string,success:bool,raw:string}|false
+ */
+function rrdtool_proxy_decode_response(string $frame, int $max_size = RRD_PROXY_MAX_RESPONSE_SIZE) : array|false {
+	if ($max_size < 1 || strlen($frame) > $max_size) {
+		return false;
+	}
+
+	$packets = explode(RRD_PROXY_END_OF_PACKET, $frame);
+
+	if (end($packets) === '') {
+		array_pop($packets);
+	}
+
+	if ($packets === []) {
+		return false;
+	}
+
+	$decoded_size = 0;
+	$decoded      = [];
+
+	foreach ($packets as $packet) {
+		$transaction = decrypt($packet);
+
+		if ($transaction === false) {
+			return false;
+		}
+
+		if (str_starts_with($transaction, "\x1f\x8b")) {
+			$transaction = rrdtool_proxy_gzdecode($transaction, $max_size - $decoded_size);
+
+			if ($transaction === false) {
+				return false;
+			}
+		}
+
+		$decoded_size += strlen($transaction);
+		$decoded[] = $transaction;
+	}
+
+	$last_packet = array_pop($decoded);
+
+	if (!preg_match('/(?:^|\r?\n)(OK u(?::[^\r\n]*)?|ERROR:[^\r\n]*)\r?\n?\z/D', $last_packet, $matches, PREG_OFFSET_CAPTURE)) {
+		return false;
+	}
+
+	$status_offset = $matches[1][1];
+	$status        = $matches[1][0];
+	$packet_output = substr($last_packet, 0, $status_offset);
+	$output        = implode('', $decoded) . rtrim($packet_output, "\r\n");
+	$raw           = $output . ($output === '' ? '' : "\n") . $status;
+
+	return [
+		'output'  => $output,
+		'status'  => $status,
+		'success' => str_starts_with($status, 'OK u'),
+		'raw'     => $raw
+	];
+}
+
 function __rrd_proxy_init(string $logopt = 'WEBLOG') : mixed {
 	global $encryption;
-	$terminator = "_EOT_\r\n";
 	$encryption = true;
 
 	$load_balancing = read_config_option('rrdp_load_balancing') == 'on' ? true : false;
@@ -130,10 +371,17 @@ function __rrd_proxy_init(string $logopt = 'WEBLOG') : mixed {
 		return false;
 	}
 
+	if (!rrdtool_proxy_set_timeouts($rrdp_socket)) {
+		cacti_log('CACTI2RRDP ERROR: Unable to configure socket time-outs.', false, $logopt, POLLER_VERBOSITY_LOW);
+		@socket_close($rrdp_socket);
+
+		return false;
+	}
+
 	// Strip brackets from IPv6 addresses for socket_connect
 	$connect_server = trim($server, '[]');
 
-	$rrdp = socket_connect($rrdp_socket, $connect_server, $port);
+	$rrdp = rrdtool_proxy_connect($rrdp_socket, $connect_server, $port);
 
 	if ($rrdp === false) {
 		// log entry ...
@@ -159,61 +407,63 @@ function __rrd_proxy_init(string $logopt = 'WEBLOG') : mixed {
 				return false;
 			}
 
-			$rrdp = socket_connect($rrdp_socket, $connect_server, $port);
-
-			if ($rrdp === false) {
-				cacti_log('CACTI2RRDP ERROR: Unable to connect to RRDtool Proxy Server #' . $rrdp_id, false, $logopt, POLLER_VERBOSITY_LOW);
+			if (!rrdtool_proxy_set_timeouts($rrdp_socket)) {
+				cacti_log('CACTI2RRDP ERROR: Unable to configure backup socket time-outs.', false, $logopt, POLLER_VERBOSITY_LOW);
+				@socket_close($rrdp_socket);
 
 				return false;
 			}
+
+			$rrdp = rrdtool_proxy_connect($rrdp_socket, $connect_server, $port);
+
+			if ($rrdp === false) {
+				cacti_log('CACTI2RRDP ERROR: Unable to connect to RRDtool Proxy Server #' . $rrdp_id, false, $logopt, POLLER_VERBOSITY_LOW);
+				@socket_close($rrdp_socket);
+
+				return false;
+			}
+		} else {
+			@socket_close($rrdp_socket);
+
+			return false;
 		}
 	}
 
 	$rrdp_fingerprint = ($rrdp_id == 1) ? read_config_option('rrdp_fingerprint') : read_config_option('rrdp_fingerprint_backup');
 
-	socket_write($rrdp_socket, read_config_option('rsa_public_key') . $terminator);
-
-	// read public key being returned by the proxy server
-	$rrdp_public_key = '';
-
-	while (1) {
-		$recv = socket_read($rrdp_socket, 1000, PHP_BINARY_READ);
-
-		if ($recv === false) {
-			// timeout
-			cacti_log('CACTI2RRDP ERROR: Public RSA Key Exchange - Time-out while reading', false, $logopt, POLLER_VERBOSITY_LOW);
-			$rrdp_public_key = false;
-
-			break;
-		}
-
-		if ($recv == '') {
-			cacti_log('CACTI2RRDP ERROR: Session closed by Proxy.', false, $logopt, POLLER_VERBOSITY_LOW);
-
-			// session closed by Proxy
-			break;
-		} else {
-			$rrdp_public_key .= $recv;
-
-			if (str_contains($rrdp_public_key, $terminator)) {
-				$rrdp_public_key = trim(trim($rrdp_public_key, $terminator));
-
-				break;
-			}
-		}
-	}
-
-	if ($rrdp_public_key === false || trim($rrdp_public_key) === '') {
-		cacti_log('CACTI2RRDP ERROR: Public RSA Key Exchange failed - no key received.', false, $logopt, POLLER_VERBOSITY_LOW);
+	if (!rrdtool_proxy_write($rrdp_socket, read_config_option('rsa_public_key') . RRD_PROXY_END_OF_SEQUENCE)) {
+		cacti_log('CACTI2RRDP ERROR: Public RSA Key Exchange - unable to send local key.', false, $logopt, POLLER_VERBOSITY_LOW);
+		@socket_close($rrdp_socket);
 
 		return false;
 	}
 
-	$public      = phpseclib3\Crypt\RSA::loadPublicKey($rrdp_public_key);
+	// read public key being returned by the proxy server
+	$rrdp_public_key = rrdtool_proxy_read_frame($rrdp_socket, RRD_PROXY_END_OF_SEQUENCE, RRD_PROXY_MAX_KEY_SIZE);
+
+	if ($rrdp_public_key === false || trim($rrdp_public_key) === '') {
+		cacti_log('CACTI2RRDP ERROR: Public RSA Key Exchange failed - no key received.', false, $logopt, POLLER_VERBOSITY_LOW);
+		@socket_close($rrdp_socket);
+
+		return false;
+	}
+
+	$rrdp_public_key = trim($rrdp_public_key);
+
+	try {
+		$public = phpseclib3\Crypt\RSA::loadPublicKey($rrdp_public_key);
+	} catch (Throwable $e) {
+		cacti_log('CACTI2RRDP ERROR: Public RSA Key Exchange returned an invalid key.', false, $logopt, POLLER_VERBOSITY_LOW);
+		@socket_close($rrdp_socket);
+
+		return false;
+	}
+
 	$fingerprint = $public->getFingerprint('md5');
 
-	if ($rrdp_fingerprint != $fingerprint) {
+	if (!is_string($rrdp_fingerprint) || !hash_equals($rrdp_fingerprint, $fingerprint)) {
 		cacti_log('CACTI2RRDP ERROR: Mismatch RSA Fingerprint.', false, $logopt, POLLER_VERBOSITY_LOW);
+		@socket_close($rrdp_socket);
 
 		return false;
 	} else {
@@ -253,13 +503,15 @@ function __rrd_close(mixed $rrdtool_pipe) : void {
 }
 
 function __rrd_proxy_close(mixed $rrdp) : void {
-	// close the rrdtool proxy server connection
-	$terminator = "_EOT_\r\n";
-
-	if ($rrdp) {
-		socket_write($rrdp[0], encrypt('quit', $rrdp[1]) . $terminator);
-		socket_shutdown($rrdp[0], 2);
-		socket_close($rrdp[0]);
+	if (is_array($rrdp) && isset($rrdp[0], $rrdp[1]) && $rrdp[0] instanceof Socket) {
+		try {
+			rrdtool_proxy_write($rrdp[0], encrypt('quit', $rrdp[1]) . RRD_PROXY_END_OF_SEQUENCE);
+		} catch (Throwable $e) {
+			// The connection still has to be closed when request encoding fails.
+		} finally {
+			@socket_shutdown($rrdp[0], 2);
+			@socket_close($rrdp[0]);
+		}
 	}
 }
 
@@ -267,13 +519,12 @@ function encrypt(string $output, string $rsa_key) : string {
 	global $encryption;
 
 	if ($encryption) {
-		$private = phpseclib3\Crypt\RSA::loadPrivateKey($rsa_key);
-		$public  = $private->getPublicKey();
-
-		$aes     = new \phpseclib3\Crypt\Rijndael('stream');
-		$aes_key = phpseclib3\Crypt\Random::string(192);
+		$public  = phpseclib3\Crypt\RSA::loadPublicKey($rsa_key);
+		$aes     = new \phpseclib3\Crypt\Rijndael('cbc');
+		$aes_key = phpseclib3\Crypt\Random::string(32);
 
 		$aes->setKey($aes_key);
+		$aes->setIV(str_repeat("\0", 16));
 		$ciphertext     = base64_encode($aes->encrypt($output));
 		$aes_key        = base64_encode($public->encrypt($aes_key));
 		$aes_key_length = str_pad(dechex(strlen($aes_key)), 3, '0', STR_PAD_LEFT);
@@ -284,32 +535,63 @@ function encrypt(string $output, string $rsa_key) : string {
 	}
 }
 
-function decrypt(string $input) : string {
-	global $encryption;
+/**
+ * Decrypt one encrypted RRDtool proxy packet.
+ *
+ * @param string $input           Encoded packet
+ * @param string $rsa_private_key Local RSA private key
+ *
+ * @return string|false Plaintext, or false when the packet is malformed
+ */
+function rrdtool_proxy_decrypt(string $input, string $rsa_private_key) : string|false {
+	if (strlen($input) < 4 || !ctype_xdigit(substr($input, 0, 3))) {
+		return false;
+	}
 
-	if ($encryption) {
-		$rsa_private_key = read_config_option('rsa_private_key');
-		$private         = phpseclib3\Crypt\RSA::loadPrivateKey($rsa_private_key);
-		$public          = $private->getPublicKey();
+	$aes_key_length = hexdec(substr($input, 0, 3));
 
-		$aes = new \phpseclib3\Crypt\Rijndael('stream');
+	if ($aes_key_length < 1 || strlen($input) <= 3 + $aes_key_length) {
+		return false;
+	}
 
-		$aes_key_length = (int) hexdec(substr($input, 0, 3));
-		$aes_key        = base64_decode(substr($input, 3, $aes_key_length), true);
-		$ciphertext     = base64_decode(substr($input, 3 + $aes_key_length), true);
+	$aes_key    = base64_decode(substr($input, 3, $aes_key_length), true);
+	$ciphertext = base64_decode(substr($input, 3 + $aes_key_length), true);
 
-		if ($aes_key === false || $ciphertext === false) {
-			return $input;
+	if ($aes_key === false || $aes_key === '' || $ciphertext === false) {
+		return false;
+	}
+
+	try {
+		$private = phpseclib3\Crypt\RSA::loadPrivateKey($rsa_private_key);
+		$aes     = new \phpseclib3\Crypt\Rijndael('cbc');
+		$aes_key = $private->decrypt($aes_key);
+
+		if (!is_string($aes_key) || $aes_key === '') {
+			return false;
 		}
 
-		$aes_key = $public->decrypt($aes_key);
-		$aes->setKey($aes_key);
-		$plaintext = $aes->decrypt($ciphertext);
+		// phpseclib 2 truncated oversized Rijndael keys to 256 bits.
+		if (strlen($aes_key) > 32) {
+			$aes_key = substr($aes_key, 0, 32);
+		}
 
-		return $plaintext;
-	} else {
+		$aes->setKey($aes_key);
+		$aes->setIV(str_repeat("\0", 16));
+
+		return $aes->decrypt($ciphertext);
+	} catch (Throwable $e) {
+		return false;
+	}
+}
+
+function decrypt(string $input) : string|false {
+	global $encryption;
+
+	if (!$encryption) {
 		return $input;
 	}
+
+	return rrdtool_proxy_decrypt($input, (string) read_config_option('rsa_private_key'));
 }
 
 function rrdtool_execute() : mixed {
@@ -595,12 +877,21 @@ function rrdtool_trim_output(string &$output) : void {
 	}
 }
 
-function __rrd_proxy_execute(string $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdp = '', string $logopt = 'WEBLOG') : mixed {
-	global $encryption;
-
-	static $last_command;
-	$end_of_packet   = "_EOP_\r\n";
-	$end_of_sequence = "_EOT_\r\n";
+/**
+ * Execute an RRDtool command through the remote proxy.
+ *
+ * @param string|array $command_line  RRDtool command string, or one argument per array element
+ * @param bool         $log_to_stdout Whether to echo log output
+ * @param int          $output_flag   Requested RRDTOOL_OUTPUT_* result mode
+ * @param mixed        $rrdp          Existing proxy connection tuple, or an empty value
+ * @param string       $logopt        Logging context identifier
+ *
+ * @return mixed Output in the requested mode, or false when transport/protocol validation fails
+ */
+function __rrd_proxy_execute(string|array $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdp = '', string $logopt = 'WEBLOG') : mixed {
+	if (is_array($command_line)) {
+		$command_line = implode(' ', array_map('cacti_escapeshellarg', $command_line));
+	}
 
 	/**
 	 * WIN32: before sending this command off to rrdtool, get rid
@@ -631,6 +922,12 @@ function __rrd_proxy_execute(string $command_line, bool $log_to_stdout, int $out
 		cacti_log('CACTI2RRDP NOTE: Connection to RRDtool proxy has already been established.', $log_to_stdout, $logopt, POLLER_VERBOSITY_DEBUG);
 	}
 
+	if (!is_array($rrdp) || !isset($rrdp[0], $rrdp[1]) || !($rrdp[0] instanceof Socket) || !is_string($rrdp[1])) {
+		cacti_log('CACTI2RRDP ERROR: Invalid proxy connection state.', $log_to_stdout, $logopt, POLLER_VERBOSITY_LOW);
+
+		return false;
+	}
+
 	$rrdp_socket     = $rrdp[0];
 	$rrdp_public_key = $rrdp[1];
 
@@ -641,58 +938,54 @@ function __rrd_proxy_execute(string $command_line, bool $log_to_stdout, int $out
 			$command_line = $compressed;
 		}
 	}
-	socket_write($rrdp_socket, encrypt($command_line, $rrdp_public_key) . $end_of_sequence);
 
-	$input  = '';
-	$output = '';
+	try {
+		$frame = encrypt($command_line, $rrdp_public_key) . RRD_PROXY_END_OF_SEQUENCE;
+	} catch (Throwable $e) {
+		cacti_log('CACTI2RRDP ERROR: Unable to encode the proxy request.', $log_to_stdout, $logopt, POLLER_VERBOSITY_LOW);
 
-	while (1) {
-		$recv = socket_read($rrdp_socket, 100000, PHP_BINARY_READ);
-
-		if ($recv === false) {
-			cacti_log('CACTI2RRDP ERROR: Data Transfer - Time-out while reading.', $log_to_stdout, $logopt, POLLER_VERBOSITY_LOW);
-
-			break;
+		if ($rrdp_auto_close) {
+			__rrd_proxy_close($rrdp);
 		}
 
-		if ($recv == '') {
-			// session closed by Proxy
-			if ($output) {
-				cacti_log('CACTI2RRDP ERROR: Session closed by Proxy.', $log_to_stdout, $logopt, POLLER_VERBOSITY_LOW);
-			}
-
-			break;
-		} else {
-			$input .= $recv;
-
-			if (str_contains($input, $end_of_sequence)) {
-				$input        = str_replace($end_of_sequence, '', $input);
-				$transactions = explode($end_of_packet, $input);
-
-				foreach ($transactions as $transaction) {
-					$packet      = $transaction;
-					$transaction = decrypt($transaction);
-
-					if ($transaction === false) {
-						cacti_log('CACTI2RRDP ERROR: Proxy message decryption failed: ###' . $packet . '###', $log_to_stdout, $logopt, POLLER_VERBOSITY_LOW);
-
-						break 2;
-					}
-
-					if (str_starts_with($transaction, "\x1f\x8b")) {
-						$transaction = gzdecode($transaction);
-					}
-					$output .= $transaction;
-
-					if (substr_count($output, 'OK u') || substr_count($output, 'ERROR:')) {
-						cacti_log('RRDP: ' . $output, $log_to_stdout, $logopt, POLLER_VERBOSITY_DEBUG);
-
-						break 2;
-					}
-				}
-			}
-		}
+		return false;
 	}
+
+	if (!rrdtool_proxy_write($rrdp_socket, $frame)) {
+		cacti_log('CACTI2RRDP ERROR: Data Transfer - unable to write complete request.', $log_to_stdout, $logopt, POLLER_VERBOSITY_LOW);
+
+		if ($rrdp_auto_close) {
+			__rrd_proxy_close($rrdp);
+		}
+
+		return false;
+	}
+
+	$frame = rrdtool_proxy_read_frame($rrdp_socket, RRD_PROXY_END_OF_SEQUENCE, RRD_PROXY_MAX_RESPONSE_SIZE);
+
+	if ($frame === false) {
+		cacti_log('CACTI2RRDP ERROR: Data Transfer - timed out, closed, or exceeded the response limit.', $log_to_stdout, $logopt, POLLER_VERBOSITY_LOW);
+
+		if ($rrdp_auto_close) {
+			__rrd_proxy_close($rrdp);
+		}
+
+		return false;
+	}
+
+	$response = rrdtool_proxy_decode_response($frame);
+
+	if ($response === false) {
+		cacti_log('CACTI2RRDP ERROR: Malformed, undecodable, or unterminated proxy response.', $log_to_stdout, $logopt, POLLER_VERBOSITY_LOW);
+
+		if ($rrdp_auto_close) {
+			__rrd_proxy_close($rrdp);
+		}
+
+		return false;
+	}
+
+	cacti_log('RRDP: ' . $response['raw'], $log_to_stdout, $logopt, POLLER_VERBOSITY_DEBUG);
 
 	if ($rrdp_auto_close) {
 		__rrd_proxy_close($rrdp);
@@ -700,32 +993,38 @@ function __rrd_proxy_execute(string $command_line, bool $log_to_stdout, int $out
 
 	switch ($output_flag) {
 		case RRDTOOL_OUTPUT_NULL:
-			return false;
+			return $response['success'] ? 'OK' : false;
 		case RRDTOOL_OUTPUT_STDOUT:
 		case RRDTOOL_OUTPUT_GRAPH_DATA:
-			$ok_pos = strpos($output, 'OK u');
-
-			return rtrim(substr($output, 0, $ok_pos !== false ? $ok_pos : null));
+			return $response['success'] ? rtrim($response['output']) : false;
 		case RRDTOOL_OUTPUT_STDERR:
-			if (substr($output, 1, 3) == 'PNG') {
+			if (!$response['success']) {
+				print $response['raw'];
+
+				return false;
+			}
+
+			if (substr($response['output'], 1, 3) == 'PNG') {
 				return 'OK';
 			}
 
-			if (str_starts_with($output, 'GIF87')) {
+			if (str_starts_with($response['output'], 'GIF87')) {
 				return 'OK';
 			}
 
-			if (str_starts_with($output, '<?xml')) {
+			if (str_starts_with($response['output'], '<?xml')) {
 				return 'SVG/XML Output OK';
 			}
 
-			print $output;
+			print $response['output'];
 
 			return true;
+		case RRDTOOL_OUTPUT_RETURN_STDERR:
+			return $response['raw'];
 		case RRDTOOL_OUTPUT_BOOLEAN:
-			return (substr_count($output, 'OK u')) ? true : false;
+			return $response['success'];
 		default:
-			return 'ERROR';
+			return false;
 	}
 }
 

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -474,9 +474,6 @@ function __rrd_proxy_init(string $logopt = 'WEBLOG') : mixed {
 			rrdtool_execute("setenv RRD_DEFAULT_FONT '" . read_config_option('path_rrdtool_default_font') . "'", false, RRDTOOL_OUTPUT_NULL, $rrdproxy, $logopt = 'WEBLOG');
 		}
 
-		// disable encryption
-		$encryption = rrdtool_execute('setcnn encryption off', false, RRDTOOL_OUTPUT_BOOLEAN, $rrdproxy, $logopt = 'WEBLOG') ? false : true;
-
 		return $rrdproxy;
 	}
 }

--- a/tests/Helpers/UnitStubs.php
+++ b/tests/Helpers/UnitStubs.php
@@ -56,6 +56,12 @@ if (!function_exists('cacti_strtolower')) {
 
 if (!function_exists('read_config_option')) {
 	function read_config_option($name) {
+		global $unit_config_options;
+
+		if (is_array($unit_config_options) && array_key_exists($name, $unit_config_options)) {
+			return $unit_config_options[$name];
+		}
+
 		return false;
 	}
 }

--- a/tests/Unit/RrdProxyProtocolTest.php
+++ b/tests/Unit/RrdProxyProtocolTest.php
@@ -337,6 +337,7 @@ it('rejects empty or non-string proxy command argument lists without throwing', 
 it('normalizes successful proxy output modes', function () {
 	$ok       = 'OK u:0.01';
 	$payload  = 'payload' . RRD_PROXY_END_OF_PACKET . $ok;
+	$binary   = "\x89PNGdata\0\r\n" . RRD_PROXY_END_OF_PACKET . $ok;
 	$png      = "\x89PNGdata" . RRD_PROXY_END_OF_PACKET . $ok;
 	$gif      = 'GIF87data' . RRD_PROXY_END_OF_PACKET . $ok;
 	$svg      = '<?xml version="1.0"?>' . RRD_PROXY_END_OF_PACKET . $ok;
@@ -346,6 +347,7 @@ it('normalizes successful proxy output modes', function () {
 	expect(rrd_proxy_execute_response($ok, RRDTOOL_OUTPUT_NULL))->toBe('OK')
 		->and(rrd_proxy_execute_response($payload, RRDTOOL_OUTPUT_STDOUT))->toBe('payload')
 		->and(rrd_proxy_execute_response($payload, RRDTOOL_OUTPUT_GRAPH_DATA))->toBe('payload')
+		->and(rrd_proxy_execute_response($binary, RRDTOOL_OUTPUT_GRAPH_DATA))->toBe("\x89PNGdata\0\r\n")
 		->and(rrd_proxy_execute_response($png, RRDTOOL_OUTPUT_STDERR))->toBe('OK')
 		->and(rrd_proxy_execute_response($gif, RRDTOOL_OUTPUT_STDERR))->toBe('OK')
 		->and(rrd_proxy_execute_response($svg, RRDTOOL_OUTPUT_STDERR))->toBe('SVG/XML Output OK')

--- a/tests/Unit/RrdProxyProtocolTest.php
+++ b/tests/Unit/RrdProxyProtocolTest.php
@@ -1,0 +1,646 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or any later version.                                   |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+
+if (!defined('POLLER_VERBOSITY_LOW')) {
+	define('POLLER_VERBOSITY_LOW', 2);
+}
+
+if (!defined('RRDTOOL_OUTPUT_NULL')) {
+	define('RRDTOOL_OUTPUT_NULL', 0);
+}
+
+if (!defined('RRDTOOL_OUTPUT_STDOUT')) {
+	define('RRDTOOL_OUTPUT_STDOUT', 1);
+}
+
+if (!defined('RRDTOOL_OUTPUT_STDERR')) {
+	define('RRDTOOL_OUTPUT_STDERR', 2);
+}
+
+if (!defined('RRDTOOL_OUTPUT_GRAPH_DATA')) {
+	define('RRDTOOL_OUTPUT_GRAPH_DATA', 3);
+}
+
+if (!defined('RRDTOOL_OUTPUT_BOOLEAN')) {
+	define('RRDTOOL_OUTPUT_BOOLEAN', 4);
+}
+
+if (!defined('RRDTOOL_OUTPUT_RETURN_STDERR')) {
+	define('RRDTOOL_OUTPUT_RETURN_STDERR', 5);
+}
+
+if (!defined('CACTI_PATH_RRA')) {
+	define('CACTI_PATH_RRA', '/var/lib/cacti/rra');
+}
+
+if (!function_exists('cacti_escapeshellarg')) {
+	function cacti_escapeshellarg(string $string, bool $quote = true) : string {
+		$escaped = str_replace(['\\', "'"], ['\\\\', "\\'"], $string);
+
+		return $quote ? "'$escaped'" : $escaped;
+	}
+}
+
+require_once dirname(__DIR__, 2) . '/lib/rrd.php';
+
+beforeEach(function () {
+	global $config, $encryption, $unit_config_options;
+
+	$config              = [];
+	$encryption          = false;
+	$unit_config_options = [];
+});
+
+afterEach(function () {
+	global $config, $encryption, $unit_config_options;
+
+	$config              = [];
+	$encryption          = false;
+	$unit_config_options = [];
+});
+
+function rrd_proxy_socket_pair() : array {
+	$sockets = [];
+
+	expect(socket_create_pair(AF_UNIX, SOCK_STREAM, 0, $sockets))->toBeTrue();
+
+	return $sockets;
+}
+
+function rrd_proxy_execute_response(string $response, int $output_flag, ?string &$request = null) : mixed {
+	[$client, $server] = rrd_proxy_socket_pair();
+
+	rrdtool_proxy_write($server, $response . RRD_PROXY_END_OF_SEQUENCE);
+	$result  = __rrd_proxy_execute('info test.rrd', false, $output_flag, [$client, 'unused']);
+	$request = socket_read($server, 4096, PHP_BINARY_READ);
+
+	socket_close($client);
+	socket_close($server);
+
+	return $result;
+}
+
+function rrd_proxy_test_read_sequence(Socket $socket) : string|false {
+	return rrdtool_proxy_read_frame($socket, RRD_PROXY_END_OF_SEQUENCE, 1048576);
+}
+
+it('configures bounded proxy socket IO', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+
+	expect(rrdtool_proxy_set_timeouts($client, 2))->toBeTrue()
+		->and(socket_get_option($client, SOL_SOCKET, SO_RCVTIMEO)['sec'])->toBe(2)
+		->and(socket_get_option($client, SOL_SOCKET, SO_SNDTIMEO)['sec'])->toBe(2)
+		->and(rrdtool_proxy_set_timeouts($client, 0))->toBeFalse();
+
+	socket_close($client);
+	socket_close($server);
+});
+
+it('connects to a listening proxy socket with an explicit deadline', function () {
+	$listener = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+	expect($listener)->toBeInstanceOf(Socket::class)
+		->and(socket_bind($listener, '127.0.0.1', 0))->toBeTrue()
+		->and(socket_listen($listener, 1))->toBeTrue();
+
+	$address = '';
+	$port    = 0;
+	socket_getsockname($listener, $address, $port);
+
+	$client = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+	expect($client)->toBeInstanceOf(Socket::class)
+		->and(rrdtool_proxy_connect($client, $address, $port, 2))->toBeTrue();
+
+	$server = socket_accept($listener);
+	expect($server)->toBeInstanceOf(Socket::class);
+
+	socket_close($server);
+	socket_close($client);
+	socket_close($listener);
+});
+
+it('rejects an invalid proxy connection deadline', function () {
+	$socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+
+	expect($socket)->toBeInstanceOf(Socket::class)
+		->and(rrdtool_proxy_connect($socket, '127.0.0.1', 1, 0))->toBeFalse();
+
+	socket_close($socket);
+});
+
+it('rejects a refused proxy connection', function () {
+	$listener = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+	socket_bind($listener, '127.0.0.1', 0);
+	$address = '';
+	$port    = 0;
+	socket_getsockname($listener, $address, $port);
+	socket_close($listener);
+
+	$socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+	expect(rrdtool_proxy_connect($socket, $address, $port, 1))->toBeFalse();
+	socket_close($socket);
+});
+
+it('writes a complete proxy frame', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+	$frame             = str_repeat('frame-data-', 128) . RRD_PROXY_END_OF_SEQUENCE;
+
+	expect(rrdtool_proxy_write($client, $frame))->toBeTrue()
+		->and(socket_read($server, strlen($frame), PHP_BINARY_READ))->toBe($frame);
+
+	socket_close($client);
+	socket_close($server);
+});
+
+it('fails a proxy write when the peer has closed', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+	socket_close($server);
+
+	expect(rrdtool_proxy_write($client, 'request'))->toBeFalse();
+	socket_close($client);
+});
+
+it('reads a complete frame without its terminator', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+
+	rrdtool_proxy_write($server, 'response' . RRD_PROXY_END_OF_SEQUENCE);
+
+	expect(rrdtool_proxy_read_frame($client, RRD_PROXY_END_OF_SEQUENCE, 128))->toBe('response');
+
+	socket_close($client);
+	socket_close($server);
+});
+
+it('rejects invalid frame limits and terminators', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+
+	expect(rrdtool_proxy_read_frame($client, '', 128))->toBeFalse()
+		->and(rrdtool_proxy_read_frame($client, RRD_PROXY_END_OF_SEQUENCE, 0))->toBeFalse()
+		->and(rrdtool_proxy_gzdecode('data', 0))->toBeFalse();
+
+	socket_close($client);
+	socket_close($server);
+});
+
+it('fails closed on truncated and oversized frames', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+
+	rrdtool_proxy_write($server, 'truncated');
+	socket_close($server);
+
+	expect(rrdtool_proxy_read_frame($client, RRD_PROXY_END_OF_SEQUENCE, 128))->toBeFalse();
+	socket_close($client);
+
+	[$client, $server] = rrd_proxy_socket_pair();
+	rrdtool_proxy_write($server, 'too-large' . RRD_PROXY_END_OF_SEQUENCE);
+
+	expect(rrdtool_proxy_read_frame($client, RRD_PROXY_END_OF_SEQUENCE, 4))->toBeFalse();
+
+	socket_close($client);
+	socket_close($server);
+});
+
+it('fails closed when a framed read times out', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+	rrdtool_proxy_set_timeouts($client, 1);
+
+	$started = microtime(true);
+	$result  = rrdtool_proxy_read_frame($client, RRD_PROXY_END_OF_SEQUENCE, 128);
+
+	expect($result)->toBeFalse()
+		->and(microtime(true) - $started)->toBeGreaterThanOrEqual(0.5)
+		->and(microtime(true) - $started)->toBeLessThan(2.5);
+
+	socket_close($client);
+	socket_close($server);
+});
+
+it('parses terminal status only from the final packet', function () {
+	$payload = "legend contains OK u and ERROR: as data\n";
+	$frame   = $payload . RRD_PROXY_END_OF_PACKET . 'OK u:0.01 s:0.02 r:0.03';
+	$result  = rrdtool_proxy_decode_response($frame);
+
+	expect($result)->toBeArray()
+		->and($result['output'])->toBe($payload)
+		->and($result['status'])->toBe('OK u:0.01 s:0.02 r:0.03')
+		->and($result['success'])->toBeTrue();
+});
+
+it('preserves an explicit proxy error result', function () {
+	$result = rrdtool_proxy_decode_response('details' . RRD_PROXY_END_OF_PACKET . 'ERROR: failed');
+
+	expect($result)->toBeArray()
+		->and($result['output'])->toBe('details')
+		->and($result['status'])->toBe('ERROR: failed')
+		->and($result['success'])->toBeFalse();
+});
+
+it('fails closed on missing status malformed compression and decoded size limits', function () {
+	$bad_gzip = "\x1f\x8bnot-gzip" . RRD_PROXY_END_OF_PACKET . 'OK u:0.01';
+	$oversize = '12345' . RRD_PROXY_END_OF_PACKET . 'OK u:0.01';
+	$zip_bomb = gzencode(str_repeat('x', 100)) . RRD_PROXY_END_OF_PACKET . 'OK u:0.01';
+
+	expect(rrdtool_proxy_decode_response(''))->toBeFalse()
+		->and(rrdtool_proxy_decode_response('payload only'))->toBeFalse()
+		->and(rrdtool_proxy_decode_response($bad_gzip))->toBeFalse()
+		->and(rrdtool_proxy_decode_response($oversize, 4))->toBeFalse()
+		->and(rrdtool_proxy_decode_response($zip_bomb, 50))->toBeFalse();
+});
+
+it('decodes compressed packets within the configured limit', function () {
+	$compressed = gzencode('compressed payload');
+	$frame      = $compressed . RRD_PROXY_END_OF_PACKET . 'OK u:0.01';
+	$result     = rrdtool_proxy_decode_response($frame, 1024);
+
+	expect($result)->toBeArray()
+		->and($result['output'])->toBe('compressed payload')
+		->and($result['success'])->toBeTrue();
+});
+
+it('rejects malformed encrypted payloads instead of returning raw input', function () {
+	global $encryption;
+
+	$encryption = true;
+
+	expect(decrypt('not-an-encrypted-packet'))->toBeFalse()
+		->and(rrdtool_proxy_decode_response('not-an-encrypted-packet' . RRD_PROXY_END_OF_PACKET . 'OK u:0.01'))->toBeFalse();
+});
+
+it('rejects a structurally valid encrypted packet when the private key is invalid', function () {
+	$packet = '004' . base64_encode('key') . base64_encode('ciphertext');
+
+	expect(rrdtool_proxy_decrypt('000x', 'invalid private key'))->toBeFalse()
+		->and(rrdtool_proxy_decrypt('004@@@@x', 'invalid private key'))->toBeFalse()
+		->and(rrdtool_proxy_decrypt($packet, 'invalid private key'))->toBeFalse();
+});
+
+it('round trips encrypted packets using the official proxy cipher contract', function () {
+	global $encryption;
+
+	$private_key = phpseclib3\Crypt\RSA::createKey(2048);
+	$public_key  = $private_key->getPublicKey();
+	$encryption  = true;
+	$packet      = encrypt('encrypted payload', (string) $public_key);
+
+	expect(rrdtool_proxy_decrypt($packet, (string) $private_key))->toBe('encrypted payload');
+});
+
+it('accepts legacy oversized Rijndael keys by applying the phpseclib 2 truncation contract', function () {
+	$private_key = phpseclib3\Crypt\RSA::createKey(4096);
+	$public_key  = $private_key->getPublicKey();
+	$legacy_key  = phpseclib3\Crypt\Random::string(192);
+	$aes         = new phpseclib3\Crypt\Rijndael('cbc');
+	$aes->setKey(substr($legacy_key, 0, 32));
+	$aes->setIV(str_repeat("\0", 16));
+
+	$encrypted_key = base64_encode($public_key->encrypt($legacy_key));
+	$ciphertext    = base64_encode($aes->encrypt('legacy payload'));
+	$packet        = str_pad(dechex(strlen($encrypted_key)), 3, '0', STR_PAD_LEFT) . $encrypted_key . $ciphertext;
+
+	expect(rrdtool_proxy_decrypt($packet, (string) $private_key))->toBe('legacy payload');
+});
+
+it('accepts array commands through the proxy execution handoff', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+
+	rrdtool_proxy_write($server, 'OK u:0.01' . RRD_PROXY_END_OF_SEQUENCE);
+
+	$result  = __rrd_proxy_execute(['info', 'file name.rrd'], false, RRDTOOL_OUTPUT_BOOLEAN, [$client, 'unused']);
+	$request = socket_read($server, 4096, PHP_BINARY_READ);
+
+	expect($result)->toBeTrue()
+		->and($request)->toContain("'info' 'file name.rrd'")
+		->and($request)->toEndWith(RRD_PROXY_END_OF_SEQUENCE);
+
+	socket_close($client);
+	socket_close($server);
+});
+
+it('normalizes successful proxy output modes', function () {
+	$ok       = 'OK u:0.01';
+	$payload  = 'payload' . RRD_PROXY_END_OF_PACKET . $ok;
+	$png      = "\x89PNGdata" . RRD_PROXY_END_OF_PACKET . $ok;
+	$gif      = 'GIF87data' . RRD_PROXY_END_OF_PACKET . $ok;
+	$svg      = '<?xml version="1.0"?>' . RRD_PROXY_END_OF_PACKET . $ok;
+	$raw      = "payload\n$ok";
+	$request  = null;
+
+	expect(rrd_proxy_execute_response($ok, RRDTOOL_OUTPUT_NULL))->toBe('OK')
+		->and(rrd_proxy_execute_response($payload, RRDTOOL_OUTPUT_STDOUT))->toBe('payload')
+		->and(rrd_proxy_execute_response($payload, RRDTOOL_OUTPUT_GRAPH_DATA))->toBe('payload')
+		->and(rrd_proxy_execute_response($png, RRDTOOL_OUTPUT_STDERR))->toBe('OK')
+		->and(rrd_proxy_execute_response($gif, RRDTOOL_OUTPUT_STDERR))->toBe('OK')
+		->and(rrd_proxy_execute_response($svg, RRDTOOL_OUTPUT_STDERR))->toBe('SVG/XML Output OK')
+		->and(rrd_proxy_execute_response($payload, RRDTOOL_OUTPUT_RETURN_STDERR))->toBe($raw)
+		->and(rrd_proxy_execute_response($ok, RRDTOOL_OUTPUT_BOOLEAN, $request))->toBeTrue()
+		->and($request)->toEndWith(RRD_PROXY_END_OF_SEQUENCE)
+		->and(rrd_proxy_execute_response($ok, 999))->toBeFalse();
+});
+
+it('fails closed for unsuccessful proxy output modes', function () {
+	$error = 'details' . RRD_PROXY_END_OF_PACKET . 'ERROR: failed';
+
+	expect(rrd_proxy_execute_response($error, RRDTOOL_OUTPUT_NULL))->toBeFalse()
+		->and(rrd_proxy_execute_response($error, RRDTOOL_OUTPUT_STDOUT))->toBeFalse()
+		->and(rrd_proxy_execute_response($error, RRDTOOL_OUTPUT_GRAPH_DATA))->toBeFalse()
+		->and(rrd_proxy_execute_response($error, RRDTOOL_OUTPUT_BOOLEAN))->toBeFalse()
+		->and(rrd_proxy_execute_response($error, RRDTOOL_OUTPUT_RETURN_STDERR))->toBe("details\nERROR: failed");
+});
+
+it('prints explicit stderr payloads and errors only in stderr mode', function () {
+	$ok    = 'diagnostic' . RRD_PROXY_END_OF_PACKET . 'OK u:0.01';
+	$error = 'details' . RRD_PROXY_END_OF_PACKET . 'ERROR: failed';
+
+	ob_start();
+	$ok_result = rrd_proxy_execute_response($ok, RRDTOOL_OUTPUT_STDERR);
+	$ok_output = ob_get_clean();
+
+	ob_start();
+	$error_result = rrd_proxy_execute_response($error, RRDTOOL_OUTPUT_STDERR);
+	$error_output = ob_get_clean();
+
+	expect($ok_result)->toBeTrue()
+		->and($ok_output)->toBe('diagnostic')
+		->and($error_result)->toBeFalse()
+		->and($error_output)->toBe("details\nERROR: failed");
+});
+
+it('rejects invalid proxy connection state', function () {
+	expect(__rrd_proxy_execute('info test.rrd', false, RRDTOOL_OUTPUT_BOOLEAN, ['not-a-socket', 'unused']))->toBeFalse();
+});
+
+it('closes a proxy connection with a framed quit command', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+
+	__rrd_proxy_close([$client, 'unused']);
+	$request = socket_read($server, 4096, PHP_BINARY_READ);
+
+	expect($request)->toBe('quit' . RRD_PROXY_END_OF_SEQUENCE);
+	socket_close($server);
+});
+
+it('still closes when encoding the quit command fails', function () {
+	global $encryption;
+
+	[$client, $server] = rrd_proxy_socket_pair();
+	$encryption        = true;
+
+	__rrd_proxy_close([$client, 'invalid private key']);
+
+	expect(socket_read($server, 4096, PHP_BINARY_READ))->toBe('');
+	socket_close($server);
+});
+
+it('fails closed across proxy write read decode and encode failures', function () {
+	global $encryption;
+
+	[$client, $server] = rrd_proxy_socket_pair();
+	socket_close($server);
+	expect(__rrd_proxy_execute('info test.rrd', false, RRDTOOL_OUTPUT_BOOLEAN, [$client, 'unused']))->toBeFalse();
+	socket_close($client);
+
+	[$client, $server] = rrd_proxy_socket_pair();
+	socket_shutdown($server, 1);
+	expect(__rrd_proxy_execute('info test.rrd', false, RRDTOOL_OUTPUT_BOOLEAN, [$client, 'unused']))->toBeFalse();
+	socket_close($client);
+	socket_close($server);
+
+	[$client, $server] = rrd_proxy_socket_pair();
+	rrdtool_proxy_write($server, 'payload without status' . RRD_PROXY_END_OF_SEQUENCE);
+	expect(__rrd_proxy_execute('info test.rrd', false, RRDTOOL_OUTPUT_BOOLEAN, [$client, 'unused']))->toBeFalse();
+	socket_close($client);
+	socket_close($server);
+
+	[$client, $server] = rrd_proxy_socket_pair();
+	$encryption        = true;
+	expect(__rrd_proxy_execute('info test.rrd', false, RRDTOOL_OUTPUT_BOOLEAN, [$client, 'invalid private key']))->toBeFalse();
+	socket_close($client);
+	socket_close($server);
+});
+
+it('compresses large proxy commands before handoff', function () {
+	[$client, $server] = rrd_proxy_socket_pair();
+	rrdtool_proxy_write($server, 'OK u:0.01' . RRD_PROXY_END_OF_SEQUENCE);
+
+	$result  = __rrd_proxy_execute('graph ' . str_repeat('A', 9000), false, RRDTOOL_OUTPUT_BOOLEAN, [$client, 'unused']);
+	$request = socket_read($server, 4096, PHP_BINARY_READ);
+
+	expect($result)->toBeTrue()
+		->and($request)->toStartWith("\x1f\x8b")
+		->and($request)->toEndWith(RRD_PROXY_END_OF_SEQUENCE);
+
+	socket_close($client);
+	socket_close($server);
+});
+
+it('negotiates an encrypted official-protocol connection end to end', function () {
+	global $config, $encryption, $unit_config_options;
+
+	if (!function_exists('pcntl_fork')) {
+		$this->markTestSkipped('pcntl is required for the proxy handshake test');
+	}
+
+	$listener = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+	socket_bind($listener, '127.0.0.1', 0);
+	socket_listen($listener, 1);
+	$address = '';
+	$port    = 0;
+	socket_getsockname($listener, $address, $port);
+
+	$client_private = phpseclib3\Crypt\RSA::createKey(2048);
+	$client_public  = $client_private->getPublicKey();
+	$server_private = phpseclib3\Crypt\RSA::createKey(2048);
+	$server_public  = $server_private->getPublicKey();
+
+	$unit_config_options = [
+		'storage_location'          => 'remote',
+		'rrdp_load_balancing'       => 'off',
+		'rrdp_server'               => $address,
+		'rrdp_port'                 => $port,
+		'rrdp_server_backup'        => '',
+		'rrdp_port_backup'          => 0,
+		'rrdp_fingerprint'          => $server_public->getFingerprint('md5'),
+		'rrdp_fingerprint_backup'   => '',
+		'rsa_public_key'            => (string) $client_public,
+		'rsa_private_key'           => (string) $client_private,
+		'path_rrdtool'              => '/usr/bin/rrdtool',
+		'path_rrdtool_default_font' => 'Arial'
+	];
+	$config = ['local_storage' => false];
+
+	$pid = pcntl_fork();
+
+	if ($pid === 0) {
+		$encryption = true;
+		$peer       = socket_accept($listener);
+
+		if (!($peer instanceof Socket)) {
+			exit(10);
+		}
+
+		$received_key = rrd_proxy_test_read_sequence($peer);
+
+		if (trim((string) $received_key) !== trim((string) $client_public)) {
+			exit(11);
+		}
+
+		if (!rrdtool_proxy_write($peer, (string) $server_public . RRD_PROXY_END_OF_SEQUENCE)) {
+			exit(12);
+		}
+
+		$setenv_command = rrd_proxy_test_read_sequence($peer);
+
+		if ($setenv_command === false || rrdtool_proxy_decrypt($setenv_command, (string) $server_private) !== "setenv RRD_DEFAULT_FONT 'Arial'") {
+			exit(13);
+		}
+
+		if (!rrdtool_proxy_write($peer, encrypt('OK u:0.00', (string) $client_public) . RRD_PROXY_END_OF_SEQUENCE)) {
+			exit(14);
+		}
+
+		$setcnn_command = rrd_proxy_test_read_sequence($peer);
+
+		if ($setcnn_command === false || rrdtool_proxy_decrypt($setcnn_command, (string) $server_private) !== 'setcnn encryption off') {
+			exit(15);
+		}
+
+		$response = encrypt("% Encryption will be disabled.\nOK u:0.00", (string) $client_public);
+
+		if (!rrdtool_proxy_write($peer, $response . RRD_PROXY_END_OF_SEQUENCE)) {
+			exit(16);
+		}
+
+		$encryption = false;
+		$command    = rrd_proxy_test_read_sequence($peer);
+
+		if ($command !== 'info test.rrd') {
+			exit(17);
+		}
+
+		if (!rrdtool_proxy_write($peer, 'OK u:0.00' . RRD_PROXY_END_OF_SEQUENCE)) {
+			exit(18);
+		}
+
+		$quit = rrd_proxy_test_read_sequence($peer);
+		socket_close($peer);
+		socket_close($listener);
+
+		exit($quit === 'quit' ? 0 : 19);
+	}
+
+	$result = __rrd_proxy_execute('info test.rrd', false, RRDTOOL_OUTPUT_BOOLEAN, '', 'TEST');
+	expect($result)->toBeTrue()
+		->and($encryption)->toBeFalse();
+
+	socket_close($listener);
+	pcntl_waitpid($pid, $status);
+
+	expect(pcntl_wifexited($status))->toBeTrue()
+		->and(pcntl_wexitstatus($status))->toBe(0);
+});
+
+it('fails closed when configured proxy endpoints are unavailable', function () {
+	global $unit_config_options;
+
+	$listener = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+	socket_bind($listener, '127.0.0.1', 0);
+	$address = '';
+	$port    = 0;
+	socket_getsockname($listener, $address, $port);
+	socket_close($listener);
+
+	$unit_config_options = [
+		'rrdp_load_balancing' => 'off',
+		'rrdp_server'         => $address,
+		'rrdp_port'           => $port
+	];
+
+	expect(__rrd_proxy_init('TEST'))->toBeFalse();
+
+	$unit_config_options = [
+		'rrdp_load_balancing' => 'on',
+		'rrdp_server'         => $address,
+		'rrdp_port'           => $port,
+		'rrdp_server_backup'  => $address,
+		'rrdp_port_backup'    => $port
+	];
+
+	expect(__rrd_proxy_init('TEST'))->toBeFalse();
+});
+
+it('fails closed on absent invalid and mismatched proxy keys', function () {
+	global $unit_config_options;
+
+	if (!function_exists('pcntl_fork')) {
+		$this->markTestSkipped('pcntl is required for the proxy key exchange test');
+	}
+
+	$client_private = phpseclib3\Crypt\RSA::createKey(2048);
+	$client_public  = $client_private->getPublicKey();
+	$server_private = phpseclib3\Crypt\RSA::createKey(2048);
+	$server_public  = $server_private->getPublicKey();
+
+	$run_exchange = function (?string $reply, string $fingerprint) use ($client_private, $client_public) : mixed {
+		global $unit_config_options;
+
+		$listener = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+		socket_bind($listener, '127.0.0.1', 0);
+		socket_listen($listener, 1);
+		$address = '';
+		$port    = 0;
+		socket_getsockname($listener, $address, $port);
+
+		$unit_config_options = [
+			'rrdp_load_balancing'       => 'off',
+			'rrdp_server'               => $address,
+			'rrdp_port'                 => $port,
+			'rrdp_server_backup'        => '',
+			'rrdp_port_backup'          => 0,
+			'rrdp_fingerprint'          => $fingerprint,
+			'rrdp_fingerprint_backup'   => '',
+			'rsa_public_key'            => (string) $client_public,
+			'rsa_private_key'           => (string) $client_private,
+			'path_rrdtool_default_font' => ''
+		];
+
+		$pid = pcntl_fork();
+
+		if ($pid === 0) {
+			$peer = socket_accept($listener);
+			rrd_proxy_test_read_sequence($peer);
+
+			if ($reply !== null) {
+				rrdtool_proxy_write($peer, $reply . RRD_PROXY_END_OF_SEQUENCE);
+			}
+
+			socket_close($peer);
+			socket_close($listener);
+			exit(0);
+		}
+
+		$result = __rrd_proxy_init('TEST');
+		socket_close($listener);
+		pcntl_waitpid($pid, $status);
+
+		expect(pcntl_wifexited($status))->toBeTrue()
+			->and(pcntl_wexitstatus($status))->toBe(0);
+
+		return $result;
+	};
+
+	expect($run_exchange(null, 'unused'))->toBeFalse()
+		->and($run_exchange('not a public key', 'unused'))->toBeFalse()
+		->and($run_exchange((string) $server_public, str_repeat('0', 47)))->toBeFalse();
+});

--- a/tests/Unit/RrdProxyProtocolTest.php
+++ b/tests/Unit/RrdProxyProtocolTest.php
@@ -518,39 +518,32 @@ it('negotiates an encrypted official-protocol connection end to end', function (
 			exit(14);
 		}
 
-		$setcnn_command = rrd_proxy_test_read_sequence($peer);
+		$command = rrd_proxy_test_read_sequence($peer);
 
-		if ($setcnn_command === false || rrdtool_proxy_decrypt($setcnn_command, (string) $server_private) !== 'setcnn encryption off') {
+		if ($command === false || rrdtool_proxy_decrypt($command, (string) $server_private) !== 'info test.rrd') {
 			exit(15);
 		}
 
-		$response = encrypt("% Encryption will be disabled.\nOK u:0.00", (string) $client_public);
+		$response = encrypt('OK u:0.00', (string) $client_public);
 
 		if (!rrdtool_proxy_write($peer, $response . RRD_PROXY_END_OF_SEQUENCE)) {
 			exit(16);
 		}
 
-		$encryption = false;
-		$command    = rrd_proxy_test_read_sequence($peer);
+		$quit = rrd_proxy_test_read_sequence($peer);
 
-		if ($command !== 'info test.rrd') {
+		if ($quit === false || rrdtool_proxy_decrypt($quit, (string) $server_private) !== 'quit') {
 			exit(17);
 		}
-
-		if (!rrdtool_proxy_write($peer, 'OK u:0.00' . RRD_PROXY_END_OF_SEQUENCE)) {
-			exit(18);
-		}
-
-		$quit = rrd_proxy_test_read_sequence($peer);
 		socket_close($peer);
 		socket_close($listener);
 
-		exit($quit === 'quit' ? 0 : 19);
+		exit(0);
 	}
 
 	$result = __rrd_proxy_execute('info test.rrd', false, RRDTOOL_OUTPUT_BOOLEAN, '', 'TEST');
 	expect($result)->toBeTrue()
-		->and($encryption)->toBeFalse();
+		->and($encryption)->toBeTrue();
 
 	socket_close($listener);
 	pcntl_waitpid($pid, $status);

--- a/tests/Unit/RrdProxyProtocolTest.php
+++ b/tests/Unit/RrdProxyProtocolTest.php
@@ -328,6 +328,12 @@ it('accepts array commands through the proxy execution handoff', function () {
 	socket_close($server);
 });
 
+it('rejects empty or non-string proxy command argument lists without throwing', function () {
+	expect(__rrd_proxy_execute([], false))->toBeFalse()
+		->and(__rrd_proxy_execute(['info', 42], false))->toBeFalse()
+		->and(__rrd_proxy_execute(['info', null], false))->toBeFalse();
+});
+
 it('normalizes successful proxy output modes', function () {
 	$ok       = 'OK u:0.01';
 	$payload  = 'payload' . RRD_PROXY_END_OF_PACKET . $ok;


### PR DESCRIPTION
## Summary

- bound RRDtool proxy connect, read, and write operations with explicit deadlines and response limits
- guarantee complete socket writes and fail closed on truncated, malformed, undecodable, or oversized frames
- parse terminal status only at the end of the final protocol packet, so status-like graph data cannot terminate a response early
- restore the encrypted handshake contract used by the official RRDProxy implementation: peer public-key encryption, CBC Rijndael, an explicit IV, and compatibility with legacy oversized keys
- normalize `RRDTOOL_OUTPUT_*` handling and support array-form commands through both local and proxy execution paths
- document the transport helpers and proxy result contract with PHPDoc

## Root cause

The client previously treated one `socket_write()` call as a complete frame, buffered responses without a size bound, searched arbitrary payload content for status markers, and returned undecoded input after malformed base64. Its phpseclib 3 handshake also requested an unsupported block-cipher mode and loaded the proxy's public key as a private key, which did not match the official proxy protocol.

This change preserves the existing `_EOP_` / `_EOT_` wire framing. It does not introduce gRPC or another RPC framework. A new authenticated/versioned protocol remains a coordinated follow-up for the Cacti and RRDProxy repositories.

Fixes #7618

## Validation

- 30 focused proxy tests with 128 assertions, including a forked end-to-end encrypted loopback handshake
- 107 RRD and graph regression tests with 307 assertions
- PHP 8.2 and PHP 8.4/Xdebug test runs
- PHPStan level 6
- PHP syntax and PHP-CS-Fixer checks
- security sink inventory and architectural-hotspot ratchets
- SQL interpolation audit

The focused coverage run exercises success and error results, timeout, refused connection, partial/failed write, truncated frame, response limit, malformed compression/base64/key material, embedded status text, legacy key compatibility, load-balanced connection failure, key/fingerprint rejection, and automatic connection close.
