### PR TITLE
Serialize process registry admission with portable locks

### DIFF
--- a/.github/workflows/process-lock-coverage.yml
+++ b/.github/workflows/process-lock-coverage.yml
@@ -1,0 +1,66 @@
+name: Process Lock Coverage
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - '.github/workflows/process-lock-coverage.yml'
+      - '.github/actions/setup-php-composer/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'lib/CactiProcessLock.php'
+      - 'phpunit-process-lock.xml'
+      - 'tests/Unit/Core/CactiProcessLockTest.php'
+  pull_request:
+    branches: [develop]
+    paths:
+      - '.github/workflows/process-lock-coverage.yml'
+      - '.github/actions/setup-php-composer/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'lib/CactiProcessLock.php'
+      - 'phpunit-process-lock.xml'
+      - 'tests/Unit/Core/CactiProcessLockTest.php'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: process-lock-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  COMPOSER_ALLOW_SUPERUSER: 1
+
+jobs:
+  coverage:
+    name: Process lock 100% coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Setup locked PHP 8.1 dependencies
+        uses: ./.github/actions/setup-php-composer
+        with:
+          php-version: '8.1'
+          coverage: xdebug
+          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
+          dependency-mode: locked-process-lock-coverage
+          install-args: --prefer-dist --no-progress --no-interaction
+
+      - name: Enforce line coverage
+        env:
+          XDEBUG_MODE: coverage
+        run: |
+          set -euo pipefail
+          include/vendor/bin/pest \
+            --configuration=phpunit-process-lock.xml \
+            --coverage \
+            --coverage-text \
+            --min=100

--- a/.github/workflows/process-lock-coverage.yml
+++ b/.github/workflows/process-lock-coverage.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup locked PHP 8.1 dependencies
+      - name: Setup locked PHP 8.2 dependencies
         uses: ./.github/actions/setup-php-composer
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: xdebug
           extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
           dependency-mode: locked-process-lock-coverage

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -96,6 +96,7 @@ Cacti CHANGELOG
 -issue#6240: Fix sorting exception in rrdtool_function_create function
 -issue#6255: Fix not showing any graphs in the subtree if there are only graphs without devices
 -issue#6258: Rename 'Data' to 'Data/Statistics' per customer request
+-issue#6515: Serialize process registry admission with database-backed Symfony locks
 -issue#6545: Add 30 and 60 second timeout options for Remote Agent and Poller settings
 -issue#6573: Create new device_change_javascript hook for THOLD plugin by xmacan
 -issue#6669: Show on the Technical Support page whether php-snmp is in use or disabled by $php_snmp_support

--- a/cacti.sql
+++ b/cacti.sql
@@ -2669,6 +2669,17 @@ CREATE TABLE `processes` (
 ) ENGINE=MEMORY COMMENT='Stores Process Status for Cacti Background Processes';
 
 --
+-- Table structure for table `process_locks`
+--
+
+CREATE TABLE `process_locks` (
+  `key_id` varchar(64) NOT NULL,
+  `key_token` varchar(44) NOT NULL,
+  `key_expiration` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`key_id`)
+) ENGINE=InnoDB COMMENT='Serializes Cacti Process Registry Mutations';
+
+--
 -- Table structure for table `reports`
 --
 

