### PR TITLE
Use Symfony Filesystem for atomic CLI writes

### DIFF
--- a/cli/genmanifest.php
+++ b/cli/genmanifest.php
@@ -24,6 +24,7 @@
 */
 
 require(__DIR__ . '/../include/cli_check.php');
+require_once(CACTI_PATH_LIBRARY . '/CactiFilesystem.php');
 require_once(CACTI_PATH_LIBRARY . '/xml.php');
 require_once(CACTI_PATH_LIBRARY . '/import.php');
 
@@ -196,7 +197,14 @@ if (cacti_sizeof($directory)) {
 			$package_manifest['manifest'] = $manifest;
 			$package_manifest['keys']     = array_unique($keys);
 
-			file_put_contents("$dir/package.manifest", json_encode($package_manifest, JSON_PRETTY_PRINT));
+			try {
+				$filesystem = new CactiFilesystem();
+				$filesystem->writeFile("$dir/package.manifest", json_encode($package_manifest, JSON_PRETTY_PRINT));
+			} catch (Symfony\Component\Filesystem\Exception\IOExceptionInterface) {
+				print "FATAL: Unable to write $dir/package.manifest" . PHP_EOL;
+
+				continue;
+			}
 
 			print "Manifest package.manifest written to $dir/package.manifest" . PHP_EOL;
 		}

--- a/cli/input_whitelist.php
+++ b/cli/input_whitelist.php
@@ -24,6 +24,7 @@
 */
 
 require(__DIR__ . '/../include/cli_check.php');
+require_once(CACTI_PATH_LIBRARY . '/CactiFilesystem.php');
 require_once(CACTI_PATH_LIBRARY . '/utility.php');
 require_once(CACTI_PATH_LIBRARY . '/poller.php');
 require_once(CACTI_PATH_LIBRARY . '/template.php');
@@ -167,7 +168,15 @@ if ($audit) {
 			$input[$value['hash']] = $value['input_string'];
 		}
 
