### PR TITLE
security: escape path_boost_log in the Boost debug redirect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -148,6 +148,7 @@ Cacti CHANGELOG
 -issue#7732: Bind device IDs and escape graph and device HTML sinks
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
+-issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect
 -issue#7469: Escape path_php_binary before it reaches shell_exec in test_data_source
 -feature#412: Import Export for Graph and Tree rules

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -1990,12 +1990,17 @@ function boost_poller_bottom() : void {
 		$command_string = cacti_escapeshellcmd((string) read_config_option('path_php_binary'));
 
 		if ($boost_debug && $boost_log != '') {
+			// exec_background() passes redirect_args to the shell unescaped, so
+			// the admin-set path must be quoted here or it becomes command
+			// injection (issue#7476, forward-port of the release/1.2.31 fix).
+			$safe_log = cacti_escapeshellarg($boost_log);
+
 			if (CACTI_SERVER_OS == 'unix') {
 				$extra_args    = '-q ' . CACTI_PATH_BASE . '/poller_boost.php --debug';
-				$redirect_args =  '>> ' . $boost_log . ' 2>&1';
+				$redirect_args =  '>> ' . $safe_log . ' 2>&1';
 			} else {
 				$extra_args    = '-q ' . CACTI_PATH_BASE . '/poller_boost.php --debug';
-				$redirect_args = '>> ' . $boost_log;
+				$redirect_args = '>> ' . $safe_log;
 			}
 		} else {
 			$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_boost.php';

--- a/tests/Unit/Security/Shell/BoostLogShellEscapeTest.php
+++ b/tests/Unit/Security/Shell/BoostLogShellEscapeTest.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression test for issue#7476.
+ *
+ * boost_poller_bottom() builds a shell redirect from path_boost_log, an
+ * admin-settable free-text Settings > Paths field, and hands it to
+ * exec_background() as $redirect_args.  exec_background() passes redirect args
+ * to the shell unescaped by design, so the path must be quoted at the call
+ * site.  release/1.2.31 wrapped it in cacti_escapeshellarg(); that fix never
+ * reached develop, leaving '>> ' . $boost_log . ' 2>&1' open to command
+ * injection.  This asserts the path is escaped before it reaches the redirect.
+ */
+
+require_once dirname(__DIR__, 3) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 4) . '/include/global.php';
+
+$boostSource = file_get_contents(__DIR__ . '/../../../../lib/boost.php');
+
+test('boost quotes path_boost_log before building the redirect', function () use ($boostSource) {
+	expect($boostSource)->toContain('$safe_log = cacti_escapeshellarg($boost_log);')
+		->and($boostSource)->toContain("'>> ' . \$safe_log . ' 2>&1'")
+		->and($boostSource)->toContain("'>> ' . \$safe_log");
+});
+
+test('boost never concatenates the raw log path into the redirect', function () use ($boostSource) {
+	expect($boostSource)->not->toContain("'>> ' . \$boost_log");
+});
+
+test('escaping the malicious log path keeps the injection inside one argument', function () {
+	// The exact payload the Docker proof-of-concept used against develop.
+	$evil = '/tmp/boost.log 2>&1; touch /tmp/pwned ; echo';
+
+	$redirect = '>> ' . cacti_escapeshellarg($evil) . ' 2>&1';
+
+	// The whole payload must sit inside a single quoted token; the ';' that
+	// would start a new command on develop is now literal data.
+	expect($redirect)->toBe(">> '/tmp/boost.log 2>&1; touch /tmp/pwned ; echo' 2>&1")
+		->and(substr_count($redirect, "'"))->toBe(2);
+});


### PR DESCRIPTION
Forward-ports the `release/1.2.31` fix for `path_boost_log`, which never reached
develop (issue#7476).

`boost_poller_bottom()` reads `path_boost_log`, an admin-settable free-text
Settings > Paths field with no shell-metacharacter validation, and concatenates
it into a shell redirect handed to `exec_background()` as `$redirect_args`.
`exec_background()` passes redirect args to the shell unescaped by design; its
own comment says only hardcoded strings belong there. `cacti_escapeshellarg()`
at the call site closes it, exactly as 1.2.31 does.

## Validation

I confirmed the injection with the real shipped code before fixing it. Using the
actual `exec_background()` and `cacti_escapeshellarg()` from each branch and the
real redirect construction, with `path_boost_log` set to
`/tmp/boost.log 2>&1; touch <marker> ; echo`:

- develop as shipped: the injected command runs, marker created
- develop with this change: the payload becomes one quoted argument, no execution
- release/1.2.31: same neutralization

## Tests

`tests/Unit/Security/Shell/BoostLogShellEscapeTest.php`, following the existing
`RrdcheckShellEscapeTest`. Verified with Pest: 3 pass on the fix, 2 fail on the
unfixed code, so the test guards the actual hole.

Requires an authenticated administrator with access to Settings > Paths.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
