### PR TITLE
security: restrict graph input fields across handoffs (CVE-2024-31458)

### DIFF
--- a/changelog.d/7669.security
+++ b/changelog.d/7669.security
@@ -1,0 +1,1 @@
+Confine graph input column names to schema-backed fields

--- a/cli/audit_graph_template_inputs.php
+++ b/cli/audit_graph_template_inputs.php
@@ -1,0 +1,108 @@
+#!/usr/bin/env php
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ */
+
+/**
+ * Read-only integrity audit for graph template inputs.
+ *
+ * This command never changes database state. It exits 2 when findings exist.
+ */
+
+require(__DIR__ . '/../include/cli_check.php');
+
+foreach (array_slice($_SERVER['argv'], 1) as $argument) {
+	if (in_array($argument, ['--version', '-V', '-v'], true)) {
+		display_version();
+		exit(0);
+	}
+
+	if (in_array($argument, ['--help', '-H', '-h'], true)) {
+		display_help();
+		exit(0);
+	}
+
+	print 'ERROR: Invalid Parameter ' . $argument . PHP_EOL;
+	exit(1);
+}
+
+/** @var array<string, mixed> $config */
+if ($config['poller_id'] > 1) {
+	print 'FATAL: This utility is designed for the main Data Collector only' . PHP_EOL;
+	exit(1);
+}
+
+$invalid_columns = [];
+
+foreach (db_fetch_assoc('SELECT id, column_name FROM graph_template_input ORDER BY id') as $input) {
+	if (!graph_template_input_column_is_allowed($input['column_name'])) {
+		$invalid_columns[] = (int) $input['id'];
+	}
+}
+
+$orphan_definitions = db_fetch_assoc('SELECT gtid.graph_template_input_id, gtid.graph_template_item_id
+	FROM graph_template_input_defs AS gtid
+	LEFT JOIN graph_template_input AS input
+	ON input.id = gtid.graph_template_input_id
+	LEFT JOIN graph_templates_item AS item
+	ON item.id = gtid.graph_template_item_id
+	WHERE input.id IS NULL OR item.id IS NULL');
+
+$cross_template_definitions = db_fetch_assoc('SELECT gtid.graph_template_input_id, gtid.graph_template_item_id
+	FROM graph_template_input_defs AS gtid
+	INNER JOIN graph_template_input AS input
+	ON input.id = gtid.graph_template_input_id
+	INNER JOIN graph_templates_item AS item
+	ON item.id = gtid.graph_template_item_id
+	WHERE input.graph_template_id <> item.graph_template_id');
+
+$non_template_definitions = db_fetch_assoc('SELECT gtid.graph_template_input_id, gtid.graph_template_item_id
+	FROM graph_template_input_defs AS gtid
+	INNER JOIN graph_templates_item AS item
+	ON item.id = gtid.graph_template_item_id
+	WHERE item.local_graph_id <> 0');
+
+$empty_inputs = db_fetch_assoc('SELECT input.id
+	FROM graph_template_input AS input
+	LEFT JOIN graph_template_input_defs AS gtid
+	ON gtid.graph_template_input_id = input.id
+	WHERE gtid.graph_template_input_id IS NULL');
+
+$findings = [
+	'disallowed column names'         => $invalid_columns,
+	'orphaned definitions'            => $orphan_definitions,
+	'cross-template definitions'      => $cross_template_definitions,
+	'non-template item definitions'   => $non_template_definitions,
+	'inputs without associated items' => $empty_inputs,
+];
+
+$finding_count = 0;
+
+foreach ($findings as $label => $rows) {
+	$count = cacti_sizeof($rows);
+	$finding_count += $count;
+	print sprintf('%-32s %d', $label . ':', $count) . PHP_EOL;
+}
+
+if ($finding_count > 0) {
+	print 'Graph template input integrity findings detected; no changes were made.' . PHP_EOL;
+	exit(2);
+}
+
+print 'Graph template input integrity audit passed.' . PHP_EOL;
+exit(0);
+
+function display_version() : void {
+	print 'Cacti Graph Template Input Audit, Version ' . get_cacti_cli_version() . ', ' . COPYRIGHT_YEARS . PHP_EOL;
+}
+
+function display_help() : void {
+	display_version();
+	print PHP_EOL . 'Usage: audit_graph_template_inputs.php [--help|--version]' . PHP_EOL . PHP_EOL;
+	print 'Reports graph template input integrity findings without changing database state.' . PHP_EOL;
+}

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -650,12 +650,29 @@ function form_save() : void {
 		$save['description']       = CactiValidator::validateInput(gnrv('description'), 'description', [], 3);
 		$save['column_name']       = CactiValidator::validateInput(gnrv('column_name'), 'column_name', [], 3);
 
+		if (!graph_template_input_column_is_allowed($save['column_name'])) {
+			raise_message('column_name_invalid', __('The selected Field Type is not a valid Graph Item field.'), MESSAGE_LEVEL_ERROR);
+			$_SESSION['sess_error_fields']['column_name'] = 'column_name';
+		}
+
+		foreach ($_POST as $var => $val) {
+			if (preg_match('/^i_(\d+)$/', $var, $matches)) {
+				input_validate_input_number($matches[1], 'i[1]');
+				$selected_graph_items[$matches[1]] = intval($matches[1]);
+			}
+		}
+
+		if (!graph_template_input_relationships_are_valid((int) $save['id'], (int) $save['graph_template_id'], array_values($selected_graph_items))) {
+			cacti_log('ERROR: Graph input save refused a cross-template relationship', false, 'SECURITY');
+			raise_message('graph_input_relationship_invalid', __('The Graph Item Input relationship is invalid.'), MESSAGE_LEVEL_ERROR);
+		}
+
 		if (is_error_message() === false) {
-			$graph_template_input_id = sql_save($save, 'graph_template_input');
+			$transaction_started       = db_begin_transaction();
+			$mutation_failed           = !$transaction_started;
+			$graph_template_input_id   = $mutation_failed ? false : sql_save($save, 'graph_template_input');
 
 			if ($graph_template_input_id) {
-				raise_message(1);
-
 				// list all graph items from the db so we can compare them with the current form
 				$db_selected_graph_item = array_rekey(
 					db_fetch_assoc_prepared('SELECT graph_template_item_id
@@ -665,22 +682,9 @@ function form_save() : void {
 					'graph_template_item_id', 'graph_template_item_id'
 				);
 
-				// list all select graph items for use down below
-				foreach ($_POST as $var => $val) {
-					if (preg_match('/^i_(\d+)$/', $var, $matches)) {
-						// ================= input validation =================
-						input_validate_input_number($matches[1], 'i[1]');
-						// ====================================================
-
-						$selected_graph_items[$matches[1]] = $matches[1];
-
-						if (isset($db_selected_graph_item[$matches[1]])) {
-							// is selected and exists in the db; old item
-							$old_members[$matches[1]] = intval($matches[1]);
-						} else {
-							// is selected and does not exist the db; new item
-							$new_members[$matches[1]] = intval($matches[1]);
-						}
+				foreach ($selected_graph_items as $graph_template_item_id) {
+					if (!isset($db_selected_graph_item[$graph_template_item_id])) {
+						$new_members[$graph_template_item_id] = $graph_template_item_id;
 					}
 				}
 
@@ -690,15 +694,30 @@ function form_save() : void {
 					}
 				}
 
-				db_execute_prepared('DELETE FROM graph_template_input_defs WHERE graph_template_input_id = ?', [$graph_template_input_id]);
+				$mutation_failed = !db_execute_prepared('DELETE FROM graph_template_input_defs WHERE graph_template_input_id = ?', [$graph_template_input_id]);
 
-				if (cacti_sizeof($selected_graph_items) > 0) {
+				if (!$mutation_failed && cacti_sizeof($selected_graph_items) > 0) {
 					foreach ($selected_graph_items as $graph_template_item_id) {
-						db_execute_prepared('INSERT INTO graph_template_input_defs (graph_template_input_id, graph_template_item_id) VALUES (?, ?)', [$graph_template_input_id, $graph_template_item_id]);
+						if (!db_execute_prepared('INSERT INTO graph_template_input_defs (graph_template_input_id, graph_template_item_id) VALUES (?, ?)', [$graph_template_input_id, $graph_template_item_id])) {
+							$mutation_failed = true;
+
+							break;
+						}
 					}
 				}
 			} else {
+				$mutation_failed = true;
+			}
+
+			if ($mutation_failed) {
+				if ($transaction_started) {
+					db_rollback_transaction();
+				}
+
 				raise_message(2);
+			} else {
+				db_commit_transaction();
+				raise_message(1);
 			}
 		}
 
@@ -1783,8 +1802,22 @@ function input_remove() : void {
 	gfrv('graph_template_id');
 	// ====================================================
 
-	db_execute_prepared('DELETE FROM graph_template_input WHERE id = ?', [grv('id')]);
-	db_execute_prepared('DELETE FROM graph_template_input_defs WHERE graph_template_input_id = ?', [grv('id')]);
+	if (!graph_template_input_relationships_are_valid((int) grv('id'), (int) grv('graph_template_id'), [])) {
+		cacti_log('ERROR: Graph input delete refused a cross-template relationship', false, 'SECURITY');
+
+		return;
+	}
+
+	if (db_begin_transaction()) {
+		$deleted_defs  = db_execute_prepared('DELETE FROM graph_template_input_defs WHERE graph_template_input_id = ?', [grv('id')]);
+		$deleted_input = $deleted_defs && db_execute_prepared('DELETE FROM graph_template_input WHERE id = ? AND graph_template_id = ?', [grv('id'), grv('graph_template_id')]);
+
+		if ($deleted_input) {
+			db_commit_transaction();
+		} else {
+			db_rollback_transaction();
+		}
+	}
 }
 
 function input_edit() : void {

--- a/graphs.php
+++ b/graphs.php
@@ -500,6 +500,31 @@ function form_save() : void {
 
 				if (cacti_sizeof($input_list)) {
 					foreach ($input_list as $input) {
+						$input_var = $input['column_name'] . '_' . $input['id'];
+
+						if (!graph_template_input_column_is_allowed($input['column_name']) ||
+							(isrv($input_var) && !graph_template_input_value_is_allowed($input['column_name'], gnrv($input_var)))) {
+							cacti_log('ERROR: Graph save refused an invalid graph input field', false, 'SECURITY');
+							raise_message('graph_input_invalid', __('A Graph Item Input contains an invalid field or value.'), MESSAGE_LEVEL_ERROR);
+
+							$input_list = [];
+
+							break;
+						}
+					}
+
+					$transaction_started = cacti_sizeof($input_list) ? db_begin_transaction() : false;
+					$mutation_failed     = cacti_sizeof($input_list) && !$transaction_started;
+
+					if ($mutation_failed) {
+						raise_message('graph_input_update_failed', __('Graph Item Input changes could not be saved.'), MESSAGE_LEVEL_ERROR);
+					}
+
+					foreach ($input_list as $input) {
+						if ($mutation_failed) {
+							break;
+						}
+
 						// we need to find out which graph items will be affected by saving this particular item
 						$item_list = db_fetch_assoc_prepared('SELECT gti.id
 							FROM graph_template_input_defs AS gtid
@@ -516,12 +541,34 @@ function form_save() : void {
 								 this is because the db and form are out of sync here, but it is ok to just skip over saving
 								 the inputs in this case. */
 								if (isrv($input['column_name'] . '_' . $input['id'])) {
-									db_execute_prepared('UPDATE graph_templates_item
+									$input_value = gnrv($input['column_name'] . '_' . $input['id']);
+
+									if (!graph_template_input_value_is_allowed($input['column_name'], $input_value)) {
+										cacti_log('ERROR: Graph save refused an invalid graph input value', false, 'SECURITY');
+										raise_message('column_value_invalid', __('A Graph Item Input contains an invalid value.'), MESSAGE_LEVEL_ERROR);
+
+										continue;
+									}
+
+									if (!db_execute_prepared('UPDATE graph_templates_item
 										SET ' . $input['column_name'] . ' = ?
 										WHERE id = ?',
-										[gnrv($input['column_name'] . '_' . $input['id']), $item['id']]);
+										[$input_value, $item['id']])) {
+										$mutation_failed = true;
+
+										break 2;
+									}
 								}
 							}
+						}
+					}
+
+					if ($transaction_started) {
+						if ($mutation_failed) {
+							db_rollback_transaction();
+							raise_message('graph_input_update_failed', __('Graph Item Input changes could not be saved.'), MESSAGE_LEVEL_ERROR);
+						} else {
+							db_commit_transaction();
 						}
 					}
 				}

--- a/include/global.php
+++ b/include/global.php
@@ -286,6 +286,7 @@ if (isset($i18n_text_log)) {
 // include base modules
 require_once(CACTI_PATH_LIBRARY . '/database.php');
 require_once(CACTI_PATH_LIBRARY . '/functions.php');
+require_once(CACTI_PATH_LIBRARY . '/graph_template_input.php');
 require_once(CACTI_PATH_LIBRARY . '/renderer.php');
 require_once(CACTI_PATH_LIBRARY . '/headers_secure.php');
 require_once(CACTI_PATH_INCLUDE . '/global_constants.php');

--- a/lib/api_graph.php
+++ b/lib/api_graph.php
@@ -410,6 +410,7 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 	$graph_item_mappings   = [];
 	$graph_template_items  = [];
 	$graph_template_graph  = [];
+	$transaction_started   = false;
 
 	if (!empty($_local_graph_id)) {
 		$graph_local = db_fetch_row_prepared('SELECT *
@@ -440,7 +441,19 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 		$save['snmp_query_id']     = $graph_local['snmp_query_id'];
 		$save['snmp_index']        = $graph_local['snmp_index'];
 
+		$transaction_started = db_begin_transaction();
+
+		if (!$transaction_started) {
+			return false;
+		}
+
 		$local_graph_id = sql_save($save, 'graph_local');
+
+		if (!$local_graph_id) {
+			db_rollback_transaction();
+
+			return false;
+		}
 
 		$graph_template_graph['title'] = str_replace('<graph_title>', $graph_template_graph['title'], $graph_title);
 	} elseif (!empty($_graph_template_id)) {
@@ -470,7 +483,37 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 			WHERE graph_template_id = ?',
 			[$_graph_template_id]);
 
+		foreach ($graph_template_inputs as $graph_template_input) {
+			if (!graph_template_input_column_is_allowed($graph_template_input['column_name'])) {
+				cacti_log('ERROR: Graph template duplication refused an invalid Graph Item Input field', false, 'SECURITY');
+
+				return false;
+			}
+		}
+
+		$invalid_input_definitions = db_fetch_cell_prepared('SELECT COUNT(*)
+			FROM graph_template_input_defs AS gtid
+			INNER JOIN graph_template_input AS gti
+			ON gti.id = gtid.graph_template_input_id
+			LEFT JOIN graph_templates_item AS item
+			ON item.id = gtid.graph_template_item_id
+			WHERE gti.graph_template_id = ?
+			AND (item.id IS NULL OR item.graph_template_id <> gti.graph_template_id OR item.local_graph_id <> 0)',
+			[$_graph_template_id]);
+
+		if ($invalid_input_definitions > 0) {
+			cacti_log('ERROR: Graph template duplication refused invalid input ownership', false, 'SECURITY');
+
+			return false;
+		}
+
 		// create new entry: graph_templates
+		$transaction_started = db_begin_transaction();
+
+		if (!$transaction_started) {
+			return false;
+		}
+
 		$save       = [];
 		$save['id'] = 0;
 
@@ -479,13 +522,19 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 		$save['multiple'] = $graph_template['multiple'];
 
 		$graph_template_id = sql_save($save, 'graph_templates');
+
+		if (!$graph_template_id) {
+			db_rollback_transaction();
+
+			return false;
+		}
 	}
 
 	$save       = [];
 	$save['id'] = 0;
 
 	// create new entry: graph_templates_graph
-	$save['local_graph_id']                = ($local_graph_id ?? 0);
+	$save['local_graph_id']                = $local_graph_id;
 	$save['local_graph_template_graph_id'] = ($graph_template_graph['local_graph_template_graph_id'] ?? 0);
 	$save['graph_template_id']             = (!empty($_local_graph_id) ? $graph_template_graph['graph_template_id'] : $graph_template_id);
 	$save['title_cache']                   = $graph_template_graph['title_cache'];
@@ -500,6 +549,12 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 
 	$graph_templates_graph_id = sql_save($save, 'graph_templates_graph');
 
+	if (!$graph_templates_graph_id) {
+		db_rollback_transaction();
+
+		return false;
+	}
+
 	// create new entry(s): graph_templates_item
 	if (cacti_sizeof($graph_template_items)) {
 		foreach ($graph_template_items as $graph_template_item) {
@@ -508,7 +563,7 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 
 			// save a hash only for graph_template copy operations
 			$save['hash']                         = (!empty($_graph_template_id) ? get_hash_graph_template(0, 'graph_template_item') : 0);
-			$save['local_graph_id']               = ($local_graph_id ?? 0);
+			$save['local_graph_id']               = $local_graph_id;
 			$save['graph_template_id']            = (!empty($_local_graph_id) ? $graph_template_item['graph_template_id'] : $graph_template_id);
 			$save['local_graph_template_item_id'] = ($graph_template_item['local_graph_template_item_id'] ?? 0);
 
@@ -517,6 +572,12 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 			}
 
 			$graph_item_mappings[$graph_template_item['id']] = sql_save($save, 'graph_templates_item');
+
+			if (!$graph_item_mappings[$graph_template_item['id']]) {
+				db_rollback_transaction();
+
+				return false;
+			}
 		}
 	}
 
@@ -535,6 +596,12 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 
 				$graph_template_input_id   = sql_save($save, 'graph_template_input');
 
+				if (!$graph_template_input_id) {
+					db_rollback_transaction();
+
+					return false;
+				}
+
 				$graph_template_input_defs = db_fetch_assoc_prepared('SELECT *
 					FROM graph_template_input_defs
 					WHERE graph_template_input_id = ?',
@@ -543,14 +610,18 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 				// create new entry(s): graph_template_input_defs (graph template only)
 				if (cacti_sizeof($graph_template_input_defs)) {
 					foreach ($graph_template_input_defs as $graph_template_input_def) {
-						db_execute_prepared('INSERT INTO graph_template_input_defs
+						if (!isset($graph_item_mappings[$graph_template_input_def['graph_template_item_id']]) || !db_execute_prepared('INSERT INTO graph_template_input_defs
 							(graph_template_input_id, graph_template_item_id)
 							VALUES (?, ?)',
 							[
 								$graph_template_input_id,
 								$graph_item_mappings[$graph_template_input_def['graph_template_item_id']]
 							]
-						);
+						)) {
+							db_rollback_transaction();
+
+							return false;
+						}
 					}
 				}
 			}
@@ -659,12 +730,20 @@ function api_duplicate_graph(int $_local_graph_id, int $_graph_template_id, stri
 	set_config_option('time_last_change_graph', time());
 
 	if ($_local_graph_id > 0) {
+		db_commit_transaction();
+
 		return $local_graph_id;
 	}
 
 	if ($_graph_template_id > 0) {
+		db_commit_transaction();
+
 		return $graph_template_id;
 	} else {
+		if ($transaction_started) {
+			db_rollback_transaction();
+		}
+
 		return false;
 	}
 }

--- a/lib/graph_template_input.php
+++ b/lib/graph_template_input.php
@@ -1,0 +1,184 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Test whether a graph template input may select a graph item field.
+ *
+ * This is an application allowlist, not a database schema check. Structural
+ * columns such as id, hash, local_graph_id, and graph_template_id must never
+ * become user-controlled graph input fields even though they exist in the
+ * graph_templates_item table.
+ */
+function graph_template_input_column_is_allowed(mixed $column_name) : bool {
+	static $allowed_columns = [
+		'graph_type_id'             => true,
+		'task_item_id'              => true,
+		'color_id'                  => true,
+		'alpha'                     => true,
+		'color2_id'                 => true,
+		'alpha2'                    => true,
+		'gradheight'                => true,
+		'consolidation_function_id' => true,
+		'cdef_id'                   => true,
+		'vdef_id'                   => true,
+		'shift'                     => true,
+		'value'                     => true,
+		'gprint_id'                 => true,
+		'textalign'                 => true,
+		'text_format'               => true,
+		'legend'                    => true,
+		'hard_return'               => true,
+		'line_width'                => true,
+		'dashes'                    => true,
+		'dash_offset'               => true,
+		'sequence'                  => true,
+	];
+
+	return is_string($column_name) && isset($allowed_columns[$column_name]);
+}
+
+/**
+ * Validate the storage shape of a graph template input value.
+ */
+function graph_template_input_value_is_allowed(mixed $column_name, mixed $value) : bool {
+	if (!graph_template_input_column_is_allowed($column_name) || !is_scalar($value)) {
+		return false;
+	}
+
+	$value = (string) $value;
+
+	if (preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $value)) {
+		return false;
+	}
+
+	if (in_array($column_name, ['graph_type_id', 'task_item_id', 'consolidation_function_id', 'cdef_id', 'vdef_id', 'gprint_id'], true)) {
+		return preg_match('/^\d{1,10}$/D', $value) === 1;
+	}
+
+	if (in_array($column_name, ['color_id', 'color2_id'], true)) {
+		return preg_match('/^(?:0|[A-Fa-f0-9]{6})$/D', $value) === 1;
+	}
+
+	if (in_array($column_name, ['alpha', 'alpha2'], true)) {
+		return preg_match('/^[A-Fa-f0-9]{2}$/D', $value) === 1;
+	}
+
+	if (in_array($column_name, ['shift', 'hard_return'], true)) {
+		return in_array($value, ['', '0', '1', 'on'], true);
+	}
+
+	if ($column_name === 'line_width') {
+		return $value === '' || (strlen($value) <= 5 && preg_match('/^\d+(?:\.\d+)?$/D', $value) === 1);
+	}
+
+	if ($column_name === 'dash_offset') {
+		return $value === '' || (strlen($value) <= 4 && preg_match('/^-?\d+(?:\.\d+)?$/D', $value) === 1);
+	}
+
+	if ($column_name === 'gradheight') {
+		return $value === '' || (strlen($value) <= 5 && preg_match('/^-?\d+(?:\.\d+)?$/D', $value) === 1);
+	}
+
+	if ($column_name === 'legend') {
+		return strlen($value) <= 30;
+	}
+
+	if ($column_name === 'sequence') {
+		return $value === '' || (strlen($value) <= 4 && preg_match('/^\d+$/D', $value) === 1);
+	}
+
+	if ($column_name === 'dashes') {
+		return strlen($value) <= 40 && ($value === '' || preg_match('/^[0-9.,[:space:]]+$/D', $value) === 1);
+	}
+
+	if ($column_name === 'textalign') {
+		return strlen($value) <= 20 && ($value === '' || preg_match('/^[A-Za-z]+$/D', $value) === 1);
+	}
+
+	return strlen($value) <= 255;
+}
+
+/**
+ * Verify that an input and all selected template items share one owner.
+ *
+ * @param array<int|string> $graph_template_item_ids
+ */
+function graph_template_input_relationships_are_valid(int $input_id, int $graph_template_id, array $graph_template_item_ids) : bool {
+	if ($graph_template_id <= 0) {
+		return false;
+	}
+
+	if ($input_id > 0 && (int) db_fetch_cell_prepared('SELECT COUNT(*)
+		FROM graph_template_input
+		WHERE id = ?
+		AND graph_template_id = ?', [$input_id, $graph_template_id]) !== 1) {
+		return false;
+	}
+
+	$graph_template_item_ids = array_values(array_unique(array_map('intval', $graph_template_item_ids)));
+
+	foreach ($graph_template_item_ids as $item_id) {
+		if ($item_id <= 0) {
+			return false;
+		}
+	}
+
+	if (!cacti_sizeof($graph_template_item_ids)) {
+		return true;
+	}
+
+	$placeholders = implode(',', array_fill(0, cacti_sizeof($graph_template_item_ids), '?'));
+
+	return (int) db_fetch_cell_prepared('SELECT COUNT(*)
+		FROM graph_templates_item
+		WHERE graph_template_id = ?
+		AND local_graph_id = 0
+		AND id IN (' . $placeholders . ')',
+		array_merge([$graph_template_id], $graph_template_item_ids)) === cacti_sizeof($graph_template_item_ids);
+}
+
+/**
+ * Validate graph-input references in one decoded XML graph template.
+ *
+ * @param array<string, mixed> $xml_array
+ */
+function graph_template_input_xml_preflight(array $xml_array) : bool {
+	if (isset($xml_array['inputs']) && !is_array($xml_array['inputs'])) {
+		return false;
+	}
+
+	$available_items = [];
+
+	foreach (isset($xml_array['items']) && is_array($xml_array['items']) ? array_keys($xml_array['items']) : [] as $item_hash) {
+		$parsed_hash = parse_xml_hash($item_hash);
+
+		if ($parsed_hash === false) {
+			return false;
+		}
+
+		$available_items[$parsed_hash['hash']] = true;
+	}
+
+	foreach ($xml_array['inputs'] ?? [] as $input) {
+		if (!is_array($input) || !isset($input['column_name'], $input['items']) || !is_string($input['items']) ||
+			!graph_template_input_column_is_allowed(xml_character_decode($input['column_name']))) {
+			return false;
+		}
+
+		foreach (array_filter(explode('|', $input['items']), static fn (string $item_hash) : bool => $item_hash !== '') as $item_hash) {
+			$parsed_hash = parse_xml_hash($item_hash);
+
+			if ($parsed_hash === false || !isset($available_items[$parsed_hash['hash']])) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}

--- a/lib/html_form_template.php
+++ b/lib/html_form_template.php
@@ -164,14 +164,14 @@ function draw_nontemplated_fields_graph_item(int $graph_template_id, int $local_
 
 	if (cacti_sizeof($input_item_list)) {
 		foreach ($input_item_list as $item) {
-			if (!db_column_exists('graph_templates_item', $item['column_name'])) {
+			if (!graph_template_input_column_is_allowed($item['column_name'])) {
 				raise_message_javascript(
-					__('Attempted SQL Injection'),
-					__('There was a SQL Injection attempted on the page'),
-					__('A client attempted to create a SQL Injection into Cacti likely from an external host with the address %s', get_client_addr())
+					__('Invalid Graph Template Input'),
+					__('The graph template cannot be rendered'),
+					__('A Graph Item Input contains an invalid Field Type.')
 				);
 
-				cacti_log(sprintf('ERROR: A client attempted to create a SQL Injection into Cacti likely from an external host with the address %s', get_client_addr()), false, 'SECURITY');
+				cacti_log('ERROR: Graph rendering refused an invalid graph input field', false, 'SECURITY');
 
 				exit;
 			}

--- a/lib/import.php
+++ b/lib/import.php
@@ -189,6 +189,10 @@ function import_xml_data(string &$xml_data, bool $import_as_new, int $profile_id
 					if (xml_detect_ignorable_hash_cache($dep_hash_cache[$type][$i]['hash'], $hash_array)) {
 						$repair++;
 					}
+				} elseif ($type == 'graph_template' && !graph_template_input_xml_preflight($hash_array)) {
+					cacti_log('ERROR: Graph template import refused invalid input relationships before the write pass', false, 'SECURITY');
+
+					return false;
 				}
 			}
 		}
@@ -229,7 +233,27 @@ function import_xml_data(string &$xml_data, bool $import_as_new, int $profile_id
 
 				switch($type) {
 					case 'graph_template':
-						$hash_cache += xml_to_graph_template($dep_hash_cache[$type][$i]['hash'], $hash_array, $hash_cache, $dep_hash_cache[$type][$i]['version'], $remove_orphans);
+						$transaction_started = $preview_only ? false : db_begin_transaction();
+
+						if (!$preview_only && !$transaction_started) {
+							return false;
+						}
+
+						$cache_add = xml_to_graph_template($dep_hash_cache[$type][$i]['hash'], $hash_array, $hash_cache, $dep_hash_cache[$type][$i]['version'], $remove_orphans);
+
+						if ($cache_add === false) {
+							if ($transaction_started) {
+								db_rollback_transaction();
+							}
+
+							return false;
+						}
+
+						if ($transaction_started) {
+							db_commit_transaction();
+						}
+
+						$hash_cache += $cache_add;
 
 						break;
 					case 'data_template':
@@ -900,6 +924,53 @@ function xml_to_graph_template(string $hash, array &$xml_array, array &$hash_cac
 
 	// track changes
 	$status = 0;
+
+	/* Validate every dynamic graph-item field before the import writes any
+	 * template records. Import is a separate producer from the web form and must
+	 * enforce the same invariant at the data handoff boundary. */
+	$available_graph_item_hashes = [];
+
+	if (isset($xml_array['items']) && is_array($xml_array['items'])) {
+		foreach (array_keys($xml_array['items']) as $item_hash) {
+			$parsed_item_hash = parse_xml_hash($item_hash);
+
+			if ($parsed_item_hash === false) {
+				cacti_log('ERROR: Graph template import refused an invalid Graph Item hash', false, 'SECURITY');
+
+				return false;
+			}
+
+			$available_graph_item_hashes[$parsed_item_hash['hash']] = true;
+		}
+	}
+
+	if (isset($xml_array['inputs']) && !is_array($xml_array['inputs'])) {
+		return false;
+	}
+
+	if (isset($xml_array['inputs'])) {
+		foreach ($xml_array['inputs'] as $item_array) {
+			$column_name = is_array($item_array) && isset($item_array['column_name'])
+				? xml_character_decode($item_array['column_name'])
+				: null;
+
+			if (!graph_template_input_column_is_allowed($column_name) || !isset($item_array['items']) || !is_string($item_array['items'])) {
+				cacti_log('ERROR: Graph template import refused an invalid Graph Item Input field', false, 'SECURITY');
+
+				return false;
+			}
+
+			foreach (array_filter(explode('|', $item_array['items']), static fn (string $item_hash) : bool => $item_hash !== '') as $item_hash) {
+				$parsed_item_hash = parse_xml_hash($item_hash);
+
+				if ($parsed_item_hash === false || !isset($available_graph_item_hashes[$parsed_item_hash['hash']])) {
+					cacti_log('ERROR: Graph template import refused an unresolved Graph Item Input relationship', false, 'SECURITY');
+
+					return false;
+				}
+			}
+		}
+	}
 
 	// import into: graph_templates
 	$_graph_template_id = db_fetch_cell_prepared('SELECT id

--- a/lib/template.php
+++ b/lib/template.php
@@ -545,6 +545,23 @@ function push_out_graph_input(int $graph_template_input_id, int $graph_template_
 		FROM graph_template_input
 		WHERE id = ?', [$graph_template_input_id]);
 
+	/* column_name is a schema identifier interpolated straight into the SELECT
+	 * and UPDATE statements below; it cannot be bound as a parameter, so confine
+	 * it to an editable graph-item field. Without this a crafted
+	 * graph_template_input row injects SQL through column_name (CVE-2024-31458). */
+	if (!cacti_sizeof($graph_input)) {
+		return;
+	}
+
+	if (!graph_template_input_column_is_allowed($graph_input['column_name'])) {
+		cacti_log('ERROR: push_out_graph_input() refused an invalid graph input field', false, 'SECURITY');
+
+		return;
+	}
+
+	$column_name        = $graph_input['column_name'];
+	$graph_template_id  = (int) $graph_input['graph_template_id'];
+
 	$graph_input_items = db_fetch_assoc_prepared('SELECT graph_template_item_id
 		FROM graph_template_input_defs
 		WHERE graph_template_input_id = ?', [$graph_template_input_id]);
@@ -567,9 +584,9 @@ function push_out_graph_input(int $graph_template_input_id, int $graph_template_
 	}
 
 	if (cacti_sizeof($session_members) == 0) {
-		$values_to_apply = db_fetch_assoc('SELECT local_graph_id,' . $graph_input['column_name'] . '
+		$values_to_apply = db_fetch_assoc('SELECT local_graph_id,' . $column_name . '
 			FROM graph_templates_item
-			WHERE graph_template_id=' . $graph_input['graph_template_id'] . " $sql_include_items
+			WHERE graph_template_id=' . $graph_template_id . " $sql_include_items
 			AND local_graph_id>0
 			GROUP BY local_graph_id");
 	} else {
@@ -579,21 +596,28 @@ function push_out_graph_input(int $graph_template_input_id, int $graph_template_
 			$new_session_members[] = $item_id;
 		}
 
-		$values_to_apply = db_fetch_assoc('SELECT local_graph_id,' . $graph_input['column_name'] . '
+		$values_to_apply = db_fetch_assoc('SELECT local_graph_id,' . $column_name . '
 			FROM graph_templates_item
-			WHERE graph_template_id=' . $graph_input['graph_template_id'] . '
+			WHERE graph_template_id=' . $graph_template_id . '
 			AND local_graph_id>0
 			AND !(' . array_to_sql_or($new_session_members, 'local_graph_template_item_id') . ") $sql_include_items GROUP BY local_graph_id");
 	}
 
 	if (cacti_sizeof($values_to_apply)) {
 		foreach ($values_to_apply as $value) {
+			if (!graph_template_input_value_is_allowed($column_name, $value[$column_name])) {
+				cacti_log('ERROR: push_out_graph_input() refused an invalid graph input value', false, 'SECURITY');
+
+				continue;
+			}
+
 			// this is just an extra check that i threw in to prevent users' graphs from getting really messed up
-			if (!(($graph_input['column_name'] == 'task_item_id') && (empty($value[$graph_input['column_name']])))) {
-				db_execute('UPDATE graph_templates_item
-					SET ' . $graph_input['column_name'] . '=' . db_qstr($value[$graph_input['column_name']]) . '
-					WHERE local_graph_id=' . $value['local_graph_id'] . "
-					AND local_graph_template_item_id=$graph_template_item_id");
+			if (!(($column_name == 'task_item_id') && (empty($value[$column_name])))) {
+				db_execute_prepared('UPDATE graph_templates_item
+					SET ' . $column_name . ' = ?
+					WHERE local_graph_id = ?
+					AND local_graph_template_item_id = ?',
+					[$value[$column_name], $value['local_graph_id'], $graph_template_item_id]);
 			}
 		}
 	}

--- a/tests/Unit/TemplateColumnSqliTest.php
+++ b/tests/Unit/TemplateColumnSqliTest.php
@@ -1,0 +1,155 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once CACTI_PATH_LIBRARY . '/graph_template_input.php';
+
+test('graph template inputs allow only editable graph item fields', function () {
+	$allowed = [
+		'graph_type_id',
+		'task_item_id',
+		'color_id',
+		'alpha',
+		'color2_id',
+		'alpha2',
+		'gradheight',
+		'consolidation_function_id',
+		'cdef_id',
+		'vdef_id',
+		'shift',
+		'value',
+		'gprint_id',
+		'textalign',
+		'text_format',
+		'legend',
+		'hard_return',
+		'line_width',
+		'dashes',
+		'dash_offset',
+		'sequence',
+	];
+
+	foreach ($allowed as $column_name) {
+		expect(graph_template_input_column_is_allowed($column_name))->toBeTrue();
+	}
+});
+
+test('graph template inputs reject structural columns and SQL syntax', function () {
+	$rejected = [
+		'id',
+		'hash',
+		'local_graph_id',
+		'local_graph_template_item_id',
+		'graph_template_id',
+		'%',
+		'_',
+		"task_item_id' OR 1=1 --",
+		'',
+		null,
+	];
+
+	foreach ($rejected as $column_name) {
+		expect(graph_template_input_column_is_allowed($column_name))->toBeFalse();
+	}
+});
+
+test('every graph template input handoff uses the application allowlist', function () {
+	$root  = dirname(__DIR__, 2);
+	$files = [
+		'graph_templates.php',
+		'graphs.php',
+		'lib/api_graph.php',
+		'lib/html_form_template.php',
+		'lib/import.php',
+		'lib/template.php',
+	];
+
+	foreach ($files as $file) {
+		$source = file_get_contents($root . '/' . $file);
+
+		expect($source)
+			->toBeString()
+			->toContain('graph_template_input_column_is_allowed(');
+	}
+});
+
+test('the push out sinks use only the validated local identifier', function () {
+	$source = file_get_contents(CACTI_PATH_LIBRARY . '/template.php');
+
+	expect(preg_match('/function push_out_graph_input\(.*?\n}\n/s', $source, $matches))->toBe(1);
+	$body = $matches[0];
+
+	$guard  = strpos($body, 'graph_template_input_column_is_allowed(');
+	$select = strpos($body, "SELECT local_graph_id,'");
+	$update = strpos($body, 'UPDATE graph_templates_item');
+
+	expect($guard)->not->toBeFalse();
+	expect($select)->not->toBeFalse();
+	expect($update)->not->toBeFalse();
+	expect($guard)->toBeLessThan($select);
+	expect($guard)->toBeLessThan($update);
+	expect($body)->toContain("'SELECT local_graph_id,' . \$column_name . '");
+	expect($body)->toContain("SET ' . \$column_name . ' = ?");
+	expect($body)->not->toContain("SET ' . \$graph_input['column_name']");
+});
+
+test('XML import validates graph input fields before its first template write', function () {
+	$source = file_get_contents(CACTI_PATH_LIBRARY . '/import.php');
+
+	expect(preg_match('/function xml_to_graph_template\(.*?\n}\n/s', $source, $matches))->toBe(1);
+	$body = $matches[0];
+	$gate = strpos($body, 'graph_template_input_column_is_allowed(');
+	$save = strpos($body, "sql_save(\$save, 'graph_templates')");
+
+	expect($gate)->not->toBeFalse();
+	expect($save)->not->toBeFalse();
+	expect($gate)->toBeLessThan($save);
+});
+
+test('graph saves preflight every input before updating graph items', function () {
+	$source = file_get_contents(CACTI_PATH_BASE . '/graphs.php');
+
+	$guard = strpos($source, 'graph_template_input_column_is_allowed(');
+	$abort = strpos($source, '$input_list = [];', $guard);
+	$write = strpos($source, 'UPDATE graph_templates_item', $guard);
+
+	expect($guard)->not->toBeFalse();
+	expect($abort)->not->toBeFalse();
+	expect($write)->not->toBeFalse();
+	expect($guard)->toBeLessThan($abort);
+	expect($abort)->toBeLessThan($write);
+});
+
+test('graph input values are validated by field shape', function () {
+	expect(graph_template_input_value_is_allowed('task_item_id', '42'))->toBeTrue();
+	expect(graph_template_input_value_is_allowed('alpha', '7F'))->toBeTrue();
+	expect(graph_template_input_value_is_allowed('text_format', "safe\ttext"))->toBeTrue();
+	expect(graph_template_input_value_is_allowed('task_item_id', '1 OR 1=1'))->toBeFalse();
+	expect(graph_template_input_value_is_allowed('alpha', 'FFFF'))->toBeFalse();
+	expect(graph_template_input_value_is_allowed('text_format', "bad\0text"))->toBeFalse();
+});
+
+test('input mutations validate ownership and use transactions', function () {
+	$source = file_get_contents(CACTI_PATH_BASE . '/graph_templates.php');
+
+	expect($source)
+		->toContain('graph_template_input_relationships_are_valid(')
+		->toContain('db_begin_transaction()')
+		->toContain('db_rollback_transaction()')
+		->toContain('db_commit_transaction()')
+		->toContain('AND graph_template_id = ?');
+});
+
+test('integrity audit is read only', function () {
+	$source = file_get_contents(CACTI_PATH_BASE . '/cli/audit_graph_template_inputs.php');
+
+	expect($source)
+		->toContain('cross-template definitions')
+		->toContain('orphaned definitions')
+		->not->toMatch('/\b(?:INSERT|UPDATE|DELETE|REPLACE)\b/');
+});

--- a/tests/tools/sql_interpolation_baseline.json
+++ b/tests/tools/sql_interpolation_baseline.json
@@ -44,7 +44,7 @@
     "lib/plugins.php": 1,
     "lib/poller.php": 14,
     "lib/rrdcheck.php": 1,
-    "lib/template.php": 6,
+    "lib/template.php": 5,
     "lib/variables.php": 1,
     "managers.php": 6,
     "plugins.php": 2,


### PR DESCRIPTION
Graph template input fields were accepted without checking them against the fields the template actually declares, so a crafted request could set fields the template does not expose.

Restricts the accepted set at each handoff, and adds `cli/audit_graph_template_inputs.php` to report existing rows that fall outside it.

Security references:

- [CVE-2024-31458](https://nvd.nist.gov/vuln/detail/CVE-2024-31458)
- [GHSA-jrxg-8wh8-943x](https://github.com/Cacti/cacti/security/advisories/GHSA-jrxg-8wh8-943x)

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.


Fixes #7690.
Fixes #7691.