### PR TITLE
security: escape path_stderrlog in the poller stderr redirect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -150,6 +150,7 @@ Cacti CHANGELOG
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect
 -issue#7469: Escape path_php_binary before it reaches shell_exec in test_data_source
+-issue#7466: Escape path_stderrlog before it reaches the poller stderr shell redirect
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/poller.php
+++ b/poller.php
@@ -736,7 +736,10 @@ while ($poller_runs_completed < $poller_runs) {
 		}
 
 		if (read_config_option('path_stderrlog') != '' && CACTI_SERVER_OS != 'win32') {
-			$extra_parms = '>> ' . read_config_option('path_stderrlog') . ' 2>&1';
+			// exec_background() passes redirect args to the shell unescaped, so
+			// this admin-set path must be quoted (issue#7466, forward-port of
+			// the release/1.2.31 fix).
+			$extra_parms = '>> ' . cacti_escapeshellarg(read_config_option('path_stderrlog')) . ' 2>&1';
 		} else {
 			$extra_parms = '';
 		}

--- a/tests/Unit/Security/Shell/StderrlogShellEscapeTest.php
+++ b/tests/Unit/Security/Shell/StderrlogShellEscapeTest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression test for issue#7466.
+ *
+ * The main poller builds an stderr redirect from path_stderrlog, an
+ * admin-settable Settings > Paths field, and passes it to exec_background()
+ * as $extra_parms.  exec_background() passes redirect args to the shell
+ * unescaped, so the path must be quoted at the call site.  release/1.2.31
+ * wrapped it in cacti_escapeshellarg(); the fix never reached develop.
+ */
+
+require_once dirname(__DIR__, 3) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 4) . '/include/global.php';
+
+$pollerSource = file_get_contents(__DIR__ . '/../../../../poller.php');
+
+test('poller quotes path_stderrlog before building the stderr redirect', function () use ($pollerSource) {
+	expect($pollerSource)->toContain("'>> ' . cacti_escapeshellarg(read_config_option('path_stderrlog')) . ' 2>&1'");
+});
+
+test('poller never concatenates the raw stderr path into the redirect', function () use ($pollerSource) {
+	expect($pollerSource)->not->toContain("'>> ' . read_config_option('path_stderrlog') . ' 2>&1'");
+});
+
+test('escaping the malicious stderr path keeps the injection inside one argument', function () {
+	$evil = '/tmp/poller.err 2>&1; touch /tmp/pwned ; echo';
+
+	$redirect = '>> ' . cacti_escapeshellarg($evil) . ' 2>&1';
+
+	expect($redirect)->toBe(">> '/tmp/poller.err 2>&1; touch /tmp/pwned ; echo' 2>&1")
+		->and(substr_count($redirect, "'"))->toBe(2);
+});


### PR DESCRIPTION
Forward-ports the `release/1.2.31` fix for `path_stderrlog`, which never reached
develop (issue#7466).

The main poller reads `path_stderrlog`, an admin-settable Settings > Paths field
with no shell-metacharacter validation, and concatenates it into a stderr
redirect handed to `exec_background()` as `$extra_parms`. `exec_background()`
passes redirect args to the shell unescaped by design. `cacti_escapeshellarg()`
at the call site closes it, exactly as 1.2.31 does.

## Validation

Confirmed with the real shipped code before fixing. Using the actual
`exec_background()` and `cacti_escapeshellarg()` from each branch and the real
redirect construction, with `path_stderrlog` set to
`/tmp/poller.err 2>&1; touch <marker> ; echo`:

- develop as shipped: the injected command runs, marker created
- develop with this change: the payload becomes one quoted argument, no execution
- release/1.2.31: same neutralization

## Tests

`tests/Unit/Security/Shell/StderrlogShellEscapeTest.php`, following the existing
`RrdcheckShellEscapeTest`. Verified with Pest: 3 pass on the fix, 2 fail on the
unfixed code.

Requires an authenticated administrator with access to Settings > Paths.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.


Fixes #7466.