### PR TITLE
Guard two divisors that PHP 8 makes fatal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -160,6 +160,7 @@ Cacti CHANGELOG
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
 -issue#7701: Confine names used as SQL identifiers in automation
 -issue#7665: Confine local RRD paths while preserving remote RRDProxy storage
+-issue#7700: Guard two divisors that PHP 8 makes fatal
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect

--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -359,14 +359,26 @@ function aggregate_graphs_insert_graph_items(int $_new_graph_id, int $_old_graph
 						WHERE color_template_id = ?',
 						[$_color_templates[$i]]);
 
-					// templating required, get color for current graph item
-					$sql = 'SELECT color_id
-						FROM color_template_items
-						WHERE color_template_id=' . $_color_templates[$i] . '
-						ORDER BY sequence
-						LIMIT ' . ($_selected_graph_index % $num_colors) . ',1';
+					// a color template with no items counts zero, and the round
+					// robin below divides by that count. PHP 8 raises
+					// DivisionByZeroError where PHP 7 warned and carried on.
+					if ($num_colors > 0) {
+						// templating required, get color for current graph item.
+						// The id is bound, as the count above already does; the
+						// offset is arithmetic on two integers, which no
+						// placeholder is needed for and MySQL will not bind in
+						// a LIMIT on every supported version.
+						$offset = $_selected_graph_index % $num_colors;
 
-					$save['color_id'] = db_fetch_cell($sql);
+						$save['color_id'] = db_fetch_cell_prepared('SELECT color_id
+							FROM color_template_items
+							WHERE color_template_id = ?
+							ORDER BY sequence
+							LIMIT ' . $offset . ',1',
+							[$_color_templates[$i]]);
+					} else {
+						$save['color_id'] = $graph_item['color_id'];
+					}
 				} else {
 					// set a color even if no color templating is required
 					$save['color_id'] = $graph_item['color_id'];

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -1624,7 +1624,10 @@ function utilities_get_mysql_recommendations() : int {
 
 					$remainingMem = ($totalMem * 0.8) - $totalMemorySans;
 
-					$recommendation = $remainingMem / $maxConnections;
+					/* max_connections is read from the server, and a user without
+					   rights to the global variable gets nothing back. Dividing by
+					   that is fatal on PHP 8 rather than the warning it once was. */
+					$recommendation = $maxConnections > 0 ? $remainingMem / $maxConnections : 0;
 
 					$compare         = '<=';
 					$passed          = ($variables[$name] >= ($recommendation / 1024 / 1024)) && $recommendation > 0;

--- a/tests/Unit/Php8ZeroDivisorGuardTest.php
+++ b/tests/Unit/Php8ZeroDivisorGuardTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Two divisors reached zero from ordinary data: a colour template with no
+ * items, and a database account that cannot read max_connections. PHP 7 warned
+ * and carried on. PHP 8 raises DivisionByZeroError, ending the request.
+ *
+ * PHPStan stays quiet about both here, because this branch's type hints let it
+ * narrow the operands. Silence from the analyser is not the same as the value
+ * being impossible at runtime, which is why these are pinned by hand.
+ */
+
+$base = dirname(__DIR__, 2);
+
+test('the sources under test are readable', function () use ($base) {
+	foreach (['/lib/api_aggregate.php', '/lib/utility.php'] as $rel) {
+		expect(file_get_contents($base . $rel))->toBeString()->not->toBeEmpty();
+	}
+});
+
+test('PHP 8 makes both division and modulo by zero fatal', function () {
+	expect(fn () => 5 % 0)->toThrow(DivisionByZeroError::class)
+		->and(fn () => 5 / 0)->toThrow(DivisionByZeroError::class);
+});
+
+test('the aggregate colour round robin checks the template has colours', function () use ($base) {
+	$src = file_get_contents($base . '/lib/api_aggregate.php');
+
+	// the id is bound now, as the count above it already was
+	expect($src)->not->toContain("WHERE color_template_id=' . \$_color_templates[\$i] . '")
+		->and($src)->toContain('WHERE color_template_id = ?');
+
+	$guard = strpos($src, 'if ($num_colors > 0) {');
+	$use   = strpos($src, '$offset = $_selected_graph_index % $num_colors;');
+
+	expect($guard)->not->toBeFalse()
+		->and($use)->not->toBeFalse()
+		->and($guard)->toBeLessThan($use);
+});
+
+test('the connection recommendation checks max_connections came back', function () use ($base) {
+	$src = file_get_contents($base . '/lib/utility.php');
+
+	expect($src)->not->toContain('$recommendation = $remainingMem / $maxConnections;')
+		->and($src)->toContain('$maxConnections > 0 ? $remainingMem / $maxConnections : 0');
+});


### PR DESCRIPTION
The same sweep as #7699, run against develop. No deprecations here either: FILTER_SANITIZE_STRING, E_STRICT, ${var} interpolation, curly string offsets, implicit nullable parameters, strftime and utf8_encode are all absent.

Two of the three divisors from #7699 exist here as well.

api_aggregate.php counts the items in a colour template and uses that count as the modulus for round robin colour assignment. A template with no items counts zero, and modulo by zero is fatal. The graph item now keeps its own colour, matching the no-templating branch beside it.

utility.php divides remaining memory by max_connections read from the server. An account without rights to the global variable gets nothing back, and the divide is fatal.

The third, rounding a report mail time to poller_interval, does not exist on develop; it has been refactored away.

Worth recording for anyone repeating this: PHPStan reports 58 findings on develop's lib/ against 8449 on 1.2.x, and flags neither of these here, because this branch's type hints let it narrow the operands. The hazard is identical in both trees. Analyser silence was a property of the annotations, not of the runtime, so I checked the sites by hand rather than trusting the count.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
