### PR TITLE
Fail closed on incomplete installer schemas

### DIFF
--- a/.github/workflows/audit-database-coverage.yml
+++ b/.github/workflows/audit-database-coverage.yml
@@ -50,15 +50,13 @@ jobs:
         with:
           php-version: '8.2'
           coverage: xdebug
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-interaction
+          tools: pest:3
 
       - name: Enforce line coverage
         env:
           XDEBUG_MODE: coverage
         run: |
-          include/vendor/bin/pest --colors=never \
+          pest --colors=never \
             --configuration=phpunit-audit.xml \
             --coverage \
             --coverage-text \

--- a/.github/workflows/audit-database-coverage.yml
+++ b/.github/workflows/audit-database-coverage.yml
@@ -50,7 +50,12 @@ jobs:
         with:
           php-version: '8.2'
           coverage: xdebug
-          tools: pest:3
+
+      - name: Install Pest
+        run: |
+          composer global config allow-plugins.pestphp/pest-plugin true
+          composer global require pestphp/pest:^3 --no-interaction --no-progress
+          echo "$(composer global config bin-dir --absolute)" >> "$GITHUB_PATH"
 
       - name: Enforce line coverage
         env:

--- a/.github/workflows/audit-database-coverage.yml
+++ b/.github/workflows/audit-database-coverage.yml
@@ -1,0 +1,65 @@
+name: Database audit coverage
+
+on:
+  push:
+    branches: [1.2.x]
+    paths:
+      - '.github/workflows/audit-database-coverage.yml'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'cli/audit_database.php'
+      - 'cli/install_cacti.php'
+      - 'lib/audit.php'
+      - 'lib/installer.php'
+      - 'phpunit-audit.xml'
+      - 'tests/Unit/AuditDatabaseMissingTableTest.php'
+      - 'tests/Unit/InstallerSchemaValidationTest.php'
+  pull_request:
+    branches: [1.2.x]
+    paths:
+      - '.github/workflows/audit-database-coverage.yml'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'cli/audit_database.php'
+      - 'cli/install_cacti.php'
+      - 'lib/audit.php'
+      - 'lib/installer.php'
+      - 'phpunit-audit.xml'
+      - 'tests/Unit/AuditDatabaseMissingTableTest.php'
+      - 'tests/Unit/InstallerSchemaValidationTest.php'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: audit-database-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: lib/audit.php 100% coverage
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.2'
+          coverage: xdebug
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Enforce line coverage
+        env:
+          XDEBUG_MODE: coverage
+        run: |
+          include/vendor/bin/pest --colors=never \
+            --configuration=phpunit-audit.xml \
+            --coverage \
+            --coverage-text \
+            --min=100

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -24,6 +24,7 @@
 */
 
 require(__DIR__ . '/../include/cli_check.php');
