### PR TITLE
ci: attach the built artifact to releases, and stop the maintenance notice failing page checks

### DIFF
--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -102,3 +102,41 @@ jobs:
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ env.artifact }}
+
+  publish:
+    name: Attach the artifact to the release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/release/')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Download the built bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh run download "$GITHUB_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "cacti-release-$GITHUB_RUN_ID" \
+            --dir dist
+
+      - name: Attach the bundle to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/}"
+
+          # The tag can arrive before anyone opens the release. Create it as a
+          # draft so an artifact is never published without a human.
+          if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release create "$tag" --repo "$GITHUB_REPOSITORY" --draft --title "$tag" \
+              --notes 'Download the cacti-*.tar.gz asset rather than the generated source archive. Only the asset carries the Composer dependencies; the source archive needs composer install.'
+          fi
+
+          gh release upload "$tag" dist/* --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -125,6 +125,10 @@ jobs:
             --name "cacti-release-$GITHUB_RUN_ID" \
             --dir dist
 
+          # Fail loudly rather than handing gh an unmatched glob.
+          count=$(find dist -type f | wc -l)
+          test "$count" -gt 0
+
       - name: Attach the bundle to the release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -139,4 +143,4 @@ jobs:
               --notes 'Download the cacti-*.tar.gz asset rather than the generated source archive. Only the asset carries the Composer dependencies; the source archive needs composer install.'
           fi
 
-          gh release upload "$tag" dist/* --repo "$GITHUB_REPOSITORY" --clobber
+          find dist -type f -print0 | xargs -0 gh release upload "$tag" --repo "$GITHUB_REPOSITORY" --clobber

--- a/tests/tools/check_all_pages.sh
+++ b/tests/tools/check_all_pages.sh
@@ -724,6 +724,7 @@ FILTERED_LOG="$(grep -v \
   -e "REINDEX Poller" \
   -e "DSDEBUG Bad Data" \
   -e "PUSHOUT Child Started" \
+  -e "MAINTENANCE INFO: Another maintenance session is already running" \
   -e "io_uring_queue_init() failed" \
   "$CACTI_LOG")" || true
 


### PR DESCRIPTION
Two pieces of release and CI plumbing, grouped so they are one review.

- **Release artifact** — the release workflow builds a bundle but never attaches it, so a tagged release ships with no downloadable artifact. Also fails the publish step when the bundle is empty rather than uploading nothing.
- **Maintenance lock notice** — `check_all_pages.sh` treats the maintenance-mode notice as unexpected output and fails. It is expected, so it is allowlisted.

2 files, +43, no existing behaviour changed.

Supersedes #7800.