### PR TITLE
ci: stabilize PPA and apt refresh on 1.2.x

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -164,6 +164,11 @@ jobs:
         else
           sudo timeout --signal=TERM 60s add-apt-repository -y --no-update ppa:ondrej/php
         fi
+        for source in /etc/apt/apt-mirrors.txt /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
+          if [ -f "$source" ]; then
+            sudo sed -i 's#http://azure.archive.ubuntu.com/ubuntu#https://archive.ubuntu.com/ubuntu#g' "$source"
+          fi
+        done
         for attempt in 1 2 3; do
           if sudo timeout --signal=TERM 300s apt-get -y \
             -o Acquire::Retries=3 \

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -162,7 +162,7 @@ jobs:
         if grep -Rqs 'ondrej/php' /etc/apt/sources.list /etc/apt/sources.list.d/; then
           echo 'ondrej/php already configured, skipping add-apt-repository'
         else
-          sudo add-apt-repository -y ppa:ondrej/php
+          sudo timeout --signal=TERM 60s add-apt-repository -y --no-update ppa:ondrej/php
         fi
         for attempt in 1 2 3; do
           if sudo timeout --signal=TERM 300s apt-get -y \

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -162,11 +162,14 @@ jobs:
         if grep -Rqs 'ondrej/php' /etc/apt/sources.list /etc/apt/sources.list.d/; then
           echo 'ondrej/php already configured, skipping add-apt-repository'
         else
-          sudo timeout --signal=TERM 60s add-apt-repository -y --no-update ppa:ondrej/php
+          if ! sudo timeout --signal=TERM 60s add-apt-repository -y --no-update ppa:ondrej/php; then
+            echo 'add-apt-repository failed or timed out after 60 seconds' >&2
+            exit 1
+          fi
         fi
         for source in /etc/apt/apt-mirrors.txt /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources; do
           if [ -f "$source" ]; then
-            sudo sed -i 's#http://azure.archive.ubuntu.com/ubuntu#https://archive.ubuntu.com/ubuntu#g' "$source"
+            sudo sed -E -i 's#https?://azure.archive.ubuntu.com/ubuntu#https://archive.ubuntu.com/ubuntu#g' "$source"
           fi
         done
         for attempt in 1 2 3; do


### PR DESCRIPTION
Closes #7762

Prevents `add-apt-repository` from starting an unbounded implicit apt refresh, bounds repository registration to 60 seconds, replaces the hosted runner’s unreachable Azure archive entry with Ubuntu’s canonical archive, and leaves the retrying `apt-get update` as the single controlled refresh.

Linux Docker validation (`ubuntu:22.04`):
- verified `--no-update` support and bounded PPA registration
- verified the Azure-to-canonical mirror rewrite against a synthetic runner mirror file
- completed the explicit bounded apt refresh
- `actionlint` reports no new finding in the changed step

Post-merge follow-up to #7756; no other open PR contains this change.