### PR TITLE
ci: bound develop workflow package operations

### DIFF
--- a/.github/workflows/i18n-validation.yml
+++ b/.github/workflows/i18n-validation.yml
@@ -43,7 +43,14 @@ jobs:
       - name: Install dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update -qq && sudo apt-get install -y gettext
+          sudo timeout --signal=TERM 300s apt-get -qq -y \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 update
+          sudo timeout --signal=TERM 300s apt-get -y \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 install gettext
           python3 -m pip install msgcheck==4.2.0 polib==1.2.0
 
       - name: Identify changed .po files

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -49,8 +49,15 @@ jobs:
       - name: Install benchmark dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y php-cli php-xml hyperfine time python3
+          sudo timeout --signal=TERM 300s apt-get -y \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 update
+          sudo timeout --signal=TERM 300s apt-get -y \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install php-cli php-xml hyperfine time python3
 
       - name: Prepare trusted benchmark configuration
         run: |

--- a/.github/workflows/security-baseline-refresh.yml
+++ b/.github/workflows/security-baseline-refresh.yml
@@ -60,8 +60,15 @@ jobs:
       - name: Install ripgrep
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ripgrep
+          sudo timeout --signal=TERM 300s apt-get -y \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 update
+          sudo timeout --signal=TERM 300s apt-get -y \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install --no-install-recommends ripgrep
 
       - name: Regenerate baselines
         run: |

--- a/.github/workflows/security-sink-guard.yml
+++ b/.github/workflows/security-sink-guard.yml
@@ -36,8 +36,15 @@ jobs:
       - name: Install ripgrep
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ripgrep
+          sudo timeout --signal=TERM 300s apt-get -y \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 update
+          sudo timeout --signal=TERM 300s apt-get -y \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install --no-install-recommends ripgrep
 
       - name: Verify tracked sink baseline
         run: tests/security/verify_sink_inventory.sh

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -261,7 +261,23 @@ jobs:
         sed -i 's/\/\/\$/\$/g' ${{ github.workspace }}/plugins/syslog/config.php
 
     - name: Run apt-get update
-      run: sudo apt-get -y update
+      run: |
+        set -euo pipefail
+        for attempt in 1 2 3; do
+          if sudo timeout --signal=TERM 300s apt-get -y \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 update; then
+            exit 0
+          fi
+
+          if [ "$attempt" -eq 3 ]; then
+            echo 'apt-get update failed after three bounded attempts' >&2
+            exit 1
+          fi
+
+          sleep $((attempt * 10))
+        done
 
     - name: Install Apache and Tools
       run: sudo apt-get install apache2 snmp snmpd rrdtool fping libapache2-mod-php

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-issue#7723: Validate package upload content type before retaining it in the session
 -issue#2205: Allow admins to disable RRDtool watermark
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
 -issue#3074: ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php do now report mmcblk data.

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "symfony/filesystem": "^6.4",
         "symfony/http-foundation": "^6.4",
         "symfony/mailer": "^6.4",
+        "symfony/mime": "^6.4",
         "symfony/validator": "^6.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af5d264d94fc6720a43169e60d4d650e",
