### PR TITLE
Generate CSRF secrets with the platform CSPRNG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 
 1.2.x
 -issue: Keep missing PHP extensions visible to the Cacti installer (PR #7747 follow-up)
+-issue: Generate persistent CSRF secrets with a cryptographic RNG
 -issue: Url encode the base64 regex filter before it reaches the query string (PR #7777)
 -issue: Make 1.2 dependency builds reproducible (PR #7747)
 -issue: Propagate background installation failures (PR #7630)

--- a/cli/refresh_csrf.php
+++ b/cli/refresh_csrf.php
@@ -78,11 +78,11 @@ if (!file_exists($path_csrf_secret)) {
 	unlink($path_csrf_secret);
 }
 
-$new_secret = csrf_generate_secret();
+$new_secret = cacti_csrf_secret_file_contents();
 if (csrf_writable($path_csrf_secret)) {
 	umask(0027);
 	$fh = fopen($path_csrf_secret, 'w');
-	fwrite($fh, '<?php $secret = "' . $new_secret . '";' . PHP_EOL);
+	fwrite($fh, $new_secret);
 	fclose($fh);
 	print "NOTE: New csrf_secret.php file written." . PHP_EOL;
 	exit(0);
@@ -106,4 +106,3 @@ function display_help () {
 	print "this key should happen periodically during non-production hours as it can" . PHP_EOL;
 	print "impact the user experience." . PHP_EOL . PHP_EOL;
 }
-

--- a/include/csrf.php
+++ b/include/csrf.php
@@ -24,11 +24,82 @@
 
 require_once($config['include_path'] .'/vendor/csrf/csrf-conf.php');
 
+function cacti_csrf_generate_secret($length = 32) {
+	if (!is_int($length) || $length < 32) {
+		$length = 32;
+	}
+
+	return bin2hex(random_bytes($length));
+}
+
+function cacti_csrf_secret_file_contents() {
+	return '<?php' . PHP_EOL .
+		'/* Cacti CSRF secret: ' . cacti_csrf_generate_secret() . ' */' . PHP_EOL;
+}
+
+function cacti_csrf_read_or_create_secret($paths) {
+	foreach ($paths as $path) {
+		if (is_file($path)) {
+			$secret = @file_get_contents($path);
+			if (is_string($secret) && $secret !== '') {
+				return $secret;
+			}
+		}
+	}
+
+	foreach ($paths as $path) {
+		$old_umask = umask(0027);
+		$handle = @fopen($path, 'x');
+		umask($old_umask);
+
+		if ($handle !== false) {
+			$secret = cacti_csrf_secret_file_contents();
+			$written = fwrite($handle, $secret);
+			fclose($handle);
+
+			if ($written === strlen($secret)) {
+				return $secret;
+			}
+
+			@unlink($path);
+		} elseif (is_file($path)) {
+			/* Another request may have won the exclusive-create race. */
+			$secret = @file_get_contents($path);
+			if (is_string($secret) && $secret !== '') {
+				return $secret;
+			}
+		}
+	}
+
+	/* Read-only web roots can still retain a strong per-session secret. */
+	csrf_start();
+	if (session_id()) {
+		if (empty($_SESSION['cacti_csrf_secret'])) {
+			$_SESSION['cacti_csrf_secret'] = cacti_csrf_generate_secret();
+		}
+
+		return $_SESSION['cacti_csrf_secret'];
+	}
+
+	return '';
+}
+
 /* cross site request forgery library */
 function csrf_startup() {
 	global $config;
 
 	if ($config['is_web']) {
+		$secret_paths = array();
+		if (!empty($config['path_csrf_secret'])) {
+			$secret_paths[] = $config['path_csrf_secret'];
+		}
+		$secret_paths[] = __DIR__ . '/vendor/csrf/csrf-secret.php';
+
+		$secret = cacti_csrf_read_or_create_secret(array_unique($secret_paths));
+		if ($secret !== '') {
+			csrf_conf('secret', $secret);
+		}
+
 		/* If you need to debug CSRF, uncomment the following line */
 		//csrf_conf('log_file', dirname(read_config_option('path_cactilog')) . '/csrf.log');
 		if (!empty($config['path_csrf_secret'])) {

--- a/install/functions.php
+++ b/install/functions.php
@@ -70,7 +70,7 @@ function install_create_csrf_secret($file) {
 		if (is_resource_writable($file)) {
 			// Write the file
 			$fh = fopen($file, 'w');
-			fwrite($fh, csrf_get_secret());
+			fwrite($fh, cacti_csrf_secret_file_contents());
 			fclose($fh);
 
 			return true;

--- a/tests/Unit/Security/Csrf/CsrfSecretGenerationTest.php
+++ b/tests/Unit/Security/Csrf/CsrfSecretGenerationTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+$GLOBALS['config'] = array(
+	'include_path' => $root . '/include',
+	'is_web' => false,
+);
+$config = &$GLOBALS['config'];
+
+require_once $root . '/include/csrf.php';
+
+test('CSRF secrets use the platform cryptographic random source', function () {
+	$first = cacti_csrf_generate_secret();
+	$second = cacti_csrf_generate_secret();
+
+	expect($first)->toMatch('/^[a-f0-9]{64}$/')
+		->and($second)->toMatch('/^[a-f0-9]{64}$/')
+		->and($second)->not->toBe($first);
+});
+
+test('persistent CSRF secret files are PHP-safe and reused', function () {
+	$directory = sys_get_temp_dir() . '/cacti_csrf_' . bin2hex(random_bytes(8));
+	mkdir($directory, 0700);
+	$path = $directory . '/csrf-secret.php';
+
+	try {
+		$first = cacti_csrf_read_or_create_secret(array($path));
+		$second = cacti_csrf_read_or_create_secret(array($path));
+
+		expect($first)->toBe($second)
+			->and(file_get_contents($path))->toBe($first)
+			->and($first)->toMatch('/^<\?php\R\/\* Cacti CSRF secret: [a-f0-9]{64} \*\/\R$/');
+	} finally {
+		@unlink($path);
+		@rmdir($directory);
+	}
+});
+
+test('legacy CSRF randomness is not used by Cacti integration paths', function () use ($root) {
+	$integration = file_get_contents($root . '/include/csrf.php');
+	$installer = file_get_contents($root . '/install/functions.php');
+	$refresh = file_get_contents($root . '/cli/refresh_csrf.php');
+
+	expect($integration)->not->toContain('mt_rand(')
+		->and($installer)->toContain('cacti_csrf_secret_file_contents()')
+		->and($refresh)->toContain('cacti_csrf_secret_file_contents()')
+		->and($refresh)->not->toContain('csrf_generate_secret()');
+});

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -277,8 +277,8 @@ dynamic_include	./color_templates.php:485		include_once($config['base_path'] . '
 dynamic_include	./graph_realtime.php:382	    <?php include($config['base_path'] . '/include/global_session.php'); ?>
 dynamic_include	./include/auth.php:121					require_once($config['base_path'] . '/auth_login.php');
 dynamic_include	./include/auth.php:176				require_once($config['base_path'] . '/auth_login.php');
+dynamic_include	./include/csrf.php:127	include_once($config['include_path'] . '/vendor/csrf/csrf-magic.php');
 dynamic_include	./include/csrf.php:25	require_once($config['include_path'] .'/vendor/csrf/csrf-conf.php');
-dynamic_include	./include/csrf.php:56	include_once($config['include_path'] . '/vendor/csrf/csrf-magic.php');
 dynamic_include	./include/global.php:277	include_once($config['library_path'] . '/database.php');
 dynamic_include	./include/global.php:278	include_once($config['library_path'] . '/functions.php');
 dynamic_include	./include/global.php:279	include_once($config['library_path'] . '/graph_template_input.php');
@@ -349,11 +349,11 @@ dynamic_include	./lib/api_automation.php:2386		include_once($config['base_path']
 dynamic_include	./lib/api_device.php:946		include_once($config['base_path'] . '/lib/utility.php');
 dynamic_include	./lib/api_device.php:947		include_once($config['base_path'] . '/lib/variables.php');
 dynamic_include	./lib/api_device.php:948		include_once($config['base_path'] . '/lib/data_query.php');
-dynamic_include	./lib/boost.php:1416		include($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/boost.php:1731			include_once($config['library_path'] . '/poller.php');
-dynamic_include	./lib/boost.php:327			include_once($config['library_path'] . '/poller.php');
-dynamic_include	./lib/boost.php:467		include_once($config['library_path'] . '/poller.php');
-dynamic_include	./lib/boost.php:817		include_once($config['library_path'] . '/rrd.php');
+dynamic_include	./lib/boost.php:1418		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/boost.php:1733			include_once($config['library_path'] . '/poller.php');
+dynamic_include	./lib/boost.php:329			include_once($config['library_path'] . '/poller.php');
+dynamic_include	./lib/boost.php:469		include_once($config['library_path'] . '/poller.php');
+dynamic_include	./lib/boost.php:819		include_once($config['library_path'] . '/rrd.php');
 dynamic_include	./lib/data_query.php:1963		include_once($config['library_path'] . '/sort.php');
 dynamic_include	./lib/data_query.php:2372		include_once($config['library_path'] . '/variables.php');
 dynamic_include	./lib/data_query.php:602		include_once($config['library_path'] . '/xml.php');
@@ -466,7 +466,7 @@ dynamic_include	./poller_boost.php:36	require_once($config['base_path'] . '/lib/
 dynamic_include	./poller_boost.php:37	require_once($config['base_path'] . '/lib/dsstats.php');
 dynamic_include	./poller_boost.php:38	require_once($config['base_path'] . '/lib/rrdcheck.php');
 dynamic_include	./poller_boost.php:39	require_once($config['base_path'] . '/lib/rrd.php');
-dynamic_include	./poller_boost.php:777		include_once($config['library_path'] . '/rrd.php');
+dynamic_include	./poller_boost.php:780		include_once($config['library_path'] . '/rrd.php');
 dynamic_include	./poller_commands.php:40	require_once($config['base_path'] . '/lib/api_device.php');
 dynamic_include	./poller_commands.php:41	require_once($config['base_path'] . '/lib/api_data_source.php');
 dynamic_include	./poller_commands.php:42	require_once($config['base_path'] . '/lib/api_graph.php');
@@ -545,6 +545,7 @@ fs_write	./cli/splice_rrd.php:47				if (($f = @fopen($path, 'a'))) {
 fs_write	./cli/splice_rrd.php:56			if (($f = @fopen($path, 'w'))) {
 fs_write	./cli/splice_rrd.php:872		return file_put_contents($xmlfile, $output);
 fs_write	./host.php:591		$stdout = fopen('php://output', 'w');
+fs_write	./include/csrf.php:52			$handle = @fopen($path, 'x');
 fs_write	./include/global_languages.php:956			file_put_contents($config['i18n_log'], $text . $eol, $mode);
 fs_write	./include/global_languages.php:964			file_put_contents($config['i18n_text_log'], $text . $eol, $mode);
 fs_write	./include/themes/midwinter/update_hash.php:61			file_put_contents($cssFile, $fileUpdated);
@@ -554,8 +555,8 @@ fs_write	./install/functions.php:365			file_put_contents($cacheFile, '<[version]
 fs_write	./install/functions.php:72				$fh = fopen($file, 'w');
 fs_write	./install/functions.php:856						$fp = fopen($config_file, 'w');
 fs_write	./lib/api_device.php:2637							file_put_contents($new_xmlfile, $data);
-fs_write	./lib/boost.php:422		$fileptr = fopen($temp_file, 'wb');
-fs_write	./lib/boost.php:574								if ($fileptr = fopen($cache_file, 'rb')) {
+fs_write	./lib/boost.php:424		$fileptr = fopen($temp_file, 'wb');
+fs_write	./lib/boost.php:576								if ($fileptr = fopen($cache_file, 'rb')) {
 fs_write	./lib/clog_webapi.php:119					$log_fh = fopen($logfile, 'w');
 fs_write	./lib/csp_report_endpoint.php:164	$input   = @fopen('php://input', 'rb');
 fs_write	./lib/csp_report_endpoint.php:199		   leaving a symlink there gave fopen() somewhere else to write. */
@@ -824,7 +825,7 @@ header_redirect	./images/index.php:25	header("Location:../index.php");
 header_redirect	./include/auth.php:50		header ('Location: ' . $config['url_path'] . 'install/');
 header_redirect	./include/auth.php:71				header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?ref=' . rawurlencode(validate_redirect_url($_SERVER['HTTP_REFERER'] ?? '', 'index.php')));
 header_redirect	./include/content/index.php:25	header("Location:../index.php");
-header_redirect	./include/csrf.php:51		header('Location: ' . validate_redirect_url($_SERVER['REQUEST_URI']));
+header_redirect	./include/csrf.php:122		header('Location: ' . validate_redirect_url($_SERVER['REQUEST_URI']));
 header_redirect	./include/fa/css/index.php:25	header("Location:../index.php");
 header_redirect	./include/fa/index.php:25	header("Location:../index.php");
 header_redirect	./include/fa/js/index.php:25	header("Location:../index.php");


### PR DESCRIPTION
## Summary

- generate new CSRF secrets with `random_bytes()` instead of the legacy helper’s `mt_rand()` fallback
- exclusively create persistent secret files with restrictive permissions and reuse the winner of concurrent creation
- store new default secret files as non-outputting PHP so they are safe beneath the web root
- retain a strong per-session secret when the configured paths are read-only
- use the same generator during installation and `refresh_csrf.php`
- regenerate the audited sink inventory for the new exclusive file-creation sink

This is defense in depth: Cacti’s active CSRF tokens are already session-bound, and I did not identify a practical cross-user forgery from the legacy generator.

## Validation

- 3 focused tests, 10 assertions
- 5 related CSRF tests, 11 assertions
- PHP syntax checks
- Composer validation and audit (no advisories)
- sink inventory policy check
- architectural hotspot policy check

The full CSRF directory also contains one pre-existing source-inspection failure: `CsrfHardeningTest` expects a `delete` action literal that is absent on the 1.2.x base. The tests affected by this change pass independently.

## Release targeting

- Target branch: `1.2.x`
- Planned milestone: `v1.2.32`
- Release line: maintenance branch; develop-only architectural work remains on `develop`.