--- a/cli/float_rrdfiles.php
+++ b/cli/float_rrdfiles.php
@@ -719,8 +719,11 @@ function float_kill_running_processes() : void {
 
 	if (cacti_sizeof($processes)) {
 		foreach ($processes as $p) {
-			cacti_log(sprintf('WARNING: Killing Cleanup %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'RFLOAT');
-			posix_kill($p['pid'], SIGTERM);
+			if (cacti_process_still_running((int) $p['pid'])) {
+				cacti_log(sprintf('WARNING: Killing Cleanup %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'RFLOAT');
+
+				posix_kill($p['pid'], SIGTERM);
+			}
 
 			unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], $p['pid']);
 		}

--- a/cli/poller_reindex_hosts.php
+++ b/cli/poller_reindex_hosts.php
@@ -466,8 +466,11 @@ function reindex_kill_running_processes() : void {
 
 	if (cacti_sizeof($processes)) {
 		foreach ($processes as $p) {
-			cacti_log(sprintf('WARNING: Killing Cleanup %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'REINDEX');
-			posix_kill($p['pid'], SIGTERM);
+			if (cacti_process_still_running((int) $p['pid'])) {
+				cacti_log(sprintf('WARNING: Killing Cleanup %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'REINDEX');
+
+				posix_kill($p['pid'], SIGTERM);
+			}
 
 			unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], $p['pid']);
 		}

--- a/cli/rebuild_poller_cache.php
+++ b/cli/rebuild_poller_cache.php
@@ -424,8 +424,11 @@ function pushout_kill_running_processes() : void {
 
 	if (cacti_sizeof($processes)) {
 		foreach ($processes as $p) {
-			cacti_log(sprintf('WARNING: Killing Cleanup %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'PUSHOUT');
-			posix_kill($p['pid'], SIGTERM);
+			if (cacti_process_still_running((int) $p['pid'])) {
+				cacti_log(sprintf('WARNING: Killing Cleanup %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'PUSHOUT');
+
+				posix_kill($p['pid'], SIGTERM);
+			}
 
 			unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], $p['pid']);
 		}

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "symfony/filesystem": "^7.4",
         "symfony/finder": "^6.4 || ^7.4",
         "symfony/http-foundation": "^7.4",
+        "symfony/lock": "^7.4",
         "symfony/mailer": "^7.4",
         "symfony/notifier": "^7.4",
         "symfony/validator": "^7.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31db7cf9f6ccd957f9f3bfb6e8824256",
+    "content-hash": "4eb5102f259eb58a970cdf42f1740c74",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -2390,6 +2390,89 @@
                 }
             ],
             "time": "2026-08-20T09:55:18+00:00"
+        },
+        {
+            "name": "symfony/lock",
+            "version": "v7.4.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/lock.git",
+                "reference": "4073e583b1cb048799706d7ba3245328858cfea6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/lock/zipball/4073e583b1cb048799706d7ba3245328858cfea6",
+                "reference": "4073e583b1cb048799706d7ba3245328858cfea6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/cache": "<6.4"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "symfony/serializer": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Lock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérémy Derussé",
+                    "email": "jeremy@derusse.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Creates and manages locks, a mechanism to provide exclusive access to a shared resource",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cas",
+                "flock",
+                "locking",
+                "mutex",
+                "redlock",
+                "semaphore"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/lock/tree/v7.4.18"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-30T20:10:52+00:00"
         },
         {
             "name": "symfony/mailer",

--- a/install/upgrades/1_3_0.php
+++ b/install/upgrades/1_3_0.php
@@ -23,6 +23,13 @@
 */
 
 function upgrade_to_1_3_0() : void {
+	db_install_execute("CREATE TABLE IF NOT EXISTS process_locks (
+		key_id varchar(64) NOT NULL,
+		key_token varchar(44) NOT NULL,
+		key_expiration int(10) unsigned NOT NULL,
+		PRIMARY KEY (key_id)
+	) ENGINE=InnoDB COMMENT='Serializes Cacti Process Registry Mutations'");
+
 	db_install_change_column('version', ['name' => 'cacti', 'type' => 'char(30)', 'null' => false, 'default' => '']);
 
 	db_install_add_column('user_auth', ['name' => 'tfa_enabled', 'type' => 'char(3)', 'null' => false, 'default' => '']);

--- a/lib/CactiProcessLock.php
+++ b/lib/CactiProcessLock.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ */
+
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+use Symfony\Component\Lock\Store\PdoStore;
+
+/**
+ * Short-lived, database-backed mutex for one Cacti process-registry key.
+ *
+ * The processes table remains the source of lifecycle, PID and timeout
+ * information. This lock only serializes admission for one logical registry
+ * row so two contenders cannot both observe an empty row and start.
+ */
+final class CactiProcessLock {
+	public const TABLE = 'process_locks';
+	public const TTL   = 30;
+
+	private LockInterface $lock;
+
+	public function __construct(LockFactory $factory, string $tasktype, string $taskname, int $taskid) {
+		$this->lock = $factory->createLock(self::key($tasktype, $taskname, $taskid), self::TTL);
+	}
+
+	public static function fromPdo(PDO $connection, string $tasktype, string $taskname, int $taskid) : self {
+		$store = new PdoStore($connection, ['db_table' => self::TABLE], 0.01, self::TTL);
+
+		return new self(new LockFactory($store), $tasktype, $taskname, $taskid);
+	}
+
+	public static function key(string $tasktype, string $taskname, int $taskid) : string {
+		return 'cacti.process.' . hash('sha256', serialize([$tasktype, $taskname, $taskid]));
+	}
+
+	public function acquire() : bool {
+		return $this->lock->acquire();
+	}
+
+	public function release() : void {
+		$this->lock->release();
+	}
+}

--- a/lib/CactiProcessLock.php
+++ b/lib/CactiProcessLock.php
@@ -33,15 +33,20 @@ final class CactiProcessLock {
 	public const TTL   = 30;
 
 	private LockInterface $lock;
+	private ?PDO $connection;
 
-	public function __construct(LockFactory $factory, string $tasktype, string $taskname, int $taskid) {
-		$this->lock = $factory->createLock(self::key($tasktype, $taskname, $taskid), self::TTL);
+	public function __construct(LockFactory $factory, string $tasktype, string $taskname, int $taskid, ?PDO $connection = null) {
+		$this->lock       = $factory->createLock(self::key($tasktype, $taskname, $taskid), self::TTL);
+		$this->connection = $connection;
 	}
 
 	public static function fromPdo(PDO $connection, string $tasktype, string $taskname, int $taskid) : self {
-		$store = new PdoStore($connection, ['db_table' => self::TABLE], 0.01, self::TTL);
+		$store = self::withExceptionMode(
+			$connection,
+			static fn () : PdoStore => new PdoStore($connection, ['db_table' => self::TABLE], 0.01, self::TTL)
+		);
 
-		return new self(new LockFactory($store), $tasktype, $taskname, $taskid);
+		return new self(new LockFactory($store), $tasktype, $taskname, $taskid, $connection);
 	}
 
 	public static function key(string $tasktype, string $taskname, int $taskid) : string {
@@ -49,10 +54,36 @@ final class CactiProcessLock {
 	}
 
 	public function acquire() : bool {
-		return $this->lock->acquire();
+		return $this->runWithRequiredMode(fn () : bool => $this->lock->acquire());
 	}
 
 	public function release() : void {
-		$this->lock->release();
+		$this->runWithRequiredMode(function () : void {
+			$this->lock->release();
+		});
+	}
+
+	private function runWithRequiredMode(callable $operation) : mixed {
+		if ($this->connection === null) {
+			return $operation();
+		}
+
+		return self::withExceptionMode($this->connection, $operation);
+	}
+
+	private static function withExceptionMode(PDO $connection, callable $operation) : mixed {
+		$original = $connection->getAttribute(PDO::ATTR_ERRMODE);
+
+		if ($original !== PDO::ERRMODE_EXCEPTION) {
+			$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+		}
+
+		try {
+			return $operation();
+		} finally {
+			if ($original !== PDO::ERRMODE_EXCEPTION) {
+				$connection->setAttribute(PDO::ATTR_ERRMODE, $original);
+			}
+		}
 	}
 }

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -2854,8 +2854,8 @@ function register_process_start(string $tasktype, string $taskname, int $taskid 
  *
  * @param string $tasktype Mandatory task type.
  * @param string $taskname Mandatory task name.
- * @param int    $taskid   Optional task id.
- * @param int    $timeout  Optional timeout.
+ * @param int    $taskid   Task id supplied by register_process_start().
+ * @param int    $timeout  Timeout supplied by register_process_start().
  *
  * @return bool True when this process may start.
  */

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -22,6 +22,8 @@
  +-------------------------------------------------------------------------+
 */
 
+require_once __DIR__ . '/CactiProcessLock.php';
+
 /**
  * exec_poll - executes a command and returns its output
  *
@@ -2772,6 +2774,36 @@ function cacti_process_pid_exists(int $pid) : bool {
 }
 
 /**
+ * Creates a database-backed mutex for one logical process-registry entry.
+ *
+ * @param string $tasktype The task type.
+ * @param string $taskname The task name.
+ * @param int    $taskid   The task id.
+ *
+ * @return CactiProcessLock|false The lock, or false when it cannot be created.
+ */
+function cacti_process_registry_lock(string $tasktype, string $taskname, int $taskid) : CactiProcessLock|false {
+	global $database_default, $database_hostname, $database_port, $database_sessions;
+
+	$key        = "$database_hostname:$database_port:$database_default";
+	$connection = $database_sessions[$key] ?? null;
+
+	if (!$connection instanceof PDO) {
+		cacti_log(sprintf('ERROR: Process registry lock has no database connection! (%s, %s, %s)', $tasktype, $taskname, $taskid), false, 'POLLER');
+
+		return false;
+	}
+
+	try {
+		return CactiProcessLock::fromPdo($connection, $tasktype, $taskname, $taskid);
+	} catch (Throwable $e) {
+		cacti_log(sprintf('ERROR: Unable to create process registry lock! (%s, %s, %s): %s', $tasktype, $taskname, $taskid, $e->getMessage()), false, 'POLLER');
+
+		return false;
+	}
+}
+
+/**
  * register_process_start - public function to register a process
  * in Cacti's process table
  *
@@ -2784,11 +2816,51 @@ function cacti_process_pid_exists(int $pid) : bool {
  *              another version is running and has not ended.
  */
 function register_process_start(string $tasktype, string $taskname, int $taskid = 0, int $timeout = 300) : bool {
-	$pid = getmypid();
-
 	if (!db_table_exists('processes')) {
 		return true;
 	}
+
+	$lock = cacti_process_registry_lock($tasktype, $taskname, $taskid);
+
+	if ($lock === false) {
+		return false;
+	}
+
+	try {
+		if (!$lock->acquire()) {
+			cacti_log(sprintf('NOTE: Process registry is being updated by another process! (%s, %s, %s)', $tasktype, $taskname, $taskid), false, 'POLLER', POLLER_VERBOSITY_MEDIUM);
+
+			return false;
+		}
+	} catch (Throwable $e) {
+		cacti_log(sprintf('ERROR: Unable to acquire process registry lock! (%s, %s, %s): %s', $tasktype, $taskname, $taskid, $e->getMessage()), false, 'POLLER');
+
+		return false;
+	}
+
+	try {
+		return register_process_start_locked($tasktype, $taskname, $taskid, $timeout);
+	} finally {
+		try {
+			$lock->release();
+		} catch (Throwable $e) {
+			cacti_log(sprintf('WARNING: Unable to release process registry lock! (%s, %s, %s): %s', $tasktype, $taskname, $taskid, $e->getMessage()), false, 'POLLER');
+		}
+	}
+}
+
+/**
+ * Performs registration while register_process_start() owns the task mutex.
+ *
+ * @param string $tasktype Mandatory task type.
+ * @param string $taskname Mandatory task name.
+ * @param int    $taskid   Optional task id.
+ * @param int    $timeout  Optional timeout.
+ *
+ * @return bool True when this process may start.
+ */
+function register_process_start_locked(string $tasktype, string $taskname, int $taskid, int $timeout) : bool {
+	$pid = getmypid();
 
 	$r = db_fetch_row_prepared('SELECT *,
 		IF(UNIX_TIMESTAMP(started) + timeout < UNIX_TIMESTAMP(), UNIX_TIMESTAMP(started), 0) AS timeout_exceeded,

--- a/lib/rrdcheck.php
+++ b/lib/rrdcheck.php
@@ -1013,9 +1013,11 @@ function rrdcheck_kill_running_processes() : void {
 
 	if (cacti_sizeof($processes)) {
 		foreach ($processes as $p) {
-			cacti_log(sprintf('WARNING: Killing rrdcheck %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'BOOST');
+			if (cacti_process_still_running((int) $p['pid'])) {
+				cacti_log(sprintf('WARNING: Killing rrdcheck %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'BOOST');
 
-			posix_kill($p['pid'], SIGTERM);
+				posix_kill($p['pid'], SIGTERM);
+			}
 
 			unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], $p['pid']);
 		}

--- a/phpunit-process-lock.xml
+++ b/phpunit-process-lock.xml
@@ -1,0 +1,16 @@
+<phpunit bootstrap="include/vendor/autoload.php" beStrictAboutOutputDuringTests="false">
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <env name="CACTI_TEST_BOOTSTRAP" value="1"/>
+    </php>
+    <source>
+        <include>
+            <file>lib/CactiProcessLock.php</file>
+        </include>
+    </source>
+    <testsuites>
+        <testsuite name="Process lock coverage">
+            <file>tests/Unit/Core/CactiProcessLockTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -412,9 +412,11 @@ function boost_kill_running_processes() : void {
 
 	if (cacti_sizeof($processes)) {
 		foreach ($processes as $p) {
-			cacti_log(sprintf('WARNING: Killing Boost %s PID %d due to another boost process starting.', ucfirst($p['taskname']), $p['pid']), true, 'BOOST');
+			if (cacti_process_still_running((int) $p['pid'])) {
+				cacti_log(sprintf('WARNING: Killing Boost %s PID %d due to another boost process starting.', ucfirst($p['taskname']), $p['pid']), true, 'BOOST');
 
-			posix_kill($p['pid'], SIGTERM);
+				posix_kill($p['pid'], SIGTERM);
+			}
 
 			unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], $p['pid']);
 		}

--- a/poller_commands.php
+++ b/poller_commands.php
@@ -422,8 +422,11 @@ function commands_kill_running_processes() : void {
 
 	if (cacti_sizeof($processes)) {
 		foreach ($processes as $p) {
-			cacti_log(sprintf('WARNING: Killing Commands %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'CLEANUP');
-			posix_kill($p['pid'], SIGTERM);
+			if (cacti_process_still_running((int) $p['pid'])) {
+				cacti_log(sprintf('WARNING: Killing Commands %s PID %d due to another due to signal or overrun.', ucfirst($p['taskname']), $p['pid']), false, 'CLEANUP');
+
+				posix_kill($p['pid'], SIGTERM);
+			}
 
 			unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], $p['pid']);
 		}

--- a/tests/Unit/Core/CactiProcessLockTest.php
+++ b/tests/Unit/Core/CactiProcessLockTest.php
@@ -1,0 +1,66 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ */
+
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
+
+require_once dirname(__DIR__, 3) . '/lib/CactiProcessLock.php';
+
+test('task keys are deterministic and preserve field boundaries', function () {
+	$key = CactiProcessLock::key('poller', 'child', 7);
+
+	expect($key)->toBe(CactiProcessLock::key('poller', 'child', 7))
+		->and($key)->toStartWith('cacti.process.')
+		->and(strlen($key))->toBe(78)
+		->and($key)->not->toBe(CactiProcessLock::key('poller:child', '7', 0))
+		->and($key)->not->toBe(CactiProcessLock::key('poller', 'child', 8));
+});
+
+test('only one owner can hold a task lock at a time', function () {
+	$factory = new LockFactory(new InMemoryStore());
+	$first   = new CactiProcessLock($factory, 'poller', 'master', 0);
+	$second  = new CactiProcessLock($factory, 'poller', 'master', 0);
+
+	expect($first->acquire())->toBeTrue()
+		->and($second->acquire())->toBeFalse();
+
+	$first->release();
+
+	expect($second->acquire())->toBeTrue();
+
+	$second->release();
+});
+
+test('pdo locks use the declared schema and release ownership', function () {
+	$connection = new PDO('sqlite::memory:');
+	$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+	$first  = CactiProcessLock::fromPdo($connection, 'reports', 'master', 0);
+	$second = CactiProcessLock::fromPdo($connection, 'reports', 'master', 0);
+
+	expect($first->acquire())->toBeTrue()
+		->and($connection->query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'process_locks'")->fetchColumn())->toBe(CactiProcessLock::TABLE)
+		->and($second->acquire())->toBeFalse();
+
+	$first->release();
+
+	expect($second->acquire())->toBeTrue();
+
+	$second->release();
+});

--- a/tests/Unit/Core/CactiProcessLockTest.php
+++ b/tests/Unit/Core/CactiProcessLockTest.php
@@ -49,18 +49,23 @@ test('only one owner can hold a task lock at a time', function () {
 
 test('pdo locks use the declared schema and release ownership', function () {
 	$connection = new PDO('sqlite::memory:');
-	$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+	$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
 	$first  = CactiProcessLock::fromPdo($connection, 'reports', 'master', 0);
 	$second = CactiProcessLock::fromPdo($connection, 'reports', 'master', 0);
 
-	expect($first->acquire())->toBeTrue()
+	expect($connection->getAttribute(PDO::ATTR_ERRMODE))->toBe(PDO::ERRMODE_SILENT)
+		->and($first->acquire())->toBeTrue()
+		->and($connection->getAttribute(PDO::ATTR_ERRMODE))->toBe(PDO::ERRMODE_SILENT)
 		->and($connection->query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'process_locks'")->fetchColumn())->toBe(CactiProcessLock::TABLE)
 		->and($second->acquire())->toBeFalse();
 
 	$first->release();
 
-	expect($second->acquire())->toBeTrue();
+	expect($connection->getAttribute(PDO::ATTR_ERRMODE))->toBe(PDO::ERRMODE_SILENT)
+		->and($second->acquire())->toBeTrue();
 
 	$second->release();
+
+	expect($connection->getAttribute(PDO::ATTR_ERRMODE))->toBe(PDO::ERRMODE_SILENT);
 });

--- a/tests/Unit/Poller/KillRunningProcessesGuardTest.php
+++ b/tests/Unit/Poller/KillRunningProcessesGuardTest.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+// A pid read from the processes table may have been recycled by an unrelated
+// process after a crash, so every kill_running_processes() variant has to
+// confirm the pid is still ours before signalling it (issue #7425).
+test('every kill_running_processes signals only a process confirmed still running', function () {
+	$root = dirname(__DIR__, 3);
+
+	$files = [
+		'/lib/dsstats.php',
+		'/lib/rrdcheck.php',
+		'/poller_boost.php',
+		'/poller_commands.php',
+		'/cli/float_rrdfiles.php',
+		'/cli/poller_reindex_hosts.php',
+		'/cli/rebuild_poller_cache.php',
+	];
+
+	foreach ($files as $file) {
+		$source = file_get_contents($root . $file);
+
+		expect($source)->not->toBeFalse();
+
+		$offset = 0;
+
+		while (($at = strpos($source, "posix_kill(\$p['pid'], SIGTERM)", $offset)) !== false) {
+			$preceding = substr($source, max(0, $at - 400), min(400, $at));
+
+			expect($preceding)->toContain(
+				'cacti_process_still_running',
+				'unguarded posix_kill in ' . $file
+			);
+
+			$offset = $at + 1;
+		}
+	}
+});

--- a/tests/Unit/Poller/KillRunningProcessesGuardTest.php
+++ b/tests/Unit/Poller/KillRunningProcessesGuardTest.php
@@ -33,10 +33,10 @@ test('every kill_running_processes signals only a process confirmed still runnin
 		while (($at = strpos($source, "posix_kill(\$p['pid'], SIGTERM)", $offset)) !== false) {
 			$preceding = substr($source, max(0, $at - 400), min(400, $at));
 
-			expect($preceding)->toContain(
-				'cacti_process_still_running',
-				'unguarded posix_kill in ' . $file
-			);
+			// toContain() takes needles, not a message, so assert plainly and
+			// name the file through the surrounding loop instead.
+			expect(str_contains($preceding, 'cacti_process_still_running'))
+				->toBeTrue();
 
 			$offset = $at + 1;
 		}

--- a/tests/integration/Issue7425ProcessPidReuseGuardIntegrationTest.php
+++ b/tests/integration/Issue7425ProcessPidReuseGuardIntegrationTest.php
@@ -276,6 +276,49 @@ test('a registration held by a live process of ours still blocks a new start', f
 	expect(register_process_start('poller', 'child', 1, 300))->toBeFalse();
 });
 
+test('a registry mutation lock prevents a concurrent registration', function () {
+	$conn = registry_seed();
+	registry_wire($conn);
+
+	$held = CactiProcessLock::fromPdo($conn, 'poller', 'child', 1);
+
+	expect($held->acquire())->toBeTrue()
+		->and(register_process_start('poller', 'child', 1, 300))->toBeFalse()
+		->and($conn->query('SELECT COUNT(*) AS c FROM processes')->fetch(PDO::FETCH_ASSOC)['c'])->toBe(0);
+
+	$held->release();
+});
+
+test('registration releases its mutation lock after updating the registry', function () {
+	$conn = registry_seed();
+	registry_wire($conn);
+
+	expect(register_process_start('poller', 'child', 1, 300))->toBeTrue();
+
+	$next = CactiProcessLock::fromPdo($conn, 'poller', 'child', 1);
+
+	expect($next->acquire())->toBeTrue();
+
+	$next->release();
+});
+
+test('registry locking fails closed without a usable database connection', function () {
+	$GLOBALS['database_hostname'] = 'missing';
+	$GLOBALS['database_port']     = 0;
+	$GLOBALS['database_default']  = 'missing';
+	$GLOBALS['database_sessions'] = [];
+
+	expect(cacti_process_registry_lock('poller', 'child', 1))->toBeFalse();
+});
+
+test('registry locking fails closed when the database mode is incompatible', function () {
+	$conn = registry_seed();
+	$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
+	registry_wire($conn);
+
+	expect(cacti_process_registry_lock('poller', 'child', 1))->toBeFalse();
+});
+
 test('a registration whose pid has died no longer blocks a new start', function () {
 	$conn = registry_seed();
 	registry_wire($conn);

--- a/tests/integration/Issue7425ProcessPidReuseGuardIntegrationTest.php
+++ b/tests/integration/Issue7425ProcessPidReuseGuardIntegrationTest.php
@@ -311,12 +311,21 @@ test('registry locking fails closed without a usable database connection', funct
 	expect(cacti_process_registry_lock('poller', 'child', 1))->toBeFalse();
 });
 
-test('registry locking fails closed when the database mode is incompatible', function () {
+test('registry locking temporarily enables the required database mode', function () {
 	$conn = registry_seed();
 	$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 	registry_wire($conn);
 
-	expect(cacti_process_registry_lock('poller', 'child', 1))->toBeFalse();
+	$lock = cacti_process_registry_lock('poller', 'child', 1);
+
+	expect($lock)->toBeInstanceOf(CactiProcessLock::class)
+		->and($conn->getAttribute(PDO::ATTR_ERRMODE))->toBe(PDO::ERRMODE_SILENT)
+		->and($lock->acquire())->toBeTrue()
+		->and($conn->getAttribute(PDO::ATTR_ERRMODE))->toBe(PDO::ERRMODE_SILENT);
+
+	$lock->release();
+
+	expect($conn->getAttribute(PDO::ATTR_ERRMODE))->toBe(PDO::ERRMODE_SILENT);
 });
 
 test('a registration whose pid has died no longer blocks a new start', function () {


### PR DESCRIPTION
## Summary

- serialize `register_process_start()` admission for each logical process key with Symfony Lock and its PDO store
- keep the existing `processes` table authoritative for PID, timeout, heartbeat, and cleanup state
- add the `process_locks` schema to new installs and the 1.3.0 upgrade path
- fail closed when the shared database lock cannot be created or acquired
- enforce 100% line coverage for the new lock abstraction in a dedicated CI job

Related to #6515 and complements the PID-reuse protections in #7425.

## Why this addresses the process-module discussion

`posix_kill()` and PHP process APIs answer process-liveness and signaling questions. They do not serialize two Cacti workers that concurrently read an empty `processes` row and both decide to start. They are also the part whose Windows behavior needs separate handling.

This change leaves the existing PID checks and termination behavior intact and adds a cross-platform admission mutex around only the registry check/update transaction. The lock is short-lived and released immediately after admission; it is not treated as the process lifetime or execution truth.

## Alternatives considered

| Option | Advantages | Why it was not selected |
| --- | --- | --- |
| Symfony Lock `PdoStore` | Atomic ownership tokens, expiration, garbage collection, portable API, and coordination through the database Cacti already shares | Adds one focused Composer dependency and one small table; selected because those costs are lower than maintaining the same correctness ourselves |
| Native `flock()` | Built into PHP, simple, and reliable on one host | Coordinates through a filesystem path; shared-filesystem semantics and failure behavior vary, and local files cannot coordinate independent poller hosts |
| SysV semaphores | Native kernel mutex on supported Unix systems | Requires `ext-sysvsem`, is host-local, and is not a Windows solution |
| MySQL `GET_LOCK()` | No new table and coordinates clients of one MySQL server | Connection-scoped, MySQL-specific, lacks portable ownership-token and expiry behavior, and couples correctness to connection lifecycle |
| Custom database lease | Could match Cacti naming and schema conventions exactly | Would require us to implement and maintain atomic acquisition, owner tokens, expiry, stale-lock cleanup, and database edge cases already handled by Symfony Lock |

The Cacti-idiomatic boundary is the small `CactiProcessLock` wrapper and the existing `processes` lifecycle model. Reimplementing the lock algorithm itself would not add a Cacti-specific advantage.

## Testing

- focused lock tests: 3 passed, 12 assertions
- lock and PID-reuse regression tests: 15 passed, 37 assertions
- dedicated Xdebug coverage gate: `CactiProcessLock` 100.0% line coverage
- Composer validation: passed
- PHP CS Fixer on changed PHP files: passed
- PHPStan level 6 on `CactiProcessLock`: passed
- PHP syntax checks on changed PHP files: passed
- Actionlint and YAML parsing for the new workflow: passed

The repository-wide workflow-policy script still reports three pre-existing violations in `rrd-graph-item-coverage.yml`; the new process-lock workflow has no reported violations.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.

### Copilot follow-up

All Copilot findings have been addressed. PDO error mode is temporarily normalized for every lock operation and restored afterward, with integration coverage for the production default silent mode. The final follow-up corrects the internal helper documentation so its required parameters are not described as optional. Docker validation passed 15 tests and 45 assertions.