### PR TITLE
security: escape path_rrdcheck_log in the rrdcheck poller redirect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -103,6 +103,7 @@ Cacti CHANGELOG
 -issue#7732: Bind device IDs and escape graph and device HTML sinks
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
+-issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/lib/rrdcheck.php
+++ b/lib/rrdcheck.php
@@ -792,10 +792,16 @@ function rrdcheck_poller_bottom() : void {
 		$command_string = read_config_option('path_php_binary');
 
 		if (read_config_option('path_rrdcheck_log') != '') {
+			// This log path reaches the shell through exec_background()'s args,
+			// which are unescaped, so quote it. No settings form exposes this
+			// value today; this is defense in depth and a forward-port of the
+			// release/1.2.31 fix (issue#7473).
+			$safe_log = cacti_escapeshellarg(read_config_option('path_rrdcheck_log'));
+
 			if (CACTI_SERVER_OS == 'unix') {
-				$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_rrdcheck.php >> ' . read_config_option('path_rrdcheck_log') . ' 2>&1';
+				$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_rrdcheck.php >> ' . $safe_log . ' 2>&1';
 			} else {
-				$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_rrdcheck.php >> ' . read_config_option('path_rrdcheck_log');
+				$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_rrdcheck.php >> ' . $safe_log;
 			}
 		} else {
 			$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_rrdcheck.php';

--- a/tests/Unit/Security/Shell/RrdcheckLogShellEscapeTest.php
+++ b/tests/Unit/Security/Shell/RrdcheckLogShellEscapeTest.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression test for issue#7473.
+ *
+ * The rrdcheck poller builds a log redirect from path_rrdcheck_log inside the
+ * args passed to exec_background(), which does not escape string args.  No
+ * settings form exposes path_rrdcheck_log today, so this is defense in depth,
+ * but the code ships the unescaped pattern and a future settings field would
+ * reactivate it.  release/1.2.31 already quotes the value.
+ */
+
+require_once dirname(__DIR__, 3) . '/Helpers/CactiStubs.php';
+require_once dirname(__DIR__, 4) . '/include/global.php';
+
+$source = file_get_contents(__DIR__ . '/../../../../lib/rrdcheck.php');
+
+test('rrdcheck quotes path_rrdcheck_log before building the log redirect', function () use ($source) {
+	expect($source)->toContain("\$safe_log = cacti_escapeshellarg(read_config_option('path_rrdcheck_log'));")
+		->and($source)->toContain("poller_rrdcheck.php >> ' . \$safe_log . ' 2>&1'");
+});
+
+test('rrdcheck never concatenates the raw log path into the redirect', function () use ($source) {
+	expect($source)->not->toContain("poller_rrdcheck.php >> ' . read_config_option('path_rrdcheck_log')");
+});
+
+test('escaping the malicious rrdcheck log path keeps the injection in one argument', function () {
+	$evil = '/tmp/rrdcheck.log 2>&1; touch /tmp/pwned ; echo';
+
+	$args = 'poller_rrdcheck.php >> ' . cacti_escapeshellarg($evil) . ' 2>&1';
+
+	expect($args)->toContain("'/tmp/rrdcheck.log 2>&1; touch /tmp/pwned ; echo'")
+		->and(substr_count($args, "'"))->toBe(2);
+});


### PR DESCRIPTION
Forward-ports the `release/1.2.31` fix for `path_rrdcheck_log`, which never
reached develop (issue#7473).

The rrdcheck poller concatenates `path_rrdcheck_log` into the args passed to
`exec_background()`, which does not escape string args on develop. A shell
metacharacter in the value would inject a command. `cacti_escapeshellarg()`
closes it, as 1.2.31 does.

## Scope

Defense in depth. No settings form exposes `path_rrdcheck_log` today, so there
is no live input path. The unescaped pattern still ships, and a future settings
field or a direct config write would reactivate it, so it is worth fixing now.

## Validation

With the value hypothetically set to
`/tmp/rrdcheck.log 2>&1; touch <marker> ; echo` and driven through develop's
real `exec_background()`:

- develop as shipped: the injected command runs, marker created
- develop with this change: the payload becomes one quoted argument, no execution
- release/1.2.31: same neutralization

## Tests

`tests/Unit/Security/Shell/RrdcheckLogShellEscapeTest.php`. Verified with Pest:
3 pass on the fix, 2 fail on the unfixed code.


Fixes #7473.