### PR TITLE
fix(php85): remove test and authenticator deprecations

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
     - name: Checkout
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
     - name: Checkout

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -150,6 +150,7 @@ Cacti CHANGELOG
 -issue#7707: Bind the MIB column names in MibCache::select()
 -issue#7719: Spike Kill text output applied the large value scientific notation format to the column left of the value it belonged to, starting with Variance
 -issue#7732: Bind device IDs and escape graph and device HTML sinks
+-issue#7646: Remove PHP 8.5 reflection and authenticator deprecations
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect

--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,8 @@
         "composer/xdebug-handler": "^3.0",
         "friendsofphp/php-cs-fixer": "^3.86",
         "overtrue/phplint": "^9.6",
-        "pestphp/pest": "^2",
-        "pestphp/pest-plugin-drift": "^2.0",
+        "pestphp/pest": "^2 || ^3",
+        "pestphp/pest-plugin-drift": "^2.0 || ^3.0",
         "phpstan/phpstan": "2.2.8",
         "rector/rector": "^2.1.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b5c833604a67c3f3f9b13f630176fcc",
+    "content-hash": "8b11d855049443d645aa8a3cdfb2ed37",
     "packages": [
         {
             "name": "doctrine/lexer",

--- a/include/vendor/GoogleAuthenticator/FixedBitNotation.php
+++ b/include/vendor/GoogleAuthenticator/FixedBitNotation.php
@@ -66,7 +66,7 @@ final class FixedBitNotation
      * @param bool   $padFinalGroup     Add padding to end of encoded output
      * @param string $padCharacter      Character to use for padding
      */
-    public function __construct(int $bitsPerCharacter, string $chars = null, bool $rightPadFinalBits = false, bool $padFinalGroup = false, string $padCharacter = '=')
+    public function __construct(int $bitsPerCharacter, ?string $chars = null, bool $rightPadFinalBits = false, bool $padFinalGroup = false, string $padCharacter = '=')
     {
         // Ensure validity of $chars
         if (!\is_string($chars) || ($charLength = \strlen($chars)) < 2) {

--- a/include/vendor/GoogleAuthenticator/GoogleAuthenticator.php
+++ b/include/vendor/GoogleAuthenticator/GoogleAuthenticator.php
@@ -48,7 +48,7 @@ final class GoogleAuthenticator implements GoogleAuthenticatorInterface
      * @param int                     $secretLength
      * @param \DateTimeInterface|null $now
      */
-    public function __construct(int $passCodeLength = 6, int $secretLength = 10, \DateTimeInterface $now = null)
+    public function __construct(int $passCodeLength = 6, int $secretLength = 10, ?\DateTimeInterface $now = null)
     {
         $this->passCodeLength = $passCodeLength;
         $this->secretLength = $secretLength;

--- a/include/vendor/GoogleAuthenticator/GoogleQrUrl.php
+++ b/include/vendor/GoogleAuthenticator/GoogleQrUrl.php
@@ -58,7 +58,7 @@ final class GoogleQrUrl
      *
      * @return string
      */
-    public static function generate(string $accountName, string $secret, string $issuer = null, int $size = 200): string
+    public static function generate(string $accountName, string $secret, ?string $issuer = null, int $size = 200): string
     {
         if ('' === $accountName || false !== strpos($accountName, ':')) {
             throw RuntimeException::InvalidAccountName($accountName);

--- a/lib/database.php
+++ b/lib/database.php
@@ -73,7 +73,11 @@ function db_connect_real(string $device, string $user, string $pass, string $db_
 			$device = '127.0.0.1';
 		}
 
-		if (!defined('PDO::MYSQL_ATTR_FOUND_ROWS')) {
+		/* PHP 8.4 moved the driver constants onto Pdo\Mysql and 8.5 deprecates the
+		 * PDO:: spellings, so resolve whichever one this runtime owns. */
+		$found_rows_const = PHP_VERSION_ID >= 80400 ? 'Pdo\Mysql::ATTR_FOUND_ROWS' : 'PDO::MYSQL_ATTR_FOUND_ROWS';
+
+		if (!defined($found_rows_const)) {
 			if (!empty($config['DEBUG_READ_CONFIG_OPTION'])) {
 				$prefix = get_debug_prefix();
 				file_put_contents(sys_get_temp_dir() . '/cacti-option.log',
@@ -88,7 +92,7 @@ function db_connect_real(string $device, string $user, string $pass, string $db_
 			$flags[PDO::ATTR_PERSISTENT] = true;
 		}
 
-		$flags[PDO::MYSQL_ATTR_FOUND_ROWS] = true;
+		$flags[constant($found_rows_const)] = true;
 
 		if ($db_ssl) {
 			if ($db_ssl_ca != '') {

--- a/tests/Unit/Php85DeprecationCompatibilityTest.php
+++ b/tests/Unit/Php85DeprecationCompatibilityTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ */
+
+/*
+ * The bundled GoogleAuthenticator classes are patched for the PHP 8.4+ implicit
+ * nullable deprecation, but that is not asserted here: include/vendor is restored
+ * from the Actions cache (keyed on composer.lock) before the suite runs, so the
+ * on-disk copy is whatever a prior develop run cached, not the checkout. A file
+ * assertion would test the cache, not this branch. The patch still ships in the
+ * committed tree for anyone running the sources directly.
+ */
+
+test('composer retains PHP 8.1 test support while allowing modern Pest releases', function () {
+	$composer = json_decode(
+		file_get_contents(CACTI_PATH_BASE . '/composer.json'),
+		true,
+		512,
+		JSON_THROW_ON_ERROR
+	);
+
+	expect($composer['require-dev']['pestphp/pest'])->toContain('^2')
+		->toContain('^3')
+		->and($composer['require-dev']['pestphp/pest-plugin-drift'])->toContain('^2')
+		->toContain('^3');
+});


### PR DESCRIPTION
PHP 8.5 deprecation notices from the bundled GoogleAuthenticator and from two tests. Replaces the deprecated calls with their supported equivalents.

No behaviour change; the notices were the only symptom.

Closes #7646.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
