### PR TITLE
Install setuptools alongside semgrep

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -34,8 +34,9 @@ jobs:
         run: |
           pipx install semgrep==1.90.0
           # semgrep 1.90.0 reaches pkg_resources through opentelemetry-instrumentation.
-          # The runner's Python no longer ships setuptools, so the import fails at startup.
-          pipx inject semgrep setuptools
+          # setuptools 81 dropped pkg_resources, and the runner ships a newer one, so the
+          # venv needs an older setuptools forced over it.
+          pipx inject semgrep 'setuptools<81' --force
 
       - name: Self-test the rules (blocking)
         run: semgrep --test tests/security/semgrep/

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -31,7 +31,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install semgrep
-        run: pipx install semgrep==1.90.0
+        run: |
+          pipx install semgrep==1.90.0
+          # semgrep 1.90.0 reaches pkg_resources through opentelemetry-instrumentation.
+          # The runner's Python no longer ships setuptools, so the import fails at startup.
+          pipx inject semgrep setuptools
 
       - name: Self-test the rules (blocking)
         run: semgrep --test tests/security/semgrep/


### PR DESCRIPTION
The Semgrep job has failed on every run since it landed, including on develop:

```
File ".../opentelemetry/instrumentation/dependencies.py", line 4, in <module>
    from pkg_resources import (
ModuleNotFoundError: No module named 'pkg_resources'
```

semgrep 1.90.0 reaches `pkg_resources` through opentelemetry-instrumentation, and the runner's Python no longer ships setuptools. `pipx inject` adds it to the same venv without moving off the pinned version.

Verification: the job reaching the self-test step at all is the check; it aborts during `semgrep --test` today.