### PR TITLE
fix(import): tell operators when MIME detection is unavailable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 Cacti CHANGELOG
 
 1.3.0-dev
--issue#7723: Validate package upload content type before retaining it in the session
 -issue#2205: Allow admins to disable RRDtool watermark
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
 -issue#3074: ss_net_snmp_disk_bytes.php and ss_net_snmp_disk_io.php do now report mmcblk data.
@@ -101,6 +100,7 @@ Cacti CHANGELOG
 -issue#7697: Guard two divisions PHP 8 made fatal
 -issue#7693: Validate host_id before it reaches the graph template query
 -issue#7719: Spike Kill text output applied the large value scientific notation format to the column left of the value it belonged to, starting with Variance
+-issue#7723: Validate package upload content type before retaining it in the session
 -issue#7732: Bind device IDs and escape graph and device HTML sinks
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php

--- a/docs/security/package-import-mime.md
+++ b/docs/security/package-import-mime.md
@@ -8,7 +8,8 @@ participate in the decision.
 
 The gate fails closed when `fileinfo` is unavailable or detection is
 inconclusive. Operators then receive an actionable import error and a security
-log entry identifies the missing extension without disclosing a temporary path.
+log entry identifies the missing or disabled extension without disclosing a
+temporary path.
 
 MIME validation is defense in depth. Package signatures, decompression limits,
 archive containment and XML parser protections remain authoritative and must not

