### PR TITLE
fix(functions): cast path_php_binary before escaping it

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -2653,10 +2653,10 @@ function test_data_source(int $data_template_id, int $host_id, int $snmp_query_i
 				$output = shell_exec($script_path);
 			} else {
 				// Script server is a bit more complicated
-				// path_php_binary is admin-set and reaches shell_exec() below; escape
+				// path_php_binary is admin-set and reaches the shell below; escape
 				// it so a shell metacharacter cannot inject a command (issue#7469,
 				// forward-port of the release/1.2.31 fix).
-				$php   = cacti_escapeshellcmd(read_config_option('path_php_binary'));
+				$php   = cacti_escapeshellcmd((string) read_config_option('path_php_binary'));
 				$parts = explode(' ', $script_path);
 
 				dsv_log('parts', $parts);
@@ -2948,7 +2948,7 @@ function test_data_source(int $data_template_id, int $host_id, int $snmp_query_i
 								$prepend = $script_queries['arg_prepend'];
 							}
 
-							$script_path = cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . get_script_query_path(trim($prepend . ' ' . $script_queries['arg_get'] . ' ' . $identifier . ' "' . $snmp_index . '"'), $script_queries['script_path'], $host_id);
+							$script_path = cacti_escapeshellcmd((string) read_config_option('path_php_binary')) . ' -q ' . get_script_query_path(trim($prepend . ' ' . $script_queries['arg_get'] . ' ' . $identifier . ' "' . $snmp_index . '"'), $script_queries['script_path'], $host_id);
 						} else {
 							$action      = POLLER_ACTION_SCRIPT;
 							$script_path = get_script_query_path(trim(($script_queries['arg_prepend'] ?? '') . ' ' . $script_queries['arg_get'] . ' ' . $identifier . ' "' . $snmp_index . '"'), $script_queries['script_path'], $host_id);

--- a/tests/Unit/Security/Shell/TestDataSourcePhpBinaryTest.php
+++ b/tests/Unit/Security/Shell/TestDataSourcePhpBinaryTest.php
@@ -28,12 +28,12 @@ require_once dirname(__DIR__, 4) . '/include/global.php';
 $source = file_get_contents(__DIR__ . '/../../../../lib/functions.php');
 
 test('the script-server branch escapes path_php_binary', function () use ($source) {
-	expect($source)->toContain("\$php   = cacti_escapeshellcmd(read_config_option('path_php_binary'));")
+	expect($source)->toContain("\$php   = cacti_escapeshellcmd((string) read_config_option('path_php_binary'));")
 		->and($source)->not->toContain("\$php   = read_config_option('path_php_binary');");
 });
 
 test('the query-script-server branch escapes path_php_binary', function () use ($source) {
-	expect($source)->toContain("\$script_path = cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q '")
+	expect($source)->toContain("\$script_path = cacti_escapeshellcmd((string) read_config_option('path_php_binary')) . ' -q '")
 		->and($source)->not->toContain("\$script_path = read_config_option('path_php_binary') . ' -q '");
 });
 


### PR DESCRIPTION
Develop has been red since 02386f5, and every open PR inherits the same failures.

That commit forward-ported the issue#7469 escaping fix but dropped the `(string)` cast, so the repo-wide scan in `PhpBinaryPathNullCoercionTest` found two unguarded call sites. Its explanatory comment also contained the literal `shell_exec()` token, which `build_architectural_helper_report.sh` matches with a bare regex that has no comment awareness, registering the comment as a new `cmd_exec` hotspot and as sink-inventory drift.

`TestDataSourcePhpBinaryTest` and `PhpBinaryPathNullCoercionTest` are mutually unsatisfiable as written: one asserts the exact literal without the cast, the other requires it. This keeps the cast, which runs before escaping and preserves the security property, and updates the two literal assertions. The negative assertions guarding the unescaped form are unchanged.

Fixes six failing checks on develop: PHP 8.2/8.3/8.4 native dependencies, PHP 8.1 locked integration, pest coverage gate, and the sink guard.

Verification: the guard test fails before this change and passes after. Full suite 1899 passed. `verify_sink_inventory.sh` and `verify_architectural_hotspots.sh` both pass.
