### PR TITLE
feat(changelog): take entries as fragment files instead of CHANGELOG edits

### DIFF
--- a/.github/scripts/check-changelog.py
+++ b/.github/scripts/check-changelog.py
@@ -13,6 +13,35 @@ from pathlib import Path
 RELEASE_HEADING = re.compile(r"^(?:\d+\.\d+\.\d+(?:-[\w.]+)?|\d+\.\d+\.x)$")
 ENTRY = re.compile(r"^-(issue|feature)(?:#\d+)?:\s+\S.*$")
 NUMBERED_ENTRY = re.compile(r"^-(?:issue|feature)#\d+:")
+FRAGMENT = re.compile(r"^(\d+)\.(issue|feature)$")
+
+
+def check_fragments(directory: Path) -> list[str]:
+	"""Validates changelog.d fragments, which replace direct CHANGELOG edits."""
+	errors: list[str] = []
+	if not directory.is_dir():
+		return errors
+
+	for item in sorted(directory.iterdir()):
+		if item.name == "README.md" or item.name.startswith("."):
+			continue
+		if not item.is_file():
+			errors.append(f"{item}: changelog.d holds fragment files only")
+			continue
+		if FRAGMENT.fullmatch(item.name) is None:
+			errors.append(f"{item}: fragment must be named <number>.issue or <number>.feature")
+			continue
+
+		text = item.read_text(encoding="utf-8")
+		body = text.strip()
+		if not body:
+			errors.append(f"{item}: fragment is empty")
+		elif len(body.splitlines()) > 1:
+			errors.append(f"{item}: fragment must be a single line")
+		elif body.startswith("-"):
+			errors.append(f"{item}: fragment holds the description only, without the -issue or -feature prefix")
+
+	return errors
 
 
 def main() -> int:
@@ -34,7 +63,7 @@ def main() -> int:
 			end = index
 			break
 
-	errors: list[str] = []
+	errors: list[str] = check_fragments(Path("changelog.d"))
 	seen_feature = False
 
 	for index in range(start + 1, end):

--- a/.github/scripts/fold-changelog.py
+++ b/.github/scripts/fold-changelog.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Fold changelog.d fragments into the CHANGELOG development section."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+FRAGMENT = re.compile(r"^(\d+)\.(issue|feature)$")
+RELEASE_HEADING = re.compile(r"^(?:\d+\.\d+\.\d+(?:-[\w.]+)?|\d+\.\d+\.x)$")
+
+
+def load_fragments(directory: Path) -> list[tuple[int, str, str]]:
+	"""Returns (number, kind, description) for every well-formed fragment."""
+	entries: list[tuple[int, str, str]] = []
+	for item in sorted(directory.iterdir()):
+		match = FRAGMENT.fullmatch(item.name)
+		if match is None:
+			continue
+		text = item.read_text(encoding="utf-8").strip()
+		if text:
+			entries.append((int(match.group(1)), match.group(2), text))
+	return entries
+
+
+def section_bounds(lines: list[str]) -> tuple[int, int]:
+	"""Locates the first release section, which is always the development one."""
+	start = next(i for i, line in enumerate(lines) if RELEASE_HEADING.fullmatch(line))
+	end = len(lines)
+	for index in range(start + 1, len(lines)):
+		if RELEASE_HEADING.fullmatch(lines[index]):
+			end = index
+			break
+	return start, end
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument("--check", action="store_true", help="report without writing")
+	args = parser.parse_args()
+
+	directory = Path("changelog.d")
+	path = Path("CHANGELOG")
+	if not path.is_file():
+		print("CHANGELOG is missing", file=sys.stderr)
+		return 1
+	if not directory.is_dir():
+		print("changelog.d is missing", file=sys.stderr)
+		return 1
+
+	fragments = load_fragments(directory)
+	if not fragments:
+		print("no fragments to fold")
+		return 0
+
+	lines = path.read_text(encoding="utf-8").splitlines()
+	start, end = section_bounds(lines)
+
+	issues = sorted((n, t) for n, kind, t in fragments if kind == "issue")
+	features = sorted((n, t) for n, kind, t in fragments if kind == "feature")
+
+	# Issues run newest first from the top of the section; features run oldest
+	# first and are appended after the last existing feature.
+	for number, text in issues:
+		lines.insert(start + 1, f"-issue#{number}: {text}")
+		end += 1
+
+	anchor = end
+	for index in range(end - 1, start, -1):
+		if lines[index].startswith("-feature"):
+			anchor = index + 1
+			break
+
+	for offset, (number, text) in enumerate(features):
+		lines.insert(anchor + offset, f"-feature#{number}: {text}")
+
+	folded = len(issues) + len(features)
+	if args.check:
+		print(f"{folded} fragment(s) would be folded")
+		return 0
+
+	path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+	for item in directory.iterdir():
+		if FRAGMENT.fullmatch(item.name):
+			item.unlink()
+
+	print(f"folded {folded} fragment(s) into CHANGELOG")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,26 @@
+# CHANGELOG fragments
+
+Add a file here instead of editing `CHANGELOG` directly. Every pull request
+that edits `CHANGELOG` lands on one of two lines, the top of the issue block or
+the end of the feature block, so merging one pull request conflicts the rest.
+A fragment is a new file per change, which nothing else touches.
+
+Name the file after the issue or pull request number:
+
+    changelog.d/7634.feature
+    changelog.d/7692.issue
+
+Put the description on a single line, with no `-feature#` or `-issue#` prefix:
+
+    Add indexes for host-template and session lookup queries
+
+The release fold turns that into:
+
+    -feature#7634: Add indexes for host-template and session lookup queries
+
+`tests` in CI validate fragment names and contents. Run the fold when cutting a
+release, which rewrites `CHANGELOG` and removes the fragments:
+
+    python3 .github/scripts/fold-changelog.py
+
+Use `--check` to see what would be folded without writing anything.


### PR DESCRIPTION
Merging any pull request currently conflicts most of the others on CHANGELOG alone. Two of last night's rebases, #7634 and #7676, had no other conflicting file.

New issue entries insert at the top of the issue block and new feature entries append after the last feature, so every pull request edits one of two lines with identical surrounding context. Git cannot infer the intended order, so it conflicts every time. The number of open pull requests makes that quadratic.

A fragment is a new file per change, so two pull requests never touch the same path and there is nothing to conflict over.

    changelog.d/7634.feature   ->  Add indexes for host-template and session lookup queries

The release fold rewrites CHANGELOG and removes the fragments:

    python3 .github/scripts/fold-changelog.py

Issues go to the top of the development section and features after the last existing feature, matching the current layout. check-changelog.py now validates fragment names and contents, so malformed fragments fail the existing required job without a new workflow.

Direct CHANGELOG edits still validate exactly as before, so in-flight pull requests need no changes and the two styles can coexist while they drain.

Verified against the real file: folding an issue and a feature fragment placed both correctly, preserved the blank line before the next heading, removed the fragments, and left the required check passing. Rejection cases covered are a bad filename, an empty fragment, a multi-line fragment, and one that wrongly includes the -feature# prefix.

I also measured why the cheaper fix is not enough. A gitattributes union merge (#7793) resolves this for local merges and rebases, but GitHub's server-side update-branch endpoint ignores gitattributes merge drivers. I confirmed that with the same two commits: clean locally, "merge conflict between base and head" through the API. Since pr-branch-update.yml uses that endpoint, only fragments fix the cascade.
