### PR TITLE
fix(installer): reject incomplete selection payloads

### DIFF
--- a/lib/installer.php
+++ b/lib/installer.php
@@ -1215,6 +1215,28 @@ class Installer implements JsonSerializable {
 		return $selected;
 	}
 
+	/* isCompleteSelectionPayload - confirms that a browser submitted every
+	 * server-rendered checkbox and only supported boolean values. */
+	private static function isCompleteSelectionPayload($submitted, $expected) {
+		unset($submitted['all']);
+
+		$submitted_keys = array_keys($submitted);
+		sort($submitted_keys);
+		sort($expected);
+
+		if ($submitted_keys !== $expected) {
+			return false;
+		}
+
+		foreach ($submitted as $value) {
+			if (!in_array($value, array(true, false, 'true', 'false', 'on', '', 1, 0, '1', '0'), true)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	/* setTemplates() - sets a list of templates that should be installed
 	 *                  during the installServer() phase.
 	 * @param_templates - an array of templates to install in the form of
@@ -1224,8 +1246,26 @@ class Installer implements JsonSerializable {
 	 *         passed that is not expected */
 	private function setTemplates($param_templates = array()) {
 		if (is_array($param_templates)) {
-			db_execute('DELETE FROM settings WHERE name like \'install_tp_%\'');
 			$known_templates = install_setup_get_templates();
+			$expected_keys   = array();
+
+			if (!is_array($known_templates)) {
+				$this->addError(Installer::STEP_TEMPLATE_INSTALL, 'Templates', 'SelectionPayload', __('Unable to load the available templates'));
+
+				return;
+			}
+
+			foreach ($known_templates as $known) {
+				$expected_keys[] = 'chk_template_' . str_replace('.', '_', $known['filename']);
+			}
+
+			if ($this->runtime === 'Web' && !self::isCompleteSelectionPayload($param_templates, $expected_keys)) {
+				$this->addError(Installer::STEP_TEMPLATE_INSTALL, 'Templates', 'SelectionPayload', __('The template selection was incomplete. Reload this installer step and select the templates again.'));
+
+				return;
+			}
+
+			db_execute('DELETE FROM settings WHERE name like \'install_tp_%\'');
 
 			log_install_medium('templates',"setTemplates(): Updating templates");
 			log_install_debug('templates',"setTemplates(): Parameter data:" . clean_up_lines(var_export($param_templates, true)));
@@ -1331,9 +1371,26 @@ class Installer implements JsonSerializable {
 	 *         conversion list due to being converted elsewhere */
 	private function setTables($param_tables = array()) {
 		if (is_array($param_tables)) {
-			db_execute('DELETE FROM settings WHERE name like \'install_table_%\'');
-
 			$known_tables = install_setup_get_tables();
+			$expected_keys = array();
+
+			if (!is_array($known_tables)) {
+				$this->addError(Installer::STEP_CHECK_TABLES, 'Tables', 'SelectionPayload', __('Unable to load the tables requiring conversion'));
+
+				return;
+			}
+
+			foreach ($known_tables as $known) {
+				$expected_keys[] = 'chk_table_' . $known['Name'];
+			}
+
+			if ($this->runtime === 'Web' && !self::isCompleteSelectionPayload($param_tables, $expected_keys)) {
+				$this->addError(Installer::STEP_CHECK_TABLES, 'Tables', 'SelectionPayload', __('The table selection was incomplete. Reload this installer step and select the tables again.'));
+
+				return;
+			}
+
+			db_execute('DELETE FROM settings WHERE name like \'install_table_%\'');
 
 			log_install_medium('tables',"setTables(): Updating Tables");
 			log_install_debug('tables',"setTables(): Parameter data:" . clean_up_lines(var_export($param_tables, true)));

--- a/lib/installer.php
+++ b/lib/installer.php
@@ -1237,6 +1237,12 @@ class Installer implements JsonSerializable {
 		return true;
 	}
 
+	/* isTableSelectable() - determines whether the web installer renders a
+	 *                       conversion checkbox for a table */
+	private static function isTableSelectable($table) {
+		return isset($table['Rows']) && is_numeric($table['Rows']) && $table['Rows'] < 1000000;
+	}
+
 	/* setTemplates() - sets a list of templates that should be installed
 	 *                  during the installServer() phase.
 	 * @param_templates - an array of templates to install in the form of
@@ -1381,7 +1387,9 @@ class Installer implements JsonSerializable {
 			}
 
 			foreach ($known_tables as $known) {
-				$expected_keys[] = 'chk_table_' . $known['Name'];
+				if (self::isTableSelectable($known)) {
+					$expected_keys[] = 'chk_table_' . $known['Name'];
+				}
 			}
 
 			if ($this->runtime === 'Web' && !self::isCompleteSelectionPayload($param_tables, $expected_keys)) {
@@ -2715,7 +2723,7 @@ class Installer implements JsonSerializable {
 				html_start_box(__('Tables'), '100%', false, '3', 'center', '', '');
 				html_header_checkbox(array(__('Name'), __('Collation'), __('Row Format'), __('Engine'), __('Rows')));
 				foreach ($tables as $id => $p) {
-					$enabled = ($p['Rows'] < 1000000 ? true : false);
+					$enabled = self::isTableSelectable($p);
 
 					$style = ($enabled ? '' : 'text-decoration: line-through;');
 

--- a/tests/Unit/InstallerSelectionPayloadTest.php
+++ b/tests/Unit/InstallerSelectionPayloadTest.php
@@ -16,6 +16,7 @@ require_once dirname(__DIR__, 2) . '/lib/installer.php';
 test('installer accepts only complete browser selection payloads', function () {
 	$method   = new ReflectionMethod(Installer::class, 'isCompleteSelectionPayload');
 	$expected = array('chk_template_one', 'chk_template_two');
+	$method->setAccessible(true);
 
 	expect($method->invoke(null, array(
 		'chk_template_one' => true,
@@ -38,4 +39,15 @@ test('installer accepts only complete browser selection payloads', function () {
 			'chk_template_one' => true,
 			'chk_template_two' => 'unexpected',
 		), $expected))->toBeFalse();
+});
+
+test('installer requires payload keys only for rendered table controls', function () {
+	$method = new ReflectionMethod(Installer::class, 'isTableSelectable');
+	$method->setAccessible(true);
+
+	expect($method->invoke(null, array('Rows' => 0)))->toBeTrue()
+		->and($method->invoke(null, array('Rows' => '999999')))->toBeTrue()
+		->and($method->invoke(null, array('Rows' => 1000000)))->toBeFalse()
+		->and($method->invoke(null, array('Rows' => 'unknown')))->toBeFalse()
+		->and($method->invoke(null, array()))->toBeFalse();
 });

--- a/tests/Unit/InstallerSelectionPayloadTest.php
+++ b/tests/Unit/InstallerSelectionPayloadTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ +-------------------------------------------------------------------------+
+ */
+
+require_once dirname(__DIR__) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 2) . '/include/global.php';
+require_once dirname(__DIR__, 2) . '/install/functions.php';
+require_once dirname(__DIR__, 2) . '/lib/installer.php';
+
+test('installer accepts only complete browser selection payloads', function () {
+	$method   = new ReflectionMethod(Installer::class, 'isCompleteSelectionPayload');
+	$expected = array('chk_template_one', 'chk_template_two');
+
+	expect($method->invoke(null, array(
+		'chk_template_one' => true,
+		'chk_template_two' => false,
+	), $expected))->toBeTrue()
+		->and($method->invoke(null, array(
+			'all'              => true,
+			'chk_template_one' => '1',
+			'chk_template_two' => '0',
+		), $expected))->toBeTrue()
+		->and($method->invoke(null, array(
+			'chk_template_one' => true,
+		), $expected))->toBeFalse()
+		->and($method->invoke(null, array(
+			'chk_template_one'   => true,
+			'chk_template_two'   => false,
+			'chk_template_three' => true,
+		), $expected))->toBeFalse()
+		->and($method->invoke(null, array(
+			'chk_template_one' => true,
+			'chk_template_two' => 'unexpected',
+		), $expected))->toBeFalse();
+});

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -35,9 +35,9 @@ cmd_exec	./lib/functions.php:7272				exec(sprintf('grep :%s: /etc/passwd | cut -
 cmd_exec	./lib/functions.php:7564	 * shell_exec() callers that already assemble the command string.
 cmd_exec	./lib/functions.php:7604		$process = proc_open($argv, $descriptors, $pipes);
 cmd_exec	./lib/functions.php:7676	 * shell_exec() and expect a string return value.
-cmd_exec	./lib/installer.php:3289				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3321						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3377						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3354				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3386						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3442						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
 cmd_exec	./lib/installer.php:823							$output = shell_exec(
 cmd_exec	./lib/ping.php:167					$result = shell_exec('ping ' . cacti_escapeshellarg($this->host['hostname']));
 cmd_exec	./lib/ping.php:169					$result = shell_exec('ping -m ' . ceil($this->timeout/1000) . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
@@ -386,7 +386,7 @@ dynamic_include	./lib/html_tree.php:831		include_once($config['library_path'] . 
 dynamic_include	./lib/html_tree.php:93		include_once($config['library_path'] . '/data_query.php');
 dynamic_include	./lib/import.php:2000		include_once($config['library_path'] . '/vdef.php');
 dynamic_include	./lib/import.php:29		include_once($config['library_path'] . '/xml.php');
-dynamic_include	./lib/installer.php:3430					include_once($upgrade_file);
+dynamic_include	./lib/installer.php:3495					include_once($upgrade_file);
 dynamic_include	./lib/mib_cache.php:57			include_once($config['include_path'] . '/vendor/phpsnmp/mib_parser.php');
 dynamic_include	./lib/plugins.php:154							include_once($plugin_include);
 dynamic_include	./lib/plugins.php:464		include_once($config['library_path'] . '/database.php');

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -34,9 +34,9 @@ cmd_exec	./lib/functions.php:7272				exec(sprintf('grep :%s: /etc/passwd | cut -
 cmd_exec	./lib/functions.php:7564	 * shell_exec() callers that already assemble the command string.
 cmd_exec	./lib/functions.php:7604		$process = proc_open($argv, $descriptors, $pipes);
 cmd_exec	./lib/functions.php:7676	 * shell_exec() and expect a string return value.
-cmd_exec	./lib/installer.php:3289				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3321						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3377						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3354				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3386						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3442						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
 cmd_exec	./lib/installer.php:823							$output = shell_exec(
 cmd_exec	./lib/ping.php:167					$result = shell_exec('ping ' . cacti_escapeshellarg($this->host['hostname']));
 cmd_exec	./lib/ping.php:169					$result = shell_exec('ping -m ' . ceil($this->timeout/1000) . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
@@ -384,7 +384,7 @@ dynamic_include	./lib/html_tree.php:831		include_once($config['library_path'] . 
 dynamic_include	./lib/html_tree.php:93		include_once($config['library_path'] . '/data_query.php');
 dynamic_include	./lib/import.php:2000		include_once($config['library_path'] . '/vdef.php');
 dynamic_include	./lib/import.php:29		include_once($config['library_path'] . '/xml.php');
-dynamic_include	./lib/installer.php:3430					include_once($upgrade_file);
+dynamic_include	./lib/installer.php:3495					include_once($upgrade_file);
 dynamic_include	./lib/mib_cache.php:57			include_once($config['include_path'] . '/vendor/phpsnmp/mib_parser.php');
 dynamic_include	./lib/plugins.php:154							include_once($plugin_include);
 dynamic_include	./lib/plugins.php:464		include_once($config['library_path'] . '/database.php');
@@ -570,7 +570,7 @@ fs_write	./lib/functions.php:719					file_put_contents(sys_get_temp_dir() . '/ca
 fs_write	./lib/functions.php:7239				file_put_contents($tmp_file, 'cacti');
 fs_write	./lib/import.php:425		$f   = fopen($filename, 'r');
 fs_write	./lib/import.php:606							$file = fopen($filename, 'wb');
-fs_write	./lib/installer.php:2890				$file = fopen($cacheFile, "r");
+fs_write	./lib/installer.php:2955				$file = fopen($cacheFile, "r");
 fs_write	./lib/poller.php:1308									if (file_put_contents($tmpfile, $contents) !== false) {
 fs_write	./lib/poller.php:1315												file_put_contents($mypath, $contents);
 fs_write	./lib/poller.php:1344								file_put_contents($mypath, $contents);


### PR DESCRIPTION
## What changed

- require web template submissions to include every server-rendered template checkbox
- require web table-conversion submissions to include every selectable table checkbox rendered by the server
- reject unknown keys and unsupported checkbox values before changing persisted selections
- preserve the last valid installer selection when a request is incomplete
- keep sparse CLI selections supported
- share the table selectability predicate between rendering and validation so million-row tables remain CLI-only
- add behavioral coverage for complete, missing, extra, invalid, and non-rendered table payloads

## Root cause

The web installer treated a missing or truncated checkbox payload as an intentional empty selection. It deleted the previously persisted `install_tp_*` or `install_table_*` rows before proving the browser returned the complete selection rendered by the server. A JavaScript selector regression could therefore silently clear all defaults and allow a fresh installation to continue without templates.

## Impact

Incomplete or stale web submissions now fail on the relevant installer step and retain the last valid plan. Operators can still explicitly deselect every row because the browser submits every checkbox with a false value; the distinction is between a complete all-false payload and missing checkbox keys.

## Validation

- PHP syntax checks for `lib/installer.php` and the new Pest test
- behavioral reflection coverage for accepted and rejected payload shapes and table-selectability boundaries
- PHP 7.4 Docker syntax checks
- security sink and architectural hotspot baselines verified
- `git diff --check`

## Branch scope

This PR targets 1.2.x and contains only the selection-handoff guard and its test. The develop equivalent is included in #7626.



Part of #7648.
