### PR TITLE
Fix Copilot feedback for password reset link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 Cacti CHANGELOG
 
 1.3.0-dev
--issue#7660: Render the password-reset action without treating login errors as trusted HTML
 -issue#7723: Validate package upload content type before retaining it in the session
 -issue#2205: Allow admins to disable RRDtool watermark
 -issue#3066: Enable the secure flag on cookies when HTTPS is enabled.
@@ -104,6 +103,7 @@ Cacti CHANGELOG
 -issue#7719: Spike Kill text output applied the large value scientific notation format to the column left of the value it belonged to, starting with Variance
 -issue#7732: Bind device IDs and escape graph and device HTML sinks
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
+-issue#7660: Render the password-reset action without treating login errors as trusted HTML
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/lib/html.php
+++ b/lib/html.php
@@ -3585,13 +3585,10 @@ function html_auth_footer(string $section, string $error = '', string $html = ''
 			</form>
 			<hr />
 			<div class='cactiAuthErrors'>
-				<?php
-				print htmle($error);
-
-	if ($password_reset_available) {
-		print ' <a href="auth_resetpassword.php">' . __esc('Reset password') . '</a>';
-	}
-	?>
+				<?php print htmle($error); ?>
+				<?php if ($password_reset_available) { ?>
+					<a href="auth_resetpassword.php"><?php print __esc('Reset password'); ?></a>
+				<?php } ?>
 			</div>
 			<div class='versionInfo'>
 				<?php print __('Version %s | %s', CACTI_VERSION_BRIEF, COPYRIGHT_YEARS_SHORT); ?>


### PR DESCRIPTION
## Summary

- move the password-reset CHANGELOG entry to the end of the 1.3.0-dev issue block
- render the reset-password action with the surrounding PHP/HTML indentation style
- retain escaping for both the login error and translated link label

## Testing

- PHP syntax check for lib/html.php
- PHP CS Fixer dry run for lib/html.php
- focused Pest coverage: 6 tests, 31 assertions

Follow-up to the Copilot review on #7757.