### PR TITLE
chore: resolve concurrent CHANGELOG appends with a union merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Every pull request appends to the same two anchors in CHANGELOG: the top of
+# the issue block and the end of the feature block. Concurrent PRs therefore
+# collide there even when they touch nothing else. check-changelog.py enforces
+# entry format and issue/feature grouping rather than numeric order, so keeping
+# both sides is a valid resolution.
+CHANGELOG merge=union


### PR DESCRIPTION
Merging any PR currently conflicts most of the others on CHANGELOG alone. Two of tonight's rebases (#7634 and #7676) had no other conflicting file.

The cause is structural rather than incidental. New issue entries insert at the top of the issue block and new feature entries append to the end of the feature block, so every PR edits one of two lines with identical surrounding context. Git cannot infer the intended order and conflicts every time.

`check-changelog.py` enforces entry format, heading separation, and issue/feature grouping. It does not enforce numeric ordering within a group, so keeping both sides is a valid resolution. Verified by swapping two adjacent feature entries on develop, which the check still passes.

Verified the behavior against the exact #7634 and #7676 collision in a scratch repository: conflict without this, clean merge preserving both entries with it.

One tradeoff worth stating: if two PRs edit the same existing entry rather than appending new ones, union keeps both versions instead of conflicting. That produces a visible duplicate line rather than silent loss, and appends are the overwhelmingly common case.

Unverified: whether GitHub's server-side update-branch endpoint honors gitattributes merge drivers, which is the path pr-branch-update.yml uses. Local merges and rebases are covered either way.