+require_once(__DIR__ . '/../lib/audit.php');
 chdir('..');
 
 if ($config['poller_id'] > 1) {
@@ -115,8 +116,10 @@ if (cacti_sizeof($parms)) {
 		upgrade_database();
 	}
 
+	$exit_code = 0;
+
 	if ($repair) {
-		repair_database();
+		$exit_code = repair_database() ? 0 : 1;
 	} elseif ($create) {
 		create_tables();
 	} elseif ($report) {
@@ -129,7 +132,7 @@ if (cacti_sizeof($parms)) {
 		display_help();
 	}
 
-	exit(0);
+	exit($exit_code);
 } else {
 	display_help();
 	exit(1);
@@ -319,31 +322,37 @@ function repair_database($run = true) {
 
 	if (cacti_sizeof($alters)) {
 		foreach($alters as $table => $changes) {
-			$tblinfo = db_fetch_row_prepared('SELECT ENGINE, SUBSTRING_INDEX(TABLE_COLLATION, "_", 1) AS COLLATION
-				FROM information_schema.tables
-				WHERE TABLE_SCHEMA = ?
-				AND TABLE_NAME = ?',
-				array($database_default, $table));
-
-			if (isset($tblinfo['COLLATION'])) {
-				$collation = $tblinfo['COLLATION'];
+			if (array_key_exists('__create_table__', $changes)) {
+				$sql       = $changes['__create_table__'];
+				$operation = 'Create';
 			} else {
-				$collation = 'utf8mb4';
-			}
+				$tblinfo = db_fetch_row_prepared('SELECT ENGINE, SUBSTRING_INDEX(TABLE_COLLATION, "_", 1) AS COLLATION
+					FROM information_schema.tables
+					WHERE TABLE_SCHEMA = ?
+					AND TABLE_NAME = ?',
+					array($database_default, $table));
 
-			if ($tblinfo['ENGINE'] == 'MyISAM') {
-				$suffix = ",\n   ENGINE=InnoDB ROW_FORMAT=Dynamic CHARSET=" . $collation;
-			} else {
-				$suffix = ",\n   ROW_FORMAT=Dynamic CHARSET=" . $collation;
-			}
+				if (isset($tblinfo['COLLATION'])) {
+					$collation = $tblinfo['COLLATION'];
+				} else {
+					$collation = 'utf8mb4';
+				}
 
-			$sql = 'ALTER TABLE `' . $table . "`\n   " . implode(",\n   ", $changes) . $suffix . ';';
+				if ($tblinfo['ENGINE'] == 'MyISAM') {
+					$suffix = ",\n   ENGINE=InnoDB ROW_FORMAT=Dynamic CHARSET=" . $collation;
+				} else {
+					$suffix = ",\n   ROW_FORMAT=Dynamic CHARSET=" . $collation;
+				}
+
+				$sql       = 'ALTER TABLE `' . $table . "`\n   " . implode(",\n   ", $changes) . $suffix . ';';
+				$operation = 'Alter';
+			}
 
 			if ($run) {
 				print '---------------------------------------------------------------------------------------------' . PHP_EOL;
-				print 'Executing Alter for Table : ' . $table;
+				print 'Executing ' . $operation . ' for Table : ' . $table;
 
-				$result = db_execute($sql);
+				$result = $sql !== false && db_execute($sql);
 
 				if ($result) {
 					$good++;
@@ -355,8 +364,8 @@ function repair_database($run = true) {
 				}
 			} else {
 				print '---------------------------------------------------------------------------------------------' . PHP_EOL;
-				print '-- Proposed Alter for Table : ' . $table . PHP_EOL . PHP_EOL;
-				print $sql . PHP_EOL . PHP_EOL;
+				print '-- Proposed ' . $operation . ' for Table : ' . $table . PHP_EOL . PHP_EOL;
+				print ($sql === false ? '-- Canonical CREATE TABLE statement unavailable' : $sql) . PHP_EOL . PHP_EOL;
 			}
 		}
 	}
@@ -365,14 +374,16 @@ function repair_database($run = true) {
 	if ($bad == 0 && $good == 0) {
 		print ($altersopt ? '-- ' : '') . 'Repair Completed!  No changes performed.' . PHP_EOL;
 	} elseif ($bad) {
-		print 'Repair Completed!  ' . $good . ' Alters succeeded and ' . $bad . ' failed!' . PHP_EOL;
+		print 'Repair Completed!  ' . $good . ' operations succeeded and ' . $bad . ' failed!' . PHP_EOL;
 	} else {
-		print 'Repair Completed!  All ' . $good . ' Alters succeeded!' . PHP_EOL;
+		print 'Repair Completed!  All ' . $good . ' operations succeeded!' . PHP_EOL;
 	}
+
+	return $bad === 0;
 }
 
 function report_audit_results($output = true) {
-	global $database_default, $altersopt;
+	global $config, $database_default, $altersopt;
 
 	$db_name = 'Tables_in_' . $database_default;
 
@@ -381,6 +392,29 @@ function report_audit_results($output = true) {
 	$tables = db_fetch_assoc('SHOW TABLES');
 
 	$alters  = array();
+	$actual_tables = array_column($tables, $db_name);
+	$expected_tables = db_fetch_assoc('SELECT DISTINCT table_name
+		FROM table_columns
+		ORDER BY table_name');
+	$expected_tables = array_column($expected_tables, 'table_name');
+	$missing_tables  = audit_missing_core_tables($expected_tables, $actual_tables);
+
+	if (cacti_sizeof($missing_tables)) {
+		$schema_sql = file_get_contents($config['base_path'] . '/cacti.sql');
+
+		foreach($missing_tables as $table_name) {
+			if ($output) {
+				print '---------------------------------------------------------------------------------------------' . PHP_EOL;
+				printf("Checking Table: %-45s - Missing core table%s", '\'' . $table_name . '\'', PHP_EOL);
+			} else {
+				printf(($altersopt ? '-- ' : '') . "Scanning Table: %-45s - Missing core table%s", '\'' . $table_name . '\'', PHP_EOL);
+			}
+
+			$alters[$table_name] = array(
+				'__create_table__' => $schema_sql === false ? false : audit_extract_create_table($schema_sql, $table_name)
+			);
+		}
+	}
 
 	$cols = array(
 		'table_type'    => 'Type',
@@ -558,7 +592,7 @@ function report_audit_results($output = true) {
 
 				if (cacti_sizeof($db_columns)) {
 					foreach($db_columns as $dbc) {
-						if (!db_column_exists($table_name, $dbc['table_field'])) {
+						if (!audit_column_exists($columns, $dbc['table_field'])) {
 							if (array_search($dbc['table_field'], $col_added) === false) {
 								if ($output) {
 									print PHP_EOL . 'WARNING Col: \'' . $dbc['table_field'] . '\' is missing from \'' . $table_name . '\'';
@@ -1113,4 +1147,3 @@ function display_help() {
 	print '    --load    - Take a pristine Cacti install and create Audit Schema and file.' . PHP_EOL;
 	print '    --alters  - Print out all the alter commands vs. executing for debugging.' . PHP_EOL . PHP_EOL;
 }
-

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -123,9 +123,9 @@ if (cacti_sizeof($parms)) {
 	} elseif ($create) {
 		create_tables();
 	} elseif ($report) {
-		report_audit_results();
+		$exit_code = report_audit_results() === false ? 1 : 0;
 	} elseif ($altersopt) {
-		repair_database(false);
+		$exit_code = repair_database(false) ? 0 : 1;
 	} elseif ($loadopt) {
 		load_audit_database();
 	} else {
@@ -317,6 +317,10 @@ function repair_database($run = true) {
 
 	$alters = report_audit_results(false);
 
+	if ($alters === false) {
+		return false;
+	}
+
 	$good = 0;
 	$bad = 0;
 
@@ -391,16 +395,35 @@ function report_audit_results($output = true) {
 
 	$tables = db_fetch_assoc('SHOW TABLES');
 
+	if (!is_array($tables)) {
+		print 'FATAL: Unable to query the tables in the active Cacti database' . PHP_EOL;
+
+		return false;
+	}
+
 	$alters  = array();
 	$actual_tables = array_column($tables, $db_name);
 	$expected_tables = db_fetch_assoc('SELECT DISTINCT table_name
 		FROM table_columns
 		ORDER BY table_name');
+
+	if (!is_array($expected_tables)) {
+		print 'FATAL: Unable to query the canonical Cacti audit schema' . PHP_EOL;
+
+		return false;
+	}
+
 	$expected_tables = array_column($expected_tables, 'table_name');
 	$missing_tables  = audit_missing_core_tables($expected_tables, $actual_tables);
 
 	if (cacti_sizeof($missing_tables)) {
 		$schema_sql = file_get_contents($config['base_path'] . '/cacti.sql');
+
+		if ($schema_sql === false) {
+			print 'FATAL: Unable to read the canonical cacti.sql schema' . PHP_EOL;
+
+			return false;
+		}
 
 		foreach($missing_tables as $table_name) {
 			if ($output) {
@@ -411,7 +434,7 @@ function report_audit_results($output = true) {
 			}
 
 			$alters[$table_name] = array(
-				'__create_table__' => $schema_sql === false ? false : audit_extract_create_table($schema_sql, $table_name)
+				'__create_table__' => audit_extract_create_table($schema_sql, $table_name)
 			);
 		}
 	}

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -820,7 +820,7 @@ function make_column_props(&$dbc) {
 }
 
 function make_column_alter($table, $dbc) {
-	$alter_cmd = 'MODIFY COLUMN `' . $dbc['table_field'] . '` ' .
+	$alter_cmd = 'MODIFY COLUMN ' . audit_quote_identifier($dbc['table_field']) . ' ' .
 		$dbc['table_type'] . ($dbc['table_null'] == 'NO' ? ' NOT NULL':'');
 
 	$alter_cmd .= make_column_props($dbc);
@@ -831,10 +831,10 @@ function make_column_alter($table, $dbc) {
 function make_column_add($table, $dbc) {
 	$after = get_previous_column($table, $dbc['table_field']);
 	if ($after != 'first') {
-		$after = 'AFTER `' . $after . '`';
+		$after = 'AFTER ' . audit_quote_identifier($after);
 	}
 
-	$alter_cmd = 'ADD COLUMN `' . $dbc['table_field'] . '` ' .
+	$alter_cmd = 'ADD COLUMN ' . audit_quote_identifier($dbc['table_field']) . ' ' .
 		$dbc['table_type'] . ($dbc['table_null'] == 'NO' ? ' NOT NULL':'');
 
 	$alter_cmd .= make_column_props($dbc);

--- a/cli/install_cacti.php
+++ b/cli/install_cacti.php
@@ -200,13 +200,14 @@ switch ($installer->getMode()) {
 log_install_always('cli', 'Installer prepared for ' . $install_mode . ' action');
 
 $message = '';
+$install_failed = false;
 if ($installer->getStep() == Installer::STEP_INSTALL_CONFIRM && $should_install) {
 	$time = '';
 	if ($force_install) {
 		$time = '-b';
 	}
 	log_install_always('cli', 'Starting installation...');
-	Installer::beginInstall($time, $installer);
+	$install_failed = !Installer::beginInstall($time, $installer);
 	log_install_always('cli', 'Finished installation...');
 }
 
@@ -231,6 +232,10 @@ switch ($installer->getStep()) {
 		break;
 }
 print PHP_EOL;
+
+if ($install_failed || $installer->getStep() === Installer::STEP_ERROR) {
+	exit(1);
+}
 
 /*  get_install_option - gets the install options from a json file */
 function get_install_option(&$options, $file, $json = true) {

--- a/lib/audit.php
+++ b/lib/audit.php
@@ -2,8 +2,29 @@
 /*
  +-------------------------------------------------------------------------+
  | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
  +-------------------------------------------------------------------------+
 */
+
+/**
+ * Quote a MySQL identifier used by the database audit repair builder.
+ *
+ * @param string $identifier Identifier from the canonical audit schema
+ *
+ * @return string Backtick-quoted identifier
+ */
+function audit_quote_identifier(string $identifier) : string {
+	return '`' . str_replace('`', '``', $identifier) . '`';
+}
 
 /**
  * Return the core schema tables that are absent from the live database.

--- a/lib/audit.php
+++ b/lib/audit.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Return the core schema tables that are absent from the live database.
+ *
+ * @param array<int, mixed> $expected_tables Tables recorded in the canonical audit schema
+ * @param array<int, mixed> $actual_tables   Tables present in the selected database
+ *
+ * @return array<int, string> Missing table names in deterministic order
+ */
+function audit_missing_core_tables(array $expected_tables, array $actual_tables) : array {
+	$expected_tables = array_values(array_unique(array_filter($expected_tables, 'is_string')));
+	$actual_tables   = array_values(array_unique(array_filter($actual_tables, 'is_string')));
+	$missing_tables  = array_values(array_diff($expected_tables, $actual_tables));
+
+	sort($missing_tables, SORT_STRING);
+
+	return $missing_tables;
+}
+
+/**
+ * Return the core table names declared by cacti.sql.
+ *
+ * @return array<int, string> Canonical table names in schema order
+ */
+function audit_schema_table_names(string $schema_sql) : array {
+	preg_match_all('/^CREATE TABLE\s+`?([A-Za-z0-9_]+)`?\s*\(/m', $schema_sql, $matches);
+
+	return array_values(array_unique($matches[1]));
+}
+
+/**
+ * Check an already-fetched SHOW COLUMNS result for an exact column name.
+ *
+ * Legacy Cacti schemas contain names such as "max-access" that are not valid
+ * inputs to the generic identifier-based database helpers.
+ *
+ * @param array<int, array<string, mixed>> $columns SHOW COLUMNS rows
+ * @param string                           $column  Expected column name
+ */
+function audit_column_exists(array $columns, string $column) : bool {
+	foreach($columns as $candidate) {
+		if (isset($candidate['Field']) && $candidate['Field'] === $column) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Extract one canonical CREATE TABLE statement from cacti.sql.
+ *
+ * @param string $schema_sql Full contents of cacti.sql
+ * @param string $table      Valid Cacti table identifier
+ *
+ * @return string|false The CREATE TABLE statement, or false when unavailable
+ */
+function audit_extract_create_table(string $schema_sql, string $table) {
+	if (!preg_match('/^[A-Za-z0-9_]+$/D', $table)) {
+		return false;
+	}
+
+	$quoted_table = preg_quote($table, '~');
+	$pattern      = '~^CREATE TABLE\s+`?' . $quoted_table . '`?\s*\(.*?^\)[^;]*;\h*$~ms';
+
+	if (preg_match($pattern, $schema_sql, $matches) !== 1) {
+		return false;
+	}
+
+	return trim($matches[0]);
+}

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -23,6 +23,7 @@
 */
 
 include_once(dirname(__FILE__) . '/../lib/poller.php');
+include_once(dirname(__FILE__) . '/../lib/audit.php');
 
 class Installer implements JsonSerializable {
 	const EXIT_DB_EMPTY = 1;
@@ -3041,6 +3042,10 @@ class Installer implements JsonSerializable {
 
 		log_install_always('', __('Finished %s Process for v%s', $which, CACTI_VERSION));
 
+		if (empty($failure)) {
+			$failure = $this->validateCoreSchema();
+		}
+
 		set_install_config_option('install_error', $failure);
 
 		if (empty($failure)) {
@@ -3065,6 +3070,35 @@ class Installer implements JsonSerializable {
 			$this->setProgress(Installer::PROGRESS_COMPLETE);
 			$this->setStep(Installer::STEP_ERROR);
 		}
+	}
+
+	private function validateCoreSchema() {
+		global $config, $database_default;
+
+		$schema_sql = file_get_contents($config['base_path'] . '/cacti.sql');
+
+		if ($schema_sql === false) {
+			return __('ERROR: Unable to validate the installed database because cacti.sql could not be read');
+		}
+
+		$expected_tables = audit_schema_table_names($schema_sql);
+
+		if (!cacti_sizeof($expected_tables)) {
+			return __('ERROR: Unable to validate the installed database because cacti.sql contains no table definitions');
+		}
+
+		$table_rows = db_fetch_assoc_prepared('SELECT TABLE_NAME
+			FROM information_schema.TABLES
+			WHERE TABLE_SCHEMA = ?',
+			array($database_default));
+		$actual_tables = array_column($table_rows, 'TABLE_NAME');
+		$missing_tables = audit_missing_core_tables($expected_tables, $actual_tables);
+
+		if (cacti_sizeof($missing_tables)) {
+			return __('ERROR: Required core database tables are missing: %s', implode(', ', $missing_tables));
+		}
+
+		return '';
 	}
 
 	private function installTemplate() {
@@ -3530,26 +3564,29 @@ class Installer implements JsonSerializable {
 
 		Installer::setPhpOption('max_execution_time', 0);
 		Installer::setPhpOption('memory_limit', -1);
+		$backgroundTime = microtime(true);
+		$success        = false;
+
 		try {
-			$backgroundTime = microtime(true);
 			if ($installer == null) {
 				$installer = new Installer();
 			}
 			$installer->setDefaults();
 			$installer->install();
-		} catch (Exception $e) {
+			$success = $installer->getStep() === Installer::STEP_COMPLETE;
+		} catch (Throwable $e) {
 			log_install_always('', __('Exception occurred during installation: #%s - %s', $e->getCode(), $e->getMessage()));
 		}
 
 		$backgroundDone = microtime(true);
 		set_install_config_option('install_complete', $backgroundDone);
-		set_install_config_option('install_step', Installer::STEP_COMPLETE);
 
 		$dateBack = DateTime::createFromFormat('U.u', $backgroundTime);
 		$dateTime = DateTime::createFromFormat('U.u', $backgroundDone);
 
 		log_install_always('', __('Installation was started at %s, completed at %s', (string) $dateBack->format('Y-m-d H:i:s'), (string) $dateTime->format('Y-m-d H:i:s')));
-		return true;
+
+		return $success;
 	}
 
 	public static function getInstallLog() {

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -3091,6 +3091,11 @@ class Installer implements JsonSerializable {
 			FROM information_schema.TABLES
 			WHERE TABLE_SCHEMA = ?',
 			array($database_default));
+
+		if (!is_array($table_rows)) {
+			return __('ERROR: Unable to query the installed database schema');
+		}
+
 		$actual_tables = array_column($table_rows, 'TABLE_NAME');
 		$missing_tables = audit_missing_core_tables($expected_tables, $actual_tables);
 

--- a/phpunit-audit.xml
+++ b/phpunit-audit.xml
@@ -1,0 +1,17 @@
+<phpunit bootstrap="include/vendor/autoload.php" beStrictAboutOutputDuringTests="false">
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="CACTI_TEST_BOOTSTRAP" value="1"/>
+    </php>
+    <source>
+        <include>
+            <file>lib/audit.php</file>
+        </include>
+    </source>
+    <testsuites>
+        <testsuite name="Database audit coverage">
+            <file>tests/Unit/AuditDatabaseMissingTableTest.php</file>
+            <file>tests/Unit/InstallerSchemaValidationTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Unit/AuditDatabaseMissingTableTest.php
+++ b/tests/Unit/AuditDatabaseMissingTableTest.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 2) . '/lib/audit.php';
+
+test('missing core tables are deduplicated and sorted', function () {
+	expect(audit_missing_core_tables(
+		array('version', 'user_auth_row_cache', 'host', 'host', null),
+		array('version', 'host', 'plugin_table', false)
+	))->toBe(array('user_auth_row_cache'));
+});
+
+test('canonical schema table names support quoted and legacy unquoted declarations', function () {
+	$schema = "CREATE TABLE `host` (\n  `id` int NOT NULL\n);\n"
+		. "CREATE TABLE user_auth_row_cache (\n  `user_id` int NOT NULL\n);\n"
+		. "CREATE TABLE `host` (\n  `id` int NOT NULL\n);";
+
+	expect(audit_schema_table_names($schema))->toBe(array('host', 'user_auth_row_cache'))
+		->and(audit_schema_table_names('SELECT 1;'))->toBe(array());
+});
+
+test('legacy hyphenated columns are matched exactly', function () {
+	$columns = array(
+		array('Field' => 'kind'),
+		array('Field' => 'max-access'),
+		array('NotField' => 'ignored'),
+	);
+
+	expect(audit_column_exists($columns, 'max-access'))->toBeTrue()
+		->and(audit_column_exists($columns, 'max_access'))->toBeFalse();
+});
+
+test('the canonical row cache create statement can be extracted', function () {
+	$schema = file_get_contents(dirname(__DIR__, 2) . '/cacti.sql');
+
+	expect($schema)->not->toBeFalse();
+
+	if ($schema === false) {
+		throw new RuntimeException('Unable to read cacti.sql');
+	}
+
+	$create = audit_extract_create_table($schema, 'user_auth_row_cache');
+
+	expect($create)->toBeString()
+		->and($create)->toContain('CREATE TABLE user_auth_row_cache (')
+		->and($create)->toContain('PRIMARY KEY (`user_id`,`class`,`hash`)')
+		->and($create)->toEndWith('ROW_FORMAT=Dynamic;');
+});
+
+test('create statement extraction fails closed', function () {
+	$schema = "CREATE TABLE `host` (\n  `id` int NOT NULL\n) ENGINE=InnoDB;";
+
+	expect(audit_extract_create_table($schema, 'host'))->toBe($schema)
+		->and(audit_extract_create_table($schema, 'does_not_exist'))->toBeFalse()
+		->and(audit_extract_create_table($schema, 'host; DROP TABLE host'))->toBeFalse();
+});

--- a/tests/Unit/AuditDatabaseMissingTableTest.php
+++ b/tests/Unit/AuditDatabaseMissingTableTest.php
@@ -58,3 +58,13 @@ test('create statement extraction fails closed', function () {
 		->and(audit_extract_create_table($schema, 'does_not_exist'))->toBeFalse()
 		->and(audit_extract_create_table($schema, 'host; DROP TABLE host'))->toBeFalse();
 });
+
+test('database audit query failures fail closed', function () {
+	$source = file_get_contents(dirname(__DIR__, 2) . '/cli/audit_database.php');
+
+	expect($source)->not->toBeFalse()
+		->and($source)->toContain('if (!is_array($tables)) {')
+		->and($source)->toContain('if (!is_array($expected_tables)) {')
+		->and($source)->toContain('if ($alters === false) {')
+		->and($source)->toContain('$exit_code = report_audit_results() === false ? 1 : 0;');
+});

--- a/tests/Unit/AuditDatabaseMissingTableTest.php
+++ b/tests/Unit/AuditDatabaseMissingTableTest.php
@@ -2,10 +2,25 @@
 /*
  +-------------------------------------------------------------------------+
  | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
  +-------------------------------------------------------------------------+
 */
 
 require_once dirname(__DIR__, 2) . '/lib/audit.php';
+
+test('legacy audit identifiers are safely quoted', function () {
+	expect(audit_quote_identifier('max-access'))->toBe('`max-access`')
+		->and(audit_quote_identifier('legacy`name'))->toBe('`legacy``name`');
+});
 
 test('missing core tables are deduplicated and sorted', function () {
 	expect(audit_missing_core_tables(
@@ -66,5 +81,7 @@ test('database audit query failures fail closed', function () {
 		->and($source)->toContain('if (!is_array($tables)) {')
 		->and($source)->toContain('if (!is_array($expected_tables)) {')
 		->and($source)->toContain('if ($alters === false) {')
+		->and(substr_count($source, "audit_quote_identifier(\$dbc['table_field'])"))->toBe(2)
+		->and($source)->toContain('audit_quote_identifier($after)')
 		->and($source)->toContain('$exit_code = report_audit_results() === false ? 1 : 0;');
 });

--- a/tests/Unit/InstallerSchemaValidationTest.php
+++ b/tests/Unit/InstallerSchemaValidationTest.php
@@ -28,7 +28,8 @@ test('installer validates the complete core schema before reporting success', fu
 
 	expect($validation)->toBeLessThan($version)
 		->and($validation)->toBeLessThan($complete)
-		->and($installerSource)->toContain('ERROR: Required core database tables are missing: %s');
+		->and($installerSource)->toContain('ERROR: Required core database tables are missing: %s')
+		->and($installerSource)->toContain('ERROR: Unable to query the installed database schema');
 });
 
 test('background and CLI installation paths preserve failure state', function () use ($installerSource, $cliSource) {

--- a/tests/Unit/InstallerSchemaValidationTest.php
+++ b/tests/Unit/InstallerSchemaValidationTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+$root            = dirname(__DIR__, 2);
+$installerSource = file_get_contents($root . '/lib/installer.php');
+$cliSource       = file_get_contents($root . '/cli/install_cacti.php');
+
+if ($installerSource === false || $cliSource === false) {
+	throw new RuntimeException('Unable to read installer sources');
+}
+
+test('installer validates the complete core schema before reporting success', function () use ($installerSource) {
+	$validation = strpos($installerSource, '$failure = $this->validateCoreSchema();');
+	$version    = strpos($installerSource, "db_execute('TRUNCATE TABLE version');");
+	$complete   = strpos($installerSource, '$this->setStep(Installer::STEP_COMPLETE);');
+
+	expect($validation)->not->toBeFalse()
+		->and($version)->not->toBeFalse()
+		->and($complete)->not->toBeFalse();
+
+	if ($validation === false || $version === false || $complete === false) {
+		throw new RuntimeException('Unable to locate installer completion sequence');
+	}
+
+	expect($validation)->toBeLessThan($version)
+		->and($validation)->toBeLessThan($complete)
+		->and($installerSource)->toContain('ERROR: Required core database tables are missing: %s');
+});
+
+test('background and CLI installation paths preserve failure state', function () use ($installerSource, $cliSource) {
+	expect($installerSource)->toContain('$success = $installer->getStep() === Installer::STEP_COMPLETE;')
+		->and($installerSource)->not->toContain("set_install_config_option('install_step', Installer::STEP_COMPLETE);")
+		->and($installerSource)->toContain('catch (Throwable $e)')
+		->and($cliSource)->toContain('$install_failed = !Installer::beginInstall($time, $installer);')
+		->and($cliSource)->toContain('if ($install_failed || $installer->getStep() === Installer::STEP_ERROR) {');
+});

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -1,9 +1,9 @@
 class	location	match
 cmd_exec	./cactid.php:102		exec('pgrep -a php | grep cactid.php', $output);
-cmd_exec	./cli/audit_database.php:148		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
-cmd_exec	./cli/audit_database.php:239								exec('php ' . $config['base_path'] . '/plugins/' . $pname . '/database_upgrade.php --type=large --force-ver=' . $old, $output, $return_var);
-cmd_exec	./cli/audit_database.php:980				$db_shell = shell_exec('which mysql');
-cmd_exec	./cli/audit_database.php:989				exec($db_shell .
+cmd_exec	./cli/audit_database.php:1037				$db_shell = shell_exec('which mysql');
+cmd_exec	./cli/audit_database.php:1046				exec($db_shell .
+cmd_exec	./cli/audit_database.php:151		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
+cmd_exec	./cli/audit_database.php:242								exec('php ' . $config['base_path'] . '/plugins/' . $pname . '/database_upgrade.php --type=large --force-ver=' . $old, $output, $return_var);
 cmd_exec	./cli/batchgapfix.php:388			exec($command, $output, $return_var);
 cmd_exec	./cli/float_rrdfiles.php:335				$response = exec($command, $output, $return);
 cmd_exec	./cli/float_rrdfiles.php:443					$response = exec($command, $output, $return);
@@ -35,10 +35,10 @@ cmd_exec	./lib/functions.php:7272				exec(sprintf('grep :%s: /etc/passwd | cut -
 cmd_exec	./lib/functions.php:7564	 * shell_exec() callers that already assemble the command string.
 cmd_exec	./lib/functions.php:7604		$process = proc_open($argv, $descriptors, $pipes);
 cmd_exec	./lib/functions.php:7676	 * shell_exec() and expect a string return value.
-cmd_exec	./lib/installer.php:3289				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3321						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3377						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:823							$output = shell_exec(
+cmd_exec	./lib/installer.php:3328				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3360						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3416						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:824							$output = shell_exec(
 cmd_exec	./lib/ping.php:167					$result = shell_exec('ping ' . cacti_escapeshellarg($this->host['hostname']));
 cmd_exec	./lib/ping.php:169					$result = shell_exec('ping -m ' . ceil($this->timeout/1000) . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 cmd_exec	./lib/ping.php:171					$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
@@ -155,8 +155,8 @@ dynamic_include	./cli/apply_automation_rules.php:35	require_once($config['base_p
 dynamic_include	./cli/apply_automation_rules.php:36	require_once($config['base_path'] . '/lib/reports.php');
 dynamic_include	./cli/apply_automation_rules.php:37	require_once($config['base_path'] . '/lib/template.php');
 dynamic_include	./cli/apply_automation_rules.php:38	require_once($config['base_path'] . '/lib/utility.php');
-dynamic_include	./cli/audit_database.php:212							include_once($plugin . '/setup.php');
-dynamic_include	./cli/audit_database.php:214								include_once($plugin . '/includes/database.php');
+dynamic_include	./cli/audit_database.php:215							include_once($plugin . '/setup.php');
+dynamic_include	./cli/audit_database.php:217								include_once($plugin . '/includes/database.php');
 dynamic_include	./cli/batchgapfix.php:35	require_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./cli/change_device.php:27	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./cli/change_device.php:28	require_once($config['base_path'] . '/lib/api_device.php');
@@ -386,7 +386,7 @@ dynamic_include	./lib/html_tree.php:831		include_once($config['library_path'] . 
 dynamic_include	./lib/html_tree.php:93		include_once($config['library_path'] . '/data_query.php');
 dynamic_include	./lib/import.php:2000		include_once($config['library_path'] . '/vdef.php');
 dynamic_include	./lib/import.php:29		include_once($config['library_path'] . '/xml.php');
-dynamic_include	./lib/installer.php:3430					include_once($upgrade_file);
+dynamic_include	./lib/installer.php:3469					include_once($upgrade_file);
 dynamic_include	./lib/mib_cache.php:57			include_once($config['include_path'] . '/vendor/phpsnmp/mib_parser.php');
 dynamic_include	./lib/plugins.php:154							include_once($plugin_include);
 dynamic_include	./lib/plugins.php:464		include_once($config['library_path'] . '/database.php');

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -1,8 +1,8 @@
 category	location	match
 cmd_exec	./cactid.php:102		exec('pgrep -a php | grep cactid.php', $output);
-cmd_exec	./cli/audit_database.php:148		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
-cmd_exec	./cli/audit_database.php:980				$db_shell = shell_exec('which mysql');
-cmd_exec	./cli/audit_database.php:989				exec($db_shell .
+cmd_exec	./cli/audit_database.php:1037				$db_shell = shell_exec('which mysql');
+cmd_exec	./cli/audit_database.php:1046				exec($db_shell .
+cmd_exec	./cli/audit_database.php:151		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
 cmd_exec	./cli/batchgapfix.php:388			exec($command, $output, $return_var);
 cmd_exec	./cli/float_rrdfiles.php:335				$response = exec($command, $output, $return);
 cmd_exec	./cli/float_rrdfiles.php:443					$response = exec($command, $output, $return);
@@ -34,10 +34,10 @@ cmd_exec	./lib/functions.php:7272				exec(sprintf('grep :%s: /etc/passwd | cut -
 cmd_exec	./lib/functions.php:7564	 * shell_exec() callers that already assemble the command string.
 cmd_exec	./lib/functions.php:7604		$process = proc_open($argv, $descriptors, $pipes);
 cmd_exec	./lib/functions.php:7676	 * shell_exec() and expect a string return value.
-cmd_exec	./lib/installer.php:3289				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3321						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3377						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:823							$output = shell_exec(
+cmd_exec	./lib/installer.php:3328				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3360						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3416						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:824							$output = shell_exec(
 cmd_exec	./lib/ping.php:167					$result = shell_exec('ping ' . cacti_escapeshellarg($this->host['hostname']));
 cmd_exec	./lib/ping.php:169					$result = shell_exec('ping -m ' . ceil($this->timeout/1000) . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 cmd_exec	./lib/ping.php:171					$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
@@ -155,8 +155,8 @@ dynamic_include	./cli/apply_automation_rules.php:35	require_once($config['base_p
 dynamic_include	./cli/apply_automation_rules.php:36	require_once($config['base_path'] . '/lib/reports.php');
 dynamic_include	./cli/apply_automation_rules.php:37	require_once($config['base_path'] . '/lib/template.php');
 dynamic_include	./cli/apply_automation_rules.php:38	require_once($config['base_path'] . '/lib/utility.php');
-dynamic_include	./cli/audit_database.php:212							include_once($plugin . '/setup.php');
-dynamic_include	./cli/audit_database.php:214								include_once($plugin . '/includes/database.php');
+dynamic_include	./cli/audit_database.php:215							include_once($plugin . '/setup.php');
+dynamic_include	./cli/audit_database.php:217								include_once($plugin . '/includes/database.php');
 dynamic_include	./cli/batchgapfix.php:35	require_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./cli/change_device.php:27	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./cli/change_device.php:28	require_once($config['base_path'] . '/lib/api_device.php');
@@ -384,7 +384,7 @@ dynamic_include	./lib/html_tree.php:831		include_once($config['library_path'] . 
 dynamic_include	./lib/html_tree.php:93		include_once($config['library_path'] . '/data_query.php');
 dynamic_include	./lib/import.php:2000		include_once($config['library_path'] . '/vdef.php');
 dynamic_include	./lib/import.php:29		include_once($config['library_path'] . '/xml.php');
-dynamic_include	./lib/installer.php:3430					include_once($upgrade_file);
+dynamic_include	./lib/installer.php:3469					include_once($upgrade_file);
 dynamic_include	./lib/mib_cache.php:57			include_once($config['include_path'] . '/vendor/phpsnmp/mib_parser.php');
 dynamic_include	./lib/plugins.php:154							include_once($plugin_include);
 dynamic_include	./lib/plugins.php:464		include_once($config['library_path'] . '/database.php');
@@ -570,7 +570,7 @@ fs_write	./lib/functions.php:719					file_put_contents(sys_get_temp_dir() . '/ca
 fs_write	./lib/functions.php:7239				file_put_contents($tmp_file, 'cacti');
 fs_write	./lib/import.php:425		$f   = fopen($filename, 'r');
 fs_write	./lib/import.php:606							$file = fopen($filename, 'wb');
-fs_write	./lib/installer.php:2890				$file = fopen($cacheFile, "r");
+fs_write	./lib/installer.php:2891				$file = fopen($cacheFile, "r");
 fs_write	./lib/poller.php:1308									if (file_put_contents($tmpfile, $contents) !== false) {
 fs_write	./lib/poller.php:1315												file_put_contents($mypath, $contents);
 fs_write	./lib/poller.php:1344								file_put_contents($mypath, $contents);


### PR DESCRIPTION
## What changed

- make the installer validate every core table from `cacti.sql` before reporting success
- preserve installer error state through background and CLI execution, including a non-zero CLI exit
- teach `audit_database` to report and repair completely missing core tables
- compare legacy hyphenated column names against `SHOW COLUMNS` results so `max-access` is not falsely reported missing
- quote and escape every column identifier emitted by the audit ALTER builder
- return a non-zero status when database repair fails
- add a focused 100% line-coverage gate for the new audit helpers

## Root cause

The audit loaded the canonical schema but iterated only tables present in the live database, so a fully missing table such as `user_auth_row_cache` was invisible. It also checked canonical column names through the generic safe-identifier helper, which correctly rejects hyphens; that made the legacy `max-access` column look absent even when present and caused a duplicate-column repair attempt.

The installer did not verify the completed schema, and its background wrapper overwrote the recorded error step with completion.

## Impact

Incomplete upgrades now stop visibly instead of appearing successful. The audit can recreate a missing core table from the trusted release schema, and healthy `snmpagent_cache.max-access` columns no longer produce a broken repair attempt.

## Validation

- Docker: MariaDB 10.11, clean 1.2.22 schema upgraded with 1.2.31
- Docker: deliberately removed `user_auth_row_cache`; installer stopped at error step 99 and CLI exited non-zero
- Docker: `audit_database --repair` recreated the missing table; subsequent audit was clean
- Docker: verified existing `max-access` is accepted and a genuinely missing column is repaired
- Docker: executed the exact backtick-quoted `snmpagent_cache.max-access` ALTER successfully on MariaDB 10.11
- Pest: 9 tests, 34 assertions
- Xdebug line coverage: `lib/audit.php` 100%
- PHPStan level 6: clean for new helper and tests
- PHP syntax and `git diff --check`: clean

