### PR TITLE
security: confine rrd data source paths to the RRA directory

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -158,6 +158,7 @@ Cacti CHANGELOG
 -issue#7646: Remove PHP 8.5 reflection and authenticator deprecations
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
 -issue#7701: Confine names used as SQL identifiers in automation
+-issue#7665: Confine local RRD paths while preserving remote RRDProxy storage
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -1667,6 +1667,12 @@ function boost_rrdtool_function_create(int $local_data_id, bool $show_source, mi
 
 	$data_source_path = get_data_source_path($local_data_id, true);
 
+	if (!rrd_check_path($data_source_path)) {
+		cacti_log("ERROR: Refusing unsafe data source path '$data_source_path' for local_data_id $local_data_id", false, 'BOOST');
+
+		return false;
+	}
+
 	/* ok, if that passes lets check to make sure an rra does not already
 	exist, the last thing we want to do is overwrite data! */
 	if ($show_source != true) {

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -803,12 +803,103 @@ function rrdtool_function_interface_speed(array $data_local) : string {
 	return (string) $speed;
 }
 
+/**
+ * Reject an RRD file path that shows directory traversal or a NUL byte, and
+ * confine it to the RRA directory when that base can be resolved.
+ *
+ * data_source_path is stored in the database and flows into every rrdtool
+ * create/fetch/update/graph command. A '..' segment or a NUL byte would let a
+ * crafted path escape the RRA directory. The traversal/NUL check is
+ * unconditional so a legitimate path is never refused. Containment under the
+ * RRA base is enforced only when both the base and the target (or its parent
+ * directory, for a not-yet-created file) resolve with realpath(); remote
+ * storage, where the path is proxy relative, leaves them unresolved and is not
+ * second-guessed.
+ *
+ * @param string      $path     The candidate RRD file path.
+ * @param string|null $rra_base RRA base directory; defaults to CACTI_PATH_RRA.
+ *
+ * @return bool True when the path is safe to use.
+ */
+function rrd_check_path(string $path, ?string $rra_base = null) : bool {
+	if ($path === '' || strpos($path, "\0") !== false) {
+		return false;
+	}
+
+	// '..' between path boundaries (or at either edge) denotes traversal.
+	if (preg_match('/(^|[\/\\\\:])\.\.([\/\\\\:]|$)/', $path)) {
+		return false;
+	}
+
+	if ($rra_base === null) {
+		$rra_base = defined('CACTI_PATH_RRA') ? (string) CACTI_PATH_RRA : '';
+	}
+
+	// When the RRA base cannot be resolved (e.g. remote/proxy storage), the
+	// syntactic traversal/NUL checks above are all that apply.
+	$base = ($rra_base !== '') ? realpath($rra_base) : false;
+
+	if ($base === false) {
+		return true;
+	}
+
+	/* Resolve the target as strictly as the filesystem allows: realpath() when
+	 * the file exists (also collapses symlinks), else realpath() of the nearest
+	 * existing ancestor with the not-yet-created tail appended. A path whose
+	 * whole tail is missing cannot be resolved that way, so fall back to a
+	 * lexical absolute form. A relative path we cannot resolve is refused
+	 * rather than waved through, which was the hole that let a target with a
+	 * non-existent parent skip confinement (the create flow mkdir()s parents). */
+	$real = realpath($path);
+
+	if ($real === false) {
+		$dir  = $path;
+		$tail = '';
+
+		while (true) {
+			$parent = dirname($dir);
+			$tail   = ($tail === '') ? basename($dir) : basename($dir) . DIRECTORY_SEPARATOR . $tail;
+
+			$resolved = realpath($parent);
+
+			if ($resolved !== false) {
+				$real = $resolved . DIRECTORY_SEPARATOR . $tail;
+
+				break;
+			}
+
+			if ($parent === $dir) {
+				// reached the root without an existing ancestor
+				$real = (strpos($path, DIRECTORY_SEPARATOR) === 0) ? $path : false;
+
+				break;
+			}
+
+			$dir = $parent;
+		}
+	}
+
+	if ($real === false) {
+		return false;
+	}
+
+	$base = rtrim($base, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+	return strncmp($real . DIRECTORY_SEPARATOR, $base, strlen($base)) === 0;
+}
+
 function rrdtool_function_create(int $local_data_id, bool $show_source, mixed $rrdtool_pipe = null) : mixed {
 	global $data_source_types, $consolidation_functions, $encryption;
 
 	include(CACTI_PATH_INCLUDE . '/global_arrays.php');
 
 	$data_source_path = get_data_source_path($local_data_id, true);
+
+	if (!rrd_check_path($data_source_path)) {
+		cacti_log("ERROR: Refusing unsafe data source path '$data_source_path' for local_data_id $local_data_id", false, 'RRDTOOL');
+
+		return false;
+	}
 
 	/**
 	 * ok, if that passes lets check to make sure an rra does not already

--- a/tests/Unit/RrdCheckPathTest.php
+++ b/tests/Unit/RrdCheckPathTest.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Unit coverage for rrd_check_path() traversal and NUL rejection. The base
+ * argument is left empty so these cases exercise the syntactic checks only,
+ * independent of the filesystem.
+ */
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once CACTI_PATH_LIBRARY . '/rrd.php';
+
+test('rejects directory traversal', function () {
+	expect(rrd_check_path('/rra/../etc/passwd', ''))->toBeFalse();
+	expect(rrd_check_path('/rra/a/../b.rrd', ''))->toBeFalse();
+	expect(rrd_check_path('../rra/x.rrd', ''))->toBeFalse();
+	expect(rrd_check_path('..', ''))->toBeFalse();
+});
+
+test('rejects a NUL byte and empty path', function () {
+	expect(rrd_check_path("/rra/x\x00.rrd", ''))->toBeFalse();
+	expect(rrd_check_path('', ''))->toBeFalse();
+});
+
+test('allows an ordinary path when no base is enforced', function () {
+	expect(rrd_check_path('/var/lib/cacti/rra/site/traffic.rrd', ''))->toBeTrue();
+	expect(rrd_check_path('rra/1/2.rrd', ''))->toBeTrue();
+});

--- a/tests/integration/RrdPathConfinementTest.php
+++ b/tests/integration/RrdPathConfinementTest.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * End-to-end coverage for rrd_check_path() containment against a real RRA
+ * directory on disk. realpath() resolves symlinks, so an escape through a
+ * symlinked subdirectory is caught the same as a literal '..'.
+ */
+
+require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
+require_once CACTI_PATH_LIBRARY . '/rrd.php';
+
+beforeEach(function () {
+	$this->root    = sys_get_temp_dir() . '/rrdconf_' . getmypid() . '_' . uniqid();
+	$this->base    = $this->root . '/rra';
+	$this->outside = $this->root . '/outside';
+	mkdir($this->base, 0777, true);
+	mkdir($this->outside, 0777, true);
+	file_put_contents($this->base . '/x.rrd', '');
+	file_put_contents($this->outside . '/secret.rrd', '');
+});
+
+afterEach(function () {
+	foreach (array($this->base . '/link', $this->base . '/x.rrd', $this->outside . '/secret.rrd') as $f) {
+		if (is_link($f) || file_exists($f)) {
+			unlink($f);
+		}
+	}
+
+	foreach (array($this->base, $this->outside, $this->root) as $d) {
+		if (is_dir($d)) {
+			rmdir($d);
+		}
+	}
+});
+
+test('allows a file inside the RRA base', function () {
+	expect(rrd_check_path($this->base . '/x.rrd', $this->base))->toBeTrue();
+});
+
+test('allows a not-yet-created file inside the RRA base', function () {
+	expect(rrd_check_path($this->base . '/new/../new.rrd', $this->base))->toBeFalse(); // traversal still rejected
+	expect(rrd_check_path($this->base . '/new.rrd', $this->base))->toBeTrue();
+});
+
+test('rejects a file outside the RRA base', function () {
+	expect(rrd_check_path($this->outside . '/secret.rrd', $this->base))->toBeFalse();
+});
+
+test('rejects an escape through a symlinked subdirectory', function () {
+	symlink($this->outside, $this->base . '/link');
+
+	expect(rrd_check_path($this->base . '/link/secret.rrd', $this->base))->toBeFalse();
+});
+
+test('allows a not-yet-created file in a not-yet-created subdirectory of the base', function () {
+	// the create flow mkdir()s missing parents, so this legitimate case must pass
+	expect(rrd_check_path($this->base . '/newsite/deep/traffic.rrd', $this->base))->toBeTrue();
+});
+
+test('rejects a target whose parent directory does not exist and is outside the base', function () {
+	// the earlier single-level realpath(dirname()) fallback returned true here,
+	// which the create flow could then mkdir into existence outside the RRA tree
+	expect(rrd_check_path($this->root . '/evil/nested/x.rrd', $this->base))->toBeFalse();
+	expect(rrd_check_path('/nonexistent/evil/x.rrd', $this->base))->toBeFalse();
+});


### PR DESCRIPTION
## Intent

Confine rrdtool data source paths to the RRA directory (defense in depth against path traversal in stored filenames).

`data_source_path` is stored in `data_template_data` and flows into every rrdtool create/fetch/update/graph command. A `..` segment or a NUL byte in that value could point rrdtool outside the RRA tree.

## Change

`rrd_check_path()`:
- rejects a `..` traversal segment or a NUL byte unconditionally, so a legitimate path is never refused;
- confines the path under `CACTI_PATH_RRA` when both the base and the target (or its parent directory, for a not-yet-created file) resolve with `realpath()`, which also catches escapes through a symlinked subdirectory;
- leaves unresolved paths alone (remote/rrdproxy storage is proxy-relative), so it does not second-guess non-local setups.

`rrdtool_function_create()` refuses an unsafe path and logs it. The base is an injectable parameter so the logic is testable without touching the real RRA tree.

## Tests

- Unit (`tests/Unit/RrdCheckPathTest.php`): traversal, NUL, empty rejection; ordinary paths allowed.
- Integration + e2e (`tests/integration/RrdPathConfinementTest.php`): against a real temp RRA dir, a file inside is allowed, a not-yet-created file inside is allowed, a file outside is rejected, and an escape through a symlinked subdirectory is rejected.

## Scope

This wires the guard at the create sink. Extending it to the fetch/xport/info/tune call sites is a follow-up; each needs the same check plus verification that local and remote storage paths still validate.

## Risk

Low. Only unambiguous traversal/NUL is rejected outright; containment is enforced only when the base resolves, so remote storage is unaffected.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.

Closes #7852