-		file_put_contents($config['input_whitelist'], json_encode($input));
+		try {
+			$filesystem = new CactiFilesystem();
+			$filesystem->writeFile($config['input_whitelist'], json_encode($input));
+		} catch (Symfony\Component\Filesystem\Exception\IOExceptionInterface) {
+			print 'ERROR: Data Input Whitelist file \'' . $config['input_whitelist'] . '\' could not be updated.' . PHP_EOL;
+
+			exit(1);
+		}
+
 		print 'SUCCESS: Data Input Whitelist file \'' . $config['input_whitelist'] . '\' successfully updated.' . PHP_EOL;
 
 		if (cacti_sizeof($pushes)) {

--- a/cli/md5sum.php
+++ b/cli/md5sum.php
@@ -24,6 +24,7 @@
 */
 
 require(__DIR__ . '/../include/cli_check.php');
+require_once(CACTI_PATH_LIBRARY . '/CactiFilesystem.php');
 
 // process calling arguments
 $parms = $_SERVER['argv'];
@@ -168,7 +169,10 @@ if ($create) {
 		exit(3);
 	}
 
-	if (file_put_contents($md5_file,$output) === false) {
+	try {
+		$filesystem = new CactiFilesystem();
+		$filesystem->writeFile($md5_file, $output);
+	} catch (Symfony\Component\Filesystem\Exception\IOExceptionInterface) {
 		printf('ERROR: Failed to write to MD5 file \'%s\'' . PHP_EOL, $md5_file);
 		exit(4);
 	}

--- a/cli/refresh_csrf.php
+++ b/cli/refresh_csrf.php
@@ -24,6 +24,7 @@
 */
 
 require(__DIR__ . '/../include/cli_check.php');
+require_once(CACTI_PATH_LIBRARY . '/CactiFilesystem.php');
 require_once(CACTI_PATH_LIBRARY . '/poller.php');
 require_once(CACTI_PATH_LIBRARY . '/utility.php');
 
@@ -69,21 +70,25 @@ print 'NOTE: Updating csrf_secret file with new information' . PHP_EOL;
 if (!file_exists(CACTI_CSRF_SECRET)) {
 	print 'WARNING: csrf_secret.php file does not exist!' . PHP_EOL;
 } elseif (!is_writable(CACTI_CSRF_SECRET)) {
-	print 'FATAL: unable to unlink csrf_secret.php!' . PHP_EOL;
+	print 'FATAL: Unable to replace csrf_secret.php!' . PHP_EOL;
 
 	exit(1);
-} else {
-	print 'NOTE: Removing old csrf_secret.php file.' . PHP_EOL;
-	unlink(CACTI_CSRF_SECRET);
 }
 
 $new_secret = csrf_generate_secret();
 
 if (csrf_writable(CACTI_CSRF_SECRET)) {
 	umask(0027);
-	$fh = fopen(CACTI_CSRF_SECRET, 'w');
-	fwrite($fh, '<?php $secret = "' . $new_secret . '";' . PHP_EOL);
-	fclose($fh);
+
+	try {
+		$filesystem = new CactiFilesystem();
+		$filesystem->writeFile(CACTI_CSRF_SECRET, '<?php $secret = "' . $new_secret . '";' . PHP_EOL);
+	} catch (Symfony\Component\Filesystem\Exception\IOExceptionInterface) {
+		print 'FATAL: Unable to write new csrf_secret.php file.' . PHP_EOL;
+
+		exit(1);
+	}
+
 	print 'NOTE: New csrf_secret.php file written.' . PHP_EOL;
 
 	exit(0);

--- a/lib/CactiFilesystem.php
+++ b/lib/CactiFilesystem.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Symfony\Component\Filesystem\Filesystem;
+
+final class CactiFilesystem {
+	private Filesystem $filesystem;
+
+	public function __construct(?Filesystem $filesystem = null) {
+		$this->filesystem = $filesystem ?? new Filesystem();
+	}
+
+	/**
+	 * Replace a complete local file atomically.
+	 *
+	 * @throws Symfony\Component\Filesystem\Exception\IOExceptionInterface
+	 */
+	public function writeFile(string $filename, string $contents) : void {
+		$this->filesystem->dumpFile($filename, $contents);
+	}
+}

--- a/tests/Unit/CactiFilesystemTest.php
+++ b/tests/Unit/CactiFilesystemTest.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Symfony\Component\Filesystem\Filesystem;
+
+require_once(__DIR__ . '/../../lib/CactiFilesystem.php');
+
+beforeEach(function () {
+	$this->directory = sys_get_temp_dir() . '/cacti-filesystem-' . bin2hex(random_bytes(8));
+	$this->filesystem = new Filesystem();
+	$this->filesystem->mkdir($this->directory);
+});
+
+afterEach(function () {
+	$this->filesystem->remove($this->directory);
+});
+
+test('writeFile creates a file with the requested contents', function () {
+	$filename = $this->directory . '/nested/config.php';
+	$contents = '<?php return true;' . PHP_EOL;
+
+	$filesystem = new CactiFilesystem();
+	$filesystem->writeFile($filename, $contents);
+
+	expect(file_get_contents($filename))->toBe($contents);
+});
+
+test('writeFile replaces existing contents', function () {
+	$filename = $this->directory . '/config.php';
+	file_put_contents($filename, 'old');
+
+	$filesystem = new CactiFilesystem();
+	$filesystem->writeFile($filename, 'new');
+
+	expect(file_get_contents($filename))->toBe('new');
+});
+
+test('writeFile delegates to Symfony Filesystem dumpFile', function () {
+	$delegate = new class extends Filesystem {
+		public array $writes = [];
+
+		public function dumpFile(string $filename, $content) : void {
+			$this->writes[] = [$filename, $content];
+		}
+	};
+
+	$filesystem = new CactiFilesystem($delegate);
+	$filesystem->writeFile('/tmp/cacti-config.php', 'contents');
+
+	expect($delegate->writes)->toBe([['/tmp/cacti-config.php', 'contents']]);
+});

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -146,13 +146,13 @@ fs_write	./cli/float_rrdfiles.php:363					$lf = fopen('/tmp/clearer.log', 'a');
 fs_write	./cli/genkey.php:207		file_put_contents("$keypair_path/package.info", $package_info);
 fs_write	./cli/genkey.php:316				if (file_put_contents("$keypair_path/package.key", $privKey)) {
 fs_write	./cli/genkey.php:330			if (file_put_contents("$keypair_path/package.pub", $pubKey)) {
-fs_write	./cli/genmanifest.php:199				file_put_contents("$dir/package.manifest", json_encode($package_manifest, JSON_PRETTY_PRINT));
+fs_write	./cli/genmanifest.php:202					$filesystem->writeFile("$dir/package.manifest", json_encode($package_manifest, JSON_PRETTY_PRINT));
 fs_write	./cli/import_package.php:171				$fp   = fopen($filename, 'r');
 fs_write	./cli/import_template.php:126				$fp       = fopen($filename,'r');
-fs_write	./cli/input_whitelist.php:170			file_put_contents($config['input_whitelist'], json_encode($input));
-fs_write	./cli/md5sum.php:171		if (file_put_contents($md5_file,$output) === false) {
+fs_write	./cli/input_whitelist.php:173				$filesystem->writeFile($config['input_whitelist'], json_encode($input));
+fs_write	./cli/md5sum.php:174			$filesystem->writeFile($md5_file, $output);
 fs_write	./cli/migrate_poller.php:240		$result = file_put_contents($migration_log_file, date('Y-m-d H:i:s') . " - $message" . PHP_EOL, FILE_APPEND);
-fs_write	./cli/refresh_csrf.php:84		$fh = fopen(CACTI_CSRF_SECRET, 'w');
+fs_write	./cli/refresh_csrf.php:85			$filesystem->writeFile(CACTI_CSRF_SECRET, '<?php $secret = "' . $new_secret . '";' . PHP_EOL);
 fs_write	./cli/rrdresize.php:247		$log_handle = fopen($tmp_backup_folder . 'tmp_rrdresize.log', 'w');
 fs_write	./cli/rrdresize.php:860					if (!file_put_contents($tmp_xml_file, $rrd_new_header . $rrd_new_body . '</rrd>')) {
 fs_write	./cli/splice_rrd.php:363	file_put_contents($newxmlfile, $new_xml);
@@ -168,6 +168,7 @@ fs_write	./install/functions.php:1584			file_put_contents(CACTI_PATH_LOG . '/' .
 fs_write	./install/functions.php:1585			file_put_contents(CACTI_PATH_LOG . '/install-complete.log', sprintf($format_log2, $day, $time, $sectionname, $levelname, $data, PHP_EOL), $flags);
 fs_write	./install/functions.php:275				$fh = fopen($file, 'w');
 fs_write	./install/functions.php:803			file_put_contents($cacheFile, '<[version]> ' . $cacti_upgrade_version . ' <[status]> ' . $status . ' <[sql]> ' . clean_up_lines($sql) . ' <[error]> ' . $database_last_error . PHP_EOL, FILE_APPEND);
+fs_write	./lib/CactiFilesystem.php:30			$this->filesystem->dumpFile($filename, $contents);
 fs_write	./lib/api_device.php:2682							file_put_contents($new_xmlfile, $data);
 fs_write	./lib/boost.php:611								if ($fileptr = fopen($cache_file, 'rb')) {
 fs_write	./lib/boost.php:761							if ($fileptr = fopen($cache_file, 'w')) {
@@ -668,7 +669,7 @@ header_redirect	./vdef.php:228			header('Location: vdef.php');
 header_redirect	./vdef.php:532		header('Location: vdef.php?action=edit&id=' . grv('id'));
 header_redirect	./vdef.php:57			header('Location: vdef.php?action=edit&id=' . grv('vdef_id'));
 header_redirect	./vdef.php:65			header('Location: vdef.php?action=edit&id=' . grv('vdef_id'));
-xml_parse	./cli/genmanifest.php:143							$xmldata = simplexml_load_string($data);
+xml_parse	./cli/genmanifest.php:144							$xmldata = simplexml_load_string($data);
 xml_parse	./cli/rrdresize.php:559						$rrd_data = json_decode(json_encode(simplexml_load_string($file_dump)), true);
 xml_parse	./install/functions.php:957				$xmlget = simplexml_load_string($xml);
 xml_parse	./lib/import.php:370		$xmlget = simplexml_load_string($data);

--- a/tests/security/build_sink_inventory.sh
+++ b/tests/security/build_sink_inventory.sh
@@ -50,5 +50,5 @@ scan "xml_parse" '\b(simplexml_load_file|simplexml_load_string|DOMDocument::load
 # Redirect/header sinks
 scan "header_redirect" '\bheader\s*\(\s*[\"\x27]Location:'
 
-# Filesystem write sinks
-scan "fs_write" '\b(file_put_contents|fopen)\s*\('
+# Filesystem write sinks, including Cacti and Symfony atomic-write abstractions
+scan "fs_write" '(?:\b(?:file_put_contents|fopen)\s*\(|->(?:writeFile|dumpFile)\s*\()'


### PR DESCRIPTION
Fixes #7710

## Summary

- add a small `CactiFilesystem` adapter for atomic complete-file replacement through Symfony Filesystem `dumpFile()`
- migrate CSRF secret rotation, data-input whitelist generation, package manifest generation, and MD5 manifest generation
- remove the CSRF delete-before-write interval
- preserve each CLI's existing success/failure reporting and exit behavior
- add focused create, replace, and delegation tests

## Why Symfony Filesystem is appropriate here

Each migrated call constructs a complete local file in memory and publishes it as one unit. `dumpFile()` writes to a temporary file in the destination directory and renames it into place. Readers therefore observe the old complete file or the new complete file, rather than an empty or partially written destination.

This is especially important for `refresh_csrf.php`: the previous sequence unlinked the active secret before opening its replacement. A failed write could leave Cacti without that file. The new sequence retains the old secret unless replacement succeeds.

Cacti already directly requires `symfony/filesystem: ^6.0`, so this PR introduces no new production dependency.

## Why other filesystem calls remain native

The audit found 96 production mutation calls, but replacement must follow behavior:

- installer bootstrap can run while Composer's vendor tree is absent;
- streams, pipes, compressed wrappers, remote URLs, and large incremental reads need native stream APIs;
- append and lock-sensitive files may require inode stability that atomic rename does not preserve;
- remote RRDproxy operations are protocol operations, not local filesystem operations;
- recursive discovery belongs to Symfony Finder;
- lexical path construction belongs to Symfony Path, while symlink-aware security containment still requires filesystem resolution;
- incremental, seek-based, or partial writes do not have complete-file replacement semantics.

The linked issue records the full operation count, exclusions, and higher-value follow-up candidates.

## Compatibility and risk

- targets `develop` / v1.3.0
- keeps the Cacti CLI bootstrap order: the adapter is loaded only after `cli_check.php` has loaded Composer
- preserves existing destination permissions; new files use the caller's current umask
- catches Symfony `IOExceptionInterface` and maps failures to the existing CLI error paths
- does not alter installer bootstrap, streaming, locking, remote I/O, or directory traversal

## Validation

- [x] Linux Docker Unit + Integration suite: 1,611 passed, 4,027 assertions
- [x] Reviewed 20 skips; all are documented unavailable external services/features
- [x] Linux Docker focused Xdebug coverage: `CactiFilesystem` 100%
- [x] Linux Docker PHPStan level 6: no errors
- [x] Linux Docker PHP-CS-Fixer dry-run: no changes required
- [x] PHP syntax checks: all changed PHP files pass
- [x] `git diff --check`: clean
- [x] No generated Composer/vendor changes included

## Manual review notes

The new adapter is intentionally limited to one method. It is not a general wrapper around every Symfony Filesystem method; future migration should add policy only when Cacti has a stable semantic contract to centralize.
