### PR TITLE
Harden Boost data handoffs and graph cache writes

### DIFF
--- a/cacti.sql
+++ b/cacti.sql
@@ -2573,8 +2573,11 @@ CREATE TABLE `poller_output_boost_local_data_ids` (
 
 CREATE TABLE `poller_output_boost_processes` (
   `sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
+  `run_id` char(32) NOT NULL default '',
+  `child_id` int(10) unsigned NOT NULL default '0',
   `status` varchar(255) default NULL,
-  PRIMARY KEY (`sock_int_value`)
+  PRIMARY KEY (`sock_int_value`),
+  UNIQUE KEY `run_child` (`run_id`,`child_id`)
 ) ENGINE=MEMORY;
 
 --

--- a/cacti.sql
+++ b/cacti.sql
@@ -2574,7 +2574,7 @@ CREATE TABLE `poller_output_boost_local_data_ids` (
 CREATE TABLE `poller_output_boost_processes` (
   `sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
   `run_id` char(32) NOT NULL default '',
-  `child_id` int(10) unsigned NOT NULL default '0',
+  `child_id` int(10) unsigned NOT NULL default 0,
   `status` varchar(255) default NULL,
   PRIMARY KEY (`sock_int_value`),
   UNIQUE KEY `run_child` (`run_id`,`child_id`)

--- a/changelog.d/7729.issue
+++ b/changelog.d/7729.issue
@@ -1,0 +1,1 @@
+Harden Boost data handoffs and graph cache writes

--- a/cmd.php
+++ b/cmd.php
@@ -449,10 +449,10 @@ if (cacti_sizeof($poller_items) && read_config_option('poller_enabled') == 'on')
 
 			if ($set_spike_kill && !substr_count($output, ':')) {
 				// insert a U in place of the actual value if the snmp agent restarts
-				$output_array[] = sprintf('(%d, %s, CURRENT_TIMESTAMP(), "U")', $item['local_data_id'], db_qstr($item['rrd_name']));
+				$output_array[] = sprintf('(%d, %s, CURRENT_TIMESTAMP(), "U")', $item['local_data_id'], db_qstr($item['rrd_name'], $poller_db_cnn_id));
 			} else {
 				// otherwise, just insert the value received from the poller
-				$output_array[] = sprintf('(%d, %s, CURRENT_TIMESTAMP(), %s)', $item['local_data_id'], db_qstr($item['rrd_name']), db_qstr($output));
+				$output_array[] = sprintf('(%d, %s, CURRENT_TIMESTAMP(), %s)', $item['local_data_id'], db_qstr($item['rrd_name'], $poller_db_cnn_id), db_qstr($output, $poller_db_cnn_id));
 			}
 
 			if ($output_count > 2000) {

--- a/cmd.php
+++ b/cmd.php
@@ -246,7 +246,7 @@ input_validate_input_number($first, 'first');
 input_validate_input_number($last, 'last');
 
 if (db_column_exists('sites', 'disabled')) {
-	$sql_where = 'AND IFNULL(s.disabled, "") != "on"';
+	$sql_where = 'AND IFNULL(s.disabled, \'\') != \'on\'';
 } else {
 	$sql_where = '';
 }
@@ -449,7 +449,7 @@ if (cacti_sizeof($poller_items) && read_config_option('poller_enabled') == 'on')
 
 			if ($set_spike_kill && !substr_count($output, ':')) {
 				// insert a U in place of the actual value if the snmp agent restarts
-				$output_array[] = sprintf('(%d, %s, CURRENT_TIMESTAMP(), "U")', $item['local_data_id'], db_qstr($item['rrd_name'], $poller_db_cnn_id));
+				$output_array[] = sprintf('(%d, %s, CURRENT_TIMESTAMP(), %s)', $item['local_data_id'], db_qstr($item['rrd_name'], $poller_db_cnn_id), db_qstr('U', $poller_db_cnn_id));
 			} else {
 				// otherwise, just insert the value received from the poller
 				$output_array[] = sprintf('(%d, %s, CURRENT_TIMESTAMP(), %s)', $item['local_data_id'], db_qstr($item['rrd_name'], $poller_db_cnn_id), db_qstr($output, $poller_db_cnn_id));

--- a/docs/audit_schema.sql
+++ b/docs/audit_schema.sql
@@ -960,7 +960,9 @@ INSERT INTO `table_columns` VALUES ('poller_output_boost',5,'last_updated','time
 INSERT INTO `table_columns` VALUES ('poller_output_boost_local_data_ids',1,'local_data_id','int(10) unsigned','NO','PRI','0','');
 INSERT INTO `table_columns` VALUES ('poller_output_boost_local_data_ids',2,'process_handler','int(10) unsigned','YES','MUL','0','');
 INSERT INTO `table_columns` VALUES ('poller_output_boost_processes',1,'sock_int_value','bigint(20) unsigned','NO','PRI',NULL,'auto_increment');
-INSERT INTO `table_columns` VALUES ('poller_output_boost_processes',2,'status','varchar(255)','YES','',NULL,'');
+INSERT INTO `table_columns` VALUES ('poller_output_boost_processes',2,'run_id','char(32)','NO','MUL','','');
+INSERT INTO `table_columns` VALUES ('poller_output_boost_processes',3,'child_id','int(10) unsigned','NO','','0','');
+INSERT INTO `table_columns` VALUES ('poller_output_boost_processes',4,'status','varchar(255)','YES','',NULL,'');
 INSERT INTO `table_columns` VALUES ('poller_output_realtime',1,'local_data_id','int(10) unsigned','NO','PRI','0','');
 INSERT INTO `table_columns` VALUES ('poller_output_realtime',2,'rrd_name','varchar(19)','NO','PRI','','');
 INSERT INTO `table_columns` VALUES ('poller_output_realtime',3,'time','timestamp','NO','PRI','0000-00-00 00:00:00','');
@@ -1621,6 +1623,8 @@ INSERT INTO `table_indexes` VALUES ('poller_output_boost',1,'time',1,'time','A',
 INSERT INTO `table_indexes` VALUES ('poller_output_boost_local_data_ids',0,'PRIMARY',1,'local_data_id',NULL,0,NULL,NULL,'','HASH','');
 INSERT INTO `table_indexes` VALUES ('poller_output_boost_local_data_ids',1,'process_handler',1,'process_handler',NULL,0,NULL,NULL,'YES','HASH','');
 INSERT INTO `table_indexes` VALUES ('poller_output_boost_processes',0,'PRIMARY',1,'sock_int_value',NULL,0,NULL,NULL,'','HASH','');
+INSERT INTO `table_indexes` VALUES ('poller_output_boost_processes',0,'run_child',1,'run_id',NULL,0,NULL,NULL,'','HASH','');
+INSERT INTO `table_indexes` VALUES ('poller_output_boost_processes',0,'run_child',2,'child_id',NULL,0,NULL,NULL,'','HASH','');
 INSERT INTO `table_indexes` VALUES ('poller_output_realtime',1,'poller_id',1,'poller_id','A',0,'191',NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('poller_output_realtime',0,'PRIMARY',1,'local_data_id','A',0,NULL,NULL,'','BTREE','');
 INSERT INTO `table_indexes` VALUES ('poller_output_realtime',0,'PRIMARY',2,'rrd_name','A',0,NULL,NULL,'','BTREE','');

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -98,21 +98,7 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_key('sessions', 'INDEX', 'user_id', ['user_id']);
 	db_install_add_key('sessions', 'INDEX', 'access', ['access']);
 
-	if (!db_table_exists('poller_output_boost_processes')) {
-		db_install_execute('CREATE TABLE `poller_output_boost_processes` (
-			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
-			`run_id` char(32) NOT NULL default \'\',
-			`child_id` int(10) unsigned NOT NULL default 0,
-			`status` varchar(255) default NULL,
-			PRIMARY KEY (`sock_int_value`),
-			UNIQUE KEY `run_child` (`run_id`, `child_id`)
-		) ENGINE=MEMORY');
-	} else {
-		db_install_execute('TRUNCATE TABLE poller_output_boost_processes');
-		db_install_add_column('poller_output_boost_processes', ['name' => 'run_id', 'type' => 'char(32)', 'NULL' => false, 'default' => '', 'after' => 'sock_int_value']);
-		db_install_add_column('poller_output_boost_processes', ['name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'run_id']);
-		db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', ['run_id', 'child_id']);
-	}
+	upgrade_boost_process_table();
 
 	// poller_output_boost_local_data_ids is a MEMORY table; its indexes default
 	// to HASH unless USING BTREE is specified. Range/ORDER BY access against
@@ -683,6 +669,40 @@ function upgrade_to_1_3_0() : void {
 	if (!db_column_exists('user_domains_ldap', 'bind_timeout')) {
 		db_install_execute('ALTER TABLE  user_domains_ldap ADD COLUMN bind_timeout INT unsigned NOT NULL default 2 AFTER network_timeout');
 	}
+}
+
+/**
+ * Bring poller_output_boost_processes up to the 1.3.0 layout.
+ *
+ * Nothing stops cron from starting poller_boost.php while the installer runs,
+ * so boost can be mid-run here.  Emptying the table would discard the
+ * completion rows the parent counts to decide whether every child finished,
+ * leaving it to drain early, warn about a crashed child and hold the run's
+ * archive tables.  Only the rows written before run_id existed have to go:
+ * the two ALTERs default all of them to ('', 0), which the new UNIQUE key
+ * cannot accept.  A child of an in-flight run records a 32 character run_id
+ * and keeps its row.
+ */
+function upgrade_boost_process_table() : void {
+	if (!db_table_exists('poller_output_boost_processes')) {
+		db_install_execute('CREATE TABLE `poller_output_boost_processes` (
+			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
+			`run_id` char(32) NOT NULL default \'\',
+			`child_id` int(10) unsigned NOT NULL default 0,
+			`status` varchar(255) default NULL,
+			PRIMARY KEY (`sock_int_value`),
+			UNIQUE KEY `run_child` (`run_id`, `child_id`)
+		) ENGINE=MEMORY');
+
+		return;
+	}
+
+	db_install_add_column('poller_output_boost_processes', ['name' => 'run_id', 'type' => 'char(32)', 'NULL' => false, 'default' => '', 'after' => 'sock_int_value']);
+	db_install_add_column('poller_output_boost_processes', ['name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'run_id']);
+
+	db_install_execute('DELETE FROM poller_output_boost_processes WHERE run_id = ?', ['']);
+
+	db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', ['run_id', 'child_id']);
 }
 
 function upgrade_reports() : void {

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -97,10 +97,22 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_key('host', 'INDEX', 'host_template_id', ['host_template_id']);
 	db_install_add_key('sessions', 'INDEX', 'user_id', ['user_id']);
 	db_install_add_key('sessions', 'INDEX', 'access', ['access']);
-	db_install_execute('TRUNCATE TABLE poller_output_boost_processes');
-	db_install_add_column('poller_output_boost_processes', ['name' => 'run_id', 'type' => 'char(32)', 'NULL' => false, 'default' => '', 'after' => 'sock_int_value']);
-	db_install_add_column('poller_output_boost_processes', ['name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'run_id']);
-	db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', ['run_id', 'child_id']);
+
+	if (!db_table_exists('poller_output_boost_processes')) {
+		db_install_execute('CREATE TABLE `poller_output_boost_processes` (
+			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
+			`run_id` char(32) NOT NULL default \'\',
+			`child_id` int(10) unsigned NOT NULL default 0,
+			`status` varchar(255) default NULL,
+			PRIMARY KEY (`sock_int_value`),
+			UNIQUE KEY `run_child` (`run_id`, `child_id`)
+		) ENGINE=MEMORY');
+	} else {
+		db_install_execute('TRUNCATE TABLE poller_output_boost_processes');
+		db_install_add_column('poller_output_boost_processes', ['name' => 'run_id', 'type' => 'char(32)', 'NULL' => false, 'default' => '', 'after' => 'sock_int_value']);
+		db_install_add_column('poller_output_boost_processes', ['name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'run_id']);
+		db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', ['run_id', 'child_id']);
+	}
 
 	// poller_output_boost_local_data_ids is a MEMORY table; its indexes default
 	// to HASH unless USING BTREE is specified. Range/ORDER BY access against

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -98,8 +98,8 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_key('sessions', 'INDEX', 'user_id', ['user_id']);
 	db_install_add_key('sessions', 'INDEX', 'access', ['access']);
 	db_install_execute('TRUNCATE TABLE poller_output_boost_processes');
-	db_install_add_column('poller_output_boost_processes', ['name' => 'run_id', 'type' => 'char(32)', 'null' => false, 'default' => '', 'after' => 'sock_int_value']);
-	db_install_add_column('poller_output_boost_processes', ['name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'null' => false, 'default' => '0', 'after' => 'run_id']);
+	db_install_add_column('poller_output_boost_processes', ['name' => 'run_id', 'type' => 'char(32)', 'NULL' => false, 'default' => '', 'after' => 'sock_int_value']);
+	db_install_add_column('poller_output_boost_processes', ['name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'run_id']);
 	db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', ['run_id', 'child_id']);
 
 	// poller_output_boost_local_data_ids is a MEMORY table; its indexes default

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -97,6 +97,10 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_key('host', 'INDEX', 'host_template_id', ['host_template_id']);
 	db_install_add_key('sessions', 'INDEX', 'user_id', ['user_id']);
 	db_install_add_key('sessions', 'INDEX', 'access', ['access']);
+	db_install_execute('TRUNCATE TABLE poller_output_boost_processes');
+	db_install_add_column('poller_output_boost_processes', ['name' => 'run_id', 'type' => 'char(32)', 'null' => false, 'default' => '', 'after' => 'sock_int_value']);
+	db_install_add_column('poller_output_boost_processes', ['name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'null' => false, 'default' => '0', 'after' => 'run_id']);
+	db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', ['run_id', 'child_id']);
 
 	// poller_output_boost_local_data_ids is a MEMORY table; its indexes default
 	// to HASH unless USING BTREE is specified. Range/ORDER BY access against

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -30,12 +30,12 @@ function upgrade_to_1_3_0() : void {
 		PRIMARY KEY (key_id)
 	) ENGINE=InnoDB COMMENT='Serializes Cacti Process Registry Mutations'");
 
-	db_install_change_column('version', ['name' => 'cacti', 'type' => 'char(30)', 'null' => false, 'default' => '']);
+	db_install_change_column('version', ['name' => 'cacti', 'type' => 'char(30)', 'NULL' => false, 'default' => '']);
 
-	db_install_add_column('user_auth', ['name' => 'tfa_enabled', 'type' => 'char(3)', 'null' => false, 'default' => '']);
-	db_install_add_column('user_auth', ['name' => 'tfa_secret', 'type' => 'char(50)', 'null' => false, 'default' => '']);
+	db_install_add_column('user_auth', ['name' => 'tfa_enabled', 'type' => 'char(3)', 'NULL' => false, 'default' => '']);
+	db_install_add_column('user_auth', ['name' => 'tfa_secret', 'type' => 'char(50)', 'NULL' => false, 'default' => '']);
 
-	db_install_add_column('poller', ['name' => 'log_level', 'type' => 'int', 'null' => false, 'default' => '-1', 'after' => 'status']);
+	db_install_add_column('poller', ['name' => 'log_level', 'type' => 'int', 'NULL' => false, 'default' => '-1', 'after' => 'status']);
 	db_install_add_column('poller', ['name' => 'dbsslkey', 'type' => 'varchar(255)', 'after' => 'dbssl']);
 	db_install_add_column('poller', ['name' => 'dbsslcert', 'type' => 'varchar(255)', 'after' => 'dbsslkey']);
 	db_install_add_column('poller', ['name' => 'dbsslca', 'type' => 'varchar(255)', 'after' => 'dbsslcert']);
@@ -60,10 +60,10 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_column('graph_templates_item', ['name' => 'alpha2', 'type' => 'char(2)', 'default' => 'FF', 'after' => 'color2_id']);
 	db_install_add_column('graph_templates_item', ['name' => 'gradheight', 'type' => 'tinyint(4)', 'default' => '50', 'after' => 'alpha2']);
 
-	db_install_add_column('sites', ['name' => 'disabled', 'type' => 'char(2)', 'null' => false, 'default' => '', 'after' => 'name']);
-	db_install_add_column('sites', ['name' => 'region', 'type' => 'varchar(30)', 'null' => false, 'default' => '', 'after' => 'country']);
+	db_install_add_column('sites', ['name' => 'disabled', 'type' => 'char(2)', 'NULL' => false, 'default' => '', 'after' => 'name']);
+	db_install_add_column('sites', ['name' => 'region', 'type' => 'varchar(30)', 'NULL' => false, 'default' => '', 'after' => 'country']);
 
-	db_install_add_column('user_domains_ldap', ['name' => 'tls_certificate', 'type' => 'tinyint(3)', 'unsigned' => true, 'null' => false, 'default' => '3']);
+	db_install_add_column('user_domains_ldap', ['name' => 'tls_certificate', 'type' => 'tinyint(3)', 'unsigned' => true, 'NULL' => false, 'default' => '3']);
 
 	db_install_add_column('graph_templates_graph', ['name' => 't_left_axis_format', 'type' => 'char(2)',  'default' => '', 'after' => 'right_axis_formatter']);
 	db_install_add_column('graph_templates_graph', ['name' => 'left_axis_format', 'type' => 'mediumint(8)', 'NULL' => true, 'after' => 't_left_axis_format']);
@@ -85,9 +85,9 @@ function upgrade_to_1_3_0() : void {
 	db_install_add_column('data_input_data', ['name' => 'local_data_id', 'type' => 'int', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'data_template_id']);
 	db_install_add_column('data_input_data', ['name' => 'host_id', 'type' => 'int', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'local_data_id']);
 
-	db_install_add_column('graph_templates', ['name' => 'last_updated', 'type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP']);
-	db_install_add_column('data_template', ['name' => 'last_updated', 'type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP']);
-	db_install_add_column('snmp_query', ['name' => 'last_updated', 'type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP']);
+	db_install_add_column('graph_templates', ['name' => 'last_updated', 'type' => 'timestamp', 'NULL' => false, 'default' => 'CURRENT_TIMESTAMP']);
+	db_install_add_column('data_template', ['name' => 'last_updated', 'type' => 'timestamp', 'NULL' => false, 'default' => 'CURRENT_TIMESTAMP']);
+	db_install_add_column('snmp_query', ['name' => 'last_updated', 'type' => 'timestamp', 'NULL' => false, 'default' => 'CURRENT_TIMESTAMP']);
 
 	db_install_add_key('data_input_data', 'INDEX', 'data_template_id', ['data_template_id']);
 	db_install_add_key('data_input_data', 'INDEX', 'local_data_id', ['local_data_id']);
@@ -137,8 +137,8 @@ function upgrade_to_1_3_0() : void {
 		}
 	}
 
-	db_install_add_column('host_snmp_query', ['name' => 'reindex_last_runtime', 'type' => 'timestamp', 'null' => false, 'default' => 'CURRENT_TIMESTAMP']);
-	db_install_add_column('host_snmp_query', ['name' => 'reindex_last_duration', 'type' => 'double', 'unsigned' => true, 'null' => false, 'default' => '0']);
+	db_install_add_column('host_snmp_query', ['name' => 'reindex_last_runtime', 'type' => 'timestamp', 'NULL' => false, 'default' => 'CURRENT_TIMESTAMP']);
+	db_install_add_column('host_snmp_query', ['name' => 'reindex_last_duration', 'type' => 'double', 'unsigned' => true, 'NULL' => false, 'default' => '0']);
 
 	db_install_execute('UPDATE data_input_data AS did
 		INNER JOIN data_template_data AS dtd
@@ -203,7 +203,7 @@ function upgrade_to_1_3_0() : void {
 	db_install_update_table('plugin_archive', $data);
 
 	// Not sure why we were adding this...
-	// db_install_add_column('user_domains', array('name' => 'tls_verify', 'type' => 'int', 'null' => false, 'default' => '0'));
+	// db_install_add_column('user_domains', array('name' => 'tls_verify', 'type' => 'int', 'NULL' => false, 'default' => '0'));
 
 	db_install_execute('UPDATE host AS h
 		LEFT JOIN sites AS s

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -22,6 +22,67 @@
  +-------------------------------------------------------------------------+
 */
 
+/** Ensure Boost children can record one completion row per run and shard. */
+function boost_ensure_process_table(bool $repair_key = false) : bool {
+	if (!db_table_exists('poller_output_boost_processes')) {
+		$created = db_execute("CREATE TABLE `poller_output_boost_processes` (
+			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
+			`run_id` char(32) NOT NULL default '',
+			`child_id` int(10) unsigned NOT NULL default 0,
+			`status` varchar(255) default NULL,
+			PRIMARY KEY (`sock_int_value`),
+			UNIQUE KEY `run_child` (`run_id`, `child_id`)
+		) ENGINE=MEMORY");
+
+		if ($created === false && !db_table_exists('poller_output_boost_processes')) {
+			cacti_log('ERROR: Unable to create poller_output_boost_processes', true, 'BOOST');
+
+			return false;
+		}
+	}
+
+	if (!db_column_exists('poller_output_boost_processes', 'run_id')) {
+		$added = db_execute("ALTER TABLE poller_output_boost_processes
+			ADD `run_id` char(32) NOT NULL default '' AFTER `sock_int_value`");
+
+		if ($added === false && !db_column_exists('poller_output_boost_processes', 'run_id')) {
+			cacti_log('ERROR: Unable to add run_id to poller_output_boost_processes', true, 'BOOST');
+
+			return false;
+		}
+	}
+
+	if (!db_column_exists('poller_output_boost_processes', 'child_id')) {
+		$added = db_execute('ALTER TABLE poller_output_boost_processes
+			ADD `child_id` int(10) unsigned NOT NULL default 0 AFTER `run_id`');
+
+		if ($added === false && !db_column_exists('poller_output_boost_processes', 'child_id')) {
+			cacti_log('ERROR: Unable to add child_id to poller_output_boost_processes', true, 'BOOST');
+
+			return false;
+		}
+	}
+
+	if ($repair_key && !db_index_exists('poller_output_boost_processes', 'run_child')) {
+		if (db_execute_prepared('DELETE FROM poller_output_boost_processes WHERE run_id = ?', ['']) === false) {
+			cacti_log('ERROR: Unable to remove legacy Boost completion rows', true, 'BOOST');
+
+			return false;
+		}
+
+		$added = db_execute('ALTER TABLE poller_output_boost_processes
+			ADD UNIQUE KEY `run_child` (`run_id`, `child_id`)');
+
+		if ($added === false && !db_index_exists('poller_output_boost_processes', 'run_child')) {
+			cacti_log('ERROR: Unable to add run_child key to poller_output_boost_processes', true, 'BOOST');
+
+			return false;
+		}
+	}
+
+	return true;
+}
+
 /**
  * Sorts a multi-dimensional array by one or more fields.
  *
@@ -606,11 +667,16 @@ function boost_atomic_write_cache(string $cache_file, string $output) : bool {
 
 	$flushed = fflush($fileptr);
 	fclose($fileptr);
-	chmod($temp_file, 0644);
 
-	$published = $flushed && @rename($temp_file, $cache_file);
+	if (!$flushed || !chmod($temp_file, 0644)) {
+		@unlink($temp_file);
 
-	if (!$published && $flushed && PHP_OS_FAMILY === 'Windows') {
+		return false;
+	}
+
+	$published = @rename($temp_file, $cache_file);
+
+	if (!$published && PHP_OS_FAMILY === 'Windows') {
 		$published = boost_replace_cache_file_on_windows($temp_file, $cache_file);
 	}
 

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -369,6 +369,14 @@ function boost_poller_on_demand(array &$results) : bool {
 		set_error_handler('boost_error_handler');
 
 		if (boost_check_correct_enabled()) {
+			// cmd.php already staged these rows when direct redirection is active.
+			if (read_config_option('boost_redirect') == 'on') {
+				restore_error_handler();
+				error_reporting($previous_error_reporting);
+
+				return false;
+			}
+
 			if (cacti_sizeof($results)) {
 				if (POLLER_ID > 1 && !boost_validate_poller_ownership($results, POLLER_ID, $conn)) { // @phpstan-ignore-line
 					cacti_log(sprintf('ERROR: Boost rejected a handoff containing data sources not assigned to poller %d.', POLLER_ID), false, 'BOOST');

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -289,44 +289,6 @@ function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bo
 	return $success;
 }
 
-/** Confirm that every handed-off data source belongs to the claiming poller. */
-function boost_validate_poller_ownership(array $results, int $poller_id, mixed $conn = false) : bool {
-	$result_ids = array_map(
-		static fn (array $result): int => (int) ($result['local_data_id'] ?? 0),
-		$results
-	);
-	$local_data_ids = array_values(array_unique(array_filter(
-		$result_ids,
-		static fn (int $local_data_id): bool => $local_data_id > 0
-	)));
-
-	if (!cacti_sizeof($local_data_ids) || in_array(0, $result_ids, true)) {
-		return false;
-	}
-
-	$assigned_ids = [];
-
-	foreach (array_chunk($local_data_ids, 1000) as $chunk) {
-		$placeholders = implode(',', array_fill(0, cacti_sizeof($chunk), '?'));
-		$params       = array_merge([$poller_id], $chunk);
-		$assigned     = db_fetch_assoc_prepared("SELECT DISTINCT local_data_id
-			FROM poller_item
-			WHERE poller_id = ?
-			AND local_data_id IN ($placeholders)", $params, true, $conn);
-
-		if ($assigned === false) {
-			return false;
-		}
-
-		$assigned_ids = array_merge($assigned_ids, array_map('intval', array_column($assigned, 'local_data_id')));
-	}
-
-	sort($assigned_ids);
-	sort($local_data_ids);
-
-	return $assigned_ids === $local_data_ids;
-}
-
 /**
  * Handles the on-demand poller boost functionality for Cacti.
  *
@@ -378,18 +340,6 @@ function boost_poller_on_demand(array &$results) : bool {
 			}
 
 			if (cacti_sizeof($results)) {
-				if (POLLER_ID > 1 && !boost_validate_poller_ownership($results, POLLER_ID, $conn)) { // @phpstan-ignore-line
-					cacti_log(sprintf('ERROR: Boost rejected a handoff containing data sources not assigned to poller %d.', POLLER_ID), false, 'BOOST');
-					restore_error_handler();
-					error_reporting($previous_error_reporting);
-
-					// The caller has already removed these rows from poller_output, so
-					// returning false here would drop the cycle entirely. Report that
-					// boost did not consume the data and let the poller write it to RRD
-					// directly, matching the database failure path below.
-					return true;
-				}
-
 				$value_tuples = [];
 
 				foreach ($results as $result) {

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -540,7 +540,28 @@ function boost_graph_cache_filename(string $cache_directory, int $local_graph_id
 
 /** Replace an existing cache object after Windows rejects rename-over-existing. */
 function boost_replace_cache_file_on_windows(string $temp_file, string $cache_file) : bool {
-	return is_file($cache_file) && @unlink($cache_file) && @rename($temp_file, $cache_file);
+	if (!is_file($temp_file) || !is_file($cache_file)) {
+		return false;
+	}
+
+	$backup_file = tempnam(dirname($cache_file), '.boost-old-');
+
+	if ($backup_file === false || !@unlink($backup_file) || !@rename($cache_file, $backup_file)) {
+		return false;
+	}
+
+	if (@rename($temp_file, $cache_file)) {
+		@unlink($backup_file);
+
+		return true;
+	}
+
+	// Keep the previously published object when the replacement cannot be
+	// installed. If the rename remains blocked, retain the backup as the
+	// recoverable copy rather than deleting it.
+	@rename($backup_file, $cache_file);
+
+	return false;
 }
 
 /** Write a complete cache object and publish it with a same-directory rename. */

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -34,7 +34,7 @@ function boost_ensure_process_table(bool $repair_key = false) : bool {
 			UNIQUE KEY `run_child` (`run_id`, `child_id`)
 		) ENGINE=MEMORY");
 
-		if ($created === false && !db_table_exists('poller_output_boost_processes')) {
+		if ($created === false) {
 			cacti_log('ERROR: Unable to create poller_output_boost_processes', true, 'BOOST');
 
 			return false;
@@ -45,7 +45,7 @@ function boost_ensure_process_table(bool $repair_key = false) : bool {
 		$added = db_execute("ALTER TABLE poller_output_boost_processes
 			ADD `run_id` char(32) NOT NULL default '' AFTER `sock_int_value`");
 
-		if ($added === false && !db_column_exists('poller_output_boost_processes', 'run_id')) {
+		if ($added === false) {
 			cacti_log('ERROR: Unable to add run_id to poller_output_boost_processes', true, 'BOOST');
 
 			return false;
@@ -56,7 +56,7 @@ function boost_ensure_process_table(bool $repair_key = false) : bool {
 		$added = db_execute('ALTER TABLE poller_output_boost_processes
 			ADD `child_id` int(10) unsigned NOT NULL default 0 AFTER `run_id`');
 
-		if ($added === false && !db_column_exists('poller_output_boost_processes', 'child_id')) {
+		if ($added === false) {
 			cacti_log('ERROR: Unable to add child_id to poller_output_boost_processes', true, 'BOOST');
 
 			return false;
@@ -73,7 +73,7 @@ function boost_ensure_process_table(bool $repair_key = false) : bool {
 		$added = db_execute('ALTER TABLE poller_output_boost_processes
 			ADD UNIQUE KEY `run_child` (`run_id`, `child_id`)');
 
-		if ($added === false && !db_index_exists('poller_output_boost_processes', 'run_child')) {
+		if ($added === false) {
 			cacti_log('ERROR: Unable to add run_child key to poller_output_boost_processes', true, 'BOOST');
 
 			return false;

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -243,7 +243,6 @@ function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bo
 	$overhead   = strlen($sql_prefix) + 1;
 	$out_buffer = '';
 	$out_length = 0;
-	$success    = true;
 	$rows       = 0;
 
 	foreach ($value_tuples as $tuple) {
@@ -257,8 +256,10 @@ function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bo
 			}
 
 			if (!$acknowledged) {
-				$success = false;
-			} elseif (db_affected_rows($conn) < $rows) {
+				return false;
+			}
+
+			if (db_affected_rows($conn) < $rows) {
 				cacti_log('WARNING: Boost staging ignored one or more duplicate sample keys.', false, 'BOOST');
 			}
 
@@ -280,13 +281,15 @@ function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bo
 		}
 
 		if (!$acknowledged) {
-			$success = false;
-		} elseif (db_affected_rows($conn) < $rows) {
+			return false;
+		}
+
+		if (db_affected_rows($conn) < $rows) {
 			cacti_log('WARNING: Boost staging ignored one or more duplicate sample keys.', false, 'BOOST');
 		}
 	}
 
-	return $success;
+	return true;
 }
 
 /**

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -172,8 +172,8 @@ function boost_error_handler(int $errno, string $errmsg, string $filename, int $
  * If `boost_rrd_update_enable` is enabled but `boost_rrd_update_system_enable`
  * is not, it updates the database to enable the system-level updates.
  *
- * If neither of the options is enabled, the function restores the default
- * error handler and returns false.
+ * If neither option is enabled, the function returns false. Error-handler
+ * ownership remains with the caller that installed it.
  *
  * @return bool Returns true if the Boost RRD update system is correctly enabled,
  *              otherwise returns false.
@@ -187,8 +187,6 @@ function boost_check_correct_enabled() : bool {
 				VALUES ('boost_rrd_update_system_enable','on')");
 		}
 	} else {
-		restore_error_handler();
-
 		return false;
 	}
 
@@ -215,11 +213,11 @@ function boost_check_correct_enabled() : bool {
  *                            VALUES tuples, e.g. "(1,'ds',NOW(),'1.23')"
  * @param mixed $conn         DB connection to use, or false for the default
  *
- * @return void
+ * @return bool True only when every chunk was accepted by the database.
  */
-function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : void {
+function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bool {
 	if (!cacti_sizeof($value_tuples)) {
-		return;
+		return true;
 	}
 
 	// max_allowed_packet is a per-server setting and this helper is called with
@@ -245,24 +243,88 @@ function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : vo
 	$overhead   = strlen($sql_prefix) + 1;
 	$out_buffer = '';
 	$out_length = 0;
+	$success    = true;
+	$rows       = 0;
 
 	foreach ($value_tuples as $tuple) {
 		$tuple_length = strlen($tuple);
 
 		if ($out_length > 0 && ($out_length + $overhead + $tuple_length) > $max_allowed_packet) {
-			db_execute($sql_prefix . $out_buffer, true, $conn);
+			try {
+				$acknowledged = db_execute($sql_prefix . $out_buffer, true, $conn) !== false;
+			} catch (Throwable) {
+				$acknowledged = false;
+			}
+
+			if (!$acknowledged) {
+				$success = false;
+			} elseif (db_affected_rows($conn) < $rows) {
+				cacti_log('WARNING: Boost staging ignored one or more duplicate sample keys.', false, 'BOOST');
+			}
 
 			$out_buffer = $tuple;
 			$out_length = $tuple_length;
+			$rows       = 1;
 		} else {
 			$out_buffer .= ($out_buffer != '' ? ',' : '') . $tuple;
 			$out_length += $tuple_length + ($out_length > 0 ? 1 : 0);
+			$rows++;
 		}
 	}
 
 	if ($out_buffer != '') {
-		db_execute($sql_prefix . $out_buffer, true, $conn);
+		try {
+			$acknowledged = db_execute($sql_prefix . $out_buffer, true, $conn) !== false;
+		} catch (Throwable) {
+			$acknowledged = false;
+		}
+
+		if (!$acknowledged) {
+			$success = false;
+		} elseif (db_affected_rows($conn) < $rows) {
+			cacti_log('WARNING: Boost staging ignored one or more duplicate sample keys.', false, 'BOOST');
+		}
 	}
+
+	return $success;
+}
+
+/** Confirm that every handed-off data source belongs to the claiming poller. */
+function boost_validate_poller_ownership(array $results, int $poller_id, mixed $conn = false) : bool {
+	$result_ids = array_map(
+		static fn (array $result): int => (int) ($result['local_data_id'] ?? 0),
+		$results
+	);
+	$local_data_ids = array_values(array_unique(array_filter(
+		$result_ids,
+		static fn (int $local_data_id): bool => $local_data_id > 0
+	)));
+
+	if (!cacti_sizeof($local_data_ids) || in_array(0, $result_ids, true)) {
+		return false;
+	}
+
+	$assigned_ids = [];
+
+	foreach (array_chunk($local_data_ids, 1000) as $chunk) {
+		$placeholders = implode(',', array_fill(0, cacti_sizeof($chunk), '?'));
+		$params       = array_merge([$poller_id], $chunk);
+		$assigned     = db_fetch_assoc_prepared("SELECT DISTINCT local_data_id
+			FROM poller_item
+			WHERE poller_id = ?
+			AND local_data_id IN ($placeholders)", $params, true, $conn);
+
+		if ($assigned === false) {
+			return false;
+		}
+
+		$assigned_ids = array_merge($assigned_ids, array_map('intval', array_column($assigned, 'local_data_id')));
+	}
+
+	sort($assigned_ids);
+	sort($local_data_ids);
+
+	return $assigned_ids === $local_data_ids;
 }
 
 /**
@@ -293,6 +355,7 @@ function boost_poller_on_demand(array &$results) : bool {
 	}
 
 	if (read_config_option('boost_rrd_update_enable') == 'on' || POLLER_ID > 1) {
+		$previous_error_reporting = error_reporting();
 		set_config_option('boost_rrd_update_enable', 'on');
 
 		// suppress warnings
@@ -306,14 +369,15 @@ function boost_poller_on_demand(array &$results) : bool {
 		set_error_handler('boost_error_handler');
 
 		if (boost_check_correct_enabled()) {
-			// if boost redirect is on, rows are being inserted directly
-			if (read_config_option('boost_redirect') == 'on') {
-				restore_error_handler();
-
-				return false;
-			}
-
 			if (cacti_sizeof($results)) {
+				if (POLLER_ID > 1 && !boost_validate_poller_ownership($results, POLLER_ID, $conn)) {
+					cacti_log(sprintf('ERROR: Boost rejected a handoff containing data sources not assigned to poller %d.', POLLER_ID), false, 'BOOST');
+					restore_error_handler();
+					error_reporting($previous_error_reporting);
+
+					return false;
+				}
+
 				$value_tuples = [];
 
 				foreach ($results as $result) {
@@ -326,16 +390,17 @@ function boost_poller_on_demand(array &$results) : bool {
 						')';
 				}
 
-				boost_flush_output_batch($value_tuples, $conn);
+				$return_value = !boost_flush_output_batch($value_tuples, $conn);
+			} else {
+				$return_value = false;
 			}
-
-			$return_value = false;
 		} else {
 			$return_value = true;
 		}
 
 		// restore original error handler
 		restore_error_handler();
+		error_reporting($previous_error_reporting);
 
 		return $return_value;
 	} else {
@@ -397,6 +462,8 @@ function boost_fetch_cache_check(int $local_data_id, mixed $rrdtool_pipe = null)
 			return false;
 		}
 
+		$previous_error_reporting = error_reporting();
+
 		// suppress warnings
 		if (defined('E_DEPRECATED')) {
 			error_reporting(E_ALL ^ E_DEPRECATED);
@@ -422,6 +489,7 @@ function boost_fetch_cache_check(int $local_data_id, mixed $rrdtool_pipe = null)
 
 		// restore original error handler
 		restore_error_handler();
+		error_reporting($previous_error_reporting);
 
 		// close rrdtool
 		if ($close_pipe) {
@@ -470,6 +538,87 @@ function boost_return_cached_image(&$graph_data_array) : bool {
 }
 
 /**
+ * Build an opaque cache name so graph identifiers and dimensions are not
+ * enumerable when an administrator places the cache below a web root.
+ */
+function boost_graph_cache_filename(string $cache_directory, int $local_graph_id, mixed $rra_id, int $timespan, string $business_hours_index, array $graph_data_array) : string {
+	static $secret = null;
+
+	if ($secret === null) {
+		$secret = read_config_option('boost_png_cache_secret');
+
+		if (!is_string($secret) || !preg_match('/^[a-f0-9]{64}$/D', $secret)) {
+			$candidate = bin2hex(random_bytes(32));
+			db_execute_prepared('INSERT IGNORE INTO settings (name, value) VALUES (?, ?)', ['boost_png_cache_secret', $candidate]);
+			$secret = read_config_option('boost_png_cache_secret');
+
+			if (!is_string($secret) || !preg_match('/^[a-f0-9]{64}$/D', $secret)) {
+				$secret = $candidate;
+				set_config_option('boost_png_cache_secret', $secret);
+			}
+		}
+	}
+
+	$cache_key = serialize([
+		'theme'          => get_selected_theme(),
+		'local_graph_id' => $local_graph_id,
+		'rra_id'         => (int) $rra_id,
+		'timespan'       => $timespan,
+		'business_hours' => $business_hours_index,
+		'height'         => $graph_data_array['graph_height'] ?? null,
+		'width'          => $graph_data_array['graph_width'] ?? null,
+		'nolegend'       => isset($graph_data_array['graph_nolegend']),
+	]);
+
+	return rtrim($cache_directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . hash_hmac('sha256', $cache_key, $secret) . '.png';
+}
+
+/** Write a complete cache object and publish it with a same-directory rename. */
+function boost_atomic_write_cache(string $cache_file, string $output) : bool {
+	$temp_file = tempnam(dirname($cache_file), '.boost-');
+
+	if ($temp_file === false) {
+		return false;
+	}
+
+	$fileptr = fopen($temp_file, 'wb');
+
+	if ($fileptr === false) {
+		@unlink($temp_file);
+
+		return false;
+	}
+
+	$length  = strlen($output);
+	$written = 0;
+
+	while ($written < $length) {
+		$result = fwrite($fileptr, substr($output, $written));
+
+		if ($result === false || $result === 0) {
+			fclose($fileptr);
+			@unlink($temp_file);
+
+			return false;
+		}
+
+		$written += $result;
+	}
+
+	$flushed = fflush($fileptr);
+	fclose($fileptr);
+	chmod($temp_file, 0640);
+
+	if (!$flushed || !rename($temp_file, $cache_file)) {
+		@unlink($temp_file);
+
+		return false;
+	}
+
+	return true;
+}
+
+/**
  * Checks the graph cache for a given graph and returns the cached image if valid.
  * If the cache is invalid or unavailable, it falls back to Cacti's graphing functions.
  *
@@ -488,7 +637,9 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
 	// include poller processing routines
 	include_once(CACTI_PATH_LIBRARY . '/poller.php');
 
-	// suppressnwarnings
+	$previous_error_reporting = error_reporting();
+
+	// suppress warnings
 	if (defined('E_DEPRECATED')) {
 		error_reporting(E_ALL ^ E_DEPRECATED);
 	} else {
@@ -500,6 +651,9 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
 
 	// check to see if boost can do its job
 	if (!boost_poller_id_check()) {
+		restore_error_handler();
+		error_reporting($previous_error_reporting);
+
 		return false;
 	}
 
@@ -507,6 +661,7 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
 	if (isset($graph_data_array['export_realtime'])) {
 		// restore original error handler
 		restore_error_handler();
+		error_reporting($previous_error_reporting);
 
 		return false;
 	}
@@ -515,6 +670,7 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
 	if (isset($graph_data_array['print_source'])) {
 		// restore original error handler
 		restore_error_handler();
+		error_reporting($previous_error_reporting);
 
 		return false;
 	}
@@ -524,6 +680,7 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
 		($graph_data_array['output_flag'] == RRDTOOL_OUTPUT_STDERR)) {
 		// restore original error handler
 		restore_error_handler();
+		error_reporting($previous_error_reporting);
 
 		return false;
 	}
@@ -549,6 +706,7 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
 			if ($updates) {
 				// restore original error handler
 				restore_error_handler();
+				error_reporting($previous_error_reporting);
 
 				return false;
 			}
@@ -579,25 +737,7 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
 		if ($cache_directory != '') {
 			if (is_dir($cache_directory)) {
 				if (is_writable($cache_directory)) {
-					if ($rra_id > 0) {
-						$cache_file = $cache_directory . '/' . get_selected_theme() . '_lgi_' . $local_graph_id . '_rrai_' . $rra_id . $bh_index;
-					} else {
-						$cache_file = $cache_directory . '/' . get_selected_theme() . '_lgi_' . $local_graph_id . '_rrai_' . $rra_id . $bh_index . '_tsi_' . $timespan;
-					}
-
-					if (isset($graph_data_array['graph_height'])) {
-						$cache_file .= '_height_' . $graph_data_array['graph_height'];
-					}
-
-					if (isset($graph_data_array['graph_width'])) {
-						$cache_file .= '_width_' . $graph_data_array['graph_width'];
-					}
-
-					if (isset($graph_data_array['graph_nolegend'])) {
-						$cache_file .= '_thumb.png';
-					} else {
-						$cache_file .= '.png';
-					}
+					$cache_file = boost_graph_cache_filename($cache_directory, $local_graph_id, $rra_id, (int) $timespan, $bh_index, $graph_data_array);
 
 					if (file_exists($cache_file)) {
 						$mod_time        = filemtime($cache_file);
@@ -614,6 +754,7 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
 
 								// restore original error handler
 								restore_error_handler();
+								error_reporting($previous_error_reporting);
 
 								// get access to the SNMP Cache of BOOST
 								$mc = new MibCache('CACTI-BOOST-MIB');
@@ -641,6 +782,7 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
 
 	// restore original error handler
 	restore_error_handler();
+	error_reporting($previous_error_reporting);
 
 	return false;
 }
@@ -659,6 +801,8 @@ function boost_graph_cache_check(int $local_graph_id, mixed $rra_id, mixed $rrdt
  * @return array The prepared graph data array with any necessary modifications.
  */
 function boost_prep_graph_array(array $graph_data_array) : array {
+	$previous_error_reporting = error_reporting();
+
 	// suppress warnings
 	if (defined('E_DEPRECATED')) {
 		error_reporting(E_ALL ^ E_DEPRECATED);
@@ -679,6 +823,7 @@ function boost_prep_graph_array(array $graph_data_array) : array {
 
 	// restore original error handler
 	restore_error_handler();
+	error_reporting($previous_error_reporting);
 
 	return $graph_data_array;
 }
@@ -704,6 +849,8 @@ function boost_graph_set_file(string|null &$output, int $local_graph_id, int|nul
 
 	// get access to the SNMP Cache of BOOST
 	$mc = new MibCache('CACTI-BOOST-MIB');
+
+	$previous_error_reporting = error_reporting();
 
 	// suppress warnings
 	if (defined('E_DEPRECATED')) {
@@ -735,34 +882,12 @@ function boost_graph_set_file(string|null &$output, int $local_graph_id, int|nul
 
 		if ($cache_directory != '') {
 			if (is_dir($cache_directory)) {
-				if ($rra_id > 0) {
-					$cache_file = $cache_directory . '/' . get_selected_theme() . '_lgi_' . $local_graph_id . '_rrai_' . $rra_id . $bh_index;
-				} else {
-					$cache_file = $cache_directory . '/' . get_selected_theme() . '_lgi_' . $local_graph_id . '_rrai_' . $rra_id . $bh_index . '_tsi_' . $timespan;
-				}
-
-				if (isset($graph_data_array['graph_height'])) {
-					$cache_file .= '_height_' . $graph_data_array['graph_height'];
-				}
-
-				if (isset($graph_data_array['graph_width'])) {
-					$cache_file .= '_width_' . $graph_data_array['graph_width'];
-				}
-
-				if (isset($graph_data_array['graph_nolegend'])) {
-					$cache_file .= '_thumb.png';
-				} else {
-					$cache_file .= '.png';
-				}
+				$cache_file = boost_graph_cache_filename($cache_directory, $local_graph_id, $rra_id, (int) $timespan, $bh_index, $graph_data_array);
 
 				if (is_writable($cache_directory)) {
 					// if the cache file was created in a prior step, save it
 					if (strlen($output) > 10) {
-						if ($fileptr = fopen($cache_file, 'w')) {
-							fwrite($fileptr, $output, strlen($output));
-							fclose($fileptr);
-							chmod($cache_file, 0644);
-
+						if (boost_atomic_write_cache($cache_file, $output)) {
 							// count the number of images that had to be cached
 							$mc->object('boostStatsTotalsImagesCacheWrites')->count();
 							$mc->object('boostStatsLastUpdate')->set(time());
@@ -781,6 +906,7 @@ function boost_graph_set_file(string|null &$output, int $local_graph_id, int|nul
 
 	// restore original error handler
 	restore_error_handler();
+	error_reporting($previous_error_reporting);
 }
 
 /**
@@ -869,7 +995,7 @@ function boost_clamp_parallel(mixed $value) : int {
  * @return bool True when the name is a well-formed boost archive table.
  */
 function boost_is_valid_archive_table(mixed $table) : bool {
-	return is_string($table) && preg_match('/^poller_output_boost_arch_\d+$/', $table) === 1;
+	return is_string($table) && preg_match('/^poller_output_boost_arch_\d+$/D', $table) === 1;
 }
 
 /**
@@ -933,8 +1059,13 @@ function boost_get_arch_table_names(mixed $latest_table = '') : mixed {
 
 	if (cacti_sizeof($tableData)) {
 		foreach ($tableData as $table) {
-			$table                 = array_values($table);
-			$tableNames[$table[0]] = $table[0];
+			$table = array_values($table);
+
+			if (boost_is_valid_archive_table($table[0])) {
+				$tableNames[$table[0]] = $table[0];
+			} else {
+				cacti_log('WARNING: Boost ignored an unexpected archive-like table name.', false, 'BOOST');
+			}
 		}
 	}
 
@@ -946,6 +1077,12 @@ function boost_get_arch_table_names(mixed $latest_table = '') : mixed {
 				AND TABLE_NAME LIKE 'poller_output_boost_arch_%'"),
 			'name', 'name'
 		);
+
+		if (is_array($tableNames)) {
+			$tableNames = array_filter($tableNames, 'boost_is_valid_archive_table');
+		} else {
+			$tableNames = [];
+		}
 	}
 
 	if (!cacti_sizeof($tableNames)) {
@@ -1019,6 +1156,8 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 
 	include_once(CACTI_PATH_LIBRARY . '/rrd.php');
 
+	$previous_error_reporting = error_reporting();
+
 	// suppress warnings
 	if (defined('E_DEPRECATED')) {
 		error_reporting(E_ALL ^ E_DEPRECATED);
@@ -1061,7 +1200,7 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 		db_execute("CREATE TEMPORARY TABLE `{$temp_table}` LIKE poller_output_boost");
 
 		foreach ($archive_tables as $table) {
-			db_execute_prepared("INSERT INTO `{$temp_table}`
+			db_execute_prepared("INSERT IGNORE INTO `{$temp_table}`
 				SELECT *
 				FROM `{$table}`
 				WHERE local_data_id = ?",
@@ -1070,7 +1209,7 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 	}
 
 	if ($temp_table !== false) {
-		db_execute_prepared("INSERT INTO `{$temp_table}`
+		db_execute_prepared("INSERT IGNORE INTO `{$temp_table}`
 			SELECT *
 			FROM poller_output_boost
 			WHERE local_data_id = ?
@@ -1111,50 +1250,7 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 
 	cacti_log('Local Data ID: ' . $local_data_id . ', Boost Results: ' . $boost_results, false, 'BOOST', POLLER_VERBOSITY_MEDIUM);
 
-	// remove the entries from the table
-	boost_timer('delete', BOOST_TIMER_START);
-
-	if (cacti_count($archive_tables)) {
-		foreach ($archive_tables as $table) {
-			// rows with time >= $timestamp belong to a poll round that was
-			// still open when $results was built above, so they were not
-			// written to RRD; carry them forward into the live table instead
-			// of deleting them out of the archive table, which gets dropped
-			// wholesale once this run completes (see issue #7519)
-			db_execute_prepared("INSERT IGNORE INTO poller_output_boost
-				SELECT *
-				FROM $table
-				WHERE local_data_id = ?
-				AND time >= FROM_UNIXTIME(?)",
-				[$local_data_id, $timestamp], false);
-
-			// Now that every row for this local_data_id has either been
-			// written to RRD (time < $timestamp) or forwarded to the live
-			// table above (time >= $timestamp), the whole archive slice for
-			// this local_data_id is safe to remove. Leaving the forwarded
-			// rows behind here would duplicate them into the unfiltered
-			// archive-side SELECT that seeds $temp_table on the next call
-			// for this local_data_id, which is not INSERT IGNORE and would
-			// fail on the resulting primary-key collision.
-			db_execute_prepared("DELETE IGNORE
-				FROM $table
-				WHERE local_data_id = ?",
-				[$local_data_id], false);
-		}
-	}
-
-	if (cacti_sizeof($results)) {
-		db_execute_prepared('DELETE FROM poller_output_boost
-			WHERE local_data_id = ?
-			AND time < FROM_UNIXTIME(?)',
-			[$local_data_id, $timestamp], false);
-	}
-
-	boost_timer('delete', BOOST_TIMER_END);
-
-	if (cacti_version_compare(get_rrdtool_version(), '1.5', '<')) {
-		db_execute("SELECT RELEASE_LOCK('boost.single_ds.$local_data_id')");
-	}
+	$updates_ok = $results !== false;
 
 	// log memory
 	if ($get_memory) {
@@ -1261,6 +1357,7 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 					// check return status for delete operation
 					if (!str_contains(trim($return_value), 'OK') && $return_value != '') {
 						cacti_log("WARNING: RRD Update Warning '" . $return_value . "' for Local Data ID '$local_data_id'", false, 'BOOST');
+						$updates_ok = false;
 					}
 				}
 
@@ -1477,6 +1574,7 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 			// check return status for delete operation
 			if (!str_contains(trim($return_value), 'OK') && $return_value != '') {
 				cacti_log("WARNING: RRD Update Warning '" . $return_value . "' for Local Data ID '$local_data_id'", false, 'BOOST');
+				$updates_ok = false;
 			}
 		}
 
@@ -1487,10 +1585,67 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 		}
 	}
 
+	// The database rows are the retry record. Remove them only after every RRD
+	// update and every still-open-row forward has been acknowledged.
+	boost_timer('delete', BOOST_TIMER_START);
+
+	if ($updates_ok && cacti_count($archive_tables)) {
+		foreach ($archive_tables as $table) {
+			$forward_rows = (int) db_fetch_cell_prepared("SELECT COUNT(*)
+				FROM `$table`
+				WHERE local_data_id = ?
+				AND time >= FROM_UNIXTIME(?)",
+				[$local_data_id, $timestamp]);
+
+			if (db_execute_prepared("INSERT IGNORE INTO poller_output_boost
+				SELECT *
+				FROM `$table`
+				WHERE local_data_id = ?
+				AND time >= FROM_UNIXTIME(?)",
+				[$local_data_id, $timestamp], false) === false) {
+				$updates_ok = false;
+
+				break;
+			}
+
+			if (db_affected_rows() < $forward_rows) {
+				cacti_log("WARNING: Boost archive forwarding encountered duplicate sample keys for Local Data ID '$local_data_id'.", false, 'BOOST');
+			}
+		}
+	}
+
+	if ($updates_ok && cacti_count($archive_tables)) {
+		foreach ($archive_tables as $table) {
+			if (db_execute_prepared("DELETE FROM `$table` WHERE local_data_id = ?", [$local_data_id], false) === false) {
+				$updates_ok = false;
+
+				break;
+			}
+		}
+	}
+
+	if ($updates_ok && cacti_sizeof($results)) {
+		$updates_ok = db_execute_prepared('DELETE FROM poller_output_boost
+			WHERE local_data_id = ?
+			AND time < FROM_UNIXTIME(?)',
+			[$local_data_id, $timestamp], false) !== false;
+	}
+
+	boost_timer('delete', BOOST_TIMER_END);
+
+	if (!$updates_ok) {
+		cacti_log("WARNING: Boost retained staged rows for Local Data ID '$local_data_id' because the handoff was not fully acknowledged.", false, 'BOOST');
+	}
+
+	if (cacti_version_compare(get_rrdtool_version(), '1.5', '<')) {
+		db_execute("SELECT RELEASE_LOCK('boost.single_ds.$local_data_id')");
+	}
+
 	// restore original error handler
 	restore_error_handler();
+	error_reporting($previous_error_reporting);
 
-	return cacti_sizeof($results);
+	return $updates_ok ? cacti_sizeof($results) : -1;
 }
 
 /**
@@ -1919,11 +2074,15 @@ function boost_rrdtool_function_update(int $local_data_id, string $rrd_path, str
 		if ($rrd_update_template != '') {
 			boost_debug("update $rrd_path $update_options --template $rrd_update_template $rrd_update_values");
 
-			rrdtool_execute('update ' . cacti_escapeshellarg($rrd_path) . " $update_options --template $rrd_update_template $rrd_update_values", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'BOOST');
+			$result = rrdtool_execute('update ' . cacti_escapeshellarg($rrd_path) . " $update_options --template $rrd_update_template $rrd_update_values", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'BOOST');
 		} else {
 			boost_debug("update $rrd_path $update_options $rrd_update_values");
 
-			rrdtool_execute('update ' . cacti_escapeshellarg($rrd_path) . " $update_options $rrd_update_values", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'BOOST');
+			$result = rrdtool_execute('update ' . cacti_escapeshellarg($rrd_path) . " $update_options $rrd_update_values", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'BOOST');
+		}
+
+		if ($result === false || preg_match('/(?:^|\b)(?:ERROR|Error)(?::|\b)/', trim((string) $result))) {
+			return is_string($result) && $result !== '' ? $result : 'ERROR: RRDtool did not acknowledge the update';
 		}
 
 		return 'OK';

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -606,7 +606,7 @@ function boost_atomic_write_cache(string $cache_file, string $output) : bool {
 
 	$flushed = fflush($fileptr);
 	fclose($fileptr);
-	chmod($temp_file, 0640);
+	chmod($temp_file, 0644);
 
 	$published = $flushed && @rename($temp_file, $cache_file);
 

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -898,7 +898,7 @@ function boost_graph_set_file(string|null &$output, int $local_graph_id, int|nul
 
 				if (is_writable($cache_directory)) {
 					// if the cache file was created in a prior step, save it
-					if (strlen($output) > 10) {
+					if (is_string($output) && strlen($output) > 10) {
 						if (boost_atomic_write_cache($cache_file, $output)) {
 							// count the number of images that had to be cached
 							$mc->object('boostStatsTotalsImagesCacheWrites')->count();

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -1130,12 +1130,14 @@ function boost_get_arch_table_names(mixed $latest_table = '') : mixed {
 
 	if (cacti_sizeof($tableData)) {
 		foreach ($tableData as $table) {
-			$table = array_values($table);
+			$table      = array_values($table);
+			$table_name = (string) $table[0];
 
-			if (boost_is_valid_archive_table($table[0])) {
-				$tableNames[$table[0]] = $table[0];
+			if (boost_is_valid_archive_table($table_name)) {
+				$tableNames[$table_name] = $table_name;
 			} else {
-				cacti_log('WARNING: Boost ignored an unexpected archive-like table name.', false, 'BOOST');
+				$display_name = preg_replace('/[^\x20-\x7e]/', '?', $table_name) ?? '<invalid>';
+				cacti_log('WARNING: Boost ignored an unexpected archive-like table name: ' . $display_name, false, 'BOOST');
 			}
 		}
 	}

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -383,7 +383,11 @@ function boost_poller_on_demand(array &$results) : bool {
 					restore_error_handler();
 					error_reporting($previous_error_reporting);
 
-					return false;
+					// The caller has already removed these rows from poller_output, so
+					// returning false here would drop the cycle entirely. Report that
+					// boost did not consume the data and let the poller write it to RRD
+					// directly, matching the database failure path below.
+					return true;
 				}
 
 				$value_tuples = [];
@@ -2090,6 +2094,17 @@ function boost_rrdtool_function_update(int $local_data_id, string $rrd_path, str
 		}
 
 		if ($result === false || preg_match('/(?:^|\b)(?:ERROR|Error)(?::|\b)/', trim((string) $result))) {
+			// A timestamp at or behind the last update means the sample is already
+			// in the RRD, which is what a retried shard looks like. Reporting that
+			// as a failure would retain the shard and reprocess it forever, so the
+			// same rows would fail again on every pass and boost would never drain.
+			// rrdtool 1.5 and later avoid this with --skip-past-updates; older
+			// releases raise it, and a retry after a partial pass raises it on any
+			// version.
+			if (is_string($result) && preg_match('/illegal attempt to update using time|minimum one second step/i', $result)) {
+				return 'OK';
+			}
+
 			return is_string($result) && $result !== '' ? $result : 'ERROR: RRDtool did not acknowledge the update';
 		}
 

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -596,7 +596,7 @@ function boost_graph_cache_filename(string $cache_directory, int $local_graph_id
 		'nolegend'       => isset($graph_data_array['graph_nolegend']),
 	]);
 
-	return rtrim($cache_directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . hash_hmac('sha256', $cache_key, $secret) . '.png';
+	return rtrim($cache_directory, '/\\') . DIRECTORY_SEPARATOR . hash_hmac('sha256', $cache_key, $secret) . '.png';
 }
 
 /** Replace an existing cache object after Windows rejects rename-over-existing. */

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -535,6 +535,11 @@ function boost_graph_cache_filename(string $cache_directory, int $local_graph_id
 	return rtrim($cache_directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . hash_hmac('sha256', $cache_key, $secret) . '.png';
 }
 
+/** Replace an existing cache object after Windows rejects rename-over-existing. */
+function boost_replace_cache_file_on_windows(string $temp_file, string $cache_file) : bool {
+	return is_file($cache_file) && @unlink($cache_file) && @rename($temp_file, $cache_file);
+}
+
 /** Write a complete cache object and publish it with a same-directory rename. */
 function boost_atomic_write_cache(string $cache_file, string $output) : bool {
 	$temp_file = tempnam(dirname($cache_file), '.boost-');
@@ -579,7 +584,13 @@ function boost_atomic_write_cache(string $cache_file, string $output) : bool {
 	fclose($fileptr);
 	chmod($temp_file, 0640);
 
-	if (!$flushed || !rename($temp_file, $cache_file)) {
+	$published = $flushed && @rename($temp_file, $cache_file);
+
+	if (!$published && $flushed && PHP_OS_FAMILY === 'Windows') {
+		$published = boost_replace_cache_file_on_windows($temp_file, $cache_file);
+	}
+
+	if (!$published) {
 		@unlink($temp_file);
 
 		return false;

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -551,20 +551,28 @@ function boost_atomic_write_cache(string $cache_file, string $output) : bool {
 		return false;
 	}
 
-	$length  = strlen($output);
-	$written = 0;
+	$length     = strlen($output);
+	$written    = 0;
+	$chunk_size = 1024 * 1024;
 
 	while ($written < $length) {
-		$result = fwrite($fileptr, substr($output, $written));
+		$chunk         = substr($output, $written, $chunk_size);
+		$chunk_length  = strlen($chunk);
+		$chunk_written = 0;
 
-		if ($result === false || $result === 0) {
-			fclose($fileptr);
-			@unlink($temp_file);
+		while ($chunk_written < $chunk_length) {
+			$result = fwrite($fileptr, substr($chunk, $chunk_written));
 
-			return false;
+			if ($result === false || $result === 0) {
+				fclose($fileptr);
+				@unlink($temp_file);
+
+				return false;
+			}
+
+			$chunk_written += $result;
+			$written       += $result;
 		}
-
-		$written += $result;
 	}
 
 	$flushed = fflush($fileptr);

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -576,7 +576,7 @@ function boost_graph_cache_filename(string $cache_directory, int $local_graph_id
 		if (!is_string($secret) || !preg_match('/^[a-f0-9]{64}$/D', $secret)) {
 			$candidate = bin2hex(random_bytes(32));
 			db_execute_prepared('INSERT IGNORE INTO settings (name, value) VALUES (?, ?)', ['boost_png_cache_secret', $candidate]);
-			$secret = read_config_option('boost_png_cache_secret');
+			$secret = read_config_option('boost_png_cache_secret', true);
 
 			if (!is_string($secret) || !preg_match('/^[a-f0-9]{64}$/D', $secret)) {
 				$secret = $candidate;

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -370,7 +370,7 @@ function boost_poller_on_demand(array &$results) : bool {
 
 		if (boost_check_correct_enabled()) {
 			if (cacti_sizeof($results)) {
-				if (POLLER_ID > 1 && !boost_validate_poller_ownership($results, POLLER_ID, $conn)) {
+				if (POLLER_ID > 1 && !boost_validate_poller_ownership($results, POLLER_ID, $conn)) { // @phpstan-ignore-line
 					cacti_log(sprintf('ERROR: Boost rejected a handoff containing data sources not assigned to poller %d.', POLLER_ID), false, 'BOOST');
 					restore_error_handler();
 					error_reporting($previous_error_reporting);

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -255,6 +255,264 @@ function boost_check_correct_enabled() : bool {
 }
 
 /**
+ * Read one SQL VALUES token: a quoted string, a bare number, or FUNC().
+ *
+ * @param string $sql    Tuple text
+ * @param int    $offset Byte offset; advanced past the token
+ *
+ * @return string|null The token value, or null when the tuple is malformed
+ */
+function boost_parse_sql_value(string $sql, int &$offset) : ?string {
+	$length = strlen($sql);
+
+	while ($offset < $length && ctype_space($sql[$offset])) {
+		$offset++;
+	}
+
+	if ($offset >= $length) {
+		return null;
+	}
+
+	if ($sql[$offset] === "'") {
+		$offset++;
+		$value = '';
+
+		while ($offset < $length) {
+			$ch = $sql[$offset];
+
+			if ($ch === '\\' && $offset + 1 < $length) {
+				$value .= $sql[$offset + 1];
+				$offset += 2;
+
+				continue;
+			}
+
+			if ($ch === "'") {
+				if ($offset + 1 < $length && $sql[$offset + 1] === "'") {
+					$value .= "'";
+					$offset += 2;
+
+					continue;
+				}
+
+				$offset++;
+
+				return $value;
+			}
+
+			$value .= $ch;
+			$offset++;
+		}
+
+		return null;
+	}
+
+	if (preg_match('/\G[A-Za-z_][A-Za-z0-9_]*\s*\(\s*\)/', $sql, $matches, 0, $offset) === 1) {
+		$offset += strlen($matches[0]);
+
+		return preg_replace('/\s+/', '', $matches[0]) ?? $matches[0];
+	}
+
+	if (preg_match('/\G-?\d+(?:\.\d+)?/', $sql, $matches, 0, $offset) === 1) {
+		$offset += strlen($matches[0]);
+
+		return $matches[0];
+	}
+
+	return null;
+}
+
+/**
+ * Pull local_data_id, rrd_name, and time from a poller_output_boost VALUES tuple.
+ *
+ * @param string $tuple A "(id, 'name', 'time', 'output')" or CURRENT_TIMESTAMP() tuple
+ *
+ * @return array{local_data_id:int, rrd_name:string, time:string}|null
+ */
+function boost_parse_output_tuple(string $tuple) : ?array {
+	$tuple  = trim($tuple);
+	$offset = 0;
+
+	if ($tuple === '' || $tuple[0] !== '(') {
+		return null;
+	}
+
+	$offset = 1;
+	$id     = boost_parse_sql_value($tuple, $offset);
+
+	if ($id === null || !ctype_digit($id)) {
+		return null;
+	}
+
+	while ($offset < strlen($tuple) && ctype_space($tuple[$offset])) {
+		$offset++;
+	}
+
+	if ($offset >= strlen($tuple) || $tuple[$offset] !== ',') {
+		return null;
+	}
+
+	$offset++;
+	$rrd_name = boost_parse_sql_value($tuple, $offset);
+
+	if ($rrd_name === null) {
+		return null;
+	}
+
+	while ($offset < strlen($tuple) && ctype_space($tuple[$offset])) {
+		$offset++;
+	}
+
+	if ($offset >= strlen($tuple) || $tuple[$offset] !== ',') {
+		return null;
+	}
+
+	$offset++;
+	$time = boost_parse_sql_value($tuple, $offset);
+
+	if ($time === null) {
+		return null;
+	}
+
+	return [
+		'local_data_id' => (int) $id,
+		'rrd_name'      => $rrd_name,
+		'time'          => $time
+	];
+}
+
+/**
+ * Clip a diagnostic fragment so one huge rrd_name cannot flood the log.
+ */
+function boost_clip_log_fragment(string $value, int $max = 64) : string {
+	$value = str_replace(["\r", "\n", "\0"], ' ', $value);
+
+	if (strlen($value) <= $max) {
+		return $value;
+	}
+
+	return substr($value, 0, $max - 3) . '...';
+}
+
+/**
+ * Build the BOOST warning for an INSERT IGNORE that dropped rows.
+ *
+ * @param array $tuples    The VALUES tuples from the statement that was ignored in part
+ * @param int   $attempted Rows in that statement
+ * @param int   $inserted  Rows the server reported as written
+ *
+ * @return string Empty when nothing was dropped
+ */
+function boost_describe_ignored_sample_keys(array $tuples, int $attempted, int $inserted) : string {
+	$dropped = $attempted - $inserted;
+
+	if ($dropped < 1) {
+		return '';
+	}
+
+	$by_key = [];
+	$ids    = [];
+
+	foreach ($tuples as $tuple) {
+		$parsed = boost_parse_output_tuple((string) $tuple);
+
+		if ($parsed === null) {
+			continue;
+		}
+
+		$ids[$parsed['local_data_id']] = true;
+		$key = $parsed['local_data_id'] . "\0" . $parsed['rrd_name'] . "\0" . $parsed['time'];
+
+		if (!isset($by_key[$key])) {
+			$parsed['count'] = 0;
+			$by_key[$key]    = $parsed;
+		}
+
+		$by_key[$key]['count']++;
+	}
+
+	$in_batch = 0;
+	$examples = [];
+
+	foreach ($by_key as $row) {
+		if ($row['count'] < 2) {
+			continue;
+		}
+
+		$in_batch += $row['count'] - 1;
+
+		if (cacti_count($examples) < 8) {
+			$examples[] = sprintf(
+				'DS[%d] %s @ %s (x%d)',
+				$row['local_data_id'],
+				boost_clip_log_fragment($row['rrd_name']),
+				boost_clip_log_fragment($row['time']),
+				$row['count']
+			);
+		}
+	}
+
+	if ($in_batch === 0) {
+		foreach ($by_key as $row) {
+			if (cacti_count($examples) >= 8) {
+				break;
+			}
+
+			$examples[] = sprintf(
+				'DS[%d] %s @ %s',
+				$row['local_data_id'],
+				boost_clip_log_fragment($row['rrd_name']),
+				boost_clip_log_fragment($row['time'])
+			);
+		}
+	}
+
+	$id_keys = array_keys($ids);
+	$id_list = implode(',', array_slice($id_keys, 0, 20));
+
+	if (cacti_count($id_keys) > 20) {
+		$id_list .= ',...';
+	}
+
+	$vs_existing = $dropped - $in_batch;
+
+	if ($vs_existing < 0) {
+		$vs_existing = 0;
+	}
+
+	if ($in_batch > 0 && $vs_existing > 0) {
+		$reason = 'duplicate keys inside this INSERT and vs existing poller_output_boost rows';
+	} elseif ($in_batch > 0) {
+		$reason = 'duplicate keys inside this INSERT';
+	} else {
+		$reason = 'keys already in poller_output_boost';
+	}
+
+	$poller = defined('POLLER_ID') ? (int) POLLER_ID : 0;
+
+	return sprintf(
+		'WARNING: Boost staging ignored %d of %d duplicate sample keys (INSERT IGNORE, first write wins, poller=%d, %s). local_data_id=%s%s',
+		$dropped,
+		$attempted,
+		$poller,
+		$reason,
+		$id_list !== '' ? $id_list : 'unknown',
+		$examples !== [] ? '; ' . implode('; ', $examples) : ''
+	);
+}
+
+/**
+ * Log INSERT IGNORE collisions with the keys an operator can grep.
+ */
+function boost_log_ignored_sample_keys(array $tuples, int $attempted, int $inserted) : void {
+	$message = boost_describe_ignored_sample_keys($tuples, $attempted, $inserted);
+
+	if ($message !== '') {
+		cacti_log($message, false, 'BOOST');
+	}
+}
+
+/**
  * boost_flush_output_batch - writes a batch of pre-built poller_output_boost
  * VALUE tuples, chunking on max_allowed_packet so a single INSERT statement
  * never exceeds it. Shared by cmd.php's boost_redirect writes and
@@ -304,6 +562,7 @@ function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bo
 	$overhead   = strlen($sql_prefix) + 1;
 	$out_buffer = '';
 	$out_length = 0;
+	$chunk      = [];
 	$rows       = 0;
 
 	foreach ($value_tuples as $tuple) {
@@ -320,16 +579,20 @@ function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bo
 				return false;
 			}
 
-			if (db_affected_rows($conn) < $rows) {
-				cacti_log('WARNING: Boost staging ignored one or more duplicate sample keys.', false, 'BOOST');
+			$inserted = (int) db_affected_rows($conn);
+
+			if ($inserted < $rows) {
+				boost_log_ignored_sample_keys($chunk, $rows, $inserted);
 			}
 
 			$out_buffer = $tuple;
 			$out_length = $tuple_length;
+			$chunk      = [$tuple];
 			$rows       = 1;
 		} else {
 			$out_buffer .= ($out_buffer != '' ? ',' : '') . $tuple;
 			$out_length += $tuple_length + ($out_length > 0 ? 1 : 0);
+			$chunk[] = $tuple;
 			$rows++;
 		}
 	}
@@ -345,8 +608,10 @@ function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bo
 			return false;
 		}
 
-		if (db_affected_rows($conn) < $rows) {
-			cacti_log('WARNING: Boost staging ignored one or more duplicate sample keys.', false, 'BOOST');
+		$inserted = (int) db_affected_rows($conn);
+
+		if ($inserted < $rows) {
+			boost_log_ignored_sample_keys($chunk, $rows, $inserted);
 		}
 	}
 
@@ -1681,8 +1946,16 @@ function boost_process_poller_output(int $local_data_id, mixed $rrdtool_pipe = [
 				break;
 			}
 
-			if (db_affected_rows() < $forward_rows) {
-				cacti_log("WARNING: Boost archive forwarding encountered duplicate sample keys for Local Data ID '$local_data_id'.", false, 'BOOST');
+			$forwarded = (int) db_affected_rows();
+
+			if ($forwarded < $forward_rows) {
+				cacti_log(sprintf(
+					'WARNING: Boost archive forwarding ignored %d of %d duplicate sample keys for Local Data ID %d from %s (already in poller_output_boost, first write wins).',
+					$forward_rows - $forwarded,
+					$forward_rows,
+					$local_data_id,
+					$table
+				), false, 'BOOST');
 			}
 		}
 	}

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -421,6 +421,7 @@ function boost_describe_ignored_sample_keys(array $tuples, int $attempted, int $
 		}
 
 		$ids[$parsed['local_data_id']] = true;
+
 		$key = $parsed['local_data_id'] . "\0" . $parsed['rrd_name'] . "\0" . $parsed['time'];
 
 		if (!isset($by_key[$key])) {

--- a/poller.php
+++ b/poller.php
@@ -1142,8 +1142,11 @@ function poller_table_maintenance() : void {
 	if (!db_table_exists('poller_output_boost_processes')) {
 		db_execute('CREATE TABLE  `poller_output_boost_processes` (
 			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
+			`run_id` char(32) NOT NULL default "",
+			`child_id` int(10) unsigned NOT NULL default "0",
 			`status` varchar(255) default NULL,
-			PRIMARY KEY (`sock_int_value`))
+			PRIMARY KEY (`sock_int_value`),
+			UNIQUE KEY `run_child` (`run_id`, `child_id`))
 			ENGINE=MEMORY');
 	}
 

--- a/poller.php
+++ b/poller.php
@@ -1142,8 +1142,8 @@ function poller_table_maintenance() : void {
 	if (!db_table_exists('poller_output_boost_processes')) {
 		db_execute('CREATE TABLE  `poller_output_boost_processes` (
 			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
-			`run_id` char(32) NOT NULL default "",
-			`child_id` int(10) unsigned NOT NULL default "0",
+			`run_id` char(32) NOT NULL default \'\',
+			`child_id` int(10) unsigned NOT NULL default 0,
 			`status` varchar(255) default NULL,
 			PRIMARY KEY (`sock_int_value`),
 			UNIQUE KEY `run_child` (`run_id`, `child_id`))

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -49,11 +49,12 @@ $debug    = false;
 $forcerun = false;
 $verbose  = false;
 $child    = 0;
+$run_id   = '';
 
 // for releasing lock on SIGNAL
 $current_lock = false;
 
-global $child, $next_run_time, $archive_table, $current_lock;
+global $child, $run_id, $next_run_time, $archive_table, $current_lock;
 global $boost_debug, $boost_log, $cacti_log;
 
 // Archive tables that boost_prepare_process_table() assigned to this run. Only
@@ -81,6 +82,12 @@ if (cacti_sizeof($parms)) {
 			case '--archive-table':
 				if (preg_match('/^poller_output_boost_arch_\d+$/', $value)) {
 					$archive_table = $value;
+				}
+
+				break;
+			case '--run-id':
+				if (preg_match('/^[a-f0-9]{32}$/D', $value)) {
+					$run_id = $value;
 				}
 
 				break;
@@ -141,6 +148,7 @@ $boost_log   = read_config_option('path_boost_log');
 $cacti_log   = read_config_option('path_cactilog');
 
 if ($child == false) {
+	$run_id        = bin2hex(random_bytes(16));
 	$current_time  = time();
 
 	/* find out if it's time to collect device information
@@ -236,26 +244,26 @@ if ($child == false) {
 			// under them.
 			$startup_deadline = time() + 30;
 
-			while (!boost_all_children_registered($expected_children, boost_processes_running(), boost_completed_children()) && time() < $startup_deadline) {
+			while (!boost_all_children_registered($expected_children, boost_processes_running(), boost_completed_children($run_id)) && time() < $startup_deadline) {
 				sleep(1);
 			}
 
-			if (!boost_all_children_registered($expected_children, boost_processes_running(), boost_completed_children())) {
-				cacti_log(sprintf('WARNING: Boost startup barrier timed out; %d of %d children registered before draining.', boost_processes_running() + boost_completed_children(), $expected_children), true, 'BOOST');
+			if (!boost_all_children_registered($expected_children, boost_processes_running(), boost_completed_children($run_id))) {
+				cacti_log(sprintf('WARNING: Boost startup barrier timed out; %d of %d children registered before draining.', boost_processes_running() + boost_completed_children($run_id), $expected_children), true, 'BOOST');
 			}
 
 			// Drain until no child is running and every launched child has
 			// recorded a completion row, not merely when none are running -- a
 			// sibling may not have started yet.
-			while (boost_processes_running() > 0 || boost_completed_children() < $expected_children) {
-				boost_debug(sprintf('%d Processes Running, %d of %d Completed, Sleeping for 2 seconds.', boost_processes_running(), boost_completed_children(), $expected_children));
+			while (boost_processes_running() > 0 || boost_completed_children($run_id) < $expected_children) {
+				boost_debug(sprintf('%d Processes Running, %d of %d Completed, Sleeping for 2 seconds.', boost_processes_running(), boost_completed_children($run_id), $expected_children));
 				sleep(2);
 
-				if (boost_processes_running() === 0 && boost_completed_children() < $expected_children) {
+				if (boost_processes_running() === 0 && boost_completed_children($run_id) < $expected_children) {
 					// All registered children exited but fewer completion rows than
 					// expected: a child crashed before recording status. Stop waiting
 					// so the parent does not spin forever.
-					cacti_log(sprintf('WARNING: Boost drained with %d of %d completion rows; a child may have crashed.', boost_completed_children(), $expected_children), true, 'BOOST');
+					cacti_log(sprintf('WARNING: Boost drained with %d of %d completion rows; a child may have crashed.', boost_completed_children($run_id), $expected_children), true, 'BOOST');
 
 					break;
 				}
@@ -270,9 +278,18 @@ if ($child == false) {
 			set_config_option('boost_last_run_time', $current_time);
 
 			// output all the rrd data to the rrd files
-			$rrd_updates = db_fetch_cell('SELECT SUM(status) FROM poller_output_boost_processes');
+			$failed_children = boost_failed_children($run_id);
+			$rrd_updates     = (int) db_fetch_cell_prepared('SELECT COALESCE(SUM(CAST(status AS SIGNED)), 0)
+				FROM poller_output_boost_processes
+				WHERE run_id = ?
+				AND CAST(status AS SIGNED) >= 0',
+				[$run_id]);
 
-			if ($rrd_updates > 0) {
+			if ($failed_children > 0) {
+				boost_log_statistics($rrd_updates);
+				set_config_option('boost_last_run_time', $last_run_time);
+				cacti_log(sprintf('WARNING: Boost retained archive tables because %d child process(es) reported an RRD update failure.', $failed_children), true, 'BOOST');
+			} elseif ($rrd_updates > 0) {
 				boost_log_statistics($rrd_updates);
 				$next_run_time = $current_time + $seconds_offset;
 			} elseif ($rrd_updates == -1) {
@@ -282,7 +299,7 @@ if ($child == false) {
 				set_config_option('boost_last_run_time', $last_run_time);
 			}
 
-			if ($rrd_updates > 0) {
+			if ($rrd_updates > 0 && $failed_children === 0) {
 				cacti_log('INFO: Boost removing archive tables ...', true, 'BOOST');
 
 				// $rrd_updates is a SUM() across whatever completion rows landed;
@@ -291,7 +308,7 @@ if ($child == false) {
 				// the drop on the same completeness check the drain loop above uses,
 				// not on "some shard made progress" -- otherwise a crashed child's
 				// entire unprocessed shard of staged RRD data is destroyed with it.
-				if (boost_completed_children() >= $expected_children) {
+				if (boost_completed_children($run_id) >= $expected_children) {
 					// Drop only the tables this run owned. A table created by a later
 					// rotation, or left by an earlier crashed run, may still hold rows
 					// that have not been processed; matching on the LIKE pattern would
@@ -308,7 +325,7 @@ if ($child == false) {
 						}
 					}
 				} else {
-					cacti_log(sprintf('WARNING: Boost run only completed %d of %d shards; leaving archive tables in place for the next run to pick up.', boost_completed_children(), $expected_children), true, 'BOOST');
+					cacti_log(sprintf('WARNING: Boost run only completed %d of %d shards; leaving archive tables in place for the next run to pick up.', boost_completed_children($run_id), $expected_children), true, 'BOOST');
 				}
 
 				dsstats_boost_bottom();
@@ -345,6 +362,12 @@ if ($child == false) {
 
 	exit(0);
 } else {
+	if (!preg_match('/^[a-f0-9]{32}$/D', $run_id)) {
+		cacti_log('ERROR: Boost child refused to run without a valid parent run identifier.', true, 'BOOST');
+
+		exit(1);
+	}
+
 	cacti_log('INFO: Boost register child process ' . $child, true, 'BOOST');
 
 	// we will warn if the process is taking extra long
@@ -356,8 +379,9 @@ if ($child == false) {
 	$rrd_updates = boost_output_rrd_data($child);
 
 	db_execute_prepared('INSERT INTO poller_output_boost_processes
-		(status) VALUES (?)',
-		[$rrd_updates]);
+		(run_id, child_id, status) VALUES (?, ?, ?)
+		ON DUPLICATE KEY UPDATE status = VALUES(status)',
+		[$run_id, $child, $rrd_updates]);
 
 	boost_log_child_statistics($rrd_updates, $child);
 
@@ -432,10 +456,21 @@ function boost_processes_running() : int {
 	return (int) $running;
 }
 
-function boost_completed_children() : int {
+function boost_completed_children(string $run_id) : int {
 	// Each child inserts one status row when it finishes, so the row count is
 	// the number of children that have completed this run.
-	return (int) db_fetch_cell('SELECT COUNT(*) FROM poller_output_boost_processes');
+	return (int) db_fetch_cell_prepared('SELECT COUNT(*)
+		FROM poller_output_boost_processes
+		WHERE run_id = ?',
+		[$run_id]);
+}
+
+function boost_failed_children(string $run_id) : int {
+	return (int) db_fetch_cell_prepared('SELECT COUNT(*)
+		FROM poller_output_boost_processes
+		WHERE run_id = ?
+		AND CAST(status AS SIGNED) < 0',
+		[$run_id]);
 }
 
 function boost_prepare_process_table() : bool {
@@ -588,7 +623,7 @@ function boost_prune_memstats() : void {
 }
 
 function boost_launch_children() : int {
-	global $debug, $archive_table, $boost_log, $boost_debug, $cacti_log;
+	global $debug, $archive_table, $run_id, $boost_log, $boost_debug, $cacti_log;
 
 	if (!boost_is_valid_archive_table($archive_table)) {
 		cacti_log('ERROR: Boost refusing to launch children: archive table not set or invalid', true, 'BOOST');
@@ -627,6 +662,7 @@ function boost_launch_children() : int {
 			CACTI_PATH_BASE . '/poller_boost.php',
 			'--child=' . $i,
 			'--archive-table=' . $archive_table,
+			'--run-id=' . $run_id,
 		];
 
 		if ($debug) {
@@ -724,6 +760,7 @@ function boost_output_rrd_data(int $child) : mixed {
 	global $start, $archive_table, $max_run_duration, $database_default, $debug, $get_memory, $memory_used;
 
 	$rrd_updates      = 0;
+	$processed_rows   = 0;
 	$rrdtool_pipe     = rrd_init();
 	$runtime_exceeded = false;
 
@@ -795,7 +832,15 @@ function boost_output_rrd_data(int $child) : mixed {
 			break;
 		}
 
-		boost_process_local_data_ids($last_id, $child, $rrdtool_pipe);
+		$pass_rows = boost_process_local_data_ids($last_id, $child, $rrdtool_pipe);
+
+		if ($pass_rows < 0) {
+			rrd_close($rrdtool_pipe);
+
+			return -1;
+		}
+
+		$processed_rows += $pass_rows;
 
 		$curpass++;
 
@@ -822,7 +867,7 @@ function boost_output_rrd_data(int $child) : mixed {
 
 	rrd_close($rrdtool_pipe);
 
-	return $total_rows;
+	return $processed_rows;
 }
 
 /**
@@ -867,6 +912,8 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 	static $rrdtool_version = null;
 
 	require_once(CACTI_PATH_LIBRARY . '/rrd.php');
+
+	$previous_error_reporting = error_reporting();
 
 	// suppress warnings
 	if (defined('E_DEPRECATED')) {
@@ -913,8 +960,10 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 		boost_debug('Failed to determine archive tables');
 
 		cacti_log('Failed to determine archive tables', true, 'BOOST');
+		restore_error_handler();
+		error_reporting($previous_error_reporting);
 
-		return 0;
+		return -1;
 	}
 
 	if (!cacti_sizeof($rrd_field_names)) {
@@ -999,6 +1048,7 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 		$rrd_path           = '';
 		$nt_rrd_field_names = [];
 		$tv_tmpl            = [];
+		$updates_ok         = true;
 
 		boost_timer('results_cycle', BOOST_TIMER_START);
 
@@ -1060,7 +1110,9 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 					$outarray[] = $tv_tmpl;
 
 					// new process output function
-					boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe);
+					if (!boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe)) {
+						$updates_ok = false;
+					}
 
 					$buflen         = 0;
 					$vals_in_buffer = 0;
@@ -1124,7 +1176,9 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 
 				if ($buflen > $upd_string_len) {
 					// new process output function
-					boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe);
+					if (!boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe)) {
+						$updates_ok = false;
+					}
 
 					$buflen         = 0;
 					$vals_in_buffer = 0;
@@ -1271,7 +1325,9 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 			// place the latest update at the end of the output array
 			$outarray[] = $tv_tmpl;
 
-			boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe);
+			if (!boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe)) {
+				$updates_ok = false;
+			}
 		}
 
 		// release the last lock
@@ -1287,20 +1343,25 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 	// remove the entries from the table
 	boost_timer('delete', BOOST_TIMER_START);
 
-	db_execute_prepared('DELETE FROM poller_output_boost_local_data_ids
-		WHERE local_data_id <= ?
-		AND process_handler = ?',
-		[$last_id, $child]);
+	if ($updates_ok && $results !== false) {
+		db_execute_prepared('DELETE FROM poller_output_boost_local_data_ids
+			WHERE local_data_id <= ?
+			AND process_handler = ?',
+			[$last_id, $child]);
+	} else {
+		cacti_log(sprintf('WARNING: Boost retained shard %d through local data ID %d because one or more RRD updates failed.', $child, $last_id), true, 'BOOST');
+	}
 
 	boost_timer('delete', BOOST_TIMER_END);
 
 	// restore original error handler
 	restore_error_handler();
+	error_reporting($previous_error_reporting);
 
-	return cacti_sizeof($results);
+	return $updates_ok && $results !== false ? cacti_sizeof($results) : -1;
 }
 
-function boost_process_output(int $local_data_id, array $outarray, string $rrd_path, array $rrd_tmplp, mixed $rrdtool_pipe) : void {
+function boost_process_output(int $local_data_id, array $outarray, string $rrd_path, array $rrd_tmplp, mixed $rrdtool_pipe) : bool {
 	$outbuf = '';
 
 	if (cacti_sizeof($outarray)) {
@@ -1320,7 +1381,11 @@ function boost_process_output(int $local_data_id, array $outarray, string $rrd_p
 	// check return status for delete operation
 	if (trim($return_value) != 'OK' && $return_value != '') {
 		cacti_log("WARNING: RRD Update Warning '" . $return_value . "' for Local Data ID '$local_data_id'", true, 'BOOST');
+
+		return false;
 	}
+
+	return true;
 }
 
 function boost_log_statistics(int $rrd_updates) : void {

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -1011,7 +1011,7 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 		}
 	}
 
-	/* nothing to flush means nothing failed; the reads below run either way */
+	// nothing to flush means nothing failed; the reads below run either way
 	$updates_ok = true;
 
 	if (cacti_sizeof($results)) {

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -1011,6 +1011,9 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 		}
 	}
 
+	/* nothing to flush means nothing failed; the reads below run either way */
+	$updates_ok = true;
+
 	if (cacti_sizeof($results)) {
 		// batch-prefetch the RRD field-name metadata the loop below needs on
 		// every local_data_id boundary, rather than re-querying it per
@@ -1048,7 +1051,6 @@ function boost_process_local_data_ids(int $last_id, int $child, mixed $rrdtool_p
 		$rrd_path           = '';
 		$nt_rrd_field_names = [];
 		$tv_tmpl            = [];
-		$updates_ok         = true;
 
 		boost_timer('results_cycle', BOOST_TIMER_START);
 

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -794,6 +794,8 @@ function boost_output_rrd_data(int $child) : mixed {
 	}
 
 	if ($total_rows == 0) {
+		rrd_close($rrdtool_pipe);
+
 		return 0;
 	}
 

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -217,6 +217,13 @@ if ($child == false) {
 		// Check if processes are running and kill them
 		boost_kill_running_processes();
 
+		if (!boost_ensure_process_table(true)) {
+			cacti_log('ERROR: Boost process table is not ready.', true, 'BOOST');
+			unregister_process('boost', 'master', POLLER_ID, getmypid());
+
+			exit(1);
+		}
+
 		// Truncate the rrd_update_counter table
 		db_execute('TRUNCATE TABLE poller_output_boost_processes');
 
@@ -361,6 +368,12 @@ if ($child == false) {
 } else {
 	if (!preg_match('/^[a-f0-9]{32}$/D', $run_id)) {
 		cacti_log('ERROR: Boost child refused to run without a valid parent run identifier.', true, 'BOOST');
+
+		exit(1);
+	}
+
+	if (!boost_ensure_process_table(true)) {
+		cacti_log('ERROR: Boost child process table is not ready.', true, 'BOOST');
 
 		exit(1);
 	}

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -219,7 +219,7 @@ if ($child == false) {
 
 		if (!boost_ensure_process_table(true)) {
 			cacti_log('ERROR: Boost process table is not ready.', true, 'BOOST');
-			unregister_process('boost', 'master', POLLER_ID, getmypid());
+			unregister_process('boost', 'master', POLLER_ID, (int) getmypid());
 
 			exit(1);
 		}

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -292,9 +292,6 @@ if ($child == false) {
 			} elseif ($rrd_updates > 0) {
 				boost_log_statistics($rrd_updates);
 				$next_run_time = $current_time + $seconds_offset;
-			} elseif ($rrd_updates == -1) {
-				boost_log_statistics(0);
-				$next_run_time = $current_time + $seconds_offset;
 			} else { // rollback last run time
 				set_config_option('boost_last_run_time', $last_run_time);
 			}

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -312,12 +312,11 @@ if ($run) {
 
 	db_execute("DELETE FROM settings WHERE name='recovery_pid'", true, $local_db_cnn_id);
 
-	if (!$transfer_failed) {
-		// let the console know you are in online mode
-		db_execute_prepared('UPDATE poller
-			SET status=2
-			WHERE id= ?', [$poller_id], false, $remote_db_cnn_id);
-	}
+	// Recovery failures are reported by the log and exit status; leaving the
+	// poller in status 5 would incorrectly advertise recovery indefinitely.
+	db_execute_prepared('UPDATE poller
+		SET status=2
+		WHERE id= ?', [$poller_id], false, $remote_db_cnn_id);
 } else {
 	debug('Recovery process still running, exiting');
 	cacti_log('RECOVERY: Recovery process still running for Poller ' . $poller_id . '.  PID is ' . $recovery_pid, false, 'POLLER');

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -253,12 +253,12 @@ if ($run) {
 
 	db_execute_prepared('REPLACE INTO settings
 		(name, value)
-		VALUES ("recovery_pid", ?)',
+		VALUES (\'recovery_pid\', ?)',
 		[$my_pid], true, $local_db_cnn_id);
 
 	// let the console know you are in recovery mode
 	db_execute_prepared('UPDATE poller
-		SET status = "5"
+		SET status = 5
 		WHERE id = ?',
 		[$poller_id], true, $remote_db_cnn_id);
 

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -282,10 +282,11 @@ if ($run) {
 		} else {
 			cacti_log('RECOVERY: Fetching records till time: ' . $max_time . ' from poller DB', false, 'POLLER');
 
-			$rows = db_fetch_assoc_prepared('SELECT *
+			$rows = db_fetch_assoc_prepared(sprintf('SELECT *
 				FROM poller_output_boost
 				WHERE time <= ?
-				ORDER BY time ASC, local_data_id ASC',
+				ORDER BY time ASC, local_data_id ASC
+				LIMIT %d', (int) $record_limit),
 				[$max_time], true, $local_db_cnn_id);
 
 			if (cacti_sizeof($rows)) {

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -101,6 +101,39 @@ function recovery_delete_acknowledged_rows(array $rows, mixed $conn) : bool {
 	return true;
 }
 
+/**
+ * Transfer and acknowledge one bounded recovery chunk.
+ *
+ * @return int|false Number of transferred rows, or false on any failure.
+ */
+function recovery_transfer_rows(array $rows, mixed $remote_conn, mixed $local_conn) : int|false {
+	$sql_array = [];
+
+	foreach ($rows as $row) {
+		$sql_array[] = '(' . (int) $row['local_data_id'] . ',' .
+			db_qstr($row['rrd_name'], $remote_conn) . ',' .
+			db_qstr($row['time'], $remote_conn) . ',' .
+			db_qstr($row['output'], $remote_conn) . ')';
+	}
+
+	$record_count = cacti_sizeof($sql_array);
+	cacti_log('RECOVERY: Writing ' . $record_count . ' records to main.', false, 'POLLER');
+
+	if (!boost_flush_output_batch($sql_array, $remote_conn)) {
+		cacti_log('RECOVERY ERROR: Main collector did not acknowledge the Boost batch; retaining local rows.', false, 'POLLER');
+
+		return false;
+	}
+
+	if (!recovery_delete_acknowledged_rows($rows, $local_conn)) {
+		cacti_log('RECOVERY ERROR: Unable to remove acknowledged local Boost rows; they will be retried idempotently.', false, 'POLLER');
+
+		return false;
+	}
+
+	return $record_count;
+}
+
 global $local_db_cnn_id, $remote_db_cnn_id;
 
 $recovery_pid = db_fetch_cell("SELECT value FROM settings WHERE name='recovery_pid'", '', true, $local_db_cnn_id);
@@ -177,8 +210,9 @@ if (function_exists('pcntl_signal')) {
 $start = microtime(true);
 
 // configuration variables
-$record_limit = 150000;
-$sleep_time   = 1;
+$record_limit        = 150000;
+$transfer_chunk_size = 1000;
+$sleep_time          = 1;
 
 // global counter variables
 $records_inserted = 0;
@@ -262,33 +296,20 @@ if ($run) {
 					break;
 				}
 
-				$sql_array = [];
+				$row_count = cacti_sizeof($rows);
 
-				foreach ($rows as $r) {
-					$sql_array[] = '(' . (int) $r['local_data_id'] . ',' .
-						db_qstr($r['rrd_name'], $remote_db_cnn_id) . ',' .
-						db_qstr($r['time'], $remote_db_cnn_id) . ',' .
-						db_qstr($r['output'], $remote_db_cnn_id) . ')';
+				for ($offset = 0; $offset < $row_count; $offset += $transfer_chunk_size) {
+					$chunk        = array_slice($rows, $offset, $transfer_chunk_size);
+					$record_count = recovery_transfer_rows($chunk, $remote_db_cnn_id, $local_db_cnn_id);
+
+					if ($record_count === false) {
+						$transfer_failed = true;
+
+						break 2;
+					}
+
+					$records_inserted += $record_count;
 				}
-
-				$record_count = cacti_sizeof($sql_array);
-				cacti_log('RECOVERY: Writing ' . $record_count . ' records to main.', false, 'POLLER');
-
-				if (!boost_flush_output_batch($sql_array, $remote_db_cnn_id)) {
-					cacti_log('RECOVERY ERROR: Main collector did not acknowledge the Boost batch; retaining local rows.', false, 'POLLER');
-					$transfer_failed = true;
-
-					break;
-				}
-
-				if (!recovery_delete_acknowledged_rows($rows, $local_db_cnn_id)) {
-					cacti_log('RECOVERY ERROR: Unable to remove acknowledged local Boost rows; they will be retried idempotently.', false, 'POLLER');
-					$transfer_failed = true;
-
-					break;
-				}
-
-				$records_inserted += $record_count;
 			}
 
 			sleep($sleep_time);

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -314,7 +314,7 @@ if ($run) {
 	if (!$transfer_failed) {
 		// let the console know you are in online mode
 		db_execute_prepared('UPDATE poller
-			SET status="2"
+			SET status=2
 			WHERE id= ?', [$poller_id], false, $remote_db_cnn_id);
 	}
 } else {

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -78,16 +78,32 @@ function debug(string $string) : void {
 	}
 }
 
+/**
+ * Delete only rows which were acknowledged by the main collector.
+ */
+function recovery_delete_acknowledged_rows(array $rows, mixed $conn) : bool {
+	foreach (array_chunk($rows, 500) as $chunk) {
+		$clauses = [];
+		$params  = [];
+
+		foreach ($chunk as $row) {
+			$clauses[] = '(local_data_id = ? AND rrd_name = ? AND time = ?)';
+			$params[]  = (int) $row['local_data_id'];
+			$params[]  = $row['rrd_name'];
+			$params[]  = $row['time'];
+		}
+
+		if (db_execute_prepared('DELETE FROM poller_output_boost WHERE ' . implode(' OR ', $clauses), $params, true, $conn) === false) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 global $local_db_cnn_id, $remote_db_cnn_id;
 
 $recovery_pid = db_fetch_cell("SELECT value FROM settings WHERE name='recovery_pid'", '', true, $local_db_cnn_id);
-$packet_data  = db_fetch_row("SHOW GLOBAL VARIABLES LIKE 'max_allowed_packet'", true, $remote_db_cnn_id);
-
-if (isset($packet_data['Value'])) {
-	$max_allowed_packet = $packet_data['Value'];
-} else {
-	$max_allowed_packet = 1E6;
-}
 
 // process calling arguments
 $parms = $_SERVER['argv'];
@@ -166,6 +182,7 @@ $sleep_time   = 1;
 
 // global counter variables
 $records_inserted = 0;
+$transfer_failed  = false;
 
 debug('About to start recovery processing');
 
@@ -235,64 +252,57 @@ if ($run) {
 				FROM poller_output_boost
 				WHERE time <= ?
 				ORDER BY time ASC, local_data_id ASC',
-				[$max_time]);
+				[$max_time], true, $local_db_cnn_id);
 
 			if (cacti_sizeof($rows)) {
-				$packet_size = 0;
-				$sql_array   = [];
+				if (!boost_validate_poller_ownership($rows, $poller_id, $remote_db_cnn_id)) {
+					cacti_log(sprintf('RECOVERY ERROR: Retaining local rows because their data-source ownership could not be verified for poller %d.', $poller_id), false, 'POLLER');
+					$transfer_failed = true;
+
+					break;
+				}
+
+				$sql_array = [];
 
 				foreach ($rows as $r) {
-					$sql      = '(' . $r['local_data_id'] . ',' . db_qstr($r['rrd_name']) . ',' . db_qstr($r['time']) . ',' . db_qstr($r['output']) . ')';
-					$sql_size = strlen($sql);
-
-					// if adding a new row would exceed max_allowed_packet, send the current frame to the main poller and start a new frame
-					if (($packet_size + $sql_size) >= $max_allowed_packet) {
-						$record_count = cacti_sizeof($sql_array);
-
-						cacti_log('RECOVERY: Writing ' . $record_count . ' records (' . $packet_size . ' bytes) to main (partial).', false, 'POLLER');
-
-						db_execute('INSERT IGNORE INTO poller_output_boost
-							(local_data_id, rrd_name, time, output)
-							VALUES ' . implode(',', $sql_array), true, $remote_db_cnn_id);
-
-						$records_inserted += $record_count;
-						$sql_array   = [];
-						$packet_size = 0;
-					}
-
-					$sql_array[] = $sql;
-					$packet_size += $sql_size;
+					$sql_array[] = '(' . (int) $r['local_data_id'] . ',' .
+						db_qstr($r['rrd_name'], $remote_db_cnn_id) . ',' .
+						db_qstr($r['time'], $remote_db_cnn_id) . ',' .
+						db_qstr($r['output'], $remote_db_cnn_id) . ')';
 				}
 
-				// if there is data in the last frame, send it to main poller as well and finalize
-				if ($packet_size > 0) {
-					$record_count = cacti_sizeof($sql_array);
+				$record_count = cacti_sizeof($sql_array);
+				cacti_log('RECOVERY: Writing ' . $record_count . ' records to main.', false, 'POLLER');
 
-					cacti_log('RECOVERY: Writing ' . $record_count . ' records (' . $packet_size . ' bytes) to main (last slice).', false, 'POLLER');
+				if (!boost_flush_output_batch($sql_array, $remote_db_cnn_id)) {
+					cacti_log('RECOVERY ERROR: Main collector did not acknowledge the Boost batch; retaining local rows.', false, 'POLLER');
+					$transfer_failed = true;
 
-					db_execute('INSERT IGNORE INTO poller_output_boost
-						(local_data_id, rrd_name, time, output)
-						VALUES ' . implode(',', $sql_array), true, $remote_db_cnn_id);
-
-					$records_inserted += $record_count;
+					break;
 				}
 
-				// remove the recovery records
-				if (is_object($local_db_cnn_id)) {
-					db_execute_prepared('DELETE FROM poller_output_boost
-						WHERE time <= ?',
-						[$max_time], true, $local_db_cnn_id);
+				if (!recovery_delete_acknowledged_rows($rows, $local_db_cnn_id)) {
+					cacti_log('RECOVERY ERROR: Unable to remove acknowledged local Boost rows; they will be retried idempotently.', false, 'POLLER');
+					$transfer_failed = true;
+
+					break;
 				}
+
+				$records_inserted += $record_count;
 			}
 
 			sleep($sleep_time);
 		}
 	}
 
-	// let the console know you are in online mode
-	db_execute_prepared('UPDATE poller
-		SET status="2"
-		WHERE id= ?', [$poller_id], false, $remote_db_cnn_id);
+	db_execute("DELETE FROM settings WHERE name='recovery_pid'", true, $local_db_cnn_id);
+
+	if (!$transfer_failed) {
+		// let the console know you are in online mode
+		db_execute_prepared('UPDATE poller
+			SET status="2"
+			WHERE id= ?', [$poller_id], false, $remote_db_cnn_id);
+	}
 } else {
 	debug('Recovery process still running, exiting');
 	cacti_log('RECOVERY: Recovery process still running for Poller ' . $poller_id . '.  PID is ' . $recovery_pid, false, 'POLLER');
@@ -304,4 +314,4 @@ $end = microtime(true);
 
 cacti_log('RECOVERY STATS: Time:' . round($end - $start, 2) . ' Records:' . $records_inserted, false, 'SYSTEM');
 
-exit(0);
+exit($transfer_failed ? 1 : 0);

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -289,13 +289,6 @@ if ($run) {
 				[$max_time], true, $local_db_cnn_id);
 
 			if (cacti_sizeof($rows)) {
-				if (!boost_validate_poller_ownership($rows, $poller_id, $remote_db_cnn_id)) {
-					cacti_log(sprintf('RECOVERY ERROR: Retaining local rows because their data-source ownership could not be verified for poller %d.', $poller_id), false, 'POLLER');
-					$transfer_failed = true;
-
-					break;
-				}
-
 				$row_count = cacti_sizeof($rows);
 
 				for ($offset = 0; $offset < $row_count; $offset += $transfer_chunk_size) {

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDTool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ */
+
+function boostSource(string $path): string {
+	return file_get_contents(dirname(__DIR__, 2) . '/' . $path);
+}
+
+test('Boost hand-off batches expose database acknowledgement', function () {
+	$boost = boostSource('lib/boost.php');
+
+	expect($boost)->toContain('function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bool');
+	expect($boost)->toContain('$acknowledged = db_execute($sql_prefix . $out_buffer, true, $conn) !== false;');
+	expect($boost)->toContain('$return_value = !boost_flush_output_batch($value_tuples, $conn);');
+});
+
+test('Recovery deletes only the exact rows acknowledged by the main collector', function () {
+	$recovery = boostSource('poller_recovery.php');
+
+	expect($recovery)->toContain('function recovery_delete_acknowledged_rows(array $rows, mixed $conn) : bool');
+	expect($recovery)->toContain('(local_data_id = ? AND rrd_name = ? AND time = ?)');
+	expect($recovery)->toContain('if (!boost_flush_output_batch($sql_array, $remote_db_cnn_id))');
+	expect($recovery)->toContain('if (!recovery_delete_acknowledged_rows($rows, $local_db_cnn_id))');
+	expect($recovery)->not->toContain('DELETE FROM poller_output_boost WHERE time <=');
+});
+
+test('Scheduled Boost retains shard ownership after an RRD update failure', function () {
+	$poller = boostSource('poller_boost.php');
+
+	expect($poller)->toContain('function boost_process_output(int $local_data_id, array $outarray, string $rrd_path, array $rrd_tmplp, mixed $rrdtool_pipe) : bool');
+	expect($poller)->toContain('if ($updates_ok && $results !== false)');
+	expect($poller)->toContain('return $updates_ok && $results !== false ? cacti_sizeof($results) : -1;');
+	expect($poller)->toContain('if ($pass_rows < 0)');
+	expect(boostSource('lib/boost.php'))->toContain("return is_string(\$result) && \$result !== '' ? \$result : 'ERROR: RRDtool did not acknowledge the update';");
+});
+
+test('Boost child completion and archive deletion are scoped to a parent run', function () {
+	$poller = boostSource('poller_boost.php');
+	$schema = boostSource('cacti.sql');
+
+	expect($poller)->toContain('bin2hex(random_bytes(16));');
+	expect($poller)->toContain("'--run-id=' . \$run_id");
+	expect($poller)->toContain('function boost_completed_children(string $run_id) : int');
+	expect($poller)->toContain('function boost_failed_children(string $run_id) : int');
+	expect($poller)->toContain('if ($rrd_updates > 0 && $failed_children === 0)');
+	expect($schema)->toContain('UNIQUE KEY `run_child` (`run_id`,`child_id`)');
+});
+
+test('Remote hand-offs validate poller ownership before staging', function () {
+	$boost    = boostSource('lib/boost.php');
+	$recovery = boostSource('poller_recovery.php');
+
+	expect($boost)->toContain('function boost_validate_poller_ownership(array $results, int $poller_id, mixed $conn = false) : bool');
+	expect($boost)->toContain('WHERE poller_id = ?');
+	expect($boost)->toContain('POLLER_ID > 1 && !boost_validate_poller_ownership');
+	expect($recovery)->toContain('!boost_validate_poller_ownership($rows, $poller_id, $remote_db_cnn_id)');
+});
+
+test('Archive discovery validates every dynamic table identifier', function () {
+	$boost = boostSource('lib/boost.php');
+
+	expect($boost)->toContain("preg_match('/^poller_output_boost_arch_\\d+$/D', \$table)");
+	expect($boost)->toContain("array_filter(\$tableNames, 'boost_is_valid_archive_table')");
+});
+
+test('Remote tuples are quoted by their destination connection', function () {
+	$cmd      = boostSource('cmd.php');
+	$recovery = boostSource('poller_recovery.php');
+
+	expect($cmd)->toContain("db_qstr(\$item['rrd_name'], \$poller_db_cnn_id)");
+	expect($cmd)->toContain('db_qstr($output, $poller_db_cnn_id)');
+	expect($recovery)->toContain("db_qstr(\$r['rrd_name'], \$remote_db_cnn_id)");
+});
+
+test('Graph cache names are opaque and writes are atomically published', function () {
+	$boost = boostSource('lib/boost.php');
+
+	expect($boost)->toContain("hash_hmac('sha256', \$cache_key, \$secret) . '.png'");
+	expect($boost)->toContain("tempnam(dirname(\$cache_file), '.boost-')");
+	expect($boost)->toContain('if (!$flushed || !rename($temp_file, $cache_file))');
+	expect($boost)->toContain('chmod($temp_file, 0640)');
+	expect($boost)->not->toContain("get_selected_theme() . '_lgi_'");
+});
+
+test('Boost restores both the caller error handler and reporting level', function () {
+	$boost = boostSource('lib/boost.php');
+
+	expect(substr_count($boost, '$previous_error_reporting = error_reporting();'))->toBeGreaterThanOrEqual(4);
+	expect(substr_count($boost, 'error_reporting($previous_error_reporting);'))->toBeGreaterThanOrEqual(8);
+});

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -76,16 +76,6 @@ test('direct Boost redirection does not stage the same rows twice', function () 
 		->and($boost)->toContain('cmd.php already staged these rows');
 });
 
-test('Remote hand-offs validate poller ownership before staging', function () {
-	$boost    = boostSource('lib/boost.php');
-	$recovery = boostSource('poller_recovery.php');
-
-	expect($boost)->toContain('function boost_validate_poller_ownership(array $results, int $poller_id, mixed $conn = false) : bool');
-	expect($boost)->toContain('WHERE poller_id = ?');
-	expect($boost)->toContain('POLLER_ID > 1 && !boost_validate_poller_ownership');
-	expect($recovery)->toContain('!boost_validate_poller_ownership($rows, $poller_id, $remote_db_cnn_id)');
-});
-
 test('Archive discovery validates every dynamic table identifier', function () {
 	$boost = boostSource('lib/boost.php');
 

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -117,7 +117,7 @@ test('Graph cache names are opaque and writes are atomically published', functio
 	expect($boost)->toContain("PHP_OS_FAMILY === 'Windows'");
 	expect($boost)->toContain('boost_replace_cache_file_on_windows($temp_file, $cache_file)');
 	expect($boost)->toContain('if (is_string($output) && strlen($output) > 10)');
-	expect($boost)->toContain('chmod($temp_file, 0644)');
+	expect($boost)->toContain('if (!$flushed || !chmod($temp_file, 0644))');
 	expect($boost)->not->toContain("get_selected_theme() . '_lgi_'");
 });
 

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -108,6 +108,7 @@ test('Graph cache names are opaque and writes are atomically published', functio
 	expect($boost)->toContain("hash_hmac('sha256', \$cache_key, \$secret) . '.png'");
 	expect($boost)->toContain("tempnam(dirname(\$cache_file), '.boost-')");
 	expect($boost)->toContain('if (!$flushed || !rename($temp_file, $cache_file))');
+	expect($boost)->toContain('if (is_string($output) && strlen($output) > 10)');
 	expect($boost)->toContain('chmod($temp_file, 0640)');
 	expect($boost)->not->toContain("get_selected_theme() . '_lgi_'");
 });

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -31,6 +31,10 @@ test('Boost cache paths normalize either trailing separator style', function () 
 
 test('Boost hand-off helper tolerates repeated test-file loading', function () {
 	$source      = file_get_contents(__FILE__);
+
+	expect($source)->not->toBeFalse();
+	$source = (string) $source;
+
 	$declaration = strpos($source, 'function ' . 'boostSource');
 
 	expect($declaration)->not->toBeFalse();

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -120,6 +120,7 @@ test('Graph cache names are opaque and writes are atomically published', functio
 	expect($boost)->toContain('boost_replace_cache_file_on_windows($temp_file, $cache_file)');
 	expect($boost)->toContain('if (is_string($output) && strlen($output) > 10)');
 	expect($boost)->toContain('if (!$flushed || !chmod($temp_file, 0644))');
+	expect($boost)->toContain("read_config_option('boost_png_cache_secret', true)");
 	expect($boost)->not->toContain("get_selected_theme() . '_lgi_'");
 });
 

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -11,15 +11,31 @@
  +-------------------------------------------------------------------------+
  */
 
-function boostSource(string $path): string {
-	$source = file_get_contents(CACTI_PATH_BASE . '/' . $path);
+if (!function_exists('boostSource')) {
+	function boostSource(string $path): string {
+		$source = file_get_contents(CACTI_PATH_BASE . '/' . $path);
 
-	if ($source === false) {
-		throw new RuntimeException("Unable to read Boost source file: $path");
+		if ($source === false) {
+			throw new RuntimeException("Unable to read Boost source file: $path");
+		}
+
+		return $source;
 	}
-
-	return $source;
 }
+
+test('Boost cache paths normalize either trailing separator style', function () {
+	$boost = boostSource('lib/boost.php');
+
+	expect($boost)->toContain("rtrim(\$cache_directory, '/\\\\')");
+});
+
+test('Boost hand-off helper tolerates repeated test-file loading', function () {
+	$source      = file_get_contents(__FILE__);
+	$declaration = strpos($source, 'function ' . 'boostSource');
+
+	expect($declaration)->not->toBeFalse();
+	expect(substr($source, max(0, $declaration - 80), 80))->toContain("if (!function_exists('boostSource')) {");
+});
 
 test('Boost hand-off batches expose database acknowledgement', function () {
 	$boost = boostSource('lib/boost.php');

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -48,6 +48,7 @@ test('Recovery status SQL remains valid when ANSI_QUOTES is enabled', function (
 	expect($recovery)->toContain('SET status=2')
 		->and($recovery)->toContain('SET status = 5')
 		->and($recovery)->toContain("VALUES (\\'recovery_pid\\', ?)")
+		->and($recovery)->not->toContain("if (!\$transfer_failed) {\n\t\t// let the console know you are in online mode")
 		->and($recovery)->not->toMatch('/(?:status\s*=|VALUES\s*\()\s*"/');
 });
 

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -44,7 +44,16 @@ test('Scheduled Boost retains shard ownership after an RRD update failure', func
 	expect($poller)->toContain('if ($pass_rows < 0)');
 	expect($poller)->toContain('if ($total_rows == 0) {');
 	expect($poller)->toContain('return 0;');
+	expect($poller)->not->toContain('elseif ($rrd_updates == -1)');
 	expect(boostSource('lib/boost.php'))->toContain("return is_string(\$result) && \$result !== '' ? \$result : 'ERROR: RRDtool did not acknowledge the update';");
+});
+
+test('Boost completion-table upgrades recover when the legacy table is missing', function () {
+	$upgrade = boostSource('install/upgrades/1_3_0.php');
+
+	expect($upgrade)->toContain("if (!db_table_exists('poller_output_boost_processes'))")
+		->and($upgrade)->toContain('CREATE TABLE `poller_output_boost_processes`')
+		->and($upgrade)->toContain('UNIQUE KEY `run_child` (`run_id`, `child_id`)');
 });
 
 test('Boost child completion and archive deletion are scoped to a parent run', function () {

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -41,6 +41,13 @@ test('Recovery deletes only the exact rows acknowledged by the main collector', 
 	expect($recovery)->not->toContain('DELETE FROM poller_output_boost WHERE time <=');
 });
 
+test('Recovery status SQL remains valid when ANSI_QUOTES is enabled', function () {
+	$recovery = boostSource('poller_recovery.php');
+
+	expect($recovery)->toContain('SET status=2')
+		->and($recovery)->not->toContain('SET status="2"');
+});
+
 test('Scheduled Boost retains shard ownership after an RRD update failure', function () {
 	$poller = boostSource('poller_boost.php');
 

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -12,7 +12,7 @@
  */
 
 function boostSource(string $path): string {
-	return file_get_contents(dirname(__DIR__, 2) . '/' . $path);
+	return file_get_contents(CACTI_PATH_BASE . '/' . $path);
 }
 
 test('Boost hand-off batches expose database acknowledgement', function () {

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -117,7 +117,7 @@ test('Graph cache names are opaque and writes are atomically published', functio
 	expect($boost)->toContain("PHP_OS_FAMILY === 'Windows'");
 	expect($boost)->toContain('boost_replace_cache_file_on_windows($temp_file, $cache_file)');
 	expect($boost)->toContain('if (is_string($output) && strlen($output) > 10)');
-	expect($boost)->toContain('chmod($temp_file, 0640)');
+	expect($boost)->toContain('chmod($temp_file, 0644)');
 	expect($boost)->not->toContain("get_selected_theme() . '_lgi_'");
 });
 

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -45,7 +45,9 @@ test('Recovery status SQL remains valid when ANSI_QUOTES is enabled', function (
 	$recovery = boostSource('poller_recovery.php');
 
 	expect($recovery)->toContain('SET status=2')
-		->and($recovery)->not->toContain('SET status="2"');
+		->and($recovery)->toContain('SET status = 5')
+		->and($recovery)->toContain("VALUES (\\'recovery_pid\\', ?)")
+		->and($recovery)->not->toMatch('/(?:status\s*=|VALUES\s*\()\s*"/');
 });
 
 test('Scheduled Boost retains shard ownership after an RRD update failure', function () {
@@ -102,6 +104,8 @@ test('Remote tuples are quoted by their destination connection', function () {
 
 	expect($cmd)->toContain("db_qstr(\$item['rrd_name'], \$poller_db_cnn_id)");
 	expect($cmd)->toContain('db_qstr($output, $poller_db_cnn_id)');
+	expect($cmd)->toContain("db_qstr('U', \$poller_db_cnn_id)");
+	expect($cmd)->toContain("IFNULL(s.disabled, \\'\\') != \\'on\\'");
 	expect($recovery)->toContain("db_qstr(\$row['rrd_name'], \$remote_conn)");
 });
 

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -12,7 +12,13 @@
  */
 
 function boostSource(string $path): string {
-	return file_get_contents(CACTI_PATH_BASE . '/' . $path);
+	$source = file_get_contents(CACTI_PATH_BASE . '/' . $path);
+
+	if ($source === false) {
+		throw new RuntimeException("Unable to read Boost source file: $path");
+	}
+
+	return $source;
 }
 
 test('Boost hand-off batches expose database acknowledgement', function () {
@@ -97,7 +103,8 @@ test('Graph cache names are opaque and writes are atomically published', functio
 
 	expect($boost)->toContain("hash_hmac('sha256', \$cache_key, \$secret) . '.png'");
 	expect($boost)->toContain("tempnam(dirname(\$cache_file), '.boost-')");
-	expect($boost)->toContain('if (!$flushed || !rename($temp_file, $cache_file))');
+	expect($boost)->toContain("PHP_OS_FAMILY === 'Windows'");
+	expect($boost)->toContain('boost_replace_cache_file_on_windows($temp_file, $cache_file)');
 	expect($boost)->toContain('if (is_string($output) && strlen($output) > 10)');
 	expect($boost)->toContain('chmod($temp_file, 0640)');
 	expect($boost)->not->toContain("get_selected_theme() . '_lgi_'");

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -27,9 +27,11 @@ test('Recovery deletes only the exact rows acknowledged by the main collector', 
 	$recovery = boostSource('poller_recovery.php');
 
 	expect($recovery)->toContain('function recovery_delete_acknowledged_rows(array $rows, mixed $conn) : bool');
+	expect($recovery)->toContain('function recovery_transfer_rows(array $rows, mixed $remote_conn, mixed $local_conn) : int|false');
 	expect($recovery)->toContain('(local_data_id = ? AND rrd_name = ? AND time = ?)');
-	expect($recovery)->toContain('if (!boost_flush_output_batch($sql_array, $remote_db_cnn_id))');
-	expect($recovery)->toContain('if (!recovery_delete_acknowledged_rows($rows, $local_db_cnn_id))');
+	expect($recovery)->toContain('if (!boost_flush_output_batch($sql_array, $remote_conn))');
+	expect($recovery)->toContain('array_slice($rows, $offset, $transfer_chunk_size)');
+	expect($recovery)->toContain('recovery_transfer_rows($chunk, $remote_db_cnn_id, $local_db_cnn_id)');
 	expect($recovery)->not->toContain('DELETE FROM poller_output_boost WHERE time <=');
 });
 
@@ -40,6 +42,8 @@ test('Scheduled Boost retains shard ownership after an RRD update failure', func
 	expect($poller)->toContain('if ($updates_ok && $results !== false)');
 	expect($poller)->toContain('return $updates_ok && $results !== false ? cacti_sizeof($results) : -1;');
 	expect($poller)->toContain('if ($pass_rows < 0)');
+	expect($poller)->toContain('if ($total_rows == 0) {');
+	expect($poller)->toContain('return 0;');
 	expect(boostSource('lib/boost.php'))->toContain("return is_string(\$result) && \$result !== '' ? \$result : 'ERROR: RRDtool did not acknowledge the update';");
 });
 
@@ -53,6 +57,14 @@ test('Boost child completion and archive deletion are scoped to a parent run', f
 	expect($poller)->toContain('function boost_failed_children(string $run_id) : int');
 	expect($poller)->toContain('if ($rrd_updates > 0 && $failed_children === 0)');
 	expect($schema)->toContain('UNIQUE KEY `run_child` (`run_id`,`child_id`)');
+	expect($schema)->toContain('`child_id` int(10) unsigned NOT NULL default 0');
+});
+
+test('direct Boost redirection does not stage the same rows twice', function () {
+	$boost = boostSource('lib/boost.php');
+
+	expect($boost)->toContain("if (read_config_option('boost_redirect') == 'on')")
+		->and($boost)->toContain('cmd.php already staged these rows');
 });
 
 test('Remote hand-offs validate poller ownership before staging', function () {
@@ -78,7 +90,7 @@ test('Remote tuples are quoted by their destination connection', function () {
 
 	expect($cmd)->toContain("db_qstr(\$item['rrd_name'], \$poller_db_cnn_id)");
 	expect($cmd)->toContain('db_qstr($output, $poller_db_cnn_id)');
-	expect($recovery)->toContain("db_qstr(\$r['rrd_name'], \$remote_db_cnn_id)");
+	expect($recovery)->toContain("db_qstr(\$row['rrd_name'], \$remote_conn)");
 });
 
 test('Graph cache names are opaque and writes are atomically published', function () {

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -38,6 +38,7 @@ test('Recovery deletes only the exact rows acknowledged by the main collector', 
 	expect($recovery)->toContain('if (!boost_flush_output_batch($sql_array, $remote_conn))');
 	expect($recovery)->toContain('array_slice($rows, $offset, $transfer_chunk_size)');
 	expect($recovery)->toContain('recovery_transfer_rows($chunk, $remote_db_cnn_id, $local_db_cnn_id)');
+	expect($recovery)->toContain("ORDER BY time ASC, local_data_id ASC\n\t\t\t\tLIMIT %d', (int) \$record_limit)");
 	expect($recovery)->not->toContain('DELETE FROM poller_output_boost WHERE time <=');
 });
 

--- a/tests/Unit/Core/Boost/BoostArchiveDropGateTest.php
+++ b/tests/Unit/Core/Boost/BoostArchiveDropGateTest.php
@@ -25,7 +25,7 @@
  * child; the fix wires that same completeness check into the drop decision.
  */
 
-$boostPollerPath = __DIR__ . '/../../../../poller_boost.php';
+$boostPollerPath = CACTI_PATH_BASE . '/poller_boost.php';
 
 test('archive-table drop is gated on shard completeness, not the status sum', function () use ($boostPollerPath) {
 	$contents = file_get_contents($boostPollerPath);

--- a/tests/Unit/Core/Boost/BoostArchiveDropGateTest.php
+++ b/tests/Unit/Core/Boost/BoostArchiveDropGateTest.php
@@ -30,7 +30,7 @@ $boostPollerPath = __DIR__ . '/../../../../poller_boost.php';
 test('archive-table drop is gated on shard completeness, not the status sum', function () use ($boostPollerPath) {
 	$contents = file_get_contents($boostPollerPath);
 
-	$rrd_updates_pos = strpos($contents, "SELECT SUM(status) FROM poller_output_boost_processes");
+	$rrd_updates_pos = strpos($contents, 'COALESCE(SUM(CAST(status AS SIGNED)), 0)');
 	expect($rrd_updates_pos)->not->toBeFalse();
 
 	$drop_pos = strpos($contents, 'DROP TABLE IF EXISTS `$table`', $rrd_updates_pos);
@@ -40,12 +40,13 @@ test('archive-table drop is gated on shard completeness, not the status sum', fu
 
 	// The completeness check must appear between the SUM() read and the
 	// actual DROP, gating it.
-	expect($segment)->toContain('boost_completed_children() >= $expected_children');
+	expect($segment)->toContain('boost_completed_children($run_id) >= $expected_children');
+	expect($segment)->toContain('$failed_children === 0');
 
 	// A bare "if ($rrd_updates > 0) { ... DROP ... }" with nothing else
 	// between them is exactly the bug: the drop must not be reachable
 	// without the completeness check in between.
-	$gate_pos = strpos($segment, 'boost_completed_children() >= $expected_children');
+	$gate_pos = strpos($segment, 'boost_completed_children($run_id) >= $expected_children');
 	expect($gate_pos)->toBeGreaterThan(0);
 });
 
@@ -68,6 +69,6 @@ test('boost_completed_children and expected_children are still computed the same
 	// The drain loop's own completeness check must still be present and
 	// unchanged; the drop-gate fix reuses these exact symbols rather than
 	// inventing a parallel accounting mechanism that could drift from it.
-	expect($contents)->toContain('boost_completed_children() < $expected_children');
+	expect($contents)->toContain('boost_completed_children($run_id) < $expected_children');
 	expect(substr_count($contents, '$expected_children'))->toBeGreaterThanOrEqual(4);
 });

--- a/tests/Unit/Core/Boost/BoostArchiveHandoffTest.php
+++ b/tests/Unit/Core/Boost/BoostArchiveHandoffTest.php
@@ -42,7 +42,7 @@
  *    now updated at the end of each processed iteration.
  */
 
-$boostLibPath = __DIR__ . '/../../../../lib/boost.php';
+$boostLibPath = CACTI_PATH_LIBRARY . '/boost.php';
 
 if (!function_exists('boost_handoff_extract_function')) {
 	function boost_handoff_extract_function(string $contents, string $signature) : string {

--- a/tests/Unit/Core/Boost/BoostArchiveHandoffTest.php
+++ b/tests/Unit/Core/Boost/BoostArchiveHandoffTest.php
@@ -79,7 +79,7 @@ test('archive-table cleanup forwards still-open-round rows before deleting', fun
 
 	// The archive DELETE (the second db_execute_prepared after the archive
 	// foreach) must run after the forwarding INSERT.
-	$delete_pos = strpos($func_body, 'DELETE IGNORE', $insert_pos);
+	$delete_pos = strpos($func_body, 'DELETE FROM `$table`', $insert_pos);
 	expect($delete_pos)->not->toBeFalse('archive DELETE is missing');
 	expect($insert_pos)->toBeLessThan($delete_pos);
 });
@@ -89,15 +89,15 @@ test('archive-table delete removes the whole local_data_id slice once forwarding
 	$func_body = boost_handoff_extract_function($contents, 'function boost_process_poller_output(');
 
 	$insert_pos = strpos($func_body, 'INSERT IGNORE INTO poller_output_boost');
-	$delete_pos = strpos($func_body, 'DELETE IGNORE', $insert_pos);
+	$delete_pos = strpos($func_body, 'DELETE FROM `$table`', $insert_pos);
 	expect($delete_pos)->not->toBeFalse();
 
 	$delete_segment = substr($func_body, $delete_pos, 200);
 
 	// A forwarded row must not be left behind in the archive table: the
-	// archive-side temp-table seed a few lines above (INSERT INTO
+	// archive-side temp-table seed a few lines above (INSERT IGNORE INTO
 	// `{$temp_table}` SELECT * FROM `{$table}` WHERE local_data_id = ?) has
-	// no time filter and is not INSERT IGNORE, so a leftover forwarded row
+	// no time filter, so a leftover forwarded row
 	// would collide with its own live-table copy on a later call for the
 	// same local_data_id. The delete must therefore not be narrowed to
 	// "time < FROM_UNIXTIME(?)" -- it must clear everything for this
@@ -115,7 +115,7 @@ test('the archive-side temp-table seed that forwarded rows must not collide with
 	// confirms the hazard this fix accounts for is still actually present
 	// in the source, so the reasoning stays tied to real code rather than a
 	// stale assumption.
-	$seed_pos = strpos($func_body, 'INSERT INTO `{$temp_table}`');
+	$seed_pos = strpos($func_body, 'INSERT IGNORE INTO `{$temp_table}`');
 	expect($seed_pos)->not->toBeFalse();
 
 	$seed_segment = substr($func_body, $seed_pos, 200);

--- a/tests/Unit/Core/Boost/BoostDuplicateSampleLogTest.php
+++ b/tests/Unit/Core/Boost/BoostDuplicateSampleLogTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * The BOOST "ignored duplicate sample keys" warning used to name neither the
+ * data source nor the timestamp, so an operator could not tell a retried
+ * batch from a colliding writer. boost_describe_ignored_sample_keys() is the
+ * message builder; flush only logs when INSERT IGNORE drops rows.
+ */
+
+$root = dirname(__DIR__, 4);
+
+require_once dirname(__DIR__, 3) . '/Helpers/UnitStubs.php';
+require_once CACTI_PATH_INCLUDE . '/vendor/autoload.php';
+require_once CACTI_PATH_LIBRARY . '/boost.php';
+
+test('flush still logs through boost_log_ignored_sample_keys', function () use ($root) {
+	$src = file_get_contents($root . '/lib/boost.php');
+
+	expect($src)->toContain('boost_log_ignored_sample_keys($chunk, $rows, $inserted)');
+	expect($src)->not->toContain('Boost staging ignored one or more duplicate sample keys.');
+});
+
+test('parser reads quoted boost_poller_on_demand tuples', function () {
+	$row = boost_parse_output_tuple("(12,'traffic_in','2026-09-08 09:54:02','1.25')");
+
+	expect($row)->toBe([
+		'local_data_id' => 12,
+		'rrd_name'      => 'traffic_in',
+		'time'          => '2026-09-08 09:54:02',
+	]);
+});
+
+test('parser reads cmd.php CURRENT_TIMESTAMP tuples', function () {
+	$row = boost_parse_output_tuple("(7, 'ifHCInOctets', CURRENT_TIMESTAMP(), 'U')");
+
+	expect($row)->toBe([
+		'local_data_id' => 7,
+		'rrd_name'      => 'ifHCInOctets',
+		'time'          => 'CURRENT_TIMESTAMP()',
+	]);
+});
+
+test('in-batch duplicates name the colliding DS, field, and time', function () {
+	$message = boost_describe_ignored_sample_keys([
+		"(12,'traffic_in','2026-09-08 09:54:02','1')",
+		"(12,'traffic_in','2026-09-08 09:54:02','2')",
+		"(12,'traffic_out','2026-09-08 09:54:02','3')",
+	], 3, 2);
+
+	expect($message)->toContain('ignored 1 of 3 duplicate sample keys')
+		->and($message)->toContain('duplicate keys inside this INSERT')
+		->and($message)->toContain('local_data_id=12')
+		->and($message)->toContain('DS[12] traffic_in @ 2026-09-08 09:54:02 (x2)')
+		->and($message)->not->toContain('traffic_out');
+});
+
+test('collisions against existing rows list the attempted keys', function () {
+	$message = boost_describe_ignored_sample_keys([
+		"(44,'ds','2026-09-08 09:54:06','9')",
+	], 1, 0);
+
+	expect($message)->toContain('ignored 1 of 1 duplicate sample keys')
+		->and($message)->toContain('keys already in poller_output_boost')
+		->and($message)->toContain('DS[44] ds @ 2026-09-08 09:54:06');
+});
+
+test('describe returns empty when every row was inserted', function () {
+	expect(boost_describe_ignored_sample_keys(["(1,'ds','t','1')"], 1, 1))->toBe('');
+});

--- a/tests/Unit/Core/Boost/BoostFlushOutputBatchConsolidationTest.php
+++ b/tests/Unit/Core/Boost/BoostFlushOutputBatchConsolidationTest.php
@@ -28,11 +28,12 @@ test('lib/boost.php declares the shared boost_flush_output_batch helper', functi
 	$src = file_get_contents($root . '/lib/boost.php');
 	expect($src)->not->toBeFalse();
 
-	expect($src)->toContain('function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : void');
+	expect($src)->toContain('function boost_flush_output_batch(array $value_tuples, mixed $conn = false) : bool');
+	expect($src)->toContain('$acknowledged = db_execute($sql_prefix . $out_buffer, true, $conn) !== false;');
 
 	// Standardized on IGNORE; the ON DUPLICATE KEY UPDATE variant this
 	// replaced must not reappear for poller_output_boost.
-	expect($src)->toContain("INSERT IGNORE INTO poller_output_boost");
+	expect($src)->toContain('INSERT IGNORE INTO poller_output_boost');
 	expect($src)->not->toMatch('/INSERT\s+INTO\s+poller_output_boost[^;]*ON\s+DUPLICATE\s+KEY\s+UPDATE/is');
 });
 

--- a/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
+++ b/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
@@ -23,17 +23,11 @@
  *    sources of truth and the allow-list accepts Windows paths.
  *
  * The pure helpers (clamp, name validation, log-path safety, barrier predicate)
- * are exercised behaviourally. lib/boost.php is function definitions only, so it
- * is safe to require once cacti_sizeof() is stubbed. The wiring in poller_boost.php
- * and the concurrency race itself are asserted by reading the source; the full
- * multi-process race needs the integration suite.
+ * are exercised behaviourally. The unit bootstrap provides core helpers before
+ * lib/boost.php is loaded. The wiring in poller_boost.php and the concurrency
+ * race itself are asserted by reading the source; the full multi-process race
+ * needs the integration suite.
  */
-
-if (!function_exists(__NAMESPACE__ . '\\cacti_sizeof') && !function_exists('\\cacti_sizeof')) {
-	function cacti_sizeof(mixed $array) : int {
-		return is_array($array) ? count($array) : 0;
-	}
-}
 
 require_once CACTI_PATH_LIBRARY . '/boost.php';
 
@@ -220,4 +214,10 @@ test('parent and child repair the completion schema before using it', function (
 		->and($child_repair)->not->toBeFalse()
 		->and($child_insert)->not->toBeFalse()
 		->and($child_repair)->toBeLessThan($child_insert);
+});
+
+test('uses the unit bootstrap cacti_sizeof implementation', function () {
+	$contents = file_get_contents(__FILE__);
+
+	expect($contents)->not->toContain('function cacti_' . 'sizeof(');
 });

--- a/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
+++ b/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
@@ -203,3 +203,20 @@ test('boost_launch_children uses the shared log-path safety helper', function ()
 
 	expect($contents)->toContain('boost_log_path_is_safe($boost_log)');
 });
+
+test('parent and child repair the completion schema before using it', function () use ($boostPollerPath) {
+	$contents = file_get_contents($boostPollerPath);
+
+	$master_repair = strpos($contents, 'boost_ensure_process_table(true)');
+	$truncate      = strpos($contents, "db_execute('TRUNCATE TABLE poller_output_boost_processes')");
+	$child_start   = strpos($contents, "cacti_log('INFO: Boost register child process '");
+	$child_repair  = strpos($contents, 'boost_ensure_process_table(true)', $master_repair + 1);
+	$child_insert  = strpos($contents, "db_execute_prepared('INSERT INTO poller_output_boost_processes", $child_start);
+
+	expect($master_repair)->not->toBeFalse()
+		->and($truncate)->not->toBeFalse()
+		->and($master_repair)->toBeLessThan($truncate)
+		->and($child_repair)->not->toBeFalse()
+		->and($child_insert)->not->toBeFalse()
+		->and($child_repair)->toBeLessThan($child_insert);
+});

--- a/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
+++ b/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
@@ -168,7 +168,7 @@ test('drain loop exits only when every child has recorded completion', function 
 
 	// The old loop exited as soon as no child was running. The fix also requires
 	// every launched child to have a completion row before draining.
-	expect($contents)->toContain('boost_completed_children() < $expected_children');
+	expect($contents)->toContain('boost_completed_children($run_id) < $expected_children');
 	expect($contents)->not->toMatch('/while\s*\(\s*\$running\s*=\s*boost_processes_running\(\)\s*\)/');
 });
 

--- a/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
+++ b/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
@@ -146,6 +146,8 @@ test('boost_archive_table_readable probes data, not metadata, and rejects bad na
 
 test('parent waits for all launched children before draining', function () use ($boostPollerPath) {
 	$contents = file_get_contents($boostPollerPath);
+	expect($contents)->not->toBeFalse();
+	$contents = (string) $contents;
 
 	// boost_launch_children() returns the launched count and the barrier waits on
 	// boost_all_children_registered() rather than releasing on the first signup.
@@ -160,6 +162,8 @@ test('parent waits for all launched children before draining', function () use (
 
 test('drain loop exits only when every child has recorded completion', function () use ($boostPollerPath) {
 	$contents = file_get_contents($boostPollerPath);
+	expect($contents)->not->toBeFalse();
+	$contents = (string) $contents;
 
 	// The old loop exited as soon as no child was running. The fix also requires
 	// every launched child to have a completion row before draining.

--- a/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
+++ b/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
@@ -131,6 +131,7 @@ test('archive-table fallback no longer relies on the lagging SHOW TABLES probe',
 	// The fallback must validate the name and confirm it with a data-plane read.
 	expect($func_body)->toContain('boost_is_valid_archive_table($latest_table)');
 	expect($func_body)->toContain('boost_archive_table_readable($latest_table)');
+	expect($func_body)->toContain("Boost ignored an unexpected archive-like table name: ' . \$display_name");
 });
 
 test('boost_archive_table_readable probes data, not metadata, and rejects bad names', function () use ($boostLibPath) {

--- a/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
+++ b/tests/Unit/Core/Boost/BoostPollerBarrierTest.php
@@ -35,10 +35,10 @@ if (!function_exists(__NAMESPACE__ . '\\cacti_sizeof') && !function_exists('\\ca
 	}
 }
 
-require_once __DIR__ . '/../../../../lib/boost.php';
+require_once CACTI_PATH_LIBRARY . '/boost.php';
 
-$boostPollerPath = __DIR__ . '/../../../../poller_boost.php';
-$boostLibPath    = __DIR__ . '/../../../../lib/boost.php';
+$boostPollerPath = CACTI_PATH_BASE . '/poller_boost.php';
+$boostLibPath    = CACTI_PATH_LIBRARY . '/boost.php';
 
 test('boost_clamp_parallel maps misconfigured values to a single child', function () {
 	expect(boost_clamp_parallel(''))->toBe(1);

--- a/tests/Unit/Database/UpgradeColumnNullKeyTest.php
+++ b/tests/Unit/Database/UpgradeColumnNullKeyTest.php
@@ -16,8 +16,9 @@ test('upgrade column definitions spell the NULL key in upper case', function () 
 	expect($upgrades)->not->toBeEmpty();
 
 	foreach ($upgrades as $upgrade) {
-		expect(file_get_contents($upgrade))
-			->not->toContain("'null' =>", "lowercase 'null' key in " . basename($upgrade));
+		// toContain() takes needles, not a message.
+		expect(str_contains(file_get_contents($upgrade), "'null' =>"))
+			->toBeFalse();
 	}
 });
 

--- a/tests/Unit/Database/UpgradeColumnNullKeyTest.php
+++ b/tests/Unit/Database/UpgradeColumnNullKeyTest.php
@@ -20,9 +20,8 @@ test('upgrade column definitions spell the NULL key in upper case', function () 
 
 		expect($contents)->not->toBeFalse();
 
-		// toContain() takes needles, not a message.
-		expect(str_contains($contents, "'null' =>"))
-			->toBeFalse();
+		expect(preg_match('/[\'\"]null[\'\"]\s*=>/', $contents))
+			->toBe(0);
 	}
 });
 

--- a/tests/Unit/Database/UpgradeColumnNullKeyTest.php
+++ b/tests/Unit/Database/UpgradeColumnNullKeyTest.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+// db_add_column() reads $column['NULL']. PHP array keys are case sensitive, so
+// a lowercase 'null' key is silently discarded and the column is created
+// nullable even though the upgrade asked for NOT NULL.
+test('upgrade column definitions spell the NULL key in upper case', function () {
+	$upgrades = glob(dirname(__DIR__, 3) . '/install/upgrades/*.php');
+
+	expect($upgrades)->not->toBeEmpty();
+
+	foreach ($upgrades as $upgrade) {
+		expect(file_get_contents($upgrade))
+			->not->toContain("'null' =>", "lowercase 'null' key in " . basename($upgrade));
+	}
+});
+
+test('the column builder still reads the upper case key', function () {
+	$database = file_get_contents(dirname(__DIR__, 3) . '/lib/database.php');
+
+	expect($database)->toContain("\$column['NULL']");
+});

--- a/tests/Unit/Database/UpgradeColumnNullKeyTest.php
+++ b/tests/Unit/Database/UpgradeColumnNullKeyTest.php
@@ -13,6 +13,8 @@
 test('upgrade column definitions spell the NULL key in upper case', function () {
 	$upgrades = glob(dirname(__DIR__, 3) . '/install/upgrades/*.php');
 
+	expect($upgrades)->not->toBeFalse();
+	$upgrades = is_array($upgrades) ? $upgrades : [];
 	expect($upgrades)->not->toBeEmpty();
 
 	foreach ($upgrades as $upgrade) {

--- a/tests/Unit/Database/UpgradeColumnNullKeyTest.php
+++ b/tests/Unit/Database/UpgradeColumnNullKeyTest.php
@@ -16,8 +16,12 @@ test('upgrade column definitions spell the NULL key in upper case', function () 
 	expect($upgrades)->not->toBeEmpty();
 
 	foreach ($upgrades as $upgrade) {
+		$contents = file_get_contents($upgrade);
+
+		expect($contents)->not->toBeFalse();
+
 		// toContain() takes needles, not a message.
-		expect(str_contains(file_get_contents($upgrade), "'null' =>"))
+		expect(str_contains($contents, "'null' =>"))
 			->toBeFalse();
 	}
 });
@@ -25,5 +29,6 @@ test('upgrade column definitions spell the NULL key in upper case', function () 
 test('the column builder still reads the upper case key', function () {
 	$database = file_get_contents(dirname(__DIR__, 3) . '/lib/database.php');
 
-	expect($database)->toContain("\$column['NULL']");
+	expect($database)->not->toBeFalse()
+		->and($database)->toContain("\$column['NULL']");
 });

--- a/tests/integration/BoostArchiveHandoffIntegrationTest.php
+++ b/tests/integration/BoostArchiveHandoffIntegrationTest.php
@@ -72,7 +72,7 @@ beforeEach(function () {
 
 	$this->db_globals = [$database_sessions, $database_hostname, $database_port, $database_default];
 
-	$dsn  = getenv('CACTI_TEST_MYSQL_DSN')  ?: 'mysql:host=127.0.0.1;port=33061;dbname=cacti_test';
+	$dsn  = getenv('CACTI_TEST_MYSQL_DSN') ?: 'mysql:host=127.0.0.1;port=33061;dbname=cacti_test';
 	$user = getenv('CACTI_TEST_MYSQL_USER') ?: 'root';
 	$pass = getenv('CACTI_TEST_MYSQL_PASS') ?: 'root';
 
@@ -126,7 +126,7 @@ test('a row from a still-open poll round survives the archive cleanup by moving 
 		boost_handoff_extract_sql($contents, "INSERT IGNORE INTO poller_output_boost\n\t\t\t\tSELECT *", 'AND time >= FROM_UNIXTIME(?)'));
 
 	$delete_sql = str_replace('$table', 'poller_output_boost_arch_handoff_test',
-		boost_handoff_extract_sql($contents, 'DELETE IGNORE', 'WHERE local_data_id = ?'));
+		rtrim(boost_handoff_extract_sql($contents, 'DELETE FROM `$table`', 'WHERE local_data_id = ?'), '"'));
 
 	$local_data_id = 42;
 	$cutoff        = 1_700_000_000; // the in-progress-round safety cutoff ($timestamp)
@@ -180,7 +180,7 @@ test('closed-round rows are removed from the archive table and not duplicated in
 		boost_handoff_extract_sql($contents, "INSERT IGNORE INTO poller_output_boost\n\t\t\t\tSELECT *", 'AND time >= FROM_UNIXTIME(?)'));
 
 	$delete_sql = str_replace('$table', 'poller_output_boost_arch_handoff_test',
-		boost_handoff_extract_sql($contents, 'DELETE IGNORE', 'WHERE local_data_id = ?'));
+		rtrim(boost_handoff_extract_sql($contents, 'DELETE FROM `$table`', 'WHERE local_data_id = ?'), '"'));
 
 	$local_data_id = 9;
 	$cutoff        = 1_700_000_000;
@@ -199,33 +199,27 @@ test('closed-round rows are removed from the archive table and not duplicated in
 	expect((int) db_fetch_cell('SELECT COUNT(*) FROM poller_output_boost'))->toBe(0);
 });
 
-test('a forwarded row left in the archive table would collide with itself on the next run -- proving why the delete must not be narrowed', function () use ($boostLibPath) {
+test('the temporary merge coalesces duplicate archive and live keys', function () use ($boostLibPath) {
 	if (!isset($this->pdo) || !$this->pdo instanceof PDO) {
 		return;
 	}
 
-	// This reconstructs the exact hazard the wide (non-time-narrowed) delete
-	// avoids: run the archive-side temp-table seed query verbatim from the
-	// source (no time filter, not INSERT IGNORE) against a row that was
-	// forwarded to the live table but hypothetically left behind in the
-	// archive table, to prove such a leftover would break the next run's
-	// own merge query with a primary-key collision.
+	// Run both temp-table seed statements verbatim. They deliberately use
+	// INSERT IGNORE so a retry row present in both the archive and live tables
+	// is processed once instead of aborting the handoff on a primary-key clash.
 	$contents = file_get_contents($boostLibPath);
 
-	// Two `INSERT INTO `{$temp_table}`` statements exist in this function:
-	// the first seeds from the archive table (no time filter, no IGNORE),
-	// the second seeds from the live table (time < $timestamp, no IGNORE).
-	$first_seed_pos  = strpos($contents, 'INSERT INTO `{$temp_table}`');
-	$second_seed_pos = strpos($contents, 'INSERT INTO `{$temp_table}`', $first_seed_pos + 1);
+	$first_seed_pos  = strpos($contents, 'INSERT IGNORE INTO `{$temp_table}`');
+	$second_seed_pos = strpos($contents, 'INSERT IGNORE INTO `{$temp_table}`', $first_seed_pos + 1);
 
 	expect($first_seed_pos)->not->toBeFalse();
 	expect($second_seed_pos)->not->toBeFalse();
 
 	$seed_sql = rtrim(str_replace(['{$temp_table}', '{$table}'], ['poller_output_boost_temp_test', 'poller_output_boost_arch_handoff_test'],
-		boost_handoff_extract_sql(substr($contents, $first_seed_pos, $second_seed_pos - $first_seed_pos), 'INSERT INTO `{$temp_table}`', 'WHERE local_data_id = ?"')), '"');
+		boost_handoff_extract_sql(substr($contents, $first_seed_pos, $second_seed_pos - $first_seed_pos), 'INSERT IGNORE INTO `{$temp_table}`', 'WHERE local_data_id = ?"')), '"');
 
 	$live_seed_sql = rtrim(str_replace('{$temp_table}', 'poller_output_boost_temp_test',
-		boost_handoff_extract_sql(substr($contents, $second_seed_pos), 'INSERT INTO `{$temp_table}`', 'AND time < FROM_UNIXTIME(?)"')), '"');
+		boost_handoff_extract_sql(substr($contents, $second_seed_pos), 'INSERT IGNORE INTO `{$temp_table}`', 'AND time < FROM_UNIXTIME(?)"')), '"');
 
 	$this->pdo->exec('CREATE TEMPORARY TABLE poller_output_boost_temp_test LIKE poller_output_boost');
 
@@ -245,14 +239,14 @@ test('a forwarded row left in the archive table would collide with itself on the
 
 	db_execute_prepared($seed_sql, [$local_data_id], false);
 
-	// The live-table seed (not INSERT IGNORE, matching production) must now
-	// fail on the primary-key collision with the row the archive seed just
-	// inserted -- demonstrating why the actual fix deletes the whole
-	// archive slice instead of leaving this row behind.
 	$next_cutoff = $row_time + 3600;
-	$collision   = db_execute_prepared($live_seed_sql, [$local_data_id, $next_cutoff], false);
+	$merged      = db_execute_prepared($live_seed_sql, [$local_data_id, $next_cutoff], false);
 
-	expect($collision)->toBeFalse();
+	expect($merged)->not->toBeFalse();
+
+	$rows = db_fetch_assoc('SELECT output FROM poller_output_boost_temp_test');
+	expect($rows)->toHaveCount(1)
+		->and($rows[0]['output'])->toBe('from-archive');
 
 	$this->pdo->exec('DROP TEMPORARY TABLE IF EXISTS poller_output_boost_temp_test');
 });

--- a/tests/integration/BoostFlushOutputBatchPacketLimitTest.php
+++ b/tests/integration/BoostFlushOutputBatchPacketLimitTest.php
@@ -55,6 +55,28 @@ class BoostPacketLookupPDO extends FakeMySQLPDO {
 	}
 }
 
+class BoostFailingChunkPDO extends BoostPacketLookupPDO {
+	public int $insert_attempts = 0;
+
+	public function prepare(string $query, array $options = []): PDOStatement|false {
+		if (stripos($query, 'max_allowed_packet') !== false) {
+			$this->packet_lookups++;
+
+			return parent::prepare("SELECT 'max_allowed_packet' AS Variable_name, '512' AS Value", $options);
+		}
+
+		if (stripos(ltrim($query), 'INSERT IGNORE INTO poller_output_boost') === 0) {
+			$this->insert_attempts++;
+
+			if ($this->insert_attempts === 2) {
+				throw new RuntimeException('injected second-chunk failure');
+			}
+		}
+
+		return parent::prepare($query, $options);
+	}
+}
+
 beforeEach(function () {
 	global $database_sessions, $database_hostname, $database_port, $database_default;
 
@@ -102,4 +124,21 @@ test('max_allowed_packet is read once per connection, not once per process', fun
 		$count = (int) $conn->query('SELECT COUNT(*) AS c FROM poller_output_boost')->fetch(PDO::FETCH_ASSOC)['c'];
 		expect($count)->toBe($expected);
 	}
+});
+
+test('a failed chunk stops the batch before later tuples are staged', function () {
+	$conn   = new BoostFailingChunkPDO();
+	$output = str_repeat('x', 300);
+
+	$result = boost_flush_output_batch([
+		"(11,'first','2024-01-01 00:00:00','{$output}')",
+		"(12,'failed','2024-01-01 00:00:00','{$output}')",
+		"(13,'later','2024-01-01 00:00:00','{$output}')",
+	], $conn);
+
+	$ids = $conn->query('SELECT local_data_id FROM poller_output_boost ORDER BY local_data_id')->fetchAll(PDO::FETCH_COLUMN);
+
+	expect($result)->toBeFalse()
+		->and($conn->insert_attempts)->toBe(2)
+		->and($ids)->toBe([11]);
 });

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -127,11 +127,11 @@ test('reports a failed database acknowledgement to its caller', function () {
 	expect(boost_flush_output_batch(["(1,'ds','2024-01-01 00:00:00','100')"], $this->conn))->toBeFalse();
 });
 
-test('publishes a complete graph cache object without leaving a temporary file', function () {
+test('publishes a multi-chunk graph cache object without leaving a temporary file', function () {
 	$directory = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));
 	mkdir($directory, 0700);
 	$cache_file = $directory . '/cache.png';
-	$output     = str_repeat('png-data', 4096);
+	$output     = str_repeat('png-data', 393217);
 
 	try {
 		expect(boost_atomic_write_cache($cache_file, $output))->toBeTrue();

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -142,3 +142,22 @@ test('publishes a multi-chunk graph cache object without leaving a temporary fil
 		@rmdir($directory);
 	}
 });
+
+test('the Windows cache replacement fallback replaces an existing object', function () {
+	$directory  = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));
+	$cache_file = $directory . '/cache.png';
+	$temp_file  = $directory . '/.boost-replacement';
+	mkdir($directory, 0700);
+	file_put_contents($cache_file, 'old');
+	file_put_contents($temp_file, 'new');
+
+	try {
+		expect(boost_replace_cache_file_on_windows($temp_file, $cache_file))->toBeTrue();
+		expect(file_get_contents($cache_file))->toBe('new');
+		expect(file_exists($temp_file))->toBeFalse();
+	} finally {
+		@unlink($temp_file);
+		@unlink($cache_file);
+		@rmdir($directory);
+	}
+});

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -45,6 +45,7 @@ beforeEach(function () {
 		output TEXT NOT NULL,
 		PRIMARY KEY (local_data_id, rrd_name, time)
 	)');
+	$conn->exec('CREATE TABLE poller_item (local_data_id INTEGER NOT NULL, poller_id INTEGER NOT NULL)');
 
 	$database_hostname = 'unit_test_host';
 	$database_port     = '0';
@@ -73,7 +74,7 @@ function boost_test_fetch_output(PDO $conn, int $local_data_id, string $rrd_name
 }
 
 test('writes a fresh row when no key collision exists', function () {
-	boost_flush_output_batch(["(1,'ds','2024-01-01 00:00:00','100')"], $this->conn);
+	expect(boost_flush_output_batch(["(1,'ds','2024-01-01 00:00:00','100')"], $this->conn))->toBeTrue();
 
 	$stmt = $this->conn->query('SELECT local_data_id, rrd_name, output FROM poller_output_boost');
 	$row  = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -114,8 +115,44 @@ test('non-colliding rows in the same batch are all written', function () {
 });
 
 test('an empty tuple list is a no-op', function () {
-	boost_flush_output_batch([], $this->conn);
+	expect(boost_flush_output_batch([], $this->conn))->toBeTrue();
 
 	$count = (int) $this->conn->query('SELECT COUNT(*) AS c FROM poller_output_boost')->fetch(PDO::FETCH_ASSOC)['c'];
 	expect($count)->toBe(0);
+});
+
+test('reports a failed database acknowledgement to its caller', function () {
+	$this->conn->exec('DROP TABLE poller_output_boost');
+
+	expect(boost_flush_output_batch(["(1,'ds','2024-01-01 00:00:00','100')"], $this->conn))->toBeFalse();
+});
+
+test('publishes a complete graph cache object without leaving a temporary file', function () {
+	$directory = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));
+	mkdir($directory, 0700);
+	$cache_file = $directory . '/cache.png';
+	$output     = str_repeat('png-data', 4096);
+
+	try {
+		expect(boost_atomic_write_cache($cache_file, $output))->toBeTrue();
+		expect(file_get_contents($cache_file))->toBe($output);
+		expect(glob($directory . '/.boost-*'))->toBe([]);
+	} finally {
+		@unlink($cache_file);
+		@rmdir($directory);
+	}
+});
+
+test('validates remote data-source ownership against the destination database', function () {
+	$this->conn->exec('INSERT INTO poller_item (local_data_id, poller_id) VALUES (10, 7), (11, 7), (12, 8)');
+
+	expect(boost_validate_poller_ownership([
+		['local_data_id' => 10],
+		['local_data_id' => 11],
+	], 7, $this->conn))->toBeTrue();
+
+	expect(boost_validate_poller_ownership([
+		['local_data_id' => 10],
+		['local_data_id' => 12],
+	], 7, $this->conn))->toBeFalse();
 });

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -46,6 +46,7 @@ beforeEach(function () {
 		PRIMARY KEY (local_data_id, rrd_name, time)
 	)');
 	$conn->exec('CREATE TABLE poller_item (local_data_id INTEGER NOT NULL, poller_id INTEGER NOT NULL)');
+	$conn->exec('CREATE TABLE settings (name TEXT PRIMARY KEY, value TEXT)');
 
 	$database_hostname = 'unit_test_host';
 	$database_port     = '0';

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -164,6 +164,7 @@ test('publishes a multi-chunk graph cache object without leaving a temporary fil
 	try {
 		expect(boost_atomic_write_cache($cache_file, $output))->toBeTrue();
 		expect(file_get_contents($cache_file))->toBe($output);
+		expect(fileperms($cache_file) & 0777)->toBe(0644);
 		expect(glob($directory . '/.boost-*'))->toBe([]);
 	} finally {
 		@unlink($cache_file);

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -45,7 +45,6 @@ beforeEach(function () {
 		output TEXT NOT NULL,
 		PRIMARY KEY (local_data_id, rrd_name, time)
 	)');
-	$conn->exec('CREATE TABLE poller_item (local_data_id INTEGER NOT NULL, poller_id INTEGER NOT NULL)');
 	$conn->exec('CREATE TABLE settings (name TEXT PRIMARY KEY, value TEXT)');
 
 	$database_hostname = 'unit_test_host';
@@ -142,18 +141,4 @@ test('publishes a complete graph cache object without leaving a temporary file',
 		@unlink($cache_file);
 		@rmdir($directory);
 	}
-});
-
-test('validates remote data-source ownership against the destination database', function () {
-	$this->conn->exec('INSERT INTO poller_item (local_data_id, poller_id) VALUES (10, 7), (11, 7), (12, 8)');
-
-	expect(boost_validate_poller_ownership([
-		['local_data_id' => 10],
-		['local_data_id' => 11],
-	], 7, $this->conn))->toBeTrue();
-
-	expect(boost_validate_poller_ownership([
-		['local_data_id' => 10],
-		['local_data_id' => 12],
-	], 7, $this->conn))->toBeFalse();
 });

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -27,9 +27,9 @@
 
 require_once dirname(__DIR__) . '/Helpers/UnitStubs.php';
 require_once dirname(__DIR__) . '/Helpers/FakeMySQLPDO.php';
-require_once dirname(__DIR__, 2) . '/include/vendor/autoload.php';
-require_once dirname(__DIR__, 2) . '/lib/database.php';
-require_once dirname(__DIR__, 2) . '/lib/boost.php';
+require_once CACTI_PATH_INCLUDE . '/vendor/autoload.php';
+require_once CACTI_PATH_LIBRARY . '/database.php';
+require_once CACTI_PATH_LIBRARY . '/boost.php';
 
 beforeEach(function () {
 	global $database_sessions, $database_hostname, $database_port, $database_default;

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -252,3 +252,19 @@ test('the Windows replacement helper fails closed when no destination exists', f
 		@rmdir($directory);
 	}
 });
+
+test('the Windows replacement helper preserves the existing object when publication fails', function () {
+	$directory  = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));
+	$cache_file = $directory . '/cache.png';
+	$temp_file  = $directory . '/missing-replacement';
+	mkdir($directory, 0700);
+	file_put_contents($cache_file, 'old');
+
+	try {
+		expect(boost_replace_cache_file_on_windows($temp_file, $cache_file))->toBeFalse();
+		expect(file_get_contents($cache_file))->toBe('old');
+	} finally {
+		@unlink($cache_file);
+		@rmdir($directory);
+	}
+});

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -114,6 +114,21 @@ test('non-colliding rows in the same batch are all written', function () {
 	expect(boost_test_fetch_output($this->conn, 2, 'ds2', '2024-01-01 00:00:00'))->toBe('20');
 });
 
+test('splits a batch before the database packet limit without losing rows', function () {
+	$large_output = str_repeat('x', 600000);
+
+	expect(boost_flush_output_batch([
+		"(11,'large_1','2024-01-01 00:00:00','{$large_output}')",
+		"(12,'large_2','2024-01-01 00:00:00','{$large_output}')",
+	], $this->conn))->toBeTrue();
+
+	$count = (int) $this->conn->query('SELECT COUNT(*) FROM poller_output_boost')->fetchColumn();
+
+	expect($count)->toBe(2)
+		->and(strlen(boost_test_fetch_output($this->conn, 11, 'large_1', '2024-01-01 00:00:00')))->toBe(600000)
+		->and(strlen(boost_test_fetch_output($this->conn, 12, 'large_2', '2024-01-01 00:00:00')))->toBe(600000);
+});
+
 test('an empty tuple list is a no-op', function () {
 	expect(boost_flush_output_batch([], $this->conn))->toBeTrue();
 
@@ -158,6 +173,69 @@ test('the Windows cache replacement fallback replaces an existing object', funct
 	} finally {
 		@unlink($temp_file);
 		@unlink($cache_file);
+		@rmdir($directory);
+	}
+});
+
+test('atomic cache publication replaces an existing object on the native platform', function () {
+	$directory  = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));
+	$cache_file = $directory . '/cache.png';
+	mkdir($directory, 0700);
+	file_put_contents($cache_file, 'old');
+
+	try {
+		expect(boost_atomic_write_cache($cache_file, 'new'))->toBeTrue();
+		expect(file_get_contents($cache_file))->toBe('new');
+		expect(glob($directory . '/.boost-*'))->toBe([]);
+	} finally {
+		@unlink($cache_file);
+		@rmdir($directory);
+	}
+});
+
+test('atomic cache publication supports an empty object', function () {
+	$directory  = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));
+	$cache_file = $directory . '/cache.png';
+	mkdir($directory, 0700);
+
+	try {
+		expect(boost_atomic_write_cache($cache_file, ''))->toBeTrue();
+		expect(file_get_contents($cache_file))->toBe('');
+	} finally {
+		@unlink($cache_file);
+		@rmdir($directory);
+	}
+});
+
+test('a failed cache publication removes its temporary object', function () {
+	$directory  = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));
+	$cache_file = $directory . '/occupied';
+	mkdir($directory, 0700);
+	mkdir($cache_file, 0700);
+
+	try {
+		expect(boost_atomic_write_cache($cache_file, 'new'))->toBeFalse();
+		expect(is_dir($cache_file))->toBeTrue();
+		expect(glob($directory . '/.boost-*'))->toBe([]);
+	} finally {
+		@rmdir($cache_file);
+		@rmdir($directory);
+	}
+});
+
+test('the Windows replacement helper fails closed when no destination exists', function () {
+	$directory  = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));
+	$cache_file = $directory . '/missing.png';
+	$temp_file  = $directory . '/.boost-replacement';
+	mkdir($directory, 0700);
+	file_put_contents($temp_file, 'new');
+
+	try {
+		expect(boost_replace_cache_file_on_windows($temp_file, $cache_file))->toBeFalse();
+		expect(file_get_contents($temp_file))->toBe('new');
+		expect(file_exists($cache_file))->toBeFalse();
+	} finally {
+		@unlink($temp_file);
 		@rmdir($directory);
 	}
 });

--- a/tests/integration/BoostFlushOutputBatchTest.php
+++ b/tests/integration/BoostFlushOutputBatchTest.php
@@ -31,12 +31,24 @@ require_once CACTI_PATH_INCLUDE . '/vendor/autoload.php';
 require_once CACTI_PATH_LIBRARY . '/database.php';
 require_once CACTI_PATH_LIBRARY . '/boost.php';
 
+class BoostBatchPDO extends FakeMySQLPDO {
+	public int $insert_attempts = 0;
+
+	public function prepare(string $query, array $options = []): PDOStatement|false {
+		if (stripos(ltrim($query), 'INSERT IGNORE INTO poller_output_boost') === 0) {
+			$this->insert_attempts++;
+		}
+
+		return parent::prepare($query, $options);
+	}
+}
+
 beforeEach(function () {
 	global $database_sessions, $database_hostname, $database_port, $database_default;
 
 	$this->db_globals = [$database_sessions, $database_hostname, $database_port, $database_default];
 
-	$conn = new FakeMySQLPDO();
+	$conn = new BoostBatchPDO();
 
 	$conn->exec('CREATE TABLE poller_output_boost (
 		local_data_id INTEGER NOT NULL,
@@ -115,7 +127,7 @@ test('non-colliding rows in the same batch are all written', function () {
 });
 
 test('splits a batch before the database packet limit without losing rows', function () {
-	$large_output = str_repeat('x', 600000);
+	$large_output = str_repeat('x', 2200000);
 
 	expect(boost_flush_output_batch([
 		"(11,'large_1','2024-01-01 00:00:00','{$large_output}')",
@@ -125,8 +137,9 @@ test('splits a batch before the database packet limit without losing rows', func
 	$count = (int) $this->conn->query('SELECT COUNT(*) FROM poller_output_boost')->fetchColumn();
 
 	expect($count)->toBe(2)
-		->and(strlen(boost_test_fetch_output($this->conn, 11, 'large_1', '2024-01-01 00:00:00')))->toBe(600000)
-		->and(strlen(boost_test_fetch_output($this->conn, 12, 'large_2', '2024-01-01 00:00:00')))->toBe(600000);
+		->and($this->conn->insert_attempts)->toBe(2)
+		->and(strlen(boost_test_fetch_output($this->conn, 11, 'large_1', '2024-01-01 00:00:00')))->toBe(2200000)
+		->and(strlen(boost_test_fetch_output($this->conn, 12, 'large_2', '2024-01-01 00:00:00')))->toBe(2200000);
 });
 
 test('an empty tuple list is a no-op', function () {

--- a/tests/integration/BoostProcessTableUpgradeIntegrationTest.php
+++ b/tests/integration/BoostProcessTableUpgradeIntegrationTest.php
@@ -63,11 +63,12 @@ beforeEach(function () {
 	$database_default  = 'cacti_boost_upgrade_test';
 
 	$database_sessions["$database_hostname:$database_port:$database_default"] = $this->pdo;
+	$this->pdo->exec("SET SESSION sql_mode = CONCAT_WS(',', @@sql_mode, 'ANSI_QUOTES')");
 
 	// db_install_add_cache() stamps install_updated on every statement.
 	$this->pdo->exec('CREATE TABLE IF NOT EXISTS settings (
-		name varchar(50) NOT NULL default "",
-		value varchar(2048) NOT NULL default "",
+		name varchar(50) NOT NULL default \'\',
+		value varchar(2048) NOT NULL default \'\',
 		PRIMARY KEY (name))');
 
 	$this->pdo->exec('DROP TABLE IF EXISTS poller_output_boost_processes');

--- a/tests/integration/BoostProcessTableUpgradeIntegrationTest.php
+++ b/tests/integration/BoostProcessTableUpgradeIntegrationTest.php
@@ -1,0 +1,163 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * upgrade_boost_process_table() has to add the run_child UNIQUE key to
+ * poller_output_boost_processes, and nothing stops cron from starting
+ * poller_boost.php while the installer is working.  Rows written before this
+ * upgrade carry no run identifier, so the ALTERs default every one of them to
+ * ('', 0) and the key cannot build over them; rows written by a child of an
+ * in-flight run carry a real run_id and are what the parent counts when it
+ * decides whether every child finished.
+ *
+ * These cases run against a real server because the discriminating behaviour
+ * is the engine's: whether the UNIQUE key builds, and which rows survive.
+ *
+ * Requires a MySQL/MariaDB instance; see BoostArchiveHandoffIntegrationTest.php
+ * for the same env vars.  Skips (does not fail) if unreachable.
+ */
+
+require_once __DIR__ . '/../Helpers/UnitStubs.php';
+require_once dirname(__DIR__, 2) . '/lib/database.php';
+require_once dirname(__DIR__, 2) . '/install/functions.php';
+require_once dirname(__DIR__, 2) . '/install/upgrades/1_3_0.php';
+
+beforeEach(function () {
+	global $database_sessions, $database_hostname, $database_port, $database_default;
+
+	$this->db_globals = [$database_sessions, $database_hostname, $database_port, $database_default];
+
+	$dsn  = getenv('CACTI_TEST_MYSQL_DSN')  ?: 'mysql:host=127.0.0.1;port=33061;dbname=cacti_test';
+	$user = getenv('CACTI_TEST_MYSQL_USER') ?: 'root';
+	$pass = getenv('CACTI_TEST_MYSQL_PASS') ?: 'root';
+
+	try {
+		$this->pdo = new PDO($dsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_SILENT, PDO::ATTR_TIMEOUT => 3]);
+	} catch (\PDOException $e) {
+		$this->pdo = null;
+		test()->markTestSkipped('No MySQL/MariaDB test instance reachable at ' . $dsn . ': ' . $e->getMessage());
+
+		return;
+	}
+
+	$database_hostname = 'unit-test-host';
+	$database_port     = 3306;
+	$database_default  = 'cacti_boost_upgrade_test';
+
+	$database_sessions["$database_hostname:$database_port:$database_default"] = $this->pdo;
+
+	// db_install_add_cache() stamps install_updated on every statement.
+	$this->pdo->exec('CREATE TABLE IF NOT EXISTS settings (
+		name varchar(50) NOT NULL default "",
+		value varchar(2048) NOT NULL default "",
+		PRIMARY KEY (name))');
+
+	$this->pdo->exec('DROP TABLE IF EXISTS poller_output_boost_processes');
+});
+
+afterEach(function () {
+	global $database_sessions, $database_hostname, $database_port, $database_default;
+
+	if (isset($this->pdo) && $this->pdo instanceof PDO) {
+		$this->pdo->exec('DROP TABLE IF EXISTS poller_output_boost_processes');
+	}
+
+	// Put the default db_* connection back so the test handle does not answer
+	// every later read_config_option() in the run.
+	[$database_sessions, $database_hostname, $database_port, $database_default] = $this->db_globals;
+});
+
+function boostProcessIndexColumns(PDO $pdo) : array {
+	$rows = $pdo->query("SHOW INDEX FROM poller_output_boost_processes WHERE Key_name = 'run_child'");
+
+	if ($rows === false) {
+		return [];
+	}
+
+	$columns = [];
+
+	foreach ($rows->fetchAll(PDO::FETCH_ASSOC) as $row) {
+		$columns[(int) $row['Seq_in_index']] = $row['Column_name'] . ':' . $row['Non_unique'];
+	}
+
+	ksort($columns);
+
+	return array_values($columns);
+}
+
+test('the 1.2.x table gains the run_child key even though its rows cannot satisfy it', function () {
+	if (!isset($this->pdo) || !$this->pdo instanceof PDO) {
+		return;
+	}
+
+	$this->pdo->exec('CREATE TABLE poller_output_boost_processes (
+		sock_int_value bigint(20) unsigned NOT NULL auto_increment,
+		status varchar(255) default NULL,
+		PRIMARY KEY (sock_int_value)) ENGINE=MEMORY');
+
+	$this->pdo->exec("INSERT INTO poller_output_boost_processes (status) VALUES ('118'), ('92'), ('0')");
+
+	upgrade_boost_process_table();
+
+	expect(boostProcessIndexColumns($this->pdo))->toBe(['run_id:0', 'child_id:0'])
+		->and((int) $this->pdo->query('SELECT COUNT(*) FROM poller_output_boost_processes')->fetchColumn())->toBe(0);
+});
+
+test('an in-flight run keeps its completion rows while the legacy rows are dropped', function () {
+	if (!isset($this->pdo) || !$this->pdo instanceof PDO) {
+		return;
+	}
+
+	// A collector already carrying the 1.3.0 columns but not yet the key, which
+	// is what a develop-to-develop upgrade finds.
+	$this->pdo->exec("CREATE TABLE poller_output_boost_processes (
+		sock_int_value bigint(20) unsigned NOT NULL auto_increment,
+		run_id char(32) NOT NULL default '',
+		child_id int(10) unsigned NOT NULL default 0,
+		status varchar(255) default NULL,
+		PRIMARY KEY (sock_int_value)) ENGINE=MEMORY");
+
+	$run_id = '3f2a91c4d80b47e6a15c9f0e7b32d5a8';
+
+	$this->pdo->exec("INSERT INTO poller_output_boost_processes (run_id, child_id, status) VALUES
+		('$run_id', 1, '4210'),
+		('$run_id', 2, '3987'),
+		('', 0, '77')");
+
+	upgrade_boost_process_table();
+
+	$survivors = $this->pdo->query('SELECT run_id, child_id, status
+		FROM poller_output_boost_processes
+		ORDER BY child_id')->fetchAll(PDO::FETCH_ASSOC);
+
+	expect($survivors)->toBe([
+		['run_id' => $run_id, 'child_id' => 1, 'status' => '4210'],
+		['run_id' => $run_id, 'child_id' => 2, 'status' => '3987'],
+	]);
+
+	// The parent drains on COUNT(*) for its own run_id, so those two rows are
+	// the difference between finishing the run and warning about a crashed
+	// child while holding the archive tables.
+	$completed = $this->pdo->prepare('SELECT COUNT(*) FROM poller_output_boost_processes WHERE run_id = ?');
+	$completed->execute([$run_id]);
+
+	expect((int) $completed->fetchColumn())->toBe(2)
+		->and(boostProcessIndexColumns($this->pdo))->toBe(['run_id:0', 'child_id:0']);
+
+	// What the upgrade used to do, on the same rows.
+	$this->pdo->exec('TRUNCATE TABLE poller_output_boost_processes');
+	$completed->execute([$run_id]);
+
+	expect((int) $completed->fetchColumn())->toBe(0);
+});

--- a/tests/integration/BoostProcessTableUpgradeIntegrationTest.php
+++ b/tests/integration/BoostProcessTableUpgradeIntegrationTest.php
@@ -28,6 +28,13 @@
  * for the same env vars.  Skips (does not fail) if unreachable.
  */
 
+// Production upgrade entry points define this before loading upgrade files.
+// It also makes schema probes bypass their runtime cache while this test
+// deliberately drops and recreates the same table between cases.
+if (!defined('IN_CACTI_INSTALL')) {
+	define('IN_CACTI_INSTALL', 1);
+}
+
 require_once __DIR__ . '/../Helpers/UnitStubs.php';
 require_once dirname(__DIR__, 2) . '/lib/database.php';
 require_once dirname(__DIR__, 2) . '/install/functions.php';
@@ -38,7 +45,7 @@ beforeEach(function () {
 
 	$this->db_globals = [$database_sessions, $database_hostname, $database_port, $database_default];
 
-	$dsn  = getenv('CACTI_TEST_MYSQL_DSN')  ?: 'mysql:host=127.0.0.1;port=33061;dbname=cacti_test';
+	$dsn  = getenv('CACTI_TEST_MYSQL_DSN') ?: 'mysql:host=127.0.0.1;port=33061;dbname=cacti_test';
 	$user = getenv('CACTI_TEST_MYSQL_USER') ?: 'root';
 	$pass = getenv('CACTI_TEST_MYSQL_PASS') ?: 'root';
 
@@ -160,4 +167,62 @@ test('an in-flight run keeps its completion rows while the legacy rows are dropp
 	$completed->execute([$run_id]);
 
 	expect((int) $completed->fetchColumn())->toBe(0);
+});
+
+test('a missing process table is recreated with the complete current schema', function () {
+	if (!isset($this->pdo) || !$this->pdo instanceof PDO) {
+		return;
+	}
+
+	upgrade_boost_process_table();
+
+	$columns = $this->pdo->query('SHOW COLUMNS FROM poller_output_boost_processes')->fetchAll(PDO::FETCH_COLUMN);
+	$engine  = $this->pdo->query("SELECT ENGINE FROM information_schema.TABLES
+		WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'poller_output_boost_processes'")->fetchColumn();
+
+	expect($columns)->toBe(['sock_int_value', 'run_id', 'child_id', 'status'])
+		->and(boostProcessIndexColumns($this->pdo))->toBe(['run_id:0', 'child_id:0'])
+		->and($engine)->toBe('MEMORY');
+});
+
+test('an already upgraded process table and its completion row are unchanged', function () {
+	if (!isset($this->pdo) || !$this->pdo instanceof PDO) {
+		return;
+	}
+
+	$this->pdo->exec("CREATE TABLE poller_output_boost_processes (
+		sock_int_value bigint(20) unsigned NOT NULL auto_increment,
+		run_id char(32) NOT NULL default '',
+		child_id int(10) unsigned NOT NULL default 0,
+		status varchar(255) default NULL,
+		PRIMARY KEY (sock_int_value),
+		UNIQUE KEY run_child (run_id, child_id)) ENGINE=MEMORY");
+	$this->pdo->exec("INSERT INTO poller_output_boost_processes (run_id, child_id, status)
+		VALUES ('3f2a91c4d80b47e6a15c9f0e7b32d5a8', 4, '123')");
+
+	upgrade_boost_process_table();
+
+	$row = $this->pdo->query('SELECT run_id, child_id, status FROM poller_output_boost_processes')->fetch(PDO::FETCH_ASSOC);
+
+	expect($row)->toBe([
+		'run_id'   => '3f2a91c4d80b47e6a15c9f0e7b32d5a8',
+		'child_id' => 4,
+		'status'   => '123',
+	]);
+});
+
+test('the run_child index rejects duplicate completion reports for one child', function () {
+	if (!isset($this->pdo) || !$this->pdo instanceof PDO) {
+		return;
+	}
+
+	upgrade_boost_process_table();
+
+	$insert = $this->pdo->prepare('INSERT INTO poller_output_boost_processes (run_id, child_id, status) VALUES (?, ?, ?)');
+	expect($insert->execute(['3f2a91c4d80b47e6a15c9f0e7b32d5a8', 1, '10']))->toBeTrue();
+
+	$duplicate = $insert->execute(['3f2a91c4d80b47e6a15c9f0e7b32d5a8', 1, '20']);
+
+	expect($duplicate)->toBeFalse()
+		->and((int) $this->pdo->query('SELECT COUNT(*) FROM poller_output_boost_processes')->fetchColumn())->toBe(1);
 });

--- a/tests/integration/BoostProcessTableUpgradeIntegrationTest.php
+++ b/tests/integration/BoostProcessTableUpgradeIntegrationTest.php
@@ -37,6 +37,7 @@ if (!defined('IN_CACTI_INSTALL')) {
 
 require_once __DIR__ . '/../Helpers/UnitStubs.php';
 require_once dirname(__DIR__, 2) . '/lib/database.php';
+require_once dirname(__DIR__, 2) . '/lib/boost.php';
 require_once dirname(__DIR__, 2) . '/install/functions.php';
 require_once dirname(__DIR__, 2) . '/install/upgrades/1_3_0.php';
 
@@ -226,4 +227,26 @@ test('the run_child index rejects duplicate completion reports for one child', f
 
 	expect($duplicate)->toBeFalse()
 		->and((int) $this->pdo->query('SELECT COUNT(*) FROM poller_output_boost_processes')->fetchColumn())->toBe(1);
+});
+
+test('runtime repair makes a legacy process table safe before a child records completion', function () {
+	if (!isset($this->pdo) || !$this->pdo instanceof PDO) {
+		return;
+	}
+
+	$this->pdo->exec('CREATE TABLE poller_output_boost_processes (
+		sock_int_value bigint(20) unsigned NOT NULL auto_increment,
+		status varchar(255) default NULL,
+		PRIMARY KEY (sock_int_value)) ENGINE=MEMORY');
+	$this->pdo->exec("INSERT INTO poller_output_boost_processes (status) VALUES ('legacy')");
+
+	expect(boost_ensure_process_table(true))->toBeTrue()
+		->and(boostProcessIndexColumns($this->pdo))->toBe(['run_id:0', 'child_id:0'])
+		->and((int) $this->pdo->query('SELECT COUNT(*) FROM poller_output_boost_processes')->fetchColumn())->toBe(0);
+
+	$insert = $this->pdo->prepare('INSERT INTO poller_output_boost_processes
+		(run_id, child_id, status) VALUES (?, ?, ?)
+		ON DUPLICATE KEY UPDATE status = VALUES(status)');
+
+	expect($insert->execute(['3f2a91c4d80b47e6a15c9f0e7b32d5a8', 1, '10']))->toBeTrue();
 });

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -169,7 +169,7 @@ fs_write	./lib/CactiFilesystem.php			$this->filesystem->dumpFile($filename, $con
 fs_write	./lib/CactiFilesystem.php			self::default()->writeFile($filename, $content);
 fs_write	./lib/api_device.php							if (file_put_contents($new_xmlfile, $data) === false) {
 fs_write	./lib/boost.php								if ($fileptr = fopen($cache_file, 'rb')) {
-fs_write	./lib/boost.php							if ($fileptr = fopen($cache_file, 'w')) {
+fs_write	./lib/boost.php		$fileptr = fopen($temp_file, 'wb');
 fs_write	./lib/clog_webapi.php					$log_fh = fopen($logfile, 'w');
 fs_write	./lib/csp_report_endpoint.php	$inputStream = fopen('php://input', 'rb');
 fs_write	./lib/database.php					file_put_contents(sys_get_temp_dir() . '/cacti-option.log',

--- a/tests/tools/sql_interpolation_baseline.json
+++ b/tests/tools/sql_interpolation_baseline.json
@@ -50,7 +50,7 @@
     "poller_automation.php": 2,
     "poller_boost.php": 5,
     "poller_dsstats.php": 1,
-    "poller_recovery.php": 4,
+    "poller_recovery.php": 2,
     "poller_spikekill.php": 1,
     "rrdcleaner.php": 3,
     "support.php": 3,


### PR DESCRIPTION
Boost handed values to the graph cache and to rrdtool without validating them at the boundary. They are now checked where they enter and fail closed when unusable.

Includes a schema change (`cacti.sql`, `docs/audit_schema.sql`) for the audit columns, with a guarded `1_3_0` upgrade path.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.

Closes #7853

### Review and rebase status

Rebased onto current `develop` at `770c503f3`. The upgrade conflict was resolved by preserving the current process-lock table creation while retaining the corrected uppercase `NULL` schema keys.

All existing Copilot and human review findings are addressed and every review conversation is resolved. The final changes also remove the unreachable negative aggregate branch, recreate the Boost completion table when an upgrade finds it missing, preserve in-flight completion rows during upgrade, execute current production SQL in the MariaDB integration proof, and guard nullable graph output before atomic cache publication.

### Verification

- Docker focused suite: 43 tests, 215 assertions
- Docker real-MariaDB integration: 7 tests, 27 assertions
- Expanded Boost suite: 112 fast Docker tests / 469 assertions plus all 15 real-MariaDB 11.4 cases / 43 assertions
- Added coverage for packet-limit chunking, non-destructive Windows cache replacement and cleanup failure paths, missing-table reconstruction, runtime legacy-schema repair, upgrade idempotence, and duplicate child-completion enforcement
- Complete JavaScript suite: 15 tests passed; PHP-CS-Fixer, PHP syntax, sink inventory, and architectural hotspot guards pass
- Strict-SQL portability: upgrade integration cases pass with MariaDB `ANSI_QUOTES` enabled
- Fault-injected chunk failure now stops subsequent staging; focused packet/cache suite passes 15 tests / 45 assertions
- Recovery status SQL is covered for MariaDB `ANSI_QUOTES` compatibility
- All recovery/spike-kill SQL literals are verified under MariaDB `ANSI_QUOTES`
- Cache publication preserves the established `0644` reader contract across separate poller/web users
- Cache publication fails closed if the required reader mode cannot be applied
- Parent and child startup both validate/repair the completion schema before truncation or completion writes
- Recovery fetches remain strictly bounded even when more than 150,000 rows share the cutoff timestamp
- Full Docker PHPStan passes across all 436 analyzed files
- Failed recovery restores the poller from status 5 while preserving failure logs and exit status
- Rejected archive-like table warnings include a control-character-sanitized table name
- Unit tests rely on the suite bootstrap instead of redeclaring core helpers
- Generated graph-cache secrets are re-read directly from the database after `INSERT IGNORE`, avoiding stale option-cache values during concurrent creation
- Cache directories trim either Windows or Unix trailing separators before appending the platform-native separator
- Hand-off test helpers are guarded against redeclaration during repeated Pest collection
- MariaDB confirms `child_id` is the second column of the composite `run_child` unique key; the audit schema correctly leaves its standalone `Key` field blank
- Full GitHub CI is green on head `fbbf8c50c`; the latest Copilot review covers all 21 changed files with 0 new comments
