### PR TITLE
ci: treat the maintenance lock notice as expected log output

### DIFF
--- a/tests/tools/check_all_pages.sh
+++ b/tests/tools/check_all_pages.sh
@@ -724,6 +724,7 @@ FILTERED_LOG="$(grep -v \
   -e "REINDEX Poller" \
   -e "DSDEBUG Bad Data" \
   -e "PUSHOUT Child Started" \
+  -e "MAINTENANCE INFO: Another maintenance session is already running" \
   -e "io_uring_queue_init() failed" \
   "$CACTI_LOG")" || true
 


### PR DESCRIPTION
check_all_pages.sh fails the integration job on any log line outside its allowlist. `MAINTENANCE INFO: Another maintenance session is already running` is not listed, so an overlapping maintenance run fails the job with exit 179 on whatever pull request happened to be building.

It hit #7707, which binds MIB column names in MibCache::select() and has nothing to do with maintenance. Tests passed, 1904 of them, and the job still failed. Rerunning the same commit unchanged passed with 27 green checks, which confirms timing rather than anything in the branch.

The line records the lock working correctly: a second run found an existing session and backed off. Comparable notices are already allowlisted, including MAILER INFO:, PCACHE NOTE, STATS: and REINDEX Child.

The allowlist stays exact-match on that sentence, so a genuine maintenance error still fails the job.

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
