### PR TITLE
fix(ci): rebase stale pull request branches instead of merging them

### DIFF
--- a/.github/workflows/pr-branch-update.yml
+++ b/.github/workflows/pr-branch-update.yml
@@ -55,17 +55,30 @@ jobs:
           failed=0
 
           for number in $(echo "$pr_numbers" | jq -r '.[]'); do
-            status=$(gh pr view "$number" --json mergeStateStatus --jq '.mergeStateStatus')
+            # mergeStateStatus reports CLEAN for branches the compare API still
+            # counts as behind, so ask compare directly.
+            refs=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}" \
+              --jq '[.base.ref, .head.label] | @tsv')
+            base_ref=$(printf '%s' "$refs" | cut -f1)
+            head_ref=$(printf '%s' "$refs" | cut -f2)
 
-            if [ "$status" != "BEHIND" ]; then
-              echo "skip #$number: mergeStateStatus=$status"
+            behind=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/compare/${base_ref}...${head_ref}" \
+              --jq '.behind_by' 2>/dev/null || echo 0)
+
+            if [ "${behind:-0}" -eq 0 ]; then
+              echo "skip #$number: not behind"
               skipped=$((skipped + 1))
               continue
             fi
 
-            echo "updating #$number (behind base branch)"
+            echo "updating #$number (behind base by $behind)"
+            # Rebase rather than merge. A merge update adds a commit per run, so
+            # each branch accumulates snapshots of old base and re-conflicts on
+            # every shared file it carries.
             if gh api -X PUT \
                 -H "Accept: application/vnd.github+json" \
+                -f update_method=rebase \
                 "repos/${GITHUB_REPOSITORY}/pulls/${number}/update-branch"; then
               updated=$((updated + 1))
             else


### PR DESCRIPTION
Two problems in the same loop.

The update call used the default merge method, so every run added a commit to the branch. Branches therefore accumulate snapshots of old develop and re-conflict on every shared file they carry, which is the main reason merging one pull request conflicts the rest.

Measured on a probe pull request. With update_method=rebase the branch went from behind=2 to behind=0 and stayed at one commit with a single parent. With the default method the same update produced a second commit with two parents, "Merge branch ... into ...". That commit is the accumulation.

The loop also gated on mergeStateStatus being BEHIND, which GitHub does not reliably report. The same probe read behind=2 on the compare API while mergeStateStatus said CLEAN, so branches that needed updating were skipped. Comparing base against head directly is accurate.

Worth reviewing deliberately rather than merging on the description:

A rebase rewrites commit SHAs and force-pushes the branch. That dismisses existing approvals and invalidates contributors' local copies. For fork branches it still requires maintainer edits to be enabled, as before.

Fixing the detection means the job will now act on branches it previously skipped, so the first run after this lands will touch considerably more pull requests than recent runs have.
