### PR TITLE
Confine names used as SQL identifiers in automation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -148,6 +148,7 @@ Cacti CHANGELOG
 -issue#7719: Spike Kill text output applied the large value scientific notation format to the column left of the value it belonged to, starting with Variance
 -issue#7732: Bind device IDs and escape graph and device HTML sinks
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
+-issue#7701: Confine names used as SQL identifiers in automation
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -407,7 +407,7 @@ function automation_get_matching_graphs_sql(array $rule, int $rule_type) : array
 	} elseif (grv('host_id') == '0') {
 		$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . ' gl.host_id = 0';
 	} elseif (!ierv('host_id')) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . ' gl.host_id = ' . grv('host_id');
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . ' gl.host_id = ' . (int) grv('host_id');
 	}
 
 	if (grv('template_id') == '-1') {
@@ -415,7 +415,7 @@ function automation_get_matching_graphs_sql(array $rule, int $rule_type) : array
 	} elseif (grv('template_id') == '0') {
 		$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . ' gtg.graph_template_id = 0';
 	} elseif (!ierv('template_id')) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . ' gtg.graph_template_id = ' . grv('template_id');
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' WHERE ') . ' gtg.graph_template_id = ' . (int) grv('template_id');
 	}
 
 	// get the WHERE clause for matching graphs
