### PR TITLE
fix(test): correct the UnitStubs path in the two tests left at Unit/Core

### DIFF
--- a/tests/Unit/Core/PhpstanLevel6BaselineFixesTest.php
+++ b/tests/Unit/Core/PhpstanLevel6BaselineFixesTest.php
@@ -41,7 +41,7 @@
  * reported by PHPStan all contain the post-fix shape.
  */
 
-$repoRoot = __DIR__ . '/../..';
+$repoRoot = __DIR__ . '/../../..';
 $sources  = [
 	'aggregate_graphs.php' => file_get_contents("$repoRoot/aggregate_graphs.php"),
 	'color_templates.php'  => file_get_contents("$repoRoot/color_templates.php"),

--- a/tests/Unit/Core/TimeTest.php
+++ b/tests/Unit/Core/TimeTest.php
@@ -14,7 +14,7 @@
 
 // UnitStubs MUST be loaded before lib/time.php so srv() and other helpers are
 // resolvable when shift_time() is exercised.
-require_once dirname(__DIR__, 3) . '/Helpers/UnitStubs.php';
+require_once dirname(__DIR__, 2) . '/Helpers/UnitStubs.php';
 require_once dirname(__DIR__, 3) . '/include/global_constants.php';
 require_once dirname(__DIR__, 3) . '/lib/time.php';
 

--- a/tests/Unit/Core/UtilityTest.php
+++ b/tests/Unit/Core/UtilityTest.php
@@ -12,7 +12,7 @@
  +-------------------------------------------------------------------------+
 */
 
-require_once dirname(__DIR__, 3) . '/Helpers/UnitStubs.php';
+require_once dirname(__DIR__, 2) . '/Helpers/UnitStubs.php';
 
 it('cacti_sizeof handles various inputs', function () {
 	expect(cacti_sizeof([1, 2, 3]))->toBe(3);

--- a/tests/Unit/DataCollection/Poller/DsstatsRrdcheckBarrierTest.php
+++ b/tests/Unit/DataCollection/Poller/DsstatsRrdcheckBarrierTest.php
@@ -31,7 +31,7 @@
  * before trusting the drain loop's running-count poll.
  */
 
-require_once __DIR__ . '/../Helpers/UnitStubs.php';
+require_once __DIR__ . '/../../../Helpers/UnitStubs.php';
 require_once __DIR__ . '/../../../../lib/dsstats.php';
 require_once __DIR__ . '/../../../../lib/rrdcheck.php';
 

--- a/tests/Unit/Security/InputValidation/ValidatorConstraintAuditTest.php
+++ b/tests/Unit/Security/InputValidation/ValidatorConstraintAuditTest.php
@@ -17,7 +17,7 @@ if (!defined('VALIDATOR_AUDIT_LIB_ONLY')) {
 	define('VALIDATOR_AUDIT_LIB_ONLY', true);
 }
 
-require_once __DIR__ . '/../tools/validator_constraint_audit.php';
+require_once __DIR__ . '/../../../tools/validator_constraint_audit.php';
 
 function validator_scan(string $php): array {
 	return validator_scan_source("<?php\n" . $php);

--- a/tests/Unit/Security/SqlInjection/SqlInterpolationAuditTest.php
+++ b/tests/Unit/Security/SqlInjection/SqlInterpolationAuditTest.php
@@ -17,7 +17,7 @@ if (!defined('SQL_AUDIT_LIB_ONLY')) {
 	define('SQL_AUDIT_LIB_ONLY', true);
 }
 
-require_once __DIR__ . '/../tools/sql_interpolation_audit.php';
+require_once __DIR__ . '/../../../tools/sql_interpolation_audit.php';
 
 function audit_db_functions(): array {
 	return array(


### PR DESCRIPTION
The unit run on `develop` aborts before executing a single test:

```
PHP Warning: require_once(/home/runner/work/cacti/cacti/Helpers/UnitStubs.php):
  Failed to open stream: No such file or directory
  in tests/Unit/Core/TimeTest.php on line 17
ERROR Failed opening required '/home/runner/work/cacti/cacti/Helpers/UnitStubs.php'
```

The require is at file scope, so the failure takes the whole suite down rather than one test.

### Cause

`#7733` moved these files one directory deeper. Their `dirname(__DIR__, 3)` still points at where they used to sit, which now resolves to the repository root rather than `tests/`.

From `tests/Unit/Core/`, `tests/Helpers/` is two levels up, not three.

### Scope

Two files, and only two. I checked every `dirname(__DIR__, N) . '/Helpers/...'` in the tree by resolving each against the filesystem:

```
resolve correctly: 69
broken: 2
  tests/Unit/Core/UtilityTest.php  (depth 3 -> /Helpers/UnitStubs.php)
  tests/Unit/Core/TimeTest.php     (depth 3 -> /Helpers/UnitStubs.php)
```

The other 69 are genuinely three levels below `tests/` because they sit under a further subdirectory, so `3` is right for them. These two are the only ones left directly at `Unit/Core`.

### Context

Found while looking into why `Cacti Commit Audit` is red on `develop`. This is one cause; it is not the only red check on that branch.
