### PR TITLE
Fail closed on missing OAuth callback state

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 
 1.3.0-dev
 -security: Replace sibling password-reset links and revoke authentication state after reset
+-issue: Fail closed when OAuth callback state is absent or mismatched
 -issue#7775: Add plugin-extensible notification API
 -issue#7746: Make PHP 8.1 dependency builds reproducible
 -issue#7672: Block loopback/link-local SSRF targets in call_remote_data_collector

--- a/oauth2.php
+++ b/oauth2.php
@@ -70,11 +70,14 @@ if (!isrv('code')) { // If we don't have an authorization code then get one
 	// Check given state against previously stored one to mitigate CSRF attack
 }
 
-if (isempty_request_var('state') || (isset($_SESSION['oauth2state']) && (grv('state') !== $_SESSION['oauth2state']))) {
+if (isempty_request_var('state') || empty($_SESSION['oauth2state']) ||
+	!hash_equals((string) $_SESSION['oauth2state'], (string) grv('state'))) {
 	unset($_SESSION['oauth2state']);
 
 	exit('Invalid state');
 } else { // Try to get an access token (using the authorization code grant)
+	unset($_SESSION['oauth2state']);
+
 	$token = $provider->getAccessToken(
 		'authorization_code',
 		[

--- a/tests/Unit/Security/Auth/CactiOAuthTest.php
+++ b/tests/Unit/Security/Auth/CactiOAuthTest.php
@@ -108,3 +108,11 @@ it('runtime OAuth entrypoints load the flat CactiOAuth helper before use', funct
         ->and($functions)->toContain("require_once(CACTI_PATH_LIBRARY . '/CactiOAuth.php')")
         ->and($functions)->toContain('CactiOAuth::getProvider');
 });
+
+it('OAuth callbacks fail closed when the session state is absent or mismatched', function () {
+    $oauth2 = file_get_contents(dirname(__DIR__, 4) . '/oauth2.php');
+
+    expect($oauth2)->toContain("empty(\$_SESSION['oauth2state'])")
+        ->and($oauth2)->toContain('hash_equals((string) $_SESSION[\'oauth2state\'], (string) grv(\'state\'))')
+        ->and($oauth2)->toContain("unset(\$_SESSION['oauth2state']);");
+});


### PR DESCRIPTION
## Summary

- reject OAuth callbacks when the session has no stored state
- compare the state with `hash_equals()`
- consume the stored state after a successful validation to prevent reuse
- add regression coverage for absent and mismatched state

This is a defense-in-depth fix for the develop OAuth flow. The callback is authenticated through the configured provider, but accepting a callback without a session state weakens the intended CSRF guarantee.

## Validation

- 18 focused tests, 30 assertions
- PHP syntax check
- sink inventory policy check
- architectural hotspot policy check
- final rebase and range-diff against `develop`

## Release targeting

- Target branch: `develop`
- Planned milestone: `v1.3.0`
- Release line: primary development branch; this is not a 1.2.x backport.
