### PR TITLE
security: run rrdtool without a shell (argv contract)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -147,6 +147,7 @@ Cacti CHANGELOG
 -issue#7719: Spike Kill text output applied the large value scientific notation format to the column left of the value it belonged to, starting with Variance
 -issue#7732: Bind device IDs and escape graph and device HTML sinks
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
+-issue#7664: Execute RRDtool commands through an argument-vector contract
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect
 -issue#7469: Escape path_php_binary before it reaches shell_exec in test_data_source

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -352,6 +352,101 @@ function rrdtool_execute() : mixed {
 }
 
 /**
+ * Run a single RRDtool command over a pipe without a shell.
+ *
+ * an argument-array proc_open executes rrdtool directly (execvp), never
+ * through /bin/sh, so shell metacharacters in $command_line cannot spawn a
+ * subprocess. The command is delivered on stdin using rrdtool's '-' mode, the
+ * same line protocol the persistent pipe uses. stderr is read on its own
+ * descriptor and appended to the return value only when $want_stderr is set,
+ * which replaces the former ' 2>&1' shell redirect.
+ *
+ * @param string $rrdtool_path Path to the rrdtool executable.
+ * @param string $command_line The assembled RRDtool command; no shell quoting needed.
+ * @param bool   $want_stderr  Fold stderr into the returned output.
+ *
+ * @return string|false Command output, or false if the process could not start.
+ */
+function rrd_execute_pipe(string $rrdtool_path, string $command_line, bool $want_stderr): string|false {
+	$command_line = rrd_strip_control_chars($command_line);
+
+	$descriptorspec = [
+		0 => ['pipe', 'r'],
+		1 => ['pipe', 'w'],
+		2 => ['pipe', 'w'],
+	];
+
+	// Suppression is intentional: a missing/invalid rrdtool path makes proc_open
+	// warn, but the false return is handled here and logged by the caller.
+	$process = @proc_open([$rrdtool_path, '-'], $descriptorspec, $pipes);
+
+	if (!is_resource($process)) {
+		return false;
+	}
+
+	fwrite($pipes[0], $command_line . "\r\nquit\r\n");
+	fclose($pipes[0]);
+
+	/* Drain stdout and stderr concurrently. Reading one to EOF before the other
+	 * can deadlock: rrdtool may block writing a full stderr buffer while the
+	 * parent waits on stdout (or vice versa). */
+	stream_set_blocking($pipes[1], false);
+	stream_set_blocking($pipes[2], false);
+
+	$stdout = '';
+	$stderr = '';
+	$open   = [1 => $pipes[1], 2 => $pipes[2]];
+
+	while (!empty($open)) {
+		$read   = array_values($open);
+		$write  = [];
+		$except = [];
+
+		if (@stream_select($read, $write, $except, null) === false) {
+			break;
+		}
+
+		foreach ($read as $stream) {
+			$chunk = fread($stream, 8192);
+
+			if ($chunk !== false && $chunk !== '') {
+				if ($stream === $pipes[1]) {
+					$stdout .= $chunk;
+				} else {
+					$stderr .= $chunk;
+				}
+			}
+
+			if (feof($stream)) {
+				$key = ($stream === $pipes[1]) ? 1 : 2;
+				fclose($stream);
+				unset($open[$key]);
+			}
+		}
+	}
+
+	foreach ($open as $stream) {
+		fclose($stream);
+	}
+
+	$exit_code = proc_close($process);
+
+	/* On PHP versions before 8.3, opening the process with an array command
+	 * defers a missing or non-executable binary to the child, which exits
+	 * 126/127 with no output instead of failing up front. Treat those codes as
+	 * a failure to run rrdtool so the result is false on every supported PHP. */
+	if ($exit_code === 126 || $exit_code === 127) {
+		return false;
+	}
+
+	if ($want_stderr && is_string($stderr) && $stderr !== '') {
+		$stdout .= $stderr;
+	}
+
+	return $stdout;
+}
+
+/**
  * Execute an RRDtool command and return the output.
  *
  * @param string|array $command_line  The RRDtool command to execute.  An array is quoted here,
@@ -390,12 +485,12 @@ function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $out
 	// output information to the log file if appropriate
 	cacti_log('CACTI2RRD: ' . read_config_option('path_rrdtool') . " $command_line", $log_to_stdout, $logopt, POLLER_VERBOSITY_DEBUG);
 
-	// if we want to see the error output from rrdtool; make sure to specify this
-	$debug = '';
+	// fold rrdtool's stderr into the returned output only when the caller asked for it
+	$want_stderr = false;
 
 	if (CACTI_SERVER_OS != 'win32') {
 		if (($output_flag == RRDTOOL_OUTPUT_STDERR || $output_flag == RRDTOOL_OUTPUT_RETURN_STDERR) && !is_resource($rrdtool_pipe)) {
-			$debug .= ' 2>&1';
+			$want_stderr = true;
 		}
 	}
 
@@ -419,61 +514,22 @@ function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $out
 		cacti_session_close();
 
 		if (is_file(read_config_option('path_rrdtool')) && is_executable(read_config_option('path_rrdtool'))) {
-			$descriptorspec = [
-				0 => ['pipe', 'r'],
-				1 => ['pipe', 'w']
-			];
-
 			if (CACTI_WEB) {
 				cacti_time_zone_set();
 			}
 
 			$attempts = 0;
 
-			$full_commandline = read_config_option('path_rrdtool') . $debug . ' ' . $command_line;
-
 			while ($attempts < 5) {
-				if (0 == 1) { // @phpstan-ignore-line
-					/**
-					 * For debugging issue associated with RRDtool, for now I'm commenting out this line
-					 * There are issues processing graphv output with the --add-jsontime option when
-					 * rrdtool is launched in the background.
-					 *
-					 * The reason for this difference is still to be determined.
-					 *
-					 * cacti_log($command_line);
-					 */
-					$process = proc_open(read_config_option('path_rrdtool') . ' - ' . $debug, $descriptorspec, $pipes);
+				/* Execute without a shell. rrd_execute_pipe() runs rrdtool via
+				 * an argument-array proc_open and feeds the command on
+				 * stdin, so shell metacharacters in the command are inert. */
+				$output = rrd_execute_pipe(read_config_option('path_rrdtool'), $command_line, $want_stderr);
 