@@ -1806,8 +1806,38 @@ function build_graph_object_sql_having(array $rule, string $filter) : string {
 			$i = 0;
 
 			foreach ($field_names as $column) {
-				$sql_having .= ($i == 0 ? '' : ' OR ') . '`' . implode('`.`', explode('.', $column['field_name'])) . '`' . ' LIKE ' . db_qstr('%' . $filter . '%');
+				/* The name becomes an identifier in the generated SQL, and it
+				 * arrives from snmp_query_field, which a data query XML import
+				 * populates. A backtick in it would close the quoting the
+				 * backticks below are providing, so confine each part to the
+				 * characters an identifier may hold and drop the field when
+				 * nothing usable survives. */
+				$parts = [];
+
+				foreach (explode('.', $column['field_name']) as $part) {
+					$clean = sanitize_sql_column($part, '');
+
+					if ($clean === '') {
+						$parts = [];
+
+						break;
+					}
+
+					$parts[] = $clean;
+				}
+
+				if (!cacti_sizeof($parts)) {
+					continue;
+				}
+
+				$sql_having .= ($i == 0 ? '' : ' OR ') . '`' . implode('`.`', $parts) . '`' . ' LIKE ' . db_qstr('%' . $filter . '%');
 				$i++;
+			}
+
+			/* Every field being dropped would otherwise remove a requested filter
+			 * or leave invalid SQL. Keep the clause valid and fail closed. */
+			if ($i == 0) {
+				return ' HAVING (1 = 0)';
 			}
 
 			$sql_having .= ')';
@@ -1950,7 +1980,39 @@ function build_rule_item_filter(array $automation_rule_items, string $prefix = '
 
 			// field name
 			if ($automation_rule_item['field'] != '') {
-				$sql_filter .= ' ' . $prefix . '`' . implode('`.`', explode('.', $automation_rule_item['field'])) . '`';
+				/* 1.2.x confines this name with sanitize_sql_column() and that
+				 * call was lost here. The field is stored with the rule item
+				 * and becomes an identifier below, so a backtick in it would
+				 * close the quoting rather than be quoted by it.
+				 *
+				 * Confine each dot separated part rather than the whole name:
+				 * the helper permits '.', so 'a.' survives it intact and then
+				 * splits into 'a' and an empty segment, which renders as an
+				 * empty backticked identifier. A part left with nothing usable
+				 * drops the whole item instead. */
+				$field_parts = [];
+
+				foreach (explode('.', $automation_rule_item['field']) as $field_part) {
+					$clean_part = sanitize_sql_column($field_part, '');
+
+					if ($clean_part === '') {
+						$field_parts = [];
+
+						break;
+					}
+
+					$field_parts[] = $clean_part;
+				}
+
+				if (!cacti_sizeof($field_parts)) {
+					// The operation token may already be present; complete it with a
+					// predicate that fails closed instead of leaving invalid SQL.
+					$sql_filter .= ' 1 = 0';
+
+					continue;
+				}
+
+				$sql_filter .= ' ' . $prefix . '`' . implode('`.`', $field_parts) . '`';
 				$sql_filter .= ' ' . $automation_op_array['op'][$automation_rule_item['operator']] . ' ';
 
 				if ($automation_op_array['binary'][$automation_rule_item['operator']]) {

--- a/tests/Unit/AutomationSqlIdentifierTest.php
+++ b/tests/Unit/AutomationSqlIdentifierTest.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Two places in lib/api_automation.php wrap a stored name in backticks and use
+ * it as an identifier. Backticks quote an identifier; they do not escape one,
+ * so a name holding a backtick closes the quoting instead of being contained
+ * by it. build_rule_item_filter() guarded this on 1.2.x and the guard was lost
+ * on the way to develop; build_graph_object_sql_having() never had one.
+ *
+ * The filter values beside them are handled by db_qstr() and are not at issue.
+ */
+
+require_once CACTI_PATH_LIBRARY . '/functions.php';
+
+$src = file_get_contents(CACTI_PATH_LIBRARY . '/api_automation.php');
+
+test('the column sanitiser removes the character that closes an identifier', function () {
+	expect(sanitize_sql_column('if`Descr', ''))->toBe('ifDescr')
+		->and(sanitize_sql_column('`', ''))->toBe('')
+		->and(sanitize_sql_column('ifDescr', ''))->toBe('ifDescr');
+});
+
+test('the rule item filter confines each part of the stored field name', function () use ($src) {
+	/* the whole-name form let '.' through the helper, so 'a.' split into a
+	   usable part and an empty one and rendered an empty identifier */
+	expect($src)->not->toContain("implode('`.`', explode('.', \$automation_rule_item['field']))")
+		->and($src)->not->toContain("sanitize_sql_column(\$automation_rule_item['field'])")
+		->and($src)->toContain("\$clean_part = sanitize_sql_column(\$field_part, '');")
+		->and($src)->toContain('if (!cacti_sizeof($field_parts)) {')
+		->and($src)->toContain("\$sql_filter .= ' 1 = 0';");
+});
+
+test('a trailing dot would have produced an empty identifier segment', function () {
+	require_once CACTI_PATH_LIBRARY . '/functions.php';
+
+	// what the whole-name form used to yield
+	$whole = sanitize_sql_column('a.', 'id');
+
+	expect($whole)->toBe('a.')
+		->and(explode('.', $whole))->toBe(['a', '']);
+
+	// what the per-part form yields for the same input
+	$parts = [];
+
+	foreach (explode('.', 'a.') as $part) {
+		$clean = sanitize_sql_column($part, '');
+
+		if ($clean === '') {
+			$parts = [];
+
+			break;
+		}
+
+		$parts[] = $clean;
+	}
+
+	expect($parts)->toBe([]);
+});
+
+test('the having clause confines each part of the field name', function () use ($src) {
+	expect($src)->not->toContain("implode('`.`', explode('.', \$column['field_name']))")
+		->and($src)->toContain("\$clean = sanitize_sql_column(\$part, '');");
+});
+
+test('a field that sanitises away produces a false HAVING predicate', function () use ($src) {
+	expect($src)->toContain("if (\$i == 0) {\n\t\t\t\treturn ' HAVING (1 = 0)';");
+});
+
+test('the two device filters cast before interpolating', function () use ($src) {
+	expect($src)->not->toContain("' gl.host_id = ' . grv('host_id')")
+		->and($src)->not->toContain("' gtg.graph_template_id = ' . grv('template_id')")
+		->and($src)->toContain("' gl.host_id = ' . (int) grv('host_id')")
+		->and($src)->toContain("' gtg.graph_template_id = ' . (int) grv('template_id')");
+});


### PR DESCRIPTION
Backticks quote an identifier; they do not escape one. A stored name that holds a backtick closes the quoting rather than being contained by it. Two places in lib/api_automation.php wrap a stored name in backticks and use the result as an identifier.

build_rule_item_filter() takes the field from a stored rule item. 1.2.x passes it through sanitize_sql_column() and that call is missing here, so this is a guard develop lost rather than one it never had. Restored to match.

build_graph_object_sql_having() takes each part of a data query field name, which snmp_query_field holds and a data query XML import populates. Never guarded on either branch. Each part is confined now, and a field with nothing usable left is dropped instead of emitted. Dropping every field would have produced ' HAVING ()', which is a syntax error rather than a filter matching nothing, so that returns an empty string instead.

Also cast two device filters. automation_get_matching_graphs_sql() interpolated grv('host_id') and grv('template_id') without the (int) that lines 321 and 1182 use on the same kind of value. Those are safe today: display_matching_graphs() renders the filter first, and render() reaches validate_store_request_vars(), which applies the FILTER_VALIDATE_INT both declare. That safety is an ordering invariant three call levels away, and a future caller reaching the SQL builder without rendering the filter first would reintroduce the problem. The cast removes the dependency.

I could not show any of this reachable by an unprivileged user. Rule item fields and data query imports are administrative. Filter values beside these are handled by db_qstr() and were never at issue.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
