### PR TITLE
fix: declare __() before the disabled-i18n fallback returns

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -101,6 +101,7 @@ Cacti CHANGELOG
 -issue#7693: Validate host_id before it reaches the graph template query
 -issue#7719: Spike Kill text output applied the large value scientific notation format to the column left of the value it belonged to, starting with Variance
 -issue#7732: Bind device IDs and escape graph and device HTML sinks
+-issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/include/global_languages.php
+++ b/include/global_languages.php
@@ -49,7 +49,7 @@ $lang2locale = get_list_of_locales();
  * This function uses gettext for translation and sprintf for formatting.
  * It supports different text domains and various formatting options.
  *
- * @return string - Returns the translated and formatted string, or false if no arguments are provided.
+ * @return string Returns the translated and formatted string, or an empty string when no arguments are provided.
  */
 if (!function_exists(__NAMESPACE__ . '\\__') && !function_exists('\\__')) {
 	function __() : string {
@@ -68,48 +68,48 @@ if (!function_exists(__NAMESPACE__ . '\\__') && !function_exists('\\__')) {
 			// convert pure text strings by using a different textdomain
 		}
 
-	/* only the last argument is allowed to initiate
-	   the use of a different textdomain */
+		/* only the last argument is allowed to initiate
+		   the use of a different textdomain */
 
-	// get gettext string
-	if (isset($i18n[(string) $args[$num - 1]]) && $args[$num - 1] != 'cacti') {
-		$args[0] = __gettext($args[0], $args[$num - 1]);
-	} else {
-		$args[0] = __gettext($args[0]);
-	}
+		// get gettext string
+		if (isset($i18n[(string) $args[$num - 1]]) && $args[$num - 1] != 'cacti') {
+			$args[0] = __gettext($args[0], $args[$num - 1]);
+		} else {
+			$args[0] = __gettext($args[0]);
+		}
 
-	$regex_num = '%([-]{0,1}[0-9]+([.][0-9]+){0,1}){0,1}';
-	$regex_str = '%([-]{0,1}[0-9]+){0,1}';
+		$regex_num = '%([-]{0,1}[0-9]+([.][0-9]+){0,1}){0,1}';
+		$regex_str = '%([-]{0,1}[0-9]+){0,1}';
 
-	$array_str = [
-		'b', // Binary
-		'o', // Integer as Octal
-		's', // String
-		'u', // Integer as Unsigned Decimal
-		'x', // Integer as hex (lowercase)
-		'X', // Integer as hex (uppercase)
-	];
+		$array_str = [
+			'b', // Binary
+			'o', // Integer as Octal
+			's', // String
+			'u', // Integer as Unsigned Decimal
+			'x', // Integer as hex (lowercase)
+			'X', // Integer as hex (uppercase)
+		];
 
-	$array_num = [
-		'd', // Decimal
-		'e', // Scientific notation (lowercase)
-		'E', // Scientific notation (uppercase)
-		'f', // Floating point (locale aware)
-		'F', // Floating point (non-locale aware)
-		'g', // General format (uses E and f styling if precision involved)
-		'G', // General format (docs say same as g but uses E and f, yet it already does???)
-		'h', // General format (like g but uses F)
-		'H', // General format (like g but uses E and F)
-	];
+		$array_num = [
+			'd', // Decimal
+			'e', // Scientific notation (lowercase)
+			'E', // Scientific notation (uppercase)
+			'f', // Floating point (locale aware)
+			'F', // Floating point (non-locale aware)
+			'g', // General format (uses E and f styling if precision involved)
+			'G', // General format (docs say same as g but uses E and f, yet it already does???)
+			'h', // General format (like g but uses F)
+			'H', // General format (like g but uses E and F)
+		];
 
-	$valid_args = [
-		'%%', // Escaped percentage (literal)
-		'%c', // Single Character
-		$regex_num . '[' . implode('', $array_num) . ']',
-		$regex_str . '[' . implode('', $array_str) . ']',
-	];
+		$valid_args = [
+			'%%', // Escaped percentage (literal)
+			'%c', // Single Character
+			$regex_num . '[' . implode('', $array_num) . ']',
+			$regex_str . '[' . implode('', $array_str) . ']',
+		];
 
-	$valid_regexp = '/(' . implode(')|(', $valid_args) . ')/';
+		$valid_regexp = '/(' . implode(')|(', $valid_args) . ')/';
 
 		if (preg_match($valid_regexp, $args[0])) {
 			// process return string against input arguments

--- a/include/global_languages.php
+++ b/include/global_languages.php
@@ -51,7 +51,7 @@ $lang2locale = get_list_of_locales();
  *
  * @return string Returns the translated and formatted string, or an empty string when no arguments are provided.
  */
-if (!function_exists(__NAMESPACE__ . '\\__') && !function_exists('\\__')) {
+if (!function_exists('__')) {
 	function __() : string {
 		global $i18n;
 
@@ -820,7 +820,6 @@ function __n(string|null $singular, string|null $plural, int $number, string $do
 function __uf(string|null $text) : string {
 	return str_replace('%%', '%', $text ?? '');
 }
-
 
 /**
  * Translates and pluralizes a string based on the given context and number.

--- a/include/global_languages.php
+++ b/include/global_languages.php
@@ -34,6 +34,92 @@ global $path2calendar, $path2timepicker, $path2colorpicker, $path2ms, $path2msfi
 // get a list of locale settings
 $lang2locale = get_list_of_locales();
 
+/*
+ * Declared before the fallback below returns.
+ *
+ * PHP hoists a top level function declaration, but not one inside a
+ * conditional, so this guarded declaration is only made when execution
+ * reaches it. Leaving it further down the file meant the disabled-i18n
+ * path returned first and left __() undefined for the rest of the request.
+ */
+
+/**
+ * Translates and formats a string based on the provided arguments.
+ *
+ * This function uses gettext for translation and sprintf for formatting.
+ * It supports different text domains and various formatting options.
+ *
+ * @return string - Returns the translated and formatted string, or false if no arguments are provided.
+ */
+if (!function_exists(__NAMESPACE__ . '\\__') && !function_exists('\\__')) {
+	function __() : string {
+		global $i18n;
+
+		$args = func_get_args();
+		$num  = func_num_args();
+
+		// this should not happen
+		if ($num < 1) {
+			return '';
+		}
+
+		if ($num == 1) {
+			return __gettext($args[0]);
+			// convert pure text strings by using a different textdomain
+		}
+
+	/* only the last argument is allowed to initiate
+	   the use of a different textdomain */
+
+	// get gettext string
+	if (isset($i18n[(string) $args[$num - 1]]) && $args[$num - 1] != 'cacti') {
+		$args[0] = __gettext($args[0], $args[$num - 1]);
+	} else {
+		$args[0] = __gettext($args[0]);
+	}
+
+	$regex_num = '%([-]{0,1}[0-9]+([.][0-9]+){0,1}){0,1}';
+	$regex_str = '%([-]{0,1}[0-9]+){0,1}';
+
+	$array_str = [
+		'b', // Binary
+		'o', // Integer as Octal
+		's', // String
+		'u', // Integer as Unsigned Decimal
+		'x', // Integer as hex (lowercase)
+		'X', // Integer as hex (uppercase)
+	];
+
+	$array_num = [
+		'd', // Decimal
+		'e', // Scientific notation (lowercase)
+		'E', // Scientific notation (uppercase)
+		'f', // Floating point (locale aware)
+		'F', // Floating point (non-locale aware)
+		'g', // General format (uses E and f styling if precision involved)
+		'G', // General format (docs say same as g but uses E and f, yet it already does???)
+		'h', // General format (like g but uses F)
+		'H', // General format (like g but uses E and F)
+	];
+
+	$valid_args = [
+		'%%', // Escaped percentage (literal)
+		'%c', // Single Character
+		$regex_num . '[' . implode('', $array_num) . ']',
+		$regex_str . '[' . implode('', $array_str) . ']',
+	];
+
+	$valid_regexp = '/(' . implode(')|(', $valid_args) . ')/';
+
+		if (preg_match($valid_regexp, $args[0])) {
+			// process return string against input arguments
+			return __uf(call_user_func_array('sprintf', $args));
+		} else {
+			return $args[0];
+		}
+	}
+}
+
 // use a fallback if i18n is disabled (default)
 if (!read_config_option('i18n_language_support') && read_config_option('i18n_language_support') != '') {
 	i18n_debug('load_fallback_procedure(1)');
@@ -735,82 +821,6 @@ function __uf(string|null $text) : string {
 	return str_replace('%%', '%', $text ?? '');
 }
 
-/**
- * Translates and formats a string based on the provided arguments.
- *
- * This function uses gettext for translation and sprintf for formatting.
- * It supports different text domains and various formatting options.
- *
- * @return string - Returns the translated and formatted string, or false if no arguments are provided.
- */
-if (!function_exists(__NAMESPACE__ . '\\__') && !function_exists('\\__')) {
-	function __() : string {
-		global $i18n;
-
-		$args = func_get_args();
-		$num  = func_num_args();
-
-		// this should not happen
-		if ($num < 1) {
-			return '';
-		}
-
-		if ($num == 1) {
-			return __gettext($args[0]);
-			// convert pure text strings by using a different textdomain
-		}
-
-	/* only the last argument is allowed to initiate
-	   the use of a different textdomain */
-
-	// get gettext string
-	if (isset($i18n[(string) $args[$num - 1]]) && $args[$num - 1] != 'cacti') {
-		$args[0] = __gettext($args[0], $args[$num - 1]);
-	} else {
-		$args[0] = __gettext($args[0]);
-	}
-
-	$regex_num = '%([-]{0,1}[0-9]+([.][0-9]+){0,1}){0,1}';
-	$regex_str = '%([-]{0,1}[0-9]+){0,1}';
-
-	$array_str = [
-		'b', // Binary
-		'o', // Integer as Octal
-		's', // String
-		'u', // Integer as Unsigned Decimal
-		'x', // Integer as hex (lowercase)
-		'X', // Integer as hex (uppercase)
-	];
-
-	$array_num = [
-		'd', // Decimal
-		'e', // Scientific notation (lowercase)
-		'E', // Scientific notation (uppercase)
-		'f', // Floating point (locale aware)
-		'F', // Floating point (non-locale aware)
-		'g', // General format (uses E and f styling if precision involved)
-		'G', // General format (docs say same as g but uses E and f, yet it already does???)
-		'h', // General format (like g but uses F)
-		'H', // General format (like g but uses E and F)
-	];
-
-	$valid_args = [
-		'%%', // Escaped percentage (literal)
-		'%c', // Single Character
-		$regex_num . '[' . implode('', $array_num) . ']',
-		$regex_str . '[' . implode('', $array_str) . ']',
-	];
-
-	$valid_regexp = '/(' . implode(')|(', $valid_args) . ')/';
-
-		if (preg_match($valid_regexp, $args[0])) {
-			// process return string against input arguments
-			return __uf(call_user_func_array('sprintf', $args));
-		} else {
-			return $args[0];
-		}
-	}
-}
 
 /**
  * Translates and pluralizes a string based on the given context and number.

--- a/tests/Unit/I18nFallbackTranslateTest.php
+++ b/tests/Unit/I18nFallbackTranslateTest.php
@@ -29,15 +29,25 @@ require_once dirname(__DIR__) . '/Helpers/IsolatedProbe.php';
  * owns.
  */
 
+function i18n_fallback_verdict() : array {
+	static $verdict;
+
+	if ($verdict === null) {
+		$verdict = cacti_test_isolated_probe(__DIR__ . '/fixtures/i18n_fallback_probe.php', ['0']);
+	}
+
+	return $verdict;
+}
+
 test('the translation API survives the disabled-i18n fallback', function () {
-	$verdict = cacti_test_isolated_probe(__DIR__ . '/fixtures/i18n_fallback_probe.php', ['0']);
+	$verdict = i18n_fallback_verdict();
 
 	expect($verdict['translate_exists'])->toBeTrue();
 	expect($verdict['translated'])->toBe('Version 1.3.0');
 });
 
 test('the unconditionally declared translation helpers are unaffected', function () {
-	$verdict = cacti_test_isolated_probe(__DIR__ . '/fixtures/i18n_fallback_probe.php', ['0']);
+	$verdict = i18n_fallback_verdict();
 
 	// These are plain top level declarations, so PHP hoists them and the early
 	// return never hid them. Asserted so a future move of __() that also moves

--- a/tests/Unit/I18nFallbackTranslateTest.php
+++ b/tests/Unit/I18nFallbackTranslateTest.php
@@ -49,7 +49,7 @@ test('the unconditionally declared translation helpers are unaffected', function
 test('__() is declared before the fallback can return', function () {
 	$src = file_get_contents(dirname(__DIR__, 2) . '/include/global_languages.php');
 
-	$declared = strpos($src, "if (!function_exists(__NAMESPACE__ . '\\\\__')");
+	$declared = strpos($src, "if (!function_exists('__'))");
 	$fallback = strpos($src, 'load_fallback_procedure();');
 
 	expect($declared)->not->toBeFalse();

--- a/tests/Unit/I18nFallbackTranslateTest.php
+++ b/tests/Unit/I18nFallbackTranslateTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__) . '/Helpers/IsolatedProbe.php';
+
+/*
+ * include/global_languages.php returns early to a fallback locale when
+ * i18n_language_support is off. __() is declared inside a function_exists()
+ * guard, and PHP does not hoist a conditional declaration, so that return used
+ * to leave __() undefined for the rest of the request.
+ *
+ * include/global.php defines CACTI_VERSION_BRIEF through get_cacti_version_text()
+ * immediately after loading this file, so the first thing to touch the missing
+ * function was Cacti's own startup: cli/install_cacti.php died with
+ * "Call to undefined function __()" before printing anything.
+ *
+ * The probe loads the file in its own process because it declares names lib/
+ * owns.
+ */
+
+test('the translation API survives the disabled-i18n fallback', function () {
+	$verdict = cacti_test_isolated_probe(__DIR__ . '/fixtures/i18n_fallback_probe.php', ['0']);
+
+	expect($verdict['translate_exists'])->toBeTrue();
+	expect($verdict['translated'])->toBe('Version 1.3.0');
+});
+
+test('the unconditionally declared translation helpers are unaffected', function () {
+	$verdict = cacti_test_isolated_probe(__DIR__ . '/fixtures/i18n_fallback_probe.php', ['0']);
+
+	// These are plain top level declarations, so PHP hoists them and the early
+	// return never hid them. Asserted so a future move of __() that also moves
+	// these is caught.
+	expect($verdict['esc_exists'])->toBeTrue();
+	expect($verdict['gettext_exists'])->toBeTrue();
+});
+
+test('__() is declared before the fallback can return', function () {
+	$src = file_get_contents(dirname(__DIR__, 2) . '/include/global_languages.php');
+
+	$declared = strpos($src, "if (!function_exists(__NAMESPACE__ . '\\\\__')");
+	$fallback = strpos($src, 'load_fallback_procedure();');
+
+	expect($declared)->not->toBeFalse();
+	expect($fallback)->not->toBeFalse();
+	expect($declared)->toBeLessThan($fallback);
+});

--- a/tests/Unit/fixtures/i18n_fallback_probe.php
+++ b/tests/Unit/fixtures/i18n_fallback_probe.php
@@ -32,6 +32,7 @@ define('CACTI_LANGUAGE_HANDLER_DEFAULT', 0);
 define('SESS_USER_LANGUAGE', 'sess_user_language');
 
 $i18n_support = $argv[1] ?? '0';
+$GLOBALS['i18n_support'] = $i18n_support;
 
 $config = ['base_path' => $root, 'include_path' => $root . '/include'];
 

--- a/tests/Unit/fixtures/i18n_fallback_probe.php
+++ b/tests/Unit/fixtures/i18n_fallback_probe.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Probe for I18nFallbackTranslateTest. Run through cacti_test_isolated_probe();
+ * prints a JSON verdict on stdout.
+ *
+ * Loads include/global_languages.php with i18n support switched off, which is
+ * the path that returns early to the fallback locale, and reports whether the
+ * translation API survived the trip. It needs its own process because the
+ * fakes below carry names lib/ declares.
+ *
+ * argv[1] is the value read_config_option() reports for i18n_language_support.
+ */
+
+$root = dirname(__DIR__, 3);
+
+define('CACTI_PATH_INCLUDE', $root . '/include');
+define('CACTI_PATH_BASE', $root);
+define('CACTI_LANGUAGE_HANDLER_DEFAULT', 0);
+define('SESS_USER_LANGUAGE', 'sess_user_language');
+
+$i18n_support = $argv[1] ?? '0';
+
+$config = ['base_path' => $root, 'include_path' => $root . '/include'];
+
+function read_config_option($name, $force = false) {
+	return $name === 'i18n_language_support' ? $GLOBALS['i18n_support'] : '';
+}
+
+function cacti_sizeof($array) {
+	return ($array === false || !is_array($array)) ? 0 : sizeof($array);
+}
+
+function cacti_count($array) {
+	return cacti_sizeof($array);
+}
+
+function db_fetch_assoc($sql, $log = true) {
+	return [];
+}
+
+function db_fetch_cell($sql, $col = '', $log = true) {
+	return false;
+}
+
+function isempty_request_var($name) {
+	return true;
+}
+
+function set_request_var($name, $value) {
+}
+
+function get_request_var($name, $default = '') {
+	return $default;
+}
+
+function grv($name, $default = '') {
+	return $default;
+}
+
+function cacti_log($message, $output = false, $environ = 'CMDPHP', $level = 0) {
+}
+
+function cacti_strtoupper($string) {
+	return strtoupper((string) $string);
+}
+
+function cacti_strtolower($string) {
+	return strtolower((string) $string);
+}
+
+require_once CACTI_PATH_INCLUDE . '/global_languages.php';
+
+print json_encode([
+	'i18n_support'     => $i18n_support,
+	'translate_exists' => function_exists('__'),
+	'esc_exists'       => function_exists('__esc'),
+	'gettext_exists'   => function_exists('__gettext'),
+	'translated'       => function_exists('__') ? __('Version %s', '1.3.0') : null,
+]);


### PR DESCRIPTION
`cli/install_cacti.php` dies before printing anything on current `develop`:

```
PHP Fatal error: Uncaught Error: Call to undefined function __()
  in lib/functions.php:7975
#0 lib/functions.php(8042): format_cacti_version_text('1.3.0.99.0.UNKN...')
#1 include/global.php(700): get_cacti_version_text()
#2 include/cli_check.php(54): include('...')
#3 cli/install_cacti.php(26): require('...')
```

### Cause

`include/global_languages.php` returns early to a fallback locale when i18n support is off:

```php
if (!read_config_option('i18n_language_support') && read_config_option('i18n_language_support') != '') {
	i18n_debug('load_fallback_procedure(1)');
	load_fallback_procedure();

	return;
}
```

`__()` was declared 700 lines below that, inside a `function_exists()` guard. PHP hoists a top level function declaration but **not** one inside a conditional, so `__()` only exists once execution reaches it. The early return meant it never did.

That is also why only `__()` broke. `__esc()`, `__gettext()`, `__n()` and `__uf()` are plain top level declarations further down the same file, and hoisting covered them. Confirmed by probing the fallback path directly:

```
{"translate_exists":false,"esc_exists":true,"gettext_exists":true}
```

`include/global.php:700` defines `CACTI_VERSION_BRIEF` through `get_cacti_version_text()` on the line after loading this file, so the first thing to touch the missing function is Cacti's own startup.

### Why it fires on a fresh install

The condition needs the setting to read falsy but not empty. On a newly loaded schema there is no `i18n_language_support` row, and the `'1'` default in `include/global_settings.php` is not available yet — that file loads at `global.php:710`, ten lines after the call that fails.

### The change

Two things, both in `include/global_languages.php`:

1. The guarded `__()` declaration moves above the fallback. This is the fix; the diff is large only because it relocates a 68 line block.
2. The guard itself is simplified from `!function_exists(__NAMESPACE__ . '\\__') && !function_exists('\\__')` to `!function_exists('__')`. The file declares no namespace, so `__NAMESPACE__ . '\\__'` was `'\__'`, and `function_exists()` ignores a leading backslash — the two clauses were the same test written twice.

Plus a CHANGELOG entry and the test below.

### Verification

Reproduced end to end against MariaDB 10.6 with `cacti.sql` freshly loaded:

- **before:** `cli/install_cacti.php --accept-eula --install --force` dies at `global.php:700` with the trace above
- **after:** startup clears line 700 and proceeds to `global.php:710`

The test loads `global_languages.php` with i18n disabled through `cacti_test_isolated_probe()`, in its own process because the probe declares names `lib/` owns. It asserts the translation API survived, that the hoisted helpers were never affected, and that `__()` is declared before the fallback can return so another move cannot reintroduce this.

### Context

Found because it fails the `Plugin Integration Tests` workflow in `Cacti/plugin_thold`, which checks out `Cacti/cacti` unpinned and installs it via the CLI. Every open pull request there is currently red on it.

The four red checks here are pre-existing on `develop` — same four fail on the branch itself, and are unrelated to this change. `Cacti Commit Audit` is one of them, and #7752 fixes one of its causes.