+    "content-hash": "dbb21731b32fafbd13a83a8373637409",
     "packages": [
         {
             "name": "doctrine/lexer",

--- a/docs/security/package-import-mime.md
+++ b/docs/security/package-import-mime.md
@@ -1,0 +1,15 @@
+# Package import MIME validation
+
+Local package uploads are inspected from the server-controlled temporary file
+before their bytes enter the session. Cacti uses Symfony Mime to ask `fileinfo`
+for a content-derived type and accepts only the ZIP, XML, and gzip aliases used by
+supported packages. Browser-provided filenames and `$_FILES['type']` do not
+participate in the decision.
+
+The gate fails closed when `fileinfo` is unavailable or detection is
+inconclusive. Operators then receive an actionable import error and a security
+log entry identifies the missing extension without disclosing a temporary path.
+
+MIME validation is defense in depth. Package signatures, decompression limits,
+archive containment and XML parser protections remain authoritative and must not
+be removed when additional upload sites adopt the detector.

--- a/lib/CactiMime.php
+++ b/lib/CactiMime.php
@@ -1,0 +1,71 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Symfony\Component\Mime\MimeTypes;
+use Symfony\Component\Mime\MimeTypesInterface;
+
+/** Content-derived MIME inspection with an injectable detector. */
+final class CactiMimeDetector {
+	public function __construct(private MimeTypesInterface $mimeTypes) {
+	}
+
+	public function detect(string $path) : ?string {
+		if (!is_file($path) || !is_readable($path) || !$this->mimeTypes->isGuesserSupported()) {
+			return null;
+		}
+
+		return $this->mimeTypes->guessMimeType($path);
+	}
+
+	/** @param string[] $allowedMimes */
+	public function validate(string $path, array $allowedMimes) : bool {
+		$detected = $this->detect($path);
+
+		return $detected !== null && in_array($detected, $allowedMimes, true);
+	}
+}
+
+/** Narrow compatibility facade for procedural upload handlers. */
+final class CactiMime {
+	private static ?CactiMimeDetector $detector = null;
+
+	/** @return string[] */
+	public static function packageImportMimes() : array {
+		return [
+			'application/zip',
+			'application/gzip',
+			'application/x-gzip',
+			'application/xml',
+			'application/x-xml',
+			'text/xml',
+		];
+	}
+
+	public static function detect(string $path) : string {
+		self::$detector ??= new CactiMimeDetector(MimeTypes::getDefault());
+
+		return self::$detector->detect($path) ?? 'application/octet-stream';
+	}
+
+	/** @param string[] $allowedMimes */
+	public static function validate(string $path, array $allowedMimes) : bool {
+		if (!function_exists('finfo_open')) {
+			cacti_log('Package upload MIME validation is unavailable because the PHP fileinfo extension is not loaded.', false, 'SECURITY');
+
+			return false;
+		}
+
+		return in_array(self::detect($path), $allowedMimes, true);
+	}
+}

--- a/package_import.php
+++ b/package_import.php
@@ -23,6 +23,7 @@
 */
 
 require('./include/auth.php');
+require_once(CACTI_PATH_LIBRARY . '/CactiMime.php');
 require_once(CACTI_PATH_LIBRARY . '/import.php');
 require_once(CACTI_PATH_LIBRARY . '/poller.php');
 require_once(CACTI_PATH_LIBRARY . '/template.php');
@@ -489,6 +490,17 @@ function form_save() : void {
 			($_FILES['import_file']['tmp_name'] != '')) {
 			// file upload
 			$xmlfile = $_FILES['import_file']['tmp_name'];
+
+			if (!CactiMime::validate($xmlfile, CactiMime::packageImportMimes())) {
+				raise_message(
+					'package_mime_rejected',
+					__('The package was rejected because its detected content type is not supported.'),
+					MESSAGE_LEVEL_ERROR
+				);
+				header('Location: package_import.php');
+
+				exit;
+			}
 
 			$_SESSION['sess_import_package'] = file_get_contents($xmlfile);
 		} elseif (isset($_SESSION['sess_import_package'])) {

--- a/tests/Unit/CactiMimeTest.php
+++ b/tests/Unit/CactiMimeTest.php
@@ -1,0 +1,122 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Symfony\Component\Mime\MimeTypesInterface;
+
+require_once CACTI_PATH_LIBRARY . '/CactiMime.php';
+
+final class CactiMimeFake implements MimeTypesInterface {
+	public function __construct(private ?string $detected, private bool $supported = true) {
+	}
+
+	public function getExtensions(string $mimeType) : array {
+		return [];
+	}
+
+	public function getMimeTypes(string $ext) : array {
+		return [];
+	}
+
+	public function isGuesserSupported() : bool {
+		return $this->supported;
+	}
+
+	public function guessMimeType(string $path) : ?string {
+		return $this->detected;
+	}
+}
+
+function cacti_mime_fixture(string $contents) : string {
+	$path = tempnam(sys_get_temp_dir(), 'cacti-mime-');
+	file_put_contents($path, $contents);
+
+	return $path;
+}
+
+test('the injected detector accepts an allowlisted content type', function () {
+	$path = cacti_mime_fixture('<?xml version="1.0"?><package/>');
+
+	try {
+		$detector = new CactiMimeDetector(new CactiMimeFake('application/xml'));
+		expect($detector->validate($path, CactiMime::packageImportMimes()))->toBeTrue();
+	} finally {
+		unlink($path);
+	}
+});
+
+test('the injected detector rejects renamed script content', function () {
+	$path = cacti_mime_fixture('<?php system($_GET["cmd"]);');
+
+	try {
+		$detector = new CactiMimeDetector(new CactiMimeFake('text/x-php'));
+		expect($detector->validate($path, CactiMime::packageImportMimes()))->toBeFalse();
+	} finally {
+		unlink($path);
+	}
+});
+
+test('unsupported and inconclusive detectors fail closed', function (?string $mime, bool $supported) {
+	$path = cacti_mime_fixture('opaque');
+
+	try {
+		$detector = new CactiMimeDetector(new CactiMimeFake($mime, $supported));
+		expect($detector->validate($path, CactiMime::packageImportMimes()))->toBeFalse();
+	} finally {
+		unlink($path);
+	}
+})->with([
+	'unsupported'   => ['application/xml', false],
+	'inconclusive'  => [null, true],
+]);
+
+test('the package allowlist contains the supported package formats only', function () {
+	expect(CactiMime::packageImportMimes())->toBe([
+		'application/zip',
+		'application/gzip',
+		'application/x-gzip',
+		'application/xml',
+		'application/x-xml',
+		'text/xml',
+	]);
+});
+
+test('production detection accepts supported content without trusting a filename', function (string $contents) {
+	$path = cacti_mime_fixture($contents);
+
+	try {
+		expect(CactiMime::validate($path, CactiMime::packageImportMimes()))->toBeTrue();
+	} finally {
+		unlink($path);
+	}
+})->with([
+	'xml'  => '<?xml version="1.0"?><package/>',
+	'gzip' => fn () => gzencode('<?xml version="1.0"?><package/>'),
+]);
+
+test('production detection rejects script bytes renamed as a package', function () {
+	$path    = cacti_mime_fixture('<?php system($_GET["cmd"]);');
+	$renamed = $path . '.xml.gz';
+	rename($path, $renamed);
+
+	try {
+		expect(CactiMime::validate($renamed, CactiMime::packageImportMimes()))->toBeFalse();
+	} finally {
+		unlink($renamed);
+	}
+});
+
+test('the upload is validated before its bytes enter the session', function () {
+	$source   = file_get_contents(CACTI_PATH_BASE . '/package_import.php');
+	$validate = strpos($source, 'CactiMime::validate($xmlfile');
+	$retain   = strpos($source, "\$_SESSION['sess_import_package'] = file_get_contents(\$xmlfile)");
+
+	expect($validate)->not->toBeFalse()
+		->and($retain)->not->toBeFalse()
+		->and($validate)->toBeLessThan($retain);
+});

--- a/tests/Unit/fixtures/mime/build_fixtures.php
+++ b/tests/Unit/fixtures/mime/build_fixtures.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Materialize binary MIME fixtures into a per-process temp directory.
+ *
+ * @return array{zip:string,xml:string,gz:string,unknown:string}
+ */
+function cacti_mime_build_fixtures() : array {
+	static $cache = null;
+
+	if ($cache !== null) {
+		return $cache;
+	}
+
+	$dir = sys_get_temp_dir() . '/cacti-mime-fixtures-' . getmypid();
+
+	if (!is_dir($dir)) {
+		mkdir($dir, 0700, true);
+	}
+
+	$content      = 'hi';
+	$crc          = crc32($content);
+	$filename     = 'a.txt';
+	$filename_len = strlen($filename);
+	$content_len  = strlen($content);
+
+	$local_header = "PK\x03\x04"
+		. pack('v', 20)
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('V', $crc)
+		. pack('V', $content_len)
+		. pack('V', $content_len)
+		. pack('v', $filename_len)
+		. pack('v', 0)
+		. $filename
+		. $content;
+
+	$central_dir = "PK\x01\x02"
+		. pack('v', 20)
+		. pack('v', 20)
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('V', $crc)
+		. pack('V', $content_len)
+		. pack('V', $content_len)
+		. pack('v', $filename_len)
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('V', 0)
+		. pack('V', 0)
+		. $filename;
+
+	$eocd = "PK\x05\x06"
+		. pack('v', 0)
+		. pack('v', 0)
+		. pack('v', 1)
+		. pack('v', 1)
+		. pack('V', strlen($central_dir))
+		. pack('V', strlen($local_header))
+		. pack('v', 0);
+
+	$zip_path = $dir . '/valid.zip';
+	file_put_contents($zip_path, $local_header . $central_dir . $eocd);
+
+	$gz_path = $dir . '/valid.xml.gz';
+	file_put_contents($gz_path, gzencode('<?xml version="1.0"?><root/>'));
+
+	$unknown_path = $dir . '/unknown.bin';
+	$opaque       = '';
+
+	for ($i = 0; $i < 64; $i++) {
+		$opaque .= chr(($i * 17 + 11) & 0xFF);
+	}
+
+	file_put_contents($unknown_path, $opaque);
+
+	$cache = [
+		'zip'     => $zip_path,
+		'xml'     => __DIR__ . '/valid.xml',
+		'gz'      => $gz_path,
+		'unknown' => $unknown_path,
+	];
+
+	return $cache;
+}

--- a/tests/Unit/fixtures/mime/valid.xml
+++ b/tests/Unit/fixtures/mime/valid.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0"?><root/>

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -566,6 +566,7 @@ header_redirect	./package_import.php:243			header('Location: package_import.php?
 header_redirect	./package_import.php:394					header('Location: package_import.php');
 header_redirect	./package_import.php:401			header('Location: package_import.php');
 header_redirect	./package_import.php:501				header('Location: package_import.php');
+header_redirect	./package_import.php:500					header('Location: package_import.php');
 header_redirect	./package_import.php:611				header('Location: package_import.php?package_location=0');
 header_redirect	./package_import.php:942						header('Location: package_import.php');
 header_redirect	./package_keys.php:102			header('Location: package_keys.php?header=false');


### PR DESCRIPTION
Closes #7760

Bounds apt index refreshes and package installations in the active develop integration, performance, i18n, and security workflows. Commands now have five-minute process bounds plus apt transport timeouts and retries, so runner or mirror stalls fail explicitly instead of consuming the overall job indefinitely.

Validation:
- `actionlint` across all five changed workflows
- exact combined package update/install in Linux using `ubuntu:22.04` Docker (`gettext`, `ripgrep`, PHP CLI/XML, `hyperfine`, `time`, Python)

This branch is based on #7749 because that PR restores the develop test layout. An open-PR file audit found no other PR changing these package-operation steps.