### PR TITLE
fix(installer): restore select-all controls on 1.2.x

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -35,6 +35,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  installer-javascript:
+    name: Installer JavaScript contracts
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+
+    - name: Test installer state handoff
+      run: node --test tests/js/installer_selection.test.js
+
   check:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/install/install.js
+++ b/install/install.js
@@ -468,30 +468,24 @@ function processStepProfileAndAutomation(StepData) {
 	setSNMPOverride();
 }
 
-function processStepTemplateInstall(StepData) {
-	var templates = StepData.Templates;
-	if (templates.all) {
-		element = $('#selectall');
+function restoreInstallerSelection(selection, fields) {
+	if (selection.all) {
+		var element = $('#selectall');
 		if (element != null && element.length > 0) {
-			element.click();
+			element.prop('checked', true);
+			selectAll(element.data('prefix'), true);
 		}
 	} else {
-		setFieldData(FIELDS_TEMPLATES, StepData.Templates);
+		setFieldData(fields, selection);
 	}
+}
 
+function processStepTemplateInstall(StepData) {
+	restoreInstallerSelection(StepData.Templates, FIELDS_TEMPLATES);
 }
 
 function processStepCheckTables(StepData) {
-	var tables = StepData.Tables;
-	if (tables.all) {
-		element = $('#selectall');
-		if (element != null && element.length > 0) {
-			element.click();
-		}
-	} else {
-		setFieldData(FIELDS_CHECK_TABLES, StepData.Tables);
-	}
-
+	restoreInstallerSelection(StepData.Tables, FIELDS_CHECK_TABLES);
 }
 
 function processStepInputValidation(StepData) {
@@ -678,6 +672,10 @@ function performStep(installStep, suppressRefresh, forceReload) {
 			$('div[class^="ui-"]').remove();
 			$('#installContent').html(data.Html);
 			$('#installContent').show();
+
+			// The installer replaces its tables through Ajax, so bind the table
+			// controls before applying the server-provided checkbox state.
+			handleTableNav();
 
 			if (typeof $('#installData').data('debug') != 'undefined') {
 				debugData = data;

--- a/tests/Unit/InstallerSelectAllTest.php
+++ b/tests/Unit/InstallerSelectAllTest.php
@@ -14,16 +14,33 @@
 
 $root = dirname(__DIR__, 2);
 
-test('installer binds ajax table controls before restoring checkbox state', function () use ($root) {
+function installer_select_all_javascript(string $root) : string {
 	$javascript = file_get_contents($root . '/install/install.js');
 
-	$content       = strpos($javascript, "$('#installContent').html(data.Html);");
-	$bindControls  = strpos($javascript, 'handleTableNav();', $content);
-	$restoreState  = strpos($javascript, 'processStepTemplateInstall(data.StepData);', $content);
-	$restoreTables = strpos($javascript, 'processStepCheckTables(data.StepData);', $content);
+	if ($javascript === false) {
+		throw new RuntimeException('Unable to read install/install.js');
+	}
 
-	expect($content)->not->toBeFalse()
-		->and($bindControls)->not->toBeFalse()
+	return $javascript;
+}
+
+test('installer binds ajax table controls before restoring checkbox state', function () use ($root) {
+	$javascript    = installer_select_all_javascript($root);
+	$contentMarker = "$('#installContent').html(data.Html);";
+	$content       = strpos($javascript, $contentMarker);
+
+	expect($content)->not->toBeFalse();
+
+	if ($content === false) {
+		throw new RuntimeException('Unable to find the installer content marker');
+	}
+
+	$contentOffset = $content + strlen($contentMarker);
+	$bindControls  = strpos($javascript, 'handleTableNav();', $contentOffset);
+	$restoreState  = strpos($javascript, 'processStepTemplateInstall(data.StepData);', $contentOffset);
+	$restoreTables = strpos($javascript, 'processStepCheckTables(data.StepData);', $contentOffset);
+
+	expect($bindControls)->not->toBeFalse()
 		->and($restoreState)->not->toBeFalse()
 		->and($restoreTables)->not->toBeFalse()
 		->and($content < $bindControls)->toBeTrue()
@@ -32,15 +49,27 @@ test('installer binds ajax table controls before restoring checkbox state', func
 });
 
 test('installer restores select all without relying on a synthetic click', function () use ($root) {
-	$javascript = file_get_contents($root . '/install/install.js');
+	$javascript = installer_select_all_javascript($root);
 
 	$start = strpos($javascript, 'function restoreInstallerSelection(');
-	$end   = strpos($javascript, 'function processStepTemplateInstall(', $start);
-	$body  = substr($javascript, $start, $end - $start);
 
-	expect($start)->not->toBeFalse()
-		->and($end)->not->toBeFalse()
-		->and($body)->toContain("element.prop('checked', true);")
+	expect($start)->not->toBeFalse();
+
+	if ($start === false) {
+		throw new RuntimeException('Unable to find restoreInstallerSelection()');
+	}
+
+	$end = strpos($javascript, 'function processStepTemplateInstall(', $start);
+
+	expect($end)->not->toBeFalse();
+
+	if ($end === false) {
+		throw new RuntimeException('Unable to find processStepTemplateInstall()');
+	}
+
+	$body = substr($javascript, $start, $end - $start);
+
+	expect($body)->toContain("element.prop('checked', true);")
 		->and($body)->toContain("selectAll(element.data('prefix'), true);")
 		->and($body)->not->toContain('element.click()');
 });

--- a/tests/Unit/InstallerSelectAllTest.php
+++ b/tests/Unit/InstallerSelectAllTest.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 2);
+
+test('installer binds ajax table controls before restoring checkbox state', function () use ($root) {
+	$javascript = file_get_contents($root . '/install/install.js');
+
+	$content       = strpos($javascript, "$('#installContent').html(data.Html);");
+	$bindControls  = strpos($javascript, 'handleTableNav();', $content);
+	$restoreState  = strpos($javascript, 'processStepTemplateInstall(data.StepData);', $content);
+	$restoreTables = strpos($javascript, 'processStepCheckTables(data.StepData);', $content);
+
+	expect($content)->not->toBeFalse()
+		->and($bindControls)->not->toBeFalse()
+		->and($restoreState)->not->toBeFalse()
+		->and($restoreTables)->not->toBeFalse()
+		->and($content < $bindControls)->toBeTrue()
+		->and($bindControls < $restoreState)->toBeTrue()
+		->and($bindControls < $restoreTables)->toBeTrue();
+});
+
+test('installer restores select all without relying on a synthetic click', function () use ($root) {
+	$javascript = file_get_contents($root . '/install/install.js');
+
+	$start = strpos($javascript, 'function restoreInstallerSelection(');
+	$end   = strpos($javascript, 'function processStepTemplateInstall(', $start);
+	$body  = substr($javascript, $start, $end - $start);
+
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse()
+		->and($body)->toContain("element.prop('checked', true);")
+		->and($body)->toContain("selectAll(element.data('prefix'), true);")
+		->and($body)->not->toContain('element.click()');
+});

--- a/tests/js/installer_selection.test.js
+++ b/tests/js/installer_selection.test.js
@@ -1,0 +1,128 @@
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const installerSource = fs.readFileSync(
+	path.join(__dirname, '..', '..', 'install', 'install.js'),
+	'utf8'
+);
+
+function loadInstaller() {
+	const state = {
+		headerAvailable: true,
+		headerChecked: false,
+		selectAllCalls: [],
+		setFieldDataCalls: [],
+	};
+
+	const header = {
+		length: 1,
+		data: (name) => name === 'prefix' ? 'chk' : undefined,
+		prop: (name, value) => {
+			if (name === 'checked') {
+				state.headerChecked = value;
+			}
+
+			return header;
+		},
+	};
+
+	function jquery(selector) {
+		if (typeof selector === 'function') {
+			return undefined;
+		}
+
+		if (selector === '#selectall') {
+			return state.headerAvailable ? header : { length: 0 };
+		}
+
+		return { length: 0 };
+	}
+
+	const context = vm.createContext({
+		$: jquery,
+		console,
+	});
+
+	vm.runInContext(installerSource, context, { filename: 'install/install.js' });
+
+	context.selectAll = (prefix, checked) => {
+		state.selectAllCalls.push({ prefix, checked });
+	};
+	context.setFieldData = (fields, selection) => {
+		state.setFieldDataCalls.push({ fields, selection });
+	};
+
+	return { context, state };
+}
+
+test('template defaults select every rendered row', () => {
+	const { context, state } = loadInstaller();
+
+	context.processStepTemplateInstall({ Templates: { all: true } });
+
+	assert.equal(state.headerChecked, true);
+	assert.deepEqual(state.selectAllCalls, [{ prefix: 'chk', checked: true }]);
+	assert.equal(state.setFieldDataCalls.length, 0);
+});
+
+test('table conversion defaults select every rendered row', () => {
+	const { context, state } = loadInstaller();
+
+	context.processStepCheckTables({ Tables: { all: true } });
+
+	assert.equal(state.headerChecked, true);
+	assert.deepEqual(state.selectAllCalls, [{ prefix: 'chk', checked: true }]);
+	assert.equal(state.setFieldDataCalls.length, 0);
+});
+
+test('saved template selections are restored individually', () => {
+	const { context, state } = loadInstaller();
+	const templates = { all: false, chk_template_local: true };
+
+	context.processStepTemplateInstall({ Templates: templates });
+
+	assert.equal(state.headerChecked, false);
+	assert.equal(state.selectAllCalls.length, 0);
+	assert.equal(state.setFieldDataCalls.length, 1);
+	assert.deepEqual(state.setFieldDataCalls[0].selection, templates);
+});
+
+test('saved table selections are restored individually', () => {
+	const { context, state } = loadInstaller();
+	const tables = { all: false, chk_table_host: true };
+
+	context.processStepCheckTables({ Tables: tables });
+
+	assert.equal(state.headerChecked, false);
+	assert.equal(state.selectAllCalls.length, 0);
+	assert.equal(state.setFieldDataCalls.length, 1);
+	assert.deepEqual(state.setFieldDataCalls[0].selection, tables);
+});
+
+test('missing select-all control does not abort installer rendering', () => {
+	const { context, state } = loadInstaller();
+	state.headerAvailable = false;
+
+	assert.doesNotThrow(() => {
+		context.processStepTemplateInstall({ Templates: { all: true } });
+	});
+	assert.equal(state.selectAllCalls.length, 0);
+});


### PR DESCRIPTION
## Summary

- rebind table navigation controls after the installer replaces its AJAX content
- restore select-all state directly instead of relying on a synthetic click
- cover template installation and table conversion state handoff with behavioral tests
- run the dependency-free installer JavaScript contract suite in CI

## Root cause

The 1.2.x CSP cleanup replaced the header checkbox's inline `selectAll()` handler with a listener installed by `handleTableNav()`. The installer then replaces `#installContent` through AJAX, discarding that listener. Its synthetic click checked only the header checkbox, leaving every template or table unchecked. A fresh installation could therefore complete without importing templates.

`develop` retains the inline handler and does not exhibit this exact regression.

## User impact

On a new 1.2.x installation, the default template selection once again selects every available template. The same correction applies to the table-conversion screen, and manually toggling either header checkbox works after AJAX navigation.

## Test coverage

The new Node contract suite executes the real functions from `install/install.js` and covers:

- default selection of all template rows
- default selection of all table-conversion rows
- restoration of saved partial template selections
- restoration of saved partial table selections
- safe handling when the select-all control is absent

The focused Pest tests also protect the AJAX binding order and prohibit a return to synthetic-click restoration. Existing CI continues to perform a complete CLI installation on PHP 8.2, 8.3, and 8.4, covering the server-side installer path.

## Validation

- Docker Node 22: `node --test tests/js/installer_selection.test.js` (`5 passed`)
- Docker PHP 8.2: focused Pest regression suite (`2 passed`)
- Docker Node 22: `node --check install/install.js`
- `php -l tests/Unit/InstallerSelectAllTest.php`
- workflow YAML parse
- `git diff --check`
