### PR TITLE
Use normalized paths for resolved containment

### DIFF
--- a/.github/workflows/path-coverage.yml
+++ b/.github/workflows/path-coverage.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup locked PHP 8.1 dependencies
+      - name: Setup locked PHP 8.2 dependencies
         uses: ./.github/actions/setup-php-composer
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: xdebug
           extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
           dependency-mode: locked-path-coverage

--- a/.github/workflows/path-coverage.yml
+++ b/.github/workflows/path-coverage.yml
@@ -1,0 +1,66 @@
+name: Path Coverage
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - '.github/workflows/path-coverage.yml'
+      - '.github/actions/setup-php-composer/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'lib/CactiPath.php'
+      - 'phpunit-path-coverage.xml'
+      - 'tests/Unit/CactiPathTest.php'
+  pull_request:
+    branches: [develop]
+    paths:
+      - '.github/workflows/path-coverage.yml'
+      - '.github/actions/setup-php-composer/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'lib/CactiPath.php'
+      - 'phpunit-path-coverage.xml'
+      - 'tests/Unit/CactiPathTest.php'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: path-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  COMPOSER_ALLOW_SUPERUSER: 1
+
+jobs:
+  coverage:
+    name: Path 100% coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Setup locked PHP 8.1 dependencies
+        uses: ./.github/actions/setup-php-composer
+        with:
+          php-version: '8.1'
+          coverage: xdebug
+          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
+          dependency-mode: locked-path-coverage
+          install-args: --prefer-dist --no-progress --no-interaction
+
+      - name: Enforce line coverage
+        env:
+          XDEBUG_MODE: coverage
+        run: |
+          set -euo pipefail
+          include/vendor/bin/pest \
+            --configuration=phpunit-path-coverage.xml \
+            --coverage \
+            --coverage-text \
+            --min=100

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -160,6 +160,7 @@ Cacti CHANGELOG
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
 -issue#7701: Confine names used as SQL identifiers in automation
 -issue#7665: Confine local RRD paths while preserving remote RRDProxy storage
+-issue#7717: Resolve path containment with Symfony Path
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect

--- a/lib/CactiPath.php
+++ b/lib/CactiPath.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Symfony\Component\Filesystem\Path;
+
+final class CactiPath {
+	public static function resolveWithinBase(string $basePath, string $candidatePath, bool $allowMissingLeaf = false) : string|false {
+		// Reject null bytes before any filesystem call. PHP 8.0+ throws ValueError
+		// when passing a string containing \0 to realpath(), so a traversal attempt
+		// would become a fatal instead of a refusal.
+		if (str_contains($basePath, "\0") || str_contains($candidatePath, "\0")) {
+			return false;
+		}
+
+		$resolvedBase      = realpath($basePath);
+		$resolvedCandidate = realpath($candidatePath);
+
+		if ($resolvedCandidate === false && $allowMissingLeaf) {
+			$parent = realpath(dirname($candidatePath));
+			$leaf   = basename($candidatePath);
+
+			if ($parent !== false && $leaf !== '' && $leaf !== '.' && $leaf !== '..') {
+				$resolvedCandidate = Path::join($parent, $leaf);
+			}
+		}
+
+		if ($resolvedBase === false || $resolvedCandidate === false ||
+			!Path::isBasePath($resolvedBase, $resolvedCandidate)) {
+			return false;
+		}
+
+		return $resolvedCandidate;
+	}
+
+	public static function makeRelativeIfWithinBase(string $path, string $basePath) : string {
+		if (!Path::isBasePath($basePath, $path)) {
+			return $path;
+		}
+
+		return Path::makeRelative($path, $basePath);
+	}
+}

--- a/link.php
+++ b/link.php
@@ -23,6 +23,7 @@
 */
 
 require_once('./include/global.php');
