### PR TITLE
Fix reports PHP-CS-Fixer baseline

### DIFF
--- a/lib/reports.php
+++ b/lib/reports.php
@@ -1890,6 +1890,7 @@ function png2jpeg(string $png_data) : string {
 		ob_start(); // start a new output buffer to capture jpeg image stream
 		imagejpeg($im);	// output to buffer
 		$ImageData = ob_get_contents(); // fetch image from buffer
+
 		if (PHP_VERSION_ID < 80500) {
 			imagedestroy($im);
 		}
@@ -1933,6 +1934,7 @@ function png2gif(string $png_data) : string {
 		ob_start(); // start a new output buffer to capture gif image stream
 		imagegif($im);	// output to buffer
 		$ImageData = ob_get_contents(); // fetch image from buffer
+
 		if (PHP_VERSION_ID < 80500) {
 			imagedestroy($im);
 		}


### PR DESCRIPTION
## Summary

Add the two blank lines required by the repository PHP-CS-Fixer configuration in `lib/reports.php`.

## Why

The PHP 8.1–8.4 matrix currently fails during its repository-wide coding-standards step before PR tests run. The formatter reports these two unchanged locations in `lib/reports.php`.

Keeping this mechanical baseline correction separate prevents unrelated feature and bug-fix branches from carrying formatting pollution.

## Validation

- `php -l lib/reports.php`
- PHP-CS-Fixer dry run for `lib/reports.php`
- `git diff --check`
