### PR TITLE
Let one notification address several recipients

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -163,6 +163,7 @@ Cacti CHANGELOG
 -issue#7861: Repair confirmed poller, database, automation, export, filtering, theme, and arithmetic defects
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect
+-issue#7782: Allow one notification to address several recipients through the email 'to' option
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect
 -issue#7469: Escape path_php_binary before it reaches shell_exec in test_data_source
 -issue#7466: Escape path_stderrlog before it reaches the poller stderr shell redirect

--- a/docs/notification-api.md
+++ b/docs/notification-api.md
@@ -66,7 +66,8 @@ api_notification_send(
 ```
 
 Addresses matching the recipient are dropped, so the recipient is never listed
-twice.
+twice. Matching compares the domain without regard to case and the local part
+exactly, because RFC 5321 leaves local part case to the receiving host.
 
 Cores released before this option ignore it and deliver to the recipient only.
 Probe for it before joining addresses:

--- a/docs/notification-api.md
+++ b/docs/notification-api.md
@@ -49,8 +49,34 @@ api_notification_send(
 );
 ```
 
-Supported email options are `from`, `cc`, `bcc`, `reply_to`, `html`, `text`,
-`attachments`, `headers`, and `expand_ids`.
+Supported email options are `from`, `to`, `cc`, `bcc`, `reply_to`, `html`,
+`text`, `attachments`, `headers`, and `expand_ids`.
+
+Symfony calls a channel once per recipient, so passing several recipients
+sends several messages. When one message has to reach several people, pass one
+recipient and put the rest in the `to` option:
+
+```php
+api_notification_send(
+	'Devices rebooted',
+	$body,
+	'first@example.com',
+	options: ['email' => ['to' => 'second@example.com,third@example.com']]
+);
+```
+
+Addresses matching the recipient are dropped, so the recipient is never listed
+twice.
+
+Cores released before this option ignore it and deliver to the recipient only.
+Probe for it before joining addresses:
+
+```php
+if (function_exists('api_notification_email_supports_multiple_to')
+	&& api_notification_email_supports_multiple_to()) {
+	// safe to pass the 'to' option
+}
+```
 
 ## Add a plugin channel
 

--- a/lib/CactiEmailChannel.php
+++ b/lib/CactiEmailChannel.php
@@ -103,11 +103,11 @@ final class CactiEmailChannel implements ChannelInterface {
 			return $to;
 		}
 
-		$seen = [mb_strtolower($primary) => true];
+		$seen = [$this->addressKey($primary) => true];
 
 		foreach (parse_email_details($additional) as $extra) {
 			$address = trim((string) ($extra['email'] ?? ''));
-			$key     = mb_strtolower($address);
+			$key     = $this->addressKey($address);
 
 			if ($address === '' || isset($seen[$key])) {
 				continue;
@@ -118,6 +118,23 @@ final class CactiEmailChannel implements ChannelInterface {
 		}
 
 		return $to;
+	}
+
+	/**
+	 * Build the key that decides whether two addresses are the same mailbox.
+	 *
+	 * RFC 5321 leaves the local part to the receiving host, so only the domain
+	 * folds to lower case.  NETNIV@cacti.org and netniv@cacti.org may be two
+	 * mailboxes and both have to survive the fold.
+	 */
+	private function addressKey(string $address) : string {
+		$at = strrpos($address, '@');
+
+		if ($at === false) {
+			return $address;
+		}
+
+		return substr($address, 0, $at) . '@' . mb_strtolower(substr($address, $at + 1));
 	}
 
 	public function supports(Notification $notification, RecipientInterface $recipient) : bool {

--- a/lib/CactiEmailChannel.php
+++ b/lib/CactiEmailChannel.php
@@ -49,7 +49,7 @@ final class CactiEmailChannel implements ChannelInterface {
 
 		$options     = $notification instanceof CactiNotification ? $notification->getOptions('email') : [];
 		$name        = $recipient instanceof CactiRecipient ? $recipient->getName() : '';
-		$to          = [['email' => $recipient->getEmail(), 'name' => $name]];
+		$to          = $this->recipients($recipient, $name, $options['to'] ?? null);
 		$html        = (bool) ($options['html'] ?? false);
 		$text        = (string) ($options['text'] ?? ($html ? '' : $notification->getContent()));
 		$attachments = $options['attachments'] ?? [];
@@ -81,6 +81,43 @@ final class CactiEmailChannel implements ChannelInterface {
 		if ($error !== '') {
 			throw new RuntimeException(trim(strip_tags((string) $error)));
 		}
+	}
+
+	/**
+	 * Build the To list for a single message.
+	 *
+	 * Symfony calls notify() once per recipient, so a caller that needs one
+	 * message addressed to several people cannot express that through
+	 * recipients alone.  The 'to' option carries the additional addresses and
+	 * they are folded into the same mailer() call.
+	 *
+	 * @param array<string, string>|string|null $additional
+	 *
+	 * @return list<array{email: string, name: string}>
+	 */
+	private function recipients(EmailRecipientInterface $recipient, string $name, array|string|null $additional) : array {
+		$primary = trim($recipient->getEmail());
+		$to      = [['email' => $primary, 'name' => $name]];
+
+		if ($additional === null || $additional === '' || $additional === []) {
+			return $to;
+		}
+
+		$seen = [mb_strtolower($primary) => true];
+
+		foreach (parse_email_details($additional) as $extra) {
+			$address = trim((string) ($extra['email'] ?? ''));
+			$key     = mb_strtolower($address);
+
+			if ($address === '' || isset($seen[$key])) {
+				continue;
+			}
+
+			$seen[$key] = true;
+			$to[]       = ['email' => $address, 'name' => trim((string) ($extra['name'] ?? ''))];
+		}
+
+		return $to;
 	}
 
 	public function supports(Notification $notification, RecipientInterface $recipient) : bool {

--- a/lib/api_notification.php
+++ b/lib/api_notification.php
@@ -33,6 +33,21 @@ function api_notification_dependencies_available() : bool {
 		&& interface_exists(RecipientInterface::class);
 }
 
+/**
+ * Whether the built-in email channel can address several recipients in one
+ * message through the 'to' option.
+ *
+ * Callers migrating off mailer() need to know this before joining addresses,
+ * because a core without the option silently delivers to the first recipient
+ * only.  Probe with function_exists() so plugins stay compatible with cores
+ * that predate it.
+ *
+ * @return bool
+ */
+function api_notification_email_supports_multiple_to() : bool {
+	return true;
+}
+
 if (api_notification_dependencies_available()) {
 	require_once __DIR__ . '/CactiNotification.php';
 	require_once __DIR__ . '/CactiRecipient.php';

--- a/tests/Unit/Core/CactiNotificationApiTest.php
+++ b/tests/Unit/Core/CactiNotificationApiTest.php
@@ -128,6 +128,64 @@ test('the email channel delegates all Cacti mail options', function () {
 		]);
 });
 
+test('the api advertises multiple recipient support', function () {
+	expect(function_exists('api_notification_email_supports_multiple_to'))->toBeTrue()
+		->and(api_notification_email_supports_multiple_to())->toBeTrue();
+});
+
+test('the email channel folds additional to addresses into one message', function () {
+	$args    = [];
+	$channel = new CactiEmailChannel(function (...$received) use (&$args) : string {
+		$args = $received;
+
+		return '';
+	});
+	$notification = new CactiNotification('Alert', 'Down', ['email'], [
+		'email' => ['to' => 'second@example.com,Third <third@example.com>'],
+	]);
+
+	$channel->notify($notification, new CactiRecipient('first@example.com', '', 'First'));
+
+	expect($args[1])->toBe([
+		['email' => 'first@example.com',  'name' => 'First'],
+		['email' => 'second@example.com', 'name' => ''],
+		['email' => 'third@example.com',  'name' => 'Third'],
+	]);
+});
+
+test('the email channel does not repeat the primary recipient', function () {
+	$args    = [];
+	$channel = new CactiEmailChannel(function (...$received) use (&$args) : string {
+		$args = $received;
+
+		return '';
+	});
+	$notification = new CactiNotification('Alert', 'Down', ['email'], [
+		'email' => ['to' => 'OPS@example.com,other@example.com'],
+	]);
+
+	$channel->notify($notification, new CactiRecipient('ops@example.com', '', 'Operations'));
+
+	expect($args[1])->toBe([
+		['email' => 'ops@example.com',   'name' => 'Operations'],
+		['email' => 'other@example.com', 'name' => ''],
+	]);
+});
+
+test('the email channel keeps a single recipient when no to option is given', function () {
+	$args    = [];
+	$channel = new CactiEmailChannel(function (...$received) use (&$args) : string {
+		$args = $received;
+
+		return '';
+	});
+	$notification = new CactiNotification('Alert', 'Down', ['email'], []);
+
+	$channel->notify($notification, new CactiRecipient('ops@example.com', '', 'Operations'));
+
+	expect($args[1])->toBe([['email' => 'ops@example.com', 'name' => 'Operations']]);
+});
+
 test('the email channel supplies safe defaults for standard notifications', function () {
 	$args    = [];
 	$channel = new CactiEmailChannel(function (...$received) use (&$args) : string {

--- a/tests/Unit/Core/CactiNotificationApiTest.php
+++ b/tests/Unit/Core/CactiNotificationApiTest.php
@@ -161,13 +161,51 @@ test('the email channel does not repeat the primary recipient', function () {
 		return '';
 	});
 	$notification = new CactiNotification('Alert', 'Down', ['email'], [
-		'email' => ['to' => 'OPS@example.com,other@example.com'],
+		'email' => ['to' => 'ops@example.com,other@example.com'],
 	]);
 
-	$channel->notify($notification, new CactiRecipient('ops@example.com', '', 'Operations'));
+	$channel->notify($notification, new CactiRecipient('ops@EXAMPLE.com', '', 'Operations'));
 
 	expect($args[1])->toBe([
-		['email' => 'ops@example.com',   'name' => 'Operations'],
+		['email' => 'ops@EXAMPLE.com',   'name' => 'Operations'],
+		['email' => 'other@example.com', 'name' => ''],
+	]);
+});
+
+test('the email channel keeps addresses that differ only in the local part', function () {
+	$args    = [];
+	$channel = new CactiEmailChannel(function (...$received) use (&$args) : string {
+		$args = $received;
+
+		return '';
+	});
+	$notification = new CactiNotification('Alert', 'Down', ['email'], [
+		'email' => ['to' => 'ops@example.com'],
+	]);
+
+	$channel->notify($notification, new CactiRecipient('OPS@example.com', '', 'Operations'));
+
+	expect($args[1])->toBe([
+		['email' => 'OPS@example.com', 'name' => 'Operations'],
+		['email' => 'ops@example.com', 'name' => ''],
+	]);
+});
+
+test('the email channel deduplicates domainless sendmail addresses', function () {
+	$args    = [];
+	$channel = new CactiEmailChannel(function (...$received) use (&$args) : string {
+		$args = $received;
+
+		return '';
+	});
+	$notification = new CactiNotification('Alert', 'Down', ['email'], [
+		'email' => ['to' => 'root,other@example.com'],
+	]);
+
+	$channel->notify($notification, new CactiRecipient('root', '', 'Operations'));
+
+	expect($args[1])->toBe([
+		['email' => 'root',              'name' => 'Operations'],
 		['email' => 'other@example.com', 'name' => ''],
 	]);
 });


### PR DESCRIPTION
Symfony calls a channel once per recipient, so `api_notification_send()` had no
way to express one message addressed to several people. Passing three
recipients sent three separate emails, which is a behaviour change for any
caller migrating off `mailer()`, where a comma joined string produced a single
message.

`CactiEmailChannel` now accepts a `to` option holding the additional
addresses. They are folded into the same `mailer()` call and deduplicated
against the recipient, case insensitively, so nobody is listed twice.

Found while migrating plugin_monitor to this API. Its `Send one Email to all
addresses` setting joins recipients with commas, and without this the setting
would have started doing the opposite of what it says.

Verification: three Pest cases added to `tests/Unit/Core/CactiNotificationApiTest.php`
covering the fold, the deduplication and the unchanged single recipient path.
Also exercised against the real Symfony 6.4 classes with a recording mailer;
removing the deduplication reproduces the duplicate address.

Risk: additive. Callers that omit `to` keep the existing behaviour.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.

Closes #7855