+require_once(CACTI_PATH_LIBRARY . '/CactiPath.php');
 
 $page = db_fetch_row_prepared('SELECT
 	id, title, style, contentfile, enabled, refresh
@@ -84,10 +85,10 @@ if (!cacti_sizeof($page)) {
 		} else {
 			print '<div id="content">';
 
-			$basepath = realpath(CACTI_PATH_INCLUDE . '/content');
-			$file     = ($basepath !== false) ? realpath($basepath . '/' . $page['contentfile']) : false;
+			$basepath = CACTI_PATH_INCLUDE . '/content';
+			$file     = CactiPath::resolveWithinBase($basepath, $basepath . '/' . $page['contentfile']);
 
-			if ($file && is_file($file) && str_starts_with($file, $basepath . DIRECTORY_SEPARATOR)) {
+			if ($file !== false && is_file($file)) {
 				require_once($file);
 			} else {
 				print '<h1>The file \'' . htmle($page['contentfile']) . '\' does not exist!!</h1>';

--- a/package_import.php
+++ b/package_import.php
@@ -23,6 +23,7 @@
 */
 
 require('./include/auth.php');
+require_once(CACTI_PATH_LIBRARY . '/CactiPath.php');
 require_once(CACTI_PATH_LIBRARY . '/import.php');
 require_once(CACTI_PATH_LIBRARY . '/poller.php');
 require_once(CACTI_PATH_LIBRARY . '/template.php');
@@ -267,8 +268,8 @@ function form_actions() : void {
 			$id = base64_decode(str_replace('chk_file_', '', $var), true);
 			$id = json_decode($id, true);
 
-			// Get rid of the basename
-			$id['pfile'] = str_replace(CACTI_PATH_BASE . '/', '', $id['pfile']);
+			// Display paths relative to the Cacti root when they are contained.
+			$id['pfile'] = CactiPath::makeRelativeIfWithinBase($id['pfile'], CACTI_PATH_BASE);
 
 			$pkg_file_list .= '<tr>' .
 				'<td style="width:50%">' . htmle($id['package']) . '</td>' .
@@ -732,23 +733,9 @@ function package_diff_file() : void {
 	$package_file     = grv('package_file');
 	$filename         = grv('filename');
 
-	$target = realpath(CACTI_PATH_BASE . '/' . $filename);
-	$base   = realpath(CACTI_PATH_BASE);
+	$target = CactiPath::resolveWithinBase(CACTI_PATH_BASE, CACTI_PATH_BASE . '/' . $filename, true);
 
 	if ($target === false) {
-		// The package may contain files that do not exist locally yet.
-		// Resolve the parent directory instead and re-attach the leaf so
-		// the containment check below still applies.
-		$parent = realpath(dirname(CACTI_PATH_BASE . '/' . $filename));
-		$leaf   = basename($filename);
-
-		if ($parent !== false && $leaf !== '.' && $leaf !== '..') {
-			$target = $parent . DIRECTORY_SEPARATOR . $leaf;
-		}
-	}
-
-	if ($target === false || $base === false ||
-		!str_starts_with($target . DIRECTORY_SEPARATOR, $base . DIRECTORY_SEPARATOR)) {
 		print __('Invalid filename specified.');
 
 		return;
@@ -1161,7 +1148,7 @@ function import_display_package_data(array $templates, array $files, string $pac
 							'&package_location=' . grv('package_location') .
 							'&package_file=' . $file_package_file .
 							'&package_name=' . $file_package_name .
-							'&filename=' . str_replace(CACTI_PATH_BASE . '/', '', $pfile);
+							'&filename=' . CactiPath::makeRelativeIfWithinBase($pfile, CACTI_PATH_BASE);
 
 						$nstatus .= ($nstatus != '' ? ', ' : '') .
 							"<a class='diffme linkEditMain' href='" . htmle($url) . "'>" . __('Differences') . '</a>';

--- a/phpunit-path-coverage.xml
+++ b/phpunit-path-coverage.xml
@@ -1,0 +1,16 @@
+<phpunit bootstrap="tests/bootstrap-unit.php" beStrictAboutOutputDuringTests="false">
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="CACTI_TEST_BOOTSTRAP" value="1"/>
+    </php>
+    <source>
+        <include>
+            <file>lib/CactiPath.php</file>
+        </include>
+    </source>
+    <testsuites>
+        <testsuite name="Path coverage">
+            <file>tests/Unit/CactiPathTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Unit/CactiPathTest.php
+++ b/tests/Unit/CactiPathTest.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Symfony\Component\Filesystem\Filesystem;
+
+require_once(CACTI_PATH_LIBRARY . '/CactiPath.php');
+
+beforeEach(function () {
+	$this->filesystem = new Filesystem();
+	$this->directory  = sys_get_temp_dir() . '/cacti-path-' . bin2hex(random_bytes(8));
+	$this->base       = $this->directory . '/base';
+	$this->sibling    = $this->directory . '/base-sibling';
+	$this->filesystem->mkdir([$this->base . '/nested', $this->sibling]);
+	$this->filesystem->touch([$this->base . '/nested/file.php', $this->sibling . '/file.php']);
+});
+
+afterEach(function () {
+	$this->filesystem->remove($this->directory);
+});
+
+test('resolveWithinBase returns a resolved file inside the base', function () {
+	$result = CactiPath::resolveWithinBase($this->base, $this->base . '/nested/../nested/file.php');
+
+	expect($result)->toBe(realpath($this->base . '/nested/file.php'));
+});
+
+test('resolveWithinBase allows the base itself', function () {
+	expect(CactiPath::resolveWithinBase($this->base, $this->base))->toBe(realpath($this->base));
+});
+
+test('resolveWithinBase rejects a sibling with the same prefix', function () {
+	expect(CactiPath::resolveWithinBase($this->base, $this->sibling . '/file.php'))->toBeFalse();
+});
+
+test('resolveWithinBase rejects a missing candidate by default', function () {
+	expect(CactiPath::resolveWithinBase($this->base, $this->base . '/nested/new.php'))->toBeFalse();
+});
+
+test('resolveWithinBase accepts a missing leaf under a resolved parent when requested', function () {
+	$result = CactiPath::resolveWithinBase($this->base, $this->base . '/nested/new.php', true);
+
+	expect($result)->toBe(realpath($this->base . '/nested') . '/new.php');
+});
+
+test('resolveWithinBase rejects a missing leaf under an outside parent', function () {
+	expect(CactiPath::resolveWithinBase($this->base, $this->sibling . '/new.php', true))->toBeFalse();
+});
+
+test('resolveWithinBase rejects a missing base', function () {
+	expect(CactiPath::resolveWithinBase($this->directory . '/missing', $this->base))->toBeFalse();
+});
+
+test('resolveWithinBase rejects an outside symlink target', function () {
+	if (DIRECTORY_SEPARATOR === '\\') {
+		$this->markTestSkipped('Symlink creation is not consistently available on Windows.');
+	}
+
+	symlink($this->sibling, $this->base . '/linked');
+
+	expect(CactiPath::resolveWithinBase($this->base, $this->base . '/linked/file.php'))->toBeFalse();
+});
+
+test('makeRelativeIfWithinBase returns a relative path for an inside candidate', function () {
+	expect(CactiPath::makeRelativeIfWithinBase($this->base . '/nested/file.php', $this->base))
+		->toBe('nested/file.php');
+});
+
+test('makeRelativeIfWithinBase preserves an outside path', function () {
+	expect(CactiPath::makeRelativeIfWithinBase($this->sibling . '/file.php', $this->base))
+		->toBe($this->sibling . '/file.php');
+});
+
+test('resolveWithinBase refuses a null byte instead of raising a ValueError', function () {
+	expect(CactiPath::resolveWithinBase($this->base, $this->base . "/file.php\0.txt"))->toBeFalse();
+	expect(CactiPath::resolveWithinBase($this->base . "\0", $this->base . '/nested/file.php'))->toBeFalse();
+	expect(CactiPath::resolveWithinBase($this->base, $this->base . "/missing\0", true))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- add `CactiPath` as a narrow Cacti-owned boundary for normalized path operations
- use resolved containment checks in `link.php` and `package_import.php`
- reject symlink and relative-segment escapes before request-supplied paths are accepted
- enforce 100% line coverage in a dedicated CI job

Fixes #7714.

## Alternatives considered

| Option | Advantages | Trade-off |
| --- | --- | --- |
| Maintained path utility behind `CactiPath` | Lexical normalization is deterministic even for paths that do not exist; the Cacti wrapper keeps vendor types out of call sites | Adds one focused dependency; selected |
| Native `realpath()` | Built into PHP and resolves symlinks | Returns `false` for nonexistent paths and cannot safely validate a destination before it is created |
| Hand-written prefix checks | No dependency | Easy to mishandle separators, `..`, roots, Windows paths, and sibling prefixes such as `/root-a` versus `/root` |

The Cacti-specific value is the small containment API and its fail-closed policy, not another path-normalization implementation.

## Testing

- focused suite: 11 tests, 13 assertions
- `CactiPath`: 100.0% line coverage
- dedicated CI command uses `--min=100`
- Actionlint, Composer validation, PHP formatting, and diff checks pass

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
