### PR TITLE
Add indexes for host-template and session lookups

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -324,6 +324,7 @@ Cacti CHANGELOG
 -feature#7368: Add a Cacti-native form API and migrate the Site editor
 -feature#7370: Allow plugins to register process tables for the technical support view
 -feature#7372: Add installer domain foundation types and lifecycle tests
+-feature#7634: Add indexes for host-template and session lookup queries
 
 1.2.x
 -issue#7212: Address a few small memory leaks in realtime graphing

--- a/cacti.sql
+++ b/cacti.sql
@@ -3266,7 +3266,9 @@ CREATE TABLE `sessions` (
   `user_agent` varchar(128) NOT NULL default '',
   `start_time` timestamp NOT NULL default current_timestamp,
   `transactions` int(10) unsigned NOT NULL default '1',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `user_id` (`user_id`),
+  KEY `access` (`access`)
 ) ENGINE=InnoDB ROW_FORMAT=Dynamic COMMENT='Used for Database based Session Storage';
 
 --

--- a/cacti.sql
+++ b/cacti.sql
@@ -2072,6 +2072,7 @@ CREATE TABLE `host` (
   created timestamp default CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
   KEY poller_id_disabled (poller_id, disabled),
+  KEY host_template_id (host_template_id),
   KEY external_id (external_id),
   KEY disabled (disabled),
   KEY status (status),

--- a/docs/audit_schema.sql
+++ b/docs/audit_schema.sql
@@ -1527,6 +1527,7 @@ INSERT INTO `table_indexes` VALUES ('graph_tree_items',1,'site_id',1,'site_id','
 INSERT INTO `table_indexes` VALUES ('host',1,'current_errors',1,'current_errors','A',1,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('host',1,'disabled',1,'disabled','A',1,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('host',1,'external_id',1,'external_id','A',1,NULL,NULL,'YES','BTREE','');
+INSERT INTO `table_indexes` VALUES ('host',1,'host_template_id',1,'host_template_id','A',1,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('host',1,'hostname',1,'hostname','A',1,NULL,NULL,'YES','BTREE','');
 INSERT INTO `table_indexes` VALUES ('host',1,'poller_id_disabled',1,'poller_id','A',1,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('host',1,'poller_id_disabled',2,'disabled','A',1,NULL,NULL,'','BTREE','');
@@ -1653,7 +1654,9 @@ INSERT INTO `table_indexes` VALUES ('reports_log',1,'source_id',1,'source_id','A
 INSERT INTO `table_indexes` VALUES ('reports_queued',0,'PRIMARY',1,'id','A',0,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('reports_queued',1,'source',1,'source','A',0,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('reports_queued',1,'source_id',1,'source_id','A',0,NULL,NULL,'','BTREE','');
+INSERT INTO `table_indexes` VALUES ('sessions',1,'access',1,'access','A',0,NULL,NULL,'YES','BTREE','');
 INSERT INTO `table_indexes` VALUES ('sessions',0,'PRIMARY',1,'id','A',0,NULL,NULL,'','BTREE','');
+INSERT INTO `table_indexes` VALUES ('sessions',1,'user_id',1,'user_id','A',0,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('settings',0,'PRIMARY',1,'name','A',285,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('settings_tree',0,'PRIMARY',1,'user_id','A',0,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('settings_tree',0,'PRIMARY',2,'graph_tree_item_id','A',0,NULL,NULL,'','BTREE','');

--- a/docs/audit_schema.sql
+++ b/docs/audit_schema.sql
@@ -700,7 +700,7 @@ INSERT INTO `table_columns` VALUES ('graph_tree_items',12,'host_regex','varchar(
 INSERT INTO `table_columns` VALUES ('host',1,'id','mediumint(8) unsigned','NO','PRI',NULL,'auto_increment');
 INSERT INTO `table_columns` VALUES ('host',2,'poller_id','int(10) unsigned','NO','MUL','1','');
 INSERT INTO `table_columns` VALUES ('host',3,'site_id','int(10) unsigned','NO','MUL','1','');
-INSERT INTO `table_columns` VALUES ('host',4,'host_template_id','mediumint(8) unsigned','NO','','0','');
+INSERT INTO `table_columns` VALUES ('host',4,'host_template_id','mediumint(8) unsigned','NO','MUL','0','');
 INSERT INTO `table_columns` VALUES ('host',5,'description','varchar(150)','NO','','','');
 INSERT INTO `table_columns` VALUES ('host',6,'hostname','varchar(100)','YES','MUL',NULL,'');
 INSERT INTO `table_columns` VALUES ('host',7,'location','varchar(40)','YES','',NULL,'');
@@ -1081,9 +1081,9 @@ INSERT INTO `table_columns` VALUES ('rrdcheck',2,'test_date','timestamp','NO',''
 INSERT INTO `table_columns` VALUES ('rrdcheck',3,'message','varchar(250)','YES','','','');
 INSERT INTO `table_columns` VALUES ('sessions',1,'id','varchar(32)','NO','PRI',NULL,'');
 INSERT INTO `table_columns` VALUES ('sessions',2,'remote_addr','varchar(25)','NO','','','');
-INSERT INTO `table_columns` VALUES ('sessions',3,'access','int(10) unsigned','YES','',NULL,'');
+INSERT INTO `table_columns` VALUES ('sessions',3,'access','int(10) unsigned','YES','MUL',NULL,'');
 INSERT INTO `table_columns` VALUES ('sessions',4,'data','mediumblob','YES','',NULL,'');
-INSERT INTO `table_columns` VALUES ('sessions',5,'user_id','int(10) unsigned','NO','','0','');
+INSERT INTO `table_columns` VALUES ('sessions',5,'user_id','int(10) unsigned','NO','MUL','0','');
 INSERT INTO `table_columns` VALUES ('sessions',6,'user_agent','varchar(128)','NO','','','');
 INSERT INTO `table_columns` VALUES ('sessions',7,'start_time','timestamp','NO','','current_timestamp()','');
 INSERT INTO `table_columns` VALUES ('sessions',8,'transactions','int(10) unsigned','NO','','1','');

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -87,6 +87,7 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_key('data_input_data', 'INDEX', 'host_id', ['host_id']);
 
 	db_install_add_key('poller_output_boost', 'INDEX', 'time', ['time']);
+	db_install_add_key('host', 'INDEX', 'host_template_id', ['host_template_id']);
 	db_install_add_key('sessions', 'INDEX', 'user_id', ['user_id']);
 	db_install_add_key('sessions', 'INDEX', 'access', ['access']);
 

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -87,6 +87,8 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_key('data_input_data', 'INDEX', 'host_id', ['host_id']);
 
 	db_install_add_key('poller_output_boost', 'INDEX', 'time', ['time']);
+	db_install_add_key('sessions', 'INDEX', 'user_id', ['user_id']);
+	db_install_add_key('sessions', 'INDEX', 'access', ['access']);
 
 	// poller_output_boost_local_data_ids is a MEMORY table; its indexes default
 	// to HASH unless USING BTREE is specified. Range/ORDER BY access against

--- a/tests/Unit/SessionLookupIndexTest.php
+++ b/tests/Unit/SessionLookupIndexTest.php
@@ -15,16 +15,20 @@ use PHPUnit\Framework\TestCase;
 final class SessionLookupIndexTest extends TestCase {
 	private string $schema;
 	private string $upgrade;
+	private string $audit;
 
 	protected function setUp(): void {
 		$schema  = file_get_contents(__DIR__ . '/../../cacti.sql');
 		$upgrade = file_get_contents(__DIR__ . '/../../install/upgrades/1_3_0.php');
+		$audit   = file_get_contents(__DIR__ . '/../../docs/audit_schema.sql');
 
 		$this->assertIsString($schema, 'Unable to read cacti.sql');
 		$this->assertIsString($upgrade, 'Unable to read the 1.3.0 upgrade');
+		$this->assertIsString($audit, 'Unable to read docs/audit_schema.sql');
 
 		$this->schema  = $schema;
 		$this->upgrade = $upgrade;
+		$this->audit   = $audit;
 	}
 
 	public function testFreshInstallSchemaIndexesSessionInvalidationAndGarbageCollectionColumns(): void {
@@ -53,6 +57,39 @@ final class SessionLookupIndexTest extends TestCase {
 		$this->assertStringContainsString(
 			"db_install_add_key('host', 'INDEX', 'host_template_id', ['host_template_id']);",
 			$this->upgrade
+		);
+	}
+
+	// audit_database.php compares each column's Key attribute; indexing a column
+	// flips it to MUL, so the audit_schema.sql table_columns rows must record it
+	// or the schema audit fails on host and sessions.
+	public function testAuditSchemaMarksIndexedColumnsAsKeyed(): void {
+		$this->assertStringContainsString(
+			"INSERT INTO `table_columns` VALUES ('host',4,'host_template_id','mediumint(8) unsigned','NO','MUL','0','');",
+			$this->audit
+		);
+		$this->assertStringContainsString(
+			"INSERT INTO `table_columns` VALUES ('sessions',3,'access','int(10) unsigned','YES','MUL',NULL,'');",
+			$this->audit
+		);
+		$this->assertStringContainsString(
+			"INSERT INTO `table_columns` VALUES ('sessions',5,'user_id','int(10) unsigned','NO','MUL','0','');",
+			$this->audit
+		);
+	}
+
+	public function testAuditSchemaRecordsTheNewIndexes(): void {
+		$this->assertStringContainsString(
+			"INSERT INTO `table_indexes` VALUES ('host',1,'host_template_id',1,'host_template_id','A',1,NULL,NULL,'','BTREE','');",
+			$this->audit
+		);
+		$this->assertStringContainsString(
+			"INSERT INTO `table_indexes` VALUES ('sessions',1,'user_id',1,'user_id','A',0,NULL,NULL,'','BTREE','');",
+			$this->audit
+		);
+		$this->assertStringContainsString(
+			"INSERT INTO `table_indexes` VALUES ('sessions',1,'access',1,'access','A',0,NULL,NULL,'YES','BTREE','');",
+			$this->audit
 		);
 	}
 }

--- a/tests/Unit/SessionLookupIndexTest.php
+++ b/tests/Unit/SessionLookupIndexTest.php
@@ -18,9 +18,9 @@ final class SessionLookupIndexTest extends TestCase {
 	private string $audit;
 
 	protected function setUp(): void {
-		$schema  = file_get_contents(__DIR__ . '/../../cacti.sql');
-		$upgrade = file_get_contents(__DIR__ . '/../../install/upgrades/1_3_0.php');
-		$audit   = file_get_contents(__DIR__ . '/../../docs/audit_schema.sql');
+		$schema  = file_get_contents(CACTI_PATH_BASE . '/cacti.sql');
+		$upgrade = file_get_contents(CACTI_PATH_BASE . '/install/upgrades/1_3_0.php');
+		$audit   = file_get_contents(CACTI_PATH_BASE . '/docs/audit_schema.sql');
 
 		$this->assertIsString($schema, 'Unable to read cacti.sql');
 		$this->assertIsString($upgrade, 'Unable to read the 1.3.0 upgrade');

--- a/tests/Unit/SessionLookupIndexTest.php
+++ b/tests/Unit/SessionLookupIndexTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+use PHPUnit\Framework\TestCase;
+
+final class SessionLookupIndexTest extends TestCase {
+	private string $schema;
+	private string $upgrade;
+
+	protected function setUp(): void {
+		$this->schema  = file_get_contents(__DIR__ . '/../../cacti.sql');
+		$this->upgrade = file_get_contents(__DIR__ . '/../../install/upgrades/1_3_0.php');
+
+		$this->assertIsString($this->schema);
+		$this->assertIsString($this->upgrade);
+	}
+
+	public function testFreshInstallSchemaIndexesSessionInvalidationAndGarbageCollectionColumns(): void {
+		$this->assertMatchesRegularExpression(
+			'/CREATE TABLE `sessions` \(.*?KEY `user_id` \(`user_id`\).*?KEY `access` \(`access`\).*?\) ENGINE=/s',
+			$this->schema
+		);
+	}
+
+	public function testUpgradeAddsSessionIndexesIdempotentlyThroughInstallerHelpers(): void {
+		$this->assertStringContainsString(
+			"db_install_add_key('sessions', 'INDEX', 'user_id', ['user_id']);",
+			$this->upgrade
+		);
+		$this->assertStringContainsString(
+			"db_install_add_key('sessions', 'INDEX', 'access', ['access']);",
+			$this->upgrade
+		);
+	}
+}

--- a/tests/Unit/SessionLookupIndexTest.php
+++ b/tests/Unit/SessionLookupIndexTest.php
@@ -23,6 +23,13 @@ final class SessionLookupIndexTest extends TestCase {
 		);
 	}
 
+	public function testFreshInstallSchemaIndexesHostTemplateFiltering(): void {
+		$this->assertMatchesRegularExpression(
+			'/CREATE TABLE `host` \(.*?KEY host_template_id \(host_template_id\).*?\) ENGINE=/s',
+			$this->schema
+		);
+	}
+
 	public function testUpgradeAddsSessionIndexesIdempotentlyThroughInstallerHelpers(): void {
 		$this->assertStringContainsString(
 			"db_install_add_key('sessions', 'INDEX', 'user_id', ['user_id']);",
@@ -30,6 +37,10 @@ final class SessionLookupIndexTest extends TestCase {
 		);
 		$this->assertStringContainsString(
 			"db_install_add_key('sessions', 'INDEX', 'access', ['access']);",
+			$this->upgrade
+		);
+		$this->assertStringContainsString(
+			"db_install_add_key('host', 'INDEX', 'host_template_id', ['host_template_id']);",
 			$this->upgrade
 		);
 	}

--- a/tests/Unit/SessionLookupIndexTest.php
+++ b/tests/Unit/SessionLookupIndexTest.php
@@ -1,4 +1,12 @@
 <?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ +-------------------------------------------------------------------------+
+ */
 
 declare(strict_types = 1);
 
@@ -9,11 +17,14 @@ final class SessionLookupIndexTest extends TestCase {
 	private string $upgrade;
 
 	protected function setUp(): void {
-		$this->schema  = file_get_contents(__DIR__ . '/../../cacti.sql');
-		$this->upgrade = file_get_contents(__DIR__ . '/../../install/upgrades/1_3_0.php');
+		$schema  = file_get_contents(__DIR__ . '/../../cacti.sql');
+		$upgrade = file_get_contents(__DIR__ . '/../../install/upgrades/1_3_0.php');
 
-		$this->assertIsString($this->schema);
-		$this->assertIsString($this->upgrade);
+		$this->assertIsString($schema, 'Unable to read cacti.sql');
+		$this->assertIsString($upgrade, 'Unable to read the 1.3.0 upgrade');
+
+		$this->schema  = $schema;
+		$this->upgrade = $upgrade;
 	}
 
 	public function testFreshInstallSchemaIndexesSessionInvalidationAndGarbageCollectionColumns(): void {


### PR DESCRIPTION
Two lookups were doing full scans. Adds the covering indexes and the matching 1.3.0 upgrade step.

Closes #7644.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
