### PR TITLE
fix: url encode the base64 regex filter before it reaches the query string

### DIFF
--- a/include/layout.js
+++ b/include/layout.js
@@ -3484,7 +3484,7 @@ function applyGraphFilter() {
 	statePushed = false;
 
 	var href = appendHeaderSuppression(graphPage+'?action='+pageAction +
-		'&rfilter=' + base64_encode($('#rfilter').val()) +
+		'&rfilter=' + encodeURIComponent(base64_encode($('#rfilter').val())) +
 		(typeof $('#host_id').val() != 'undefined' ? '&host_id=' + $('#host_id').val():'') +
 		'&columns=' + $('#columns').val() +
 		'&graphs='  + $('#graphs').val() +
@@ -3567,7 +3567,7 @@ function handlePopState() {
 function applyGraphTimespan() {
 	var href = appendHeaderSuppression(graphPage+'?action='+pageAction+
 		'&predefined_timespan='+$('#predefined_timespan').val()+
-		($('#rfilter').length ? '&rfilter=' + base64_encode($('#rfilter').val()):'') +
+		($('#rfilter').length ? '&rfilter=' + encodeURIComponent(base64_encode($('#rfilter').val())):'') +
 		'&predefined_timeshift='+$('#predefined_timeshift').val());
 
 	closeDateFilters();


### PR DESCRIPTION
Fixes #7776.

The regex filter is base64 encoded in the browser and decoded on the server. The encoder is correct, but the result is concatenated straight into the query string:

```js
'&rfilter=' + base64_encode($('#rfilter').val())
```

The base64 alphabet contains `+`, which a query string reads as a space. When the encoding contains one, PHP receives a corrupted value, `is_base64_encoded()` rejects it because its character class excludes spaces, the decode in `lib/html_utility.php` is skipped, and the raw base64 is written back into the search box.

```
测试        sent=5rWL6K+V             received=5rWL6K V   -> box shows 5rWL6K V
中文搜索    sent=5Lit5paH5pCc57Si     received=unchanged  -> decodes correctly
```

It is not language specific. `中文搜索` works only because its encoding has no `+`; `sw>1` encodes to `c3c+MQ==` and breaks the same way. Non-ASCII input hits it far more often, which is why it presents as a Chinese character problem.

Two sites are affected, both string concatenations:

* `applyGraphFilter()`
* `applyGraphTimespan()`

Ten lines below the first one, `urlParams.set('rfilter', ...)` already percent encodes and has never had the problem, as does the object form passed to `postUrl()`. Those are left alone.

No server side change: the decode is correct once the value arrives intact.

### Verification

Round trip through `parse_str()` with the server's own `is_base64_encoded()`:

| input | before | after |
| --- | --- | --- |
| 测试 | `RAW: 5rWL6K V` | 测试 |
| 路由器测试 | `RAW: 6Lev55Sx5Zmo5rWL6K V` | 路由器测试 |
| sw>1 | `RAW: c3c MQ==` | sw>1 |
| 中文搜索 | 中文搜索 | 中文搜索 |
| router | router | router |

Previously working input is unchanged.

`develop` needs the same change; the call sites moved and it has two more in `lib/html_filter.php` and `lib/html_graph.php`. Happy to follow up separately.