### PR TITLE
fix(reports): restore coding standard spacing

### DIFF
--- a/lib/reports.php
+++ b/lib/reports.php
@@ -1890,6 +1890,7 @@ function png2jpeg(string $png_data) : string {
 		ob_start(); // start a new output buffer to capture jpeg image stream
 		imagejpeg($im);	// output to buffer
 		$ImageData = ob_get_contents(); // fetch image from buffer
+
 		if (PHP_VERSION_ID < 80500) {
 			imagedestroy($im);
 		}
@@ -1933,6 +1934,7 @@ function png2gif(string $png_data) : string {
 		ob_start(); // start a new output buffer to capture gif image stream
 		imagegif($im);	// output to buffer
 		$ImageData = ob_get_contents(); // fetch image from buffer
+
 		if (PHP_VERSION_ID < 80500) {
 			imagedestroy($im);
 		}


### PR DESCRIPTION
## Summary

- restore the blank lines required by the project PHP-CS-Fixer configuration
- return the develop PHP 8.1-8.4 syntax matrix to the product-test stages

## Validation

- `php -l lib/reports.php`
- `composer run-script phpcsfixer` (382 files, zero findings)

## Context

The develop syntax workflow has failed at the coding-standards step since #7515. This keeps the unrelated correction out of installer resilience PR #7626.