### PR TITLE
ci(security): scope Semgrep SARIF to changed PHP files

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -61,7 +61,7 @@ jobs:
           esac
 
           if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
-            base_sha="$(git rev-parse HEAD^)"
+            base_sha="$(git rev-parse --verify HEAD^ 2>/dev/null || git rev-parse --verify HEAD)"
           fi
 
           git cat-file -e "${base_sha}^{commit}"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,9 +1,9 @@
 name: Semgrep (Cacti taint rules)
 
 # Runs the Cacti-aware Semgrep rules (tests/security/semgrep/cacti-security.yml).
-# The rule self-test is a hard gate; the whole-tree scan is advisory and its
+# The rule self-test is a hard gate; the differential scan is advisory and its
 # findings are published to the code-scanning tab rather than failing the build
-# (see tests/security/semgrep/README.md for why it is not a pass/fail baseline).
+# (see tests/security/semgrep/README.md for why it is not a pass/fail gate).
 
 on:
   push:
@@ -32,7 +32,40 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Resolve scan baseline
+        id: baseline
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          case "$EVENT_NAME" in
+            pull_request)
+              base_sha="$PR_BASE_SHA"
+              ;;
+            push)
+              base_sha="$PUSH_BASE_SHA"
+              ;;
+            merge_group)
+              base_sha="$MERGE_GROUP_BASE_SHA"
+              ;;
+            *)
+              base_sha=""
+              ;;
+          esac
+
+          if [[ -z "$base_sha" || "$base_sha" =~ ^0+$ ]]; then
+            base_sha="$(git rev-parse HEAD^)"
+          fi
+
+          git cat-file -e "${base_sha}^{commit}"
+          echo "sha=$base_sha" >> "$GITHUB_OUTPUT"
 
       - name: Self-test the rules (blocking)
         run: |
@@ -45,23 +78,42 @@ jobs:
             semgrep/semgrep@sha256:e04d2cb132288d90035db8791d64f610cb255b21e727b94db046243b30c01ae9 \
             semgrep --test tests/security/semgrep/
 
-      - name: Advisory scan (non-blocking)
+      - name: Advisory differential scan (non-blocking)
         continue-on-error: true
         run: |
           set -euo pipefail
