### PR TITLE
Escape database sourced names in report and package export output

### DIFF
--- a/lib/reports.php
+++ b/lib/reports.php
@@ -1421,22 +1421,22 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 			}
 
 			if (!empty($tree_name) && empty($leaf_name) && empty($host_name)) {
-				$title           = $title_delimiter . __('Tree:') . " $tree_name";
+				$title           = $title_delimiter . __('Tree:') . ' ' . htmle($tree_name);
 				$title_delimiter = ' > ';
 			}
 
 			if (!empty($leaf_name)) {
-				$title .= $title_delimiter . " $leaf_name";
+				$title .= $title_delimiter . ' ' . htmle($leaf_name);
 				$title_delimiter = ' > ';
 			}
 
 			if (!empty($host_name)) {
-				$title .= $title_delimiter . " $host_name";
+				$title .= $title_delimiter . ' ' . htmle($host_name);
 				$title_delimiter = ' > ';
 			}
 
 			if (!empty($graph_name) && !$nested) {
-				$title .= $title_delimiter . " $graph_name";
+				$title .= $title_delimiter . ' ' . htmle($graph_name);
 				$title_delimiter = ' > ';
 			}
 
@@ -1674,11 +1674,11 @@ function reports_expand_tree(array &$report, array $item, int $parent, int $outp
 									$outstr .= "\t\t<tr class='text_row'>" . PHP_EOL;
 
 									if ($format_ok) {
-										$outstr .= "\t\t\t<td class='text'>" . __('Data Query:') . ' ' . $data_query['name'] . PHP_EOL;
+										$outstr .= "\t\t\t<td class='text'>" . __('Data Query:') . ' ' . htmle($data_query['name']) . PHP_EOL;
 										$outstr .= "\t\t\t</td>" . PHP_EOL;
 										$outstr .= "\t\t</tr>" . PHP_EOL;
 									} else {
-										$outstr .= "\t\t\t<td class='text' style='text-align:" . $alignment[$item['align']] . ';font-size: ' . $item['font_size'] . "pt;'>" . __('Data Query:') . ' ' . $data_query['name'] . PHP_EOL;
+										$outstr .= "\t\t\t<td class='text' style='text-align:" . $alignment[$item['align']] . ';font-size: ' . $item['font_size'] . "pt;'>" . __('Data Query:') . ' ' . htmle($data_query['name']) . PHP_EOL;
 										$outstr .= "\t\t\t</td>" . PHP_EOL;
 										$outstr .= "\t\t</tr>" . PHP_EOL;
 									}

--- a/package.php
+++ b/package.php
@@ -438,7 +438,7 @@ function export() : void {
 		<tr>
 			<td class='saveRow'>
 				<input type='hidden' name='action' value='save'>
-				<input type='hidden' id='name' name='name' value='<?php print $detail['name']; ?>'>
+				<input type='hidden' id='name' name='name' value='<?php print htmle($detail['name']); ?>'>
 				<button class='export ui-button ui-corner-all ui-widget ui-state-active' type='submit'><?php print __('Package'); ?></button>
 			</td>
 		</tr>

--- a/tests/Unit/ReportsOutputEncodingTest.php
+++ b/tests/Unit/ReportsOutputEncodingTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Regression test for GHSA-mgcq-r6vm-4xhw and GHSA-pc79-jxf4-wmqr.
+ *
+ * Report rendering and the package export form emitted database sourced names
+ * straight into HTML.  reports_expand_device() already escaped its device
+ * description, so the unescaped siblings in reports_expand_tree() were an
+ * oversight rather than a deliberate exception; they are covered here too.
+ *
+ * @group regression
+ */
+
+$reportsPath = dirname(__DIR__, 2) . '/lib/reports.php';
+$packagePath = dirname(__DIR__, 2) . '/package.php';
+
+test('the data query name is escaped in both report rendering branches', function () use ($reportsPath) {
+	$source = file_get_contents($reportsPath);
+
+	expect($source)->not->toMatch("/' ' \. \\\$data_query\['name'\]/");
+	expect(substr_count($source, "htmle(\$data_query['name'])"))->toBe(2);
+});
+
+test('every tree title component is escaped as it is built', function () use ($reportsPath) {
+	$source = file_get_contents($reportsPath);
+
+	foreach (['tree_name', 'leaf_name', 'host_name', 'graph_name'] as $part) {
+		expect($source)->not->toMatch('/\$title_delimiter \. " \$' . $part . '"/');
+		expect($source)->toContain("htmle(\$$part)");
+	}
+});
+
+test('the package export form escapes the object name', function () use ($packagePath) {
+	$source = file_get_contents($packagePath);
+
+	expect($source)->not->toMatch("/value='<\?php print \\\$detail\['name'\]; \?>'/");
+	expect($source)->toContain("print htmle(\$detail['name'])");
+});
+
+test('the escaping helper neutralises both quote styles and script tags', function () {
+	require_once dirname(__DIR__, 2) . '/lib/html.php';
+
+	$payload = '\'"><script>alert(1)</script>';
+	$escaped = htmle($payload);
+
+	expect($escaped)->not->toContain('<script');
+	expect($escaped)->not->toContain('"');
+	expect($escaped)->not->toContain("'");
+});


### PR DESCRIPTION
Report rendering and the package export form emitted database sourced names straight into HTML.

`lib/reports.php` concatenated `$data_query['name']` into the report body in both the plain and styled branches. `package.php` printed `$detail['name']` into a hidden input value; `html_escape()` uses `ENT_QUOTES`, so the single-quoted attribute is covered.

While fixing those I checked the rest of `reports_expand_tree()`, because the sibling `reports_expand_device()` already escapes its device description at line 1207. Four more values in the same function reached `<h3>$title</h3>` unescaped: `graph_tree.name`, `graph_tree_items.title`, `host.description` and `graph_templates_graph.title_cache`. Given the neighbouring function escapes and these do not, this reads as an oversight rather than a deliberate exception, so they are escaped here too.

No new functions, so there is no new module for a coverage gate to sit on. The regression test pins each call site and asserts the escaping helper neutralises both quote styles.

Verification: 4 tests / 15 assertions pass. Security sink and architectural hotspot gates clean, php-cs-fixer clean.
