### PR TITLE
fix(installer): propagate background installation failures

### DIFF
--- a/install/background.php
+++ b/install/background.php
@@ -47,6 +47,7 @@ global $cli_install;
 
 $cli_install = true;
 $now = time();
+$installer_process_timeout = 86400;
 
 if (cacti_sizeof($params) == 0) {
 	log_install_always('','no parameters passed' . PHP_EOL);
@@ -56,7 +57,10 @@ if (cacti_sizeof($params) == 0) {
 $registered_process = false;
 
 if (function_exists('register_process_start')) {
-	if (!register_process_start('install', 'master', '0', 600)) {
+	/* Installer schema conversions can legitimately run longer than the
+	 * generic process timeout. Dead processes are still reclaimed immediately
+	 * by register_process_start() through its PID-liveness check. */
+	if (!register_process_start('install', 'master', '0', $installer_process_timeout)) {
 		exit(0);
 	}
 

--- a/install/background.php
+++ b/install/background.php
@@ -53,10 +53,14 @@ if (cacti_sizeof($params) == 0) {
 	exit(0);
 }
 
+$registered_process = false;
+
 if (function_exists('register_process_start')) {
 	if (!register_process_start('install', 'master', '0', 600)) {
 		exit(0);
 	}
+
+	$registered_process = true;
 } else {
 	$running = read_config_option('installer_running', true);
 
@@ -67,11 +71,16 @@ if (function_exists('register_process_start')) {
 	set_config_option('installer_running', $now);
 }
 
-Installer::beginInstall($params[0]);
+$completed = false;
 
-if (function_exists('register_process_start')) {
-	unregister_process('install', 'master', 0);
-} else {
-	set_config_option('installer_running', '');
+try {
+	$completed = Installer::beginInstall($params[0]);
+} finally {
+	if ($registered_process) {
+		unregister_process('install', 'master', 0);
+	} else {
+		set_config_option('installer_running', '');
+	}
 }
 
+exit($completed ? 0 : 1);

--- a/tests/Unit/InstallerBackgroundContractTest.php
+++ b/tests/Unit/InstallerBackgroundContractTest.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRTool-based Graphing Solution                      |
+ +-------------------------------------------------------------------------+
+ */
+
+$root = dirname(__DIR__, 2);
+
+test('background installation always releases its lock and propagates failure', function () use ($root) {
+	$source = file_get_contents($root . '/install/background.php');
+
+	expect($source)->not->toBeFalse();
+	expect($source)->toContain('$registered_process = false;');
+	expect($source)->toContain('$registered_process = true;');
+	expect($source)->toMatch('/try\s*\{.*Installer::beginInstall\(\$params\[0\]\).*\}\s*finally\s*\{/s');
+	expect($source)->toContain("unregister_process('install', 'master', 0);");
+	expect($source)->toContain("set_config_option('installer_running', '');");
+	expect($source)->toContain('exit($completed ? 0 : 1);');
+});

--- a/tests/Unit/InstallerBackgroundContractTest.php
+++ b/tests/Unit/InstallerBackgroundContractTest.php
@@ -23,6 +23,9 @@ test('background installation always releases its lock and propagates failure', 
 	$source = file_get_contents($root . '/install/background.php');
 
 	expect($source)->not->toBeFalse();
+	expect($source)->toContain('$installer_process_timeout = 86400;');
+	expect($source)->toContain("register_process_start('install', 'master', '0', \$installer_process_timeout)");
+	expect($source)->not->toContain("register_process_start('install', 'master', '0', 600)");
 	expect($source)->toContain('$registered_process = false;');
 	expect($source)->toContain('$registered_process = true;');
 	expect($source)->toMatch('/try\s*\{.*Installer::beginInstall\(\$params\[0\]\).*\}\s*finally\s*\{/s');


### PR DESCRIPTION
## Summary

- preserve whether the process-registry lock was actually acquired
- protect legitimate long-running schema migrations with a 24-hour process lease
- release either lock implementation from a `finally` block
- return exit status 1 when `Installer::beginInstall()` reports failure
- add a regression contract for lock cleanup and exit-status propagation

## Root cause

The 1.2.x background installer ignored the boolean returned by `Installer::beginInstall()` and then reached the end of the PHP script, which reports success to its caller. Lock cleanup also ran only after a normal return. An exception or other throwable could therefore leave the installer registered as running until its timeout, while ordinary fail-closed outcomes still appeared successful to process supervisors. The generic 10-minute process timeout could also SIGTERM a healthy installer during long-running DDL when another launch attempted to acquire the lock.

## Impact

The process registry still reclaims dead PIDs immediately, but no longer kills healthy installer migrations after only 10 minutes. The background process also releases its process-registry or settings-based lock even when installation exits abnormally. A normal `false` result is returned to the parent process as exit status 1 instead of 0.

This PR targets 1.2.x only and does not overlap the schema validation, checkbox rendering, or selection-handoff changes in #7624, #7625, and #7628. The develop equivalent is already contained in #7626.

## Validation

- Pest: 1 test, 10 assertions
- PHP 7.4 Docker syntax checks
- PHP 8.1 Docker syntax checks
- security sink inventory: clean
- architectural hotspot guard: clean
- `git diff --check`: clean



Part of #7648.