--- a/lib/CactiMime.php
+++ b/lib/CactiMime.php
@@ -66,7 +66,7 @@ final class CactiMime {
 	/** @param string[] $allowedMimes */
 	public static function validate(string $path, array $allowedMimes) : bool {
 		if (!self::detectionAvailable()) {
-			cacti_log('Package upload MIME validation is unavailable because the PHP fileinfo extension is not loaded.', false, 'SECURITY');
+			cacti_log('Package upload MIME validation is unavailable because the PHP fileinfo extension is missing or disabled.', false, 'SECURITY');
 
 			return false;
 		}

--- a/lib/CactiMime.php
+++ b/lib/CactiMime.php
@@ -58,9 +58,14 @@ final class CactiMime {
 		return self::$detector->detect($path) ?? 'application/octet-stream';
 	}
 
+	/** Callers use this to tell a rejected type apart from an unusable detector. */
+	public static function detectionAvailable() : bool {
+		return function_exists('finfo_open');
+	}
+
 	/** @param string[] $allowedMimes */
 	public static function validate(string $path, array $allowedMimes) : bool {
-		if (!function_exists('finfo_open')) {
+		if (!self::detectionAvailable()) {
 			cacti_log('Package upload MIME validation is unavailable because the PHP fileinfo extension is not loaded.', false, 'SECURITY');
 
 			return false;

--- a/package_import.php
+++ b/package_import.php
@@ -492,11 +492,19 @@ function form_save() : void {
 			$xmlfile = $_FILES['import_file']['tmp_name'];
 
 			if (!CactiMime::validate($xmlfile, CactiMime::packageImportMimes())) {
-				raise_message(
-					'package_mime_rejected',
-					__('The package was rejected because its detected content type is not supported.'),
-					MESSAGE_LEVEL_ERROR
-				);
+				if (CactiMime::detectionAvailable()) {
+					raise_message(
+						'package_mime_rejected',
+						__('The package was rejected because its detected content type is not supported.'),
+						MESSAGE_LEVEL_ERROR
+					);
+				} else {
+					raise_message(
+						'package_mime_unavailable',
+						__('The package was rejected because content type detection is unavailable. Install the PHP fileinfo extension and retry the import.'),
+						MESSAGE_LEVEL_ERROR
+					);
+				}
 				header('Location: package_import.php');
 
 				exit;

--- a/package_import.php
+++ b/package_import.php
@@ -501,7 +501,7 @@ function form_save() : void {
 				} else {
 					raise_message(
 						'package_mime_unavailable',
-						__('The package was rejected because content type detection is unavailable. Install the PHP fileinfo extension and retry the import.'),
+						__('The package was rejected because content type detection is unavailable. Install or enable the PHP fileinfo extension and retry the import.'),
 						MESSAGE_LEVEL_ERROR
 					);
 				}

--- a/tests/HandOff/CactiMimeHandOffTest.php
+++ b/tests/HandOff/CactiMimeHandOffTest.php
@@ -15,6 +15,7 @@
 if (!file_exists(__DIR__ . '/../../lib/CactiMime.php')) {
 	test('CactiMime hand-off: feature not present on this branch', function () {})
 		->skip('lib/CactiMime.php absent — feature PR #7074 not merged into develop yet');
+
 	return;
 }
 
@@ -42,8 +43,8 @@ if (!function_exists('cacti_log')) {
  *   - The allowlist returned by packageImportMimes() drives the caller's
  *     accept/reject branch (the same branch that issues raise_message +
  *     header('Location: ...') in package_import.php form_save()).
- *   - When libmagic is absent, validate(strict=true) returns false and
- *     that boolean propagates to the caller's reject path.
+ *   - When libmagic is absent, validate() returns false and that boolean
+ *     propagates to the caller's reject path.
  */
 
 beforeAll(function () {
@@ -148,23 +149,23 @@ test('allowlist drives the caller reject branch for a PHP payload renamed .zip',
 	unlink($tmp_name);
 });
 
-test('libmagic absence drives validate(strict=true) to false at the caller boundary', function () {
-	// CactiMimeTest already verifies the strict-mode boolean inside the
+test('libmagic absence drives validate() to false at the caller boundary', function () {
+	// CactiMimeTest already verifies the fail-closed boolean inside the
 	// class via a subprocess. This hand-off variant asserts the same
 	// boolean reaches the caller's reject branch -- the one that emits
-	// the "import_mime_unavailable" raise_message and redirects the user.
+	// the "package_mime_unavailable" raise_message and redirects the user.
 	$fx         = cacti_mime_build_fixtures();
-	$scriptPath = tempnam(sys_get_temp_dir(), 'cacti-mime-handoff-strict-');
+	$scriptPath = tempnam(sys_get_temp_dir(), 'cacti-mime-handoff-unavailable-');
 	$libPath    = realpath(__DIR__ . '/../../lib/CactiMime.php');
 
 	// The subprocess models the caller's boundary explicitly: it
 	// invokes validate() and prints the exact branch token the caller
-	// would take (ACCEPT or REJECT). When finfo is disabled, strict
-	// mode must yield REJECT.
+	// would take (ACCEPT or REJECT). When finfo is disabled it must
+	// yield REJECT.
 	$script  = "<?php\n";
 	$script .= 'require_once ' . var_export($libPath, true) . ";\n";
 	$script .= "if (!function_exists('cacti_log')) { function cacti_log(\$s,\$o=false,\$e='CMDPHP',\$l=''){ return true; } }\n";
-	$script .= '$ok = CactiMime::validate($argv[1], CactiMime::packageImportMimes(), true);' . "\n";
+	$script .= '$ok = CactiMime::validate($argv[1], CactiMime::packageImportMimes());' . "\n";
 	$script .= 'echo $ok ? "ACCEPT" : "REJECT";' . "\n";
 
 	file_put_contents($scriptPath, $script);

--- a/tests/Unit/CactiMimeTest.php
+++ b/tests/Unit/CactiMimeTest.php
@@ -120,3 +120,15 @@ test('the upload is validated before its bytes enter the session', function () {
 		->and($retain)->not->toBeFalse()
 		->and($validate)->toBeLessThan($retain);
 });
+
+test('an unusable detector and a rejected type produce different operator messages', function () {
+	$source = file_get_contents(CACTI_PATH_BASE . '/package_import.php');
+
+	expect($source)->toContain('package_mime_rejected')
+		->and($source)->toContain('package_mime_unavailable')
+		->and($source)->toContain('CactiMime::detectionAvailable()');
+});
+
+test('detectionAvailable reports the fileinfo extension', function () {
+	expect(CactiMime::detectionAvailable())->toBe(function_exists('finfo_open'));
+});


### PR DESCRIPTION
Follow-up to the Copilot review on #7758, which merged before the comments were addressed.

Three of the four comments held up.

`CactiMime::validate()` returns false both when the detected type is not allowlisted and when the fileinfo extension is missing, but `package_import.php` reported only the first. `docs/security/package-import-mime.md` already promises an actionable error for the fileinfo case, so the caller now asks `CactiMime::detectionAvailable()` and raises `package_mime_unavailable` with the extension to install. Fail-closed behavior is unchanged.

`tests/HandOff/CactiMimeHandOffTest.php` called `validate($path, $mimes, true)` and named the test after a `strict` parameter the class never had. PHP ignores the extra argument, so nothing failed, but the test read as if fail-closed were opt-in. Argument and naming dropped; fail-closed is unconditional.

`-issue#7723` sat at the top of the 1.3.0-dev block instead of in numeric order. Moved between 7719 and 7732.

The fourth comment, stale line numbers in `sink_inventory.baseline.tsv`, is not a defect. `tests/security/verify_sink_inventory.sh` strips the trailing `:LINE` before comparing, deliberately, so that line drift from an unrelated edit or a develop merge does not trip the gate. The verifier passes on this branch.

Verification, PHP 8.4:

```
pest           1846 passed, 25 skipped, 2 failed (OrbEnvironmentTest, no Orb locally)
php -l         clean
php-cs-fixer   0 of 391 files need fixing
phpstan L6     no errors
tests/tools/pre-commit          guard-rails passed
verify_sink_inventory.sh        OK
check_hardening_patterns.php    clean
```