-					if (!is_resource($process)) {
-						$attempts++;
+				if ($output === false) {
+					$attempts++;
 
-						unset($process);
-					} else {
-						fwrite($pipes[0], $command_line . "\r\nquit\r\n");
-						fclose($pipes[0]);
-						$fp = $pipes[1];
-					}
-
-					if (!isset($fp)) {
-						rrdtool_reset_language();
-
-						return 'Error';
-					}
-
-					// get the output regardless of the output type
-					$output = '';
-
-					while (!feof($fp)) {
-						$output .= fgets($fp, 10000);
-					}
-
-					if (isset($process)) {
-						fclose($fp);
-						proc_close($process);
-					}
-				} else {
-					$output = shell_exec($full_commandline);
+					continue;
 				}
 
 				if ($output_flag == RRDTOOL_OUTPUT_STDOUT || $output_flag == RRDTOOL_OUTPUT_GRAPH_DATA) {

--- a/tests/Unit/RrdControlCharTest.php
+++ b/tests/Unit/RrdControlCharTest.php
@@ -42,6 +42,7 @@ test('newline in a DS field cannot split the shell command line', function () {
 
 test('all C0 controls and DEL are removed, printable bytes kept', function () {
 	$controls = '';
+
 	for ($i = 0; $i <= 0x1f; $i++) {
 		$controls .= chr($i);
 	}
@@ -51,7 +52,7 @@ test('all C0 controls and DEL are removed, printable bytes kept', function () {
 	// NUL specifically
 	expect(rrd_strip_control_chars("path\x00.rrd"))->toBe('path.rrd');
 	// legitimate command text is untouched
-	$cmd = "graph - --imgformat=PNG DEF:a=/rra/x.rrd:ds:AVERAGE LINE1:a#00FF00:\"Traffic\"";
+	$cmd = 'graph - --imgformat=PNG DEF:a=/rra/x.rrd:ds:AVERAGE LINE1:a#00FF00:"Traffic"';
 	expect(rrd_strip_control_chars($cmd))->toBe($cmd);
 });
 
@@ -62,10 +63,10 @@ test('always returns a string, even on empty and multibyte input', function () {
 	expect(rrd_strip_control_chars("t\xC3\xA9st\ndata"))->toBe("t\xC3\xA9stdata");
 });
 
-test('both the local and proxy execute paths sanitize the command line', function () {
+test('the local, proxy, and pipe primitives sanitize the command line', function () {
 	$src = file_get_contents(dirname(__DIR__, 2) . '/lib/rrd.php');
 
-	// __rrd_execute() (local pipe/shell) and __rrd_proxy_execute() (rrdp proxy)
-	// must both pass the assembled command through the stripper before it is sent.
-	expect(substr_count($src, '$command_line = rrd_strip_control_chars($command_line);'))->toBeGreaterThanOrEqual(2);
+	// The high-level local/proxy paths and the low-level pipe primitive must all
+	// strip controls before a line is sent to an RRDtool protocol endpoint.
+	expect(substr_count($src, '$command_line = rrd_strip_control_chars($command_line);'))->toBeGreaterThanOrEqual(3);
 });

--- a/tests/Unit/RrdExecutePipeTest.php
+++ b/tests/Unit/RrdExecutePipeTest.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Unit coverage for rrd_execute_pipe(): the no-shell execution primitive behind
+ * the rrdtool argv contract. A shell-script test double stands in for rrdtool.
+ */
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once CACTI_PATH_LIBRARY . '/rrd.php';
+
+function _fake_rrdtool(): string {
+	return dirname(__DIR__) . '/integration/fixtures/fake_rrdtool.sh';
+}
+
+test('returns false when the rrdtool executable cannot be run', function () {
+	// proc_open() warns on a missing binary; the function handles the false
+	// return, so swallow the expected warning (the '@' operator is ignored by
+	// the test runner's error handler).
+	set_error_handler(static function () {
+		return true;
+	});
+
+	try {
+		$out = rrd_execute_pipe('/nonexistent/path/to/rrdtool', 'info /x.rrd', false);
+	} finally {
+		restore_error_handler();
+	}
+
+	expect($out)->toBeFalse();
+});
+
+test('returns stdout from the process', function () {
+	$out = rrd_execute_pipe(_fake_rrdtool(), 'info /x.rrd', false);
+
+	expect($out)->toContain('FAKERRD-OK');
+});
+
+test('control characters cannot inject a second stdin command', function () {
+	$stdinFile = tempnam(sys_get_temp_dir(), 'rrdpipe');
+	putenv('FAKE_RRD_STDIN_FILE=' . $stdinFile);
+
+	try {
+		rrd_execute_pipe(_fake_rrdtool(), "info /x.rrd\r\nfetch /other.rrd AVERAGE\0", false);
+		$stdin = (string) file_get_contents($stdinFile);
+
+		expect($stdin)->not->toContain("\nfetch")
+			->and($stdin)->not->toContain("\0")
+			->and($stdin)->toContain('info /x.rrdfetch /other.rrd AVERAGE')
+			->and($stdin)->toEndWith("\r\nquit\r\n");
+	} finally {
+		putenv('FAKE_RRD_STDIN_FILE');
+
+		if (is_string($stdinFile) && file_exists($stdinFile)) {
+			unlink($stdinFile);
+		}
+	}
+});
+
+test('stderr is excluded unless requested', function () {
+	putenv('FAKE_RRD_STDERR=a warning line');
+
+	try {
+		$without = rrd_execute_pipe(_fake_rrdtool(), 'info /x.rrd', false);
+		$with    = rrd_execute_pipe(_fake_rrdtool(), 'info /x.rrd', true);
+
+		expect($without)->not->toContain('a warning line');
+		expect($with)->toContain('a warning line');
+	} finally {
+		putenv('FAKE_RRD_STDERR');
+	}
+});

--- a/tests/Unit/Security/Shell/RrdEscapeCommandRemovalTest.php
+++ b/tests/Unit/Security/Shell/RrdEscapeCommandRemovalTest.php
@@ -20,7 +20,7 @@ declare(strict_types = 1);
  * @group regression
  */
 
-$rrdPath = dirname(__DIR__, 4) . '/lib/rrd.php';
+$rrdPath = CACTI_PATH_LIBRARY . '/rrd.php';
 
 test('escape_command is gone from lib/rrd.php', function () use ($rrdPath) {
 	$source = file_get_contents($rrdPath);
@@ -32,7 +32,7 @@ test('escape_command is gone from lib/rrd.php', function () use ($rrdPath) {
 test('escape_command is not redefined elsewhere under lib', function () {
 	$found = [];
 
-	foreach (glob(dirname(__DIR__, 4) . '/lib/*.php') as $file) {
+	foreach (glob(CACTI_PATH_LIBRARY . '/*.php') as $file) {
 		if (preg_match('/function\s+escape_command\s*\(/', file_get_contents($file))) {
 			$found[] = basename($file);
 		}
@@ -47,11 +47,16 @@ test('__rrd_execute escapes array arguments one at a time', function () use ($rr
 	expect($source)->toContain("\$command_line = implode(' ', array_map('cacti_escapeshellarg', \$command_line));");
 });
 
-test('the shell_exec command line is assembled without a whole-command escape', function () use ($rrdPath) {
+test('the one-shot rrdtool sink runs without a shell', function () use ($rrdPath) {
 	$source = file_get_contents($rrdPath);
 
-	expect($source)->toContain("\$full_commandline = read_config_option('path_rrdtool') . \$debug . ' ' . \$command_line;");
-	expect($source)->toContain('$output = shell_exec($full_commandline);');
+	// The shell path is gone: no shell_exec, no assembled whole-command string.
+	expect($source)->not->toContain('shell_exec(');
+	expect($source)->not->toContain('$full_commandline');
+
+	// rrdtool runs via proc_open() with an argument array (never /bin/sh) and
+	// the command is delivered on stdin, so shell metacharacters are inert.
+	expect($source)->toContain("proc_open([\$rrdtool_path, '-']");
 });
 
 test('the pipe writers pass the command line through untouched', function () use ($rrdPath) {

--- a/tests/integration/RrdArgvExecutionTest.php
+++ b/tests/integration/RrdArgvExecutionTest.php
@@ -1,0 +1,138 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * End-to-end coverage for the rrdtool argv contract. rrd_execute_pipe() runs a
+ * real subprocess (a shell-script rrdtool double) via proc_open() with an
+ * argument array. The double records the argv it received and the command it
+ * read on stdin, and never interprets the payload, so these tests prove that
+ * shell metacharacters in an rrdtool command cannot spawn a subprocess.
+ */
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once CACTI_PATH_LIBRARY . '/rrd.php';
+
+function _rrd_argv_fake(): string {
+	return __DIR__ . '/fixtures/fake_rrdtool.sh';
+}
+
+/* Run $fn with PHP warnings swallowed. proc_open() warns on a missing binary
+ * and the test runner's error handler ignores the '@' operator, so this keeps
+ * the expected-warning cases from being flagged as risky. */
+function _rrd_silence(callable $fn) {
+	set_error_handler(static function () {
+		return true;
+	});
+
+	try {
+		return $fn();
+	} finally {
+		restore_error_handler();
+	}
+}
+
+function _rrd_unlink_if_exists(string $path): void {
+	if (file_exists($path)) {
+		unlink($path);
+	}
+}
+
+test('rrdtool is invoked with argv "-" only, never the command as arguments', function () {
+	$argvFile = tempnam(sys_get_temp_dir(), 'rrdargv');
+	putenv('FAKE_RRD_ARGV_FILE=' . $argvFile);
+
+	try {
+		rrd_execute_pipe(_rrd_argv_fake(), 'graph - --imgformat=PNG DEF:a=/x.rrd:d:AVERAGE', false);
+		$argv = array_values(array_filter(explode("\n", (string) file_get_contents($argvFile)), fn ($l) => $l !== ''));
+
+		expect($argv)->toBe(['-']);
+	} finally {
+		putenv('FAKE_RRD_ARGV_FILE');
+		_rrd_unlink_if_exists($argvFile);
+	}
+});
+
+test('the full command is delivered to rrdtool on stdin', function () {
+	$stdinFile = tempnam(sys_get_temp_dir(), 'rrdin');
+	putenv('FAKE_RRD_STDIN_FILE=' . $stdinFile);
+
+	try {
+		rrd_execute_pipe(_rrd_argv_fake(), 'info /rra/x.rrd', false);
+		$stdin = (string) file_get_contents($stdinFile);
+
+		expect($stdin)->toContain('info /rra/x.rrd');
+		expect($stdin)->toContain('quit');
+	} finally {
+		putenv('FAKE_RRD_STDIN_FILE');
+		_rrd_unlink_if_exists($stdinFile);
+	}
+});
+
+test('shell metacharacters in the command cannot execute (POC 08/14)', function () {
+	$marker = sys_get_temp_dir() . '/rrd_argv_marker_' . getmypid();
+	_rrd_unlink_if_exists($marker);
+
+	// If any shell interpreted the command, one of these would create $marker.
+	$payload = "graph -; touch $marker ; \$(touch $marker) ; `touch $marker`";
+	rrd_execute_pipe(_rrd_argv_fake(), $payload, false);
+
+	expect(file_exists($marker))->toBeFalse();
+	_rrd_unlink_if_exists($marker);
+});
+
+test('a newline-split payload cannot inject a second argv command', function () {
+	$marker = sys_get_temp_dir() . '/rrd_argv_nl_' . getmypid();
+	_rrd_unlink_if_exists($marker);
+
+	$payload = "info /rra/x.rrd\ntouch $marker";
+	rrd_execute_pipe(_rrd_argv_fake(), $payload, false);
+
+	// The double reads the whole payload on stdin and never runs it as a command.
+	expect(file_exists($marker))->toBeFalse();
+	_rrd_unlink_if_exists($marker);
+});
+
+test('large stdout and stderr are both captured without deadlock', function () {
+	// The double writes ~200 KB to each of stdout and stderr, well past a pipe
+	// buffer. Reading one stream to EOF before the other would hang here.
+	putenv('FAKE_RRD_STDOUT_BYTES=200000');
+	putenv('FAKE_RRD_STDERR_BYTES=200000');
+
+	try {
+		$out = rrd_execute_pipe(_rrd_argv_fake(), 'graph -', true);
+
+		expect(substr_count($out, 'A'))->toBeGreaterThanOrEqual(200000);
+		expect(substr_count($out, 'E'))->toBeGreaterThanOrEqual(200000);
+	} finally {
+		putenv('FAKE_RRD_STDOUT_BYTES');
+		putenv('FAKE_RRD_STDERR_BYTES');
+	}
+});
+
+test('stderr is folded into output only when requested', function () {
+	putenv('FAKE_RRD_STDERR=a diagnostic line');
+
+	try {
+		expect(rrd_execute_pipe(_rrd_argv_fake(), 'info /x.rrd', false))->not->toContain('a diagnostic line');
+		expect(rrd_execute_pipe(_rrd_argv_fake(), 'info /x.rrd', true))->toContain('a diagnostic line');
+	} finally {
+		putenv('FAKE_RRD_STDERR');
+	}
+});
+
+test('a non-existent rrdtool binary returns false', function () {
+	$rc = _rrd_silence(fn () => rrd_execute_pipe('/nonexistent/rrdtool', 'info /x.rrd', false));
+
+	expect($rc)->toBeFalse();
+});

--- a/tests/integration/fixtures/fake_rrdtool.sh
+++ b/tests/integration/fixtures/fake_rrdtool.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Test double for rrdtool used by the argv-contract tests. It records the argv
+# it was invoked with and the command it received on stdin, then echoes a fixed
+# marker. It never interprets the payload, so if the caller used a shell the
+# injected command would run before this script ever sees it.
+#
+# FAKE_RRD_STDOUT_BYTES=N   emit N bytes on stdout before the marker
+# FAKE_RRD_STDERR_BYTES=N   emit N bytes on stderr (large stderr for drain tests)
+# FAKE_RRD_STDERR=text      emit one line on stderr
+if [ -n "$FAKE_RRD_ARGV_FILE" ]; then
+	: > "$FAKE_RRD_ARGV_FILE"
+	for a in "$@"; do printf '%s\n' "$a" >> "$FAKE_RRD_ARGV_FILE"; done
+fi
+if [ -n "$FAKE_RRD_STDIN_FILE" ]; then
+	cat > "$FAKE_RRD_STDIN_FILE"
+else
+	cat > /dev/null
+fi
+if [ -n "$FAKE_RRD_STDERR_BYTES" ]; then
+	head -c "$FAKE_RRD_STDERR_BYTES" /dev/zero | tr '\0' 'E' >&2
+fi
+if [ -n "$FAKE_RRD_STDOUT_BYTES" ]; then
+	head -c "$FAKE_RRD_STDOUT_BYTES" /dev/zero | tr '\0' 'A'
+fi
+printf 'FAKERRD-OK\n'
+[ -n "$FAKE_RRD_STDERR" ] && printf '%s\n' "$FAKE_RRD_STDERR" >&2
+exit 0

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -74,9 +74,8 @@ cmd_exec	./lib/poller.php:56	 * @param array  $pipes               The array of 
 cmd_exec	./lib/poller.php:57	 * @param mixed  $proc_fd             The file descriptor returned from proc_open()
 cmd_exec	./lib/poller.php:89					$fp = popen($command, 'r');
 cmd_exec	./lib/poller.php:91					$fp = popen($command, 'rb');
-cmd_exec	./lib/rrd.php:1076					$fp = popen($rrd_cmd, 'r');
-cmd_exec	./lib/rrd.php:413						$process = proc_open(read_config_option('path_rrdtool') . ' - ' . $debug, $descriptorspec, $pipes);
-cmd_exec	./lib/rrd.php:443						$output = shell_exec($full_commandline);
+cmd_exec	./lib/rrd.php:1130					$fp = popen($rrd_cmd, 'r');
+cmd_exec	./lib/rrd.php:352		$process = @proc_open([$rrdtool_path, '-'], $descriptorspec, $pipes);
 cmd_exec	./lib/rrd.php:91		$process = popen($command, 'w');
 cmd_exec	./lib/rrdcheck.php:837		$process = proc_open($command, $fds, $pipes);
 cmd_exec	./lib/snmp.php:203			exec($command, $snmp_value, $return_var);
@@ -125,8 +124,8 @@ dynamic_include	./lib/installer.php:4110					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
 dynamic_include	./lib/renderer.php:138				include $__cacti_template_file;
-dynamic_include	./lib/rrd.php:3021			include($rrdtheme);
-dynamic_include	./lib/rrd.php:4573			include($themefile);
+dynamic_include	./lib/rrd.php:3075			include($rrdtheme);
+dynamic_include	./lib/rrd.php:4627			include($themefile);
 dynamic_include	./link.php:91					require_once($file);
 dynamic_include	./plugins.php:1832				require_once($setup_file);
 dynamic_include	./reports.php:35		require_once($reportit_api);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -74,9 +74,8 @@ cmd_exec	./lib/poller.php:56	 * @param array  $pipes               The array of 
 cmd_exec	./lib/poller.php:57	 * @param mixed  $proc_fd             The file descriptor returned from proc_open()
 cmd_exec	./lib/poller.php:89					$fp = popen($command, 'r');
 cmd_exec	./lib/poller.php:91					$fp = popen($command, 'rb');
-cmd_exec	./lib/rrd.php:1076					$fp = popen($rrd_cmd, 'r');
-cmd_exec	./lib/rrd.php:413						$process = proc_open(read_config_option('path_rrdtool') . ' - ' . $debug, $descriptorspec, $pipes);
-cmd_exec	./lib/rrd.php:443						$output = shell_exec($full_commandline);
+cmd_exec	./lib/rrd.php:1130					$fp = popen($rrd_cmd, 'r');
+cmd_exec	./lib/rrd.php:352		$process = @proc_open([$rrdtool_path, '-'], $descriptorspec, $pipes);
 cmd_exec	./lib/rrd.php:91		$process = popen($command, 'w');
 cmd_exec	./lib/rrdcheck.php:837		$process = proc_open($command, $fds, $pipes);
 cmd_exec	./lib/snmp.php:203			exec($command, $snmp_value, $return_var);
@@ -129,8 +128,8 @@ dynamic_include	./lib/installer.php:4110					include_once($upgrade_file);
 dynamic_include	./lib/plugins.php:96						include_once($full_path);
 dynamic_include	./lib/plugins.php:981			require_once($setup_file);
 dynamic_include	./lib/renderer.php:138				include $__cacti_template_file;
-dynamic_include	./lib/rrd.php:3021			include($rrdtheme);
-dynamic_include	./lib/rrd.php:4573			include($themefile);
+dynamic_include	./lib/rrd.php:3075			include($rrdtheme);
+dynamic_include	./lib/rrd.php:4627			include($themefile);
 dynamic_include	./link.php:91					require_once($file);
 dynamic_include	./plugins.php:1832				require_once($setup_file);
 dynamic_include	./reports.php:35		require_once($reportit_api);
@@ -197,7 +196,7 @@ fs_write	./lib/plugins.php:2378				$fh = fopen($file, 'w');
 fs_write	./lib/poller.php:1443									if (file_put_contents($tmpfile, $contents) !== false) {
 fs_write	./lib/poller.php:1450												file_put_contents($mypath, $contents);
 fs_write	./lib/poller.php:1479								file_put_contents($mypath, $contents);
-fs_write	./lib/rrd.php:2883					if ($fp = fopen($graph_data_array['export_realtime'], 'w')) {
+fs_write	./lib/rrd.php:2937					if ($fp = fopen($graph_data_array['export_realtime'], 'w')) {
 fs_write	./lib/spikekill.php:806			return file_put_contents($xmlfile, $output);
 fs_write	./package_import.php:226							file_put_contents($xmlfile, $data);
 fs_write	./package_import.php:497				file_put_contents($xmlfile, $_SESSION['sess_import_package']);


### PR DESCRIPTION
## Intent

Run rrdtool without a shell, closing shell-metacharacter command injection in the one-shot rrdtool path.

The one-shot sink assembled `path_rrdtool . ' ' . $command_line` and passed it to `shell_exec()`. Any shell metacharacter in a value that reached the command line (DS min/max, COMMENT/GPRINT/legend text, CDEF/VDEF, DS names, host/query substituted values) executed as the web user. The no-shell `proc_open` path beside it was dead code (`if (0 == 1)`).

## Change

`rrd_execute_pipe()` runs rrdtool via `proc_open()` with an **argument array**, which executes the binary directly (execvp) and never through `/bin/sh`, and delivers the command on stdin using rrdtool's `-` mode (the same line protocol the persistent pipe already uses). Shell metacharacters are inert because no shell is involved. stderr is captured on its own descriptor and folded into the output only when the caller requested it, replacing the former ` 2>&1` redirect. The dead `if (0 == 1)` branch, `$full_commandline`, and the `shell_exec()` call are removed.

## Tests

- Unit (`tests/Unit/RrdExecutePipeTest.php`): returns false on an unrunnable binary; returns stdout; stderr folded only when requested.
- Integration + e2e (`tests/integration/RrdArgvExecutionTest.php`, `fixtures/fake_rrdtool.sh`): a shell-script rrdtool double records its argv and stdin. Tests assert the argv is `-` only (the command is never passed as arguments), the full command arrives on stdin, and payloads with `;`, `$( )`, backticks, or embedded newlines create no side effect (no shell ran them).

## Risk / note for review

This changes the one-shot execution model. The old `if (0 == 1)` stdin branch carried a comment about graphv `--add-jsontime` output "when rrdtool is launched in the background." This path is synchronous (it reads stdout directly, not backgrounded), but please exercise graph, graphv/JSON export, fetch, xport, and info rendering before merge to confirm parity. Behavior is otherwise unchanged; the persistent-pipe path is untouched.


---

**Merge order:** this depends on #7615. Both rewrite the same rrdtool execution path in `lib/rrd.php` and they overlap by about 50 lines in `__rrd_execute()` / `rrdtool_execute()`, so whichever lands second needs a rebase. #7615 is the larger change (roughly 593 lines across ~25 functions), so it should go first and this one rebased onto it. Kept separate rather than folded in so the argv contract stays reviewable on its own.

For the record, this does **not** supersede #7663. Running rrdtool without a shell closes shell interpretation, but rrdtool's pipe protocol is line based, so a CR or LF inside a field value still splits one command into two. #7663 strips those, and also covers `__rrd_proxy_execute()`, which is a different transport. The two are complementary and do not overlap by line.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
