### PR TITLE
Restore notification coverage and workflow policy gates

### DIFF
--- a/.github/workflows/rrd-graph-item-coverage.yml
+++ b/.github/workflows/rrd-graph-item-coverage.yml
@@ -38,11 +38,14 @@ env:
 jobs:
   coverage:
     name: RRD graph item 100% coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Setup PHP 8.4 with Xdebug
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2

--- a/lib/CactiNotification.php
+++ b/lib/CactiNotification.php
@@ -25,7 +25,6 @@ use Symfony\Component\Notifier\Notification\Notification;
 final class CactiNotification extends Notification {
 	/** @var array<string, mixed> */
 	private array $options;
-	private bool $sealed = false;
 
 	/**
 	 * @param list<string>         $channels
@@ -41,52 +40,37 @@ final class CactiNotification extends Notification {
 		}
 
 		$this->options = $options;
-		$this->sealed  = true;
 	}
 
 	public function subject(string $subject) : static {
-		$this->assertMutable();
-
-		return parent::subject($subject);
+		$this->immutable();
 	}
 
 	public function content(string $content) : static {
-		$this->assertMutable();
-
-		return parent::content($content);
+		$this->immutable();
 	}
 
 	public function importance(string $importance) : static {
-		$this->assertMutable();
-
-		return parent::importance($importance);
+		$this->immutable();
 	}
 
 	public function importanceFromLogLevelName(string $level) : static {
-		$this->assertMutable();
-
-		return parent::importanceFromLogLevelName($level);
+		$this->immutable();
 	}
 
 	public function emoji(string $emoji) : static {
-		$this->assertMutable();
-
-		return parent::emoji($emoji);
+		$this->immutable();
 	}
 
 	public function exception(Throwable $exception) : static {
-		$this->assertMutable();
-
-		return parent::exception($exception);
+		$this->immutable();
 	}
 
 	/**
 	 * @param list<string> $channels
 	 */
 	public function channels(array $channels) : static {
-		$this->assertMutable();
-
-		return parent::channels($channels);
+		$this->immutable();
 	}
 
 	/**
@@ -98,9 +82,7 @@ final class CactiNotification extends Notification {
 		return is_array($options) ? $options : [];
 	}
 
-	private function assertMutable() : void {
-		if ($this->sealed) {
-			throw new LogicException('Cacti notifications are immutable after construction.');
-		}
+	private function immutable() : never {
+		throw new LogicException('Cacti notifications are immutable after construction.');
 	}
 }

--- a/lib/api_notification.php
+++ b/lib/api_notification.php
@@ -41,7 +41,11 @@ if (api_notification_dependencies_available()) {
 
 function api_notification_assert_dependencies() : void {
 	if (!api_notification_dependencies_available()) {
+		// Dependency absence is validated in an isolated process; it cannot be
+		// reproduced after this coverage process has loaded the vendor classes.
+		// @codeCoverageIgnoreStart
 		throw new RuntimeException('Symfony Notifier dependencies are unavailable. Run Composer install to restore the vendor tree.');
+		// @codeCoverageIgnoreEnd
 	}
 }
 

--- a/tests/Unit/Core/CactiNotificationApiTest.php
+++ b/tests/Unit/Core/CactiNotificationApiTest.php
@@ -71,6 +71,9 @@ test('Cacti notifications cannot be mutated after construction', function () {
 		->and(fn () => $notification->subject('Changed'))->toThrow(\LogicException::class, 'immutable')
 		->and(fn () => $notification->content('Changed'))->toThrow(\LogicException::class, 'immutable')
 		->and(fn () => $notification->importance(Notification::IMPORTANCE_LOW))->toThrow(\LogicException::class, 'immutable')
+		->and(fn () => $notification->importanceFromLogLevelName('error'))->toThrow(\LogicException::class, 'immutable')
+		->and(fn () => $notification->emoji('warning'))->toThrow(\LogicException::class, 'immutable')
+		->and(fn () => $notification->exception(new RuntimeException('failure')))->toThrow(\LogicException::class, 'immutable')
 		->and(fn () => $notification->channels(['chat']))->toThrow(\LogicException::class, 'immutable');
 });
 


### PR DESCRIPTION
## What this fixes

- makes immutable notification methods terminate explicitly so their unreachable parent calls no longer count against coverage
- covers every public immutability guard and excludes only the dependency-absence branch that is validated in an isolated process
- pins the RRD coverage job to the approved runner, adds its timeout, and disables persisted checkout credentials

## Validation

- notification API: 15 tests, 69 assertions, 100.0% line coverage in Docker
- workflow policy checker passes
- PHP CS Fixer passes
- PHPStan level 6 passes

No production notification behavior changes: mutation after construction still fails closed.