+
+          targets=()
+
+          while IFS= read -r path; do
+            case "$path" in
+              include/vendor/*|plugins/*|tests/*)
+                ;;
+              *)
+                targets+=("$path")
+                ;;
+            esac
+          done < <(git diff --name-only --diff-filter=ACMR \
+            "${{ steps.baseline.outputs.sha }}" HEAD -- '*.php')
+
+          if (( ${#targets[@]} == 0 )); then
+            empty_target="$(mktemp --suffix=.php "${RUNNER_TEMP}/semgrep-empty.XXXXXX")"
+            targets=("$empty_target")
+          fi
+
           docker run --rm \
             --user "$(id -u):$(id -g)" \
             --env HOME=/tmp \
             --volume "${PWD}:/src" \
+            --volume "${RUNNER_TEMP}:${RUNNER_TEMP}" \
             --workdir /src \
             semgrep/semgrep@sha256:e04d2cb132288d90035db8791d64f610cb255b21e727b94db046243b30c01ae9 \
             semgrep scan \
             --config tests/security/semgrep/cacti-security.yml \
-            --exclude 'include/vendor' --exclude 'tests' --exclude 'plugins' \
             --exclude '*.min.js' \
             --timeout 0 --timeout-threshold 0 --max-target-bytes 0 \
             --metrics off --sarif --output semgrep.sarif \
-            lib/ include/ ./*.php
+            "${targets[@]}"
 
       - name: Upload findings to code scanning
         uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/tests/security/semgrep/README.md
+++ b/tests/security/semgrep/README.md
@@ -36,13 +36,15 @@ Two steps:
    runs the rules against the annotated fixtures and fails if a rule stops
    matching what it should (or starts matching what it should not). This keeps
    the rules honest without depending on a whole-tree scan.
-2. **Advisory scan (non-blocking)** — a full scan whose findings are uploaded
-   to the GitHub code-scanning tab. It does not fail the build: `grv()` returns
-   the *validated* value when the page registered a filter, which Semgrep
-   cannot see, so a whole-tree run includes known-safe sites, and taint
-   analysis over Cacti's large files is not perfectly deterministic run to run.
-   A baseline pass/fail gate on that is flaky by nature, so findings are
-   surfaced for review rather than gated.
+2. **Advisory changed-file scan (non-blocking)** — compares the checked-out
+   commit with the pull request base, the previous pushed commit, or the merge
+   group's base, then scans only changed PHP files outside `include/vendor`,
+   `plugins`, and `tests`. It does not fail the build: `grv()` returns the
+   *validated* value when the page registered a filter, which Semgrep cannot
+   see, so a whole-tree result includes known-safe sites, and taint analysis
+   over Cacti's large files is not perfectly deterministic run to run.
+   File-scoped results keep that historical noise out of unrelated pull
+   requests while still surfacing request-to-sink flows in changed code.
 
 A finding is a prompt to confirm, not proof of a bug: check whether the source
 is actually unvalidated on that path, then fix (bind the value, cast, or

--- a/tests/security/semgrep/README.md
+++ b/tests/security/semgrep/README.md
@@ -38,13 +38,15 @@ Two steps:
    the rules honest without depending on a whole-tree scan.
 2. **Advisory changed-file scan (non-blocking)** — compares the checked-out
    commit with the pull request base, the previous pushed commit, or the merge
-   group's base, then scans only changed PHP files outside `include/vendor`,
-   `plugins`, and `tests`. It does not fail the build: `grv()` returns the
-   *validated* value when the page registered a filter, which Semgrep cannot
-   see, so a whole-tree result includes known-safe sites, and taint analysis
-   over Cacti's large files is not perfectly deterministic run to run.
-   File-scoped results keep that historical noise out of unrelated pull
-   requests while still surfacing request-to-sink flows in changed code.
+   group's base. Manual runs use the previous commit when one exists; on a
+   parentless commit they use the current commit and therefore have no changed
+   PHP files. The scan includes only changed PHP files outside
+   `include/vendor`, `plugins`, and `tests`. It does not fail the build: `grv()`
+   returns the *validated* value when the page registered a filter, which
+   Semgrep cannot see, so a whole-tree result includes known-safe sites, and
+   taint analysis over Cacti's large files is not perfectly deterministic run
+   to run. File-scoped results keep that historical noise out of unrelated
+   pull requests while still surfacing request-to-sink flows in changed code.
 
 A finding is a prompt to confirm, not proof of a bug: check whether the source
 is actually unvalidated on that path, then fix (bind the value, cast, or


### PR DESCRIPTION
## Summary

- scope the advisory Cacti Semgrep scan to PHP files changed from the event baseline
- upload an empty, valid SARIF result when a change contains no in-scope PHP files
- fetch full history and resolve the correct baseline for pull requests, pushes, merge queues, and manual runs
- document the changed-file ratchet
- bring the RRD coverage workflow into compliance with the repository's Linux workflow policy

## Why

The whole-tree custom taint scan uploads roughly 420 known-baseline, low-confidence findings on every unrelated pull request. Semgrep's built-in baseline mode was also nondeterministic for these large PHP taint rules: an unchanged PHP tree produced eight false "new" findings in the pinned Linux image. Scanning only changed PHP files gives stable PR signal and lets the next develop analysis close the existing alert flood without disabling the rules.

The repository policy check also identified an existing RRD coverage workflow violation, so this PR pins Ubuntu 24.04, adds a job timeout, and disables persisted checkout credentials.

## Validation

- `actionlint` passed for both changed workflows
- pinned Linux Semgrep image: rule self-tests, 3/3 passed
- pinned Linux Semgrep image: no-PHP-change SARIF, 0 results and 0 errors
- pinned Linux Semgrep image: changed-file scan of `vdef.php`, 10 expected findings and 0 errors
- Ubuntu 24.04: temporary target creation verified
- Linux Python 3.12: workflow policy checks passed
- GitHub Actions: Cacti Semgrep, workflow policy, and RRD coverage checks passed
- repository hooks through mise PHP 8.2: PHP lint, PHP CS Fixer, and PHPStan passed

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>