### PR TITLE
Bind the MIB column names in MibCache::select()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -145,6 +145,7 @@ Cacti CHANGELOG
 -issue#7696: Repair the string sanitisers in lib/functions.php
 -issue#7697: Guard two divisions PHP 8 made fatal
 -issue#7693: Validate host_id before it reaches the graph template query
+-issue#7707: Bind the MIB column names in MibCache::select()
 -issue#7719: Spike Kill text output applied the large value scientific notation format to the column left of the value it belonged to, starting with Variance
 -issue#7732: Bind device IDs and escape graph and device HTML sinks
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled

--- a/lib/mib_cache.php
+++ b/lib/mib_cache.php
@@ -270,13 +270,18 @@ class MibCache {
 					$filter = $oid_entry . '.%.' . $this->active_table_entry;
 
 					// fetch all values of specific columns given for that MIB table row
+					/* The names are bound rather than pasted between quotes. The
+					   caller passes them, and a quote in one used to close the
+					   string and leave the rest as SQL. */
+					$placeholders = implode(',', array_fill(0, cacti_sizeof($column), '?'));
+
 					$entries = db_fetch_assoc_prepared("SELECT name, value
 						FROM snmpagent_cache
-						WHERE name IN ('" . implode("','", $column) . "')
+						WHERE name IN ($placeholders)
 						AND oid LIKE ?
 						GROUP BY name
 						ORDER BY oid",
-						[$filter]);
+						array_merge(array_values($column), [$filter]));
 
 					if ($entries && cacti_sizeof($entries) > 0) {
 						foreach ($entries as $entry) {
@@ -323,21 +328,35 @@ class MibCache {
 				// fetch only the values of one single column
 				$filter = $oid_entry . '.%.%';
 
-				return db_fetch_assoc_prepared("SELECT value AS '" . $column . "'
+				/* The alias is an identifier and cannot be bound, so confine it
+				   to the characters one may hold. It was pasted between quotes
+				   before, where a quote in the name ended the alias. */
+				/* The helper's default is 'id', which would quietly rename the
+				   returned key to a real column name when the input strips to
+				   nothing. Ask for an empty default and refuse instead. */
+				$alias = sanitize_sql_column($column, '');
+
+				if ($alias === '') {
+					return [];
+				}
+
+				return db_fetch_assoc_prepared('SELECT value AS `' . $alias . '`
 					FROM snmpagent_cache
 					WHERE name = ?
 					AND oid LIKE ?
-					ORDER BY oid",
+					ORDER BY oid',
 					[$column, $filter]);
 			} elseif (is_array($column) && cacti_sizeof($column) > 0) {
 				// fetch values of specific columns given
 				$filter = $oid_entry . '.%.%';
 
+				$placeholders = implode(',', array_fill(0, cacti_sizeof($column), '?'));
+
 				$entries = db_fetch_assoc_prepared("SELECT name, value
 					FROM snmpagent_cache
-					WHERE name IN ('" . implode("','", $column) . "')
+					WHERE name IN ($placeholders)
 					AND oid LIKE ?
-					ORDER BY oid", [$filter]);
+					ORDER BY oid", array_merge(array_values($column), [$filter]));
 
 				if (cacti_sizeof($entries)) {
 					$num_objects        = cacti_sizeof($column);

--- a/tests/Unit/MibCacheSqlBindingTest.php
+++ b/tests/Unit/MibCacheSqlBindingTest.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * MibCache::select() pasted the column names it was given between quotes to
+ * build an IN list, and pasted a single name into a column alias. Backticks
+ * and quotes delimit; they do not escape. A name holding the delimiter ended
+ * the list or the alias and left the remainder as SQL. Every caller in the
+ * tree passes a literal array today, so nothing reached it, but the signature
+ * accepts anything and the next caller would not have known.
+ */
+
+require_once CACTI_PATH_LIBRARY . '/functions.php';
+
+$src = file_get_contents(CACTI_PATH_LIBRARY . '/mib_cache.php');
+
+test('the source read succeeded', function () use ($src) {
+	expect($src)->toBeString()->not->toBeEmpty();
+});
+
+test('column names are bound, not pasted into the IN list', function () use ($src) {
+	expect($src)->not->toContain('implode("\',\'", $column)')
+		->and(substr_count($src, "array_fill(0, cacti_sizeof(\$column), '?')"))->toBe(2)
+		->and(substr_count($src, 'array_merge(array_values($column), [$filter])'))->toBe(2);
+});
+
+test('the alias is confined to identifier characters', function () use ($src) {
+	expect($src)->not->toContain('SELECT value AS \'" . $column . "\'')
+		->and($src)->toContain("\$alias = sanitize_sql_column(\$column, '');")
+		->and($src)->toContain("if (\$alias === '') {");
+});
+
+test('a name carrying the delimiter cannot escape the alias', function () {
+
+	// the shape that used to close the alias and continue the statement
+	expect(sanitize_sql_column("x` UNION SELECT password FROM user_auth -- "))
+		->not->toContain('`')
+		->and(sanitize_sql_column("x' UNION SELECT 1 -- "))->not->toContain("'");
+});
+
+test('placeholder count always matches the values bound', function () {
+	foreach ([1, 2, 5, 17] as $n) {
+		$column = array_fill(0, $n, 'cactiApplDeviceIndex');
+
+		$placeholders = implode(',', array_fill(0, cacti_sizeof($column), '?'));
+		$params       = array_merge(array_values($column), ['filter']);
+
+		expect(substr_count($placeholders, '?'))->toBe($n)
+			->and(cacti_sizeof($params))->toBe($n + 1);
+	}
+});


### PR DESCRIPTION
MibCache::select() built its query by pasting the names it was handed into the statement. Three places, all in the same method.

Two build an IN list as "WHERE name IN ('" . implode("','", $column) . "')". A name holding a single quote closes the string and the rest of it is SQL. The oid LIKE ? beside it was already bound, so the query mixed both idioms in one statement.

The third pastes a single name into a column alias, SELECT value AS '" . $column . "'. Same problem, different delimiter.

The names are bound now, with a placeholder per element and the values merged into the parameter list, so the count cannot drift from the list. Both sites already sit behind is_array($column) && cacti_sizeof($column) > 0, so an empty IN () is not reachable. The alias cannot be bound because it is an identifier, so it goes through sanitize_sql_column() and into backticks.

Nothing reaches this today. All three callers in lib/snmpagent.php pass literal arrays such as ['cactiApplDeviceIndex', 'cactiApplDeviceStatus']. The method signature is select(mixed $column = false) though, so it accepts anything, and the first caller to pass something dynamic would have had no warning. db_qstr() appears exactly once in the file and this was where it was missing.

Five tests, run on Linux under PHP 8.1 in a container: 5 passed, 17 assertions. One of them checks the placeholder count tracks the values bound rather than only that the pasting is gone.

1.2.x carries the same three sites and gets its own change.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
