### PR TITLE
Scope local-login password rehash to realm 0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 Cacti CHANGELOG
 
 1.3.0-dev
--issue#7684: Scope the local-login password rehash to realm 0 and only rehash after a successful login
 -issue#2205: Allow admins to disable RRDtool watermark
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
 -issue#3074: ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php do now report mmcblk data.
@@ -86,6 +85,7 @@ Cacti CHANGELOG
 -issue#7536: Consolidate the four hand-written poller_output_boost inserts into one shared helper
 -issue#7535: Consolidate the poller_item delete call sites behind poller_item_delete_for_data_source() and poller_item_delete_for_host()
 -issue#7576: Stop passing an unset path_php_binary into string parameters
+-issue#7684: Scope the local-login password rehash to realm 0 and only rehash after a successful login
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-issue#7684: Scope the local-login password rehash to realm 0 and only rehash after a successful login
 -issue#2205: Allow admins to disable RRDtool watermark
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
 -issue#3074: ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php do now report mmcblk data.

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -3836,37 +3836,34 @@ function local_auth_login_process(string $username) : array {
 		$user = secpass_login_process($username);
 
 		/**
-		 * If the password needs to be rehashed for security purposes,
-		 * do that now.
+		 * secpass_login_process() returns a partial row on success and [] on any
+		 * failure. Only when it succeeded do we load the full row the caller needs
+		 * and rehash the stored password if the algorithm has moved on. The old
+		 * code re-verified the password here independently: it ran bcrypt a second
+		 * time on every login, and for a correct password on a locked/disabled
+		 * account it repopulated $user even though the primary check had rejected
+		 * the login.
 		 */
-		$stored_pass = db_fetch_cell_prepared('SELECT password
-			FROM user_auth
-			WHERE username = ?
-			AND realm = 0',
-			[$username]);
+		if (cacti_sizeof($user)) {
+			$stored_pass = $user['password'] ?? '';
 
-		if ($stored_pass != '') {
-			$password = gnrv('login_password');
+			$user = db_fetch_row_prepared('SELECT *
+				FROM user_auth
+				WHERE username = ?
+				AND realm = 0',
+				[$username]);
 
-			$valid = compat_password_verify($password, $stored_pass);
+			if ($stored_pass != '' && compat_password_needs_rehash($stored_pass, PASSWORD_DEFAULT)) {
+				$password  = gnrv('login_password');
+				$rehashed  = compat_password_hash($password, PASSWORD_DEFAULT);
 
-			cacti_log("DEBUG: User '" . $username . "' password for rehash is " . ($valid ? '' : 'in') . 'valid', false, 'AUTH', POLLER_VERBOSITY_DEBUG);
+				db_check_password_length();
 
-			if ($valid) {
-				$user = db_fetch_row_prepared('SELECT *
-					FROM user_auth
+				db_execute_prepared('UPDATE user_auth
+					SET password = ?
 					WHERE username = ?
 					AND realm = 0',
-					[$username]);
-
-				if (compat_password_needs_rehash($stored_pass, PASSWORD_DEFAULT)) {
-					$password = compat_password_hash($password, PASSWORD_DEFAULT);
-					db_check_password_length();
-					db_execute_prepared('UPDATE user_auth
-						SET password = ?
-						WHERE username = ?',
-						[$password, $username]);
-				}
+					[$rehashed, $username]);
 			}
 		}
 	}

--- a/tests/Unit/AuthRehashScopeTest.php
+++ b/tests/Unit/AuthRehashScopeTest.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * The local-login password rehash must be scoped to realm 0 and must only run
+ * when the primary login succeeded. The old code wrote the password column with
+ * no realm predicate (overwriting other realms' rows for the same username) and
+ * re-verified the password a second time, which also repopulated $user for a
+ * correct password on a locked account.
+ */
+
+$authSrc = file_get_contents(dirname(__DIR__, 2) . '/lib/auth.php');
+
+function _local_login_body(string $src): string {
+	$start = strpos($src, 'function local_auth_login_process(');
+	expect($start)->not->toBeFalse();
+	$end = strpos($src, "\nfunction ", $start + 1);
+
+	return substr($src, $start, ($end === false ? strlen($src) : $end) - $start);
+}
+
+test('the rehash update is scoped to realm 0', function () use ($authSrc) {
+	$body = _local_login_body($authSrc);
+
+	$update = strpos($body, 'UPDATE user_auth');
+	expect($update)->not->toBeFalse();
+
+	// the write that follows must carry the realm predicate
+	$tail = substr($body, $update);
+	expect($tail)->toContain('SET password = ?');
+	expect(preg_match('/UPDATE user_auth\s+SET password = \?\s+WHERE username = \?\s+AND realm = 0/', $body))->toBe(1);
+});
+
+test('rehash only runs after a successful login, without a second verify', function () use ($authSrc) {
+	$body = _local_login_body($authSrc);
+
+	// gated on the successful secpass result, not an independent re-verify
+	expect($body)->toContain('if (cacti_sizeof($user)) {');
+	// the redundant second password verification is gone
+	expect($body)->not->toContain('$valid = compat_password_verify(');
+	// and it no longer re-reads the hash it already has from secpass_login_process()
+	expect($body)->not->toContain("db_fetch_cell_prepared('SELECT password");
+});


### PR DESCRIPTION
### Intent

The local-login password rehash could overwrite the wrong rows and ran an unnecessary second password verification.

### Changes

- **Realm scope.** `local_auth_login_process()` rehashed with `UPDATE user_auth SET password=? WHERE username=?` — no realm predicate, while every SELECT in the function is scoped `AND realm = 0`. If a username exists in more than one realm (a local account and an LDAP/domain account share the name), a local login overwrote the `password` column of every realm's row. Add `AND realm = 0`.
- **Single verification, success-gated.** The function re-fetched the stored hash and re-verified the password independently of `secpass_login_process()` — a second bcrypt on every login. For a correct password on a locked/disabled account it also repopulated `$user` even though the primary check had rejected the login (the caller's `$error` check still blocked it, but the state was misleading). Now the rehash runs only when `secpass_login_process()` succeeded, reusing the hash it already verified.

### Scope / risk

No change to whether a login succeeds or to the returned full user row (the `SELECT *` re-fetch is preserved for the success path). Removes one bcrypt per local login.

### Verification

`tests/Unit/AuthRehashScopeTest.php` (realm-scoped UPDATE, success-gated rehash, no second verify or re-read). Existing auth suites, PHPStan L6, sink gate, php-cs-fixer pass.

Closes #7684.
