### PR TITLE
Keep missing PHP extensions visible to the installer

### DIFF
--- a/.github/workflows/dependency-compatibility.yml
+++ b/.github/workflows/dependency-compatibility.yml
@@ -57,6 +57,17 @@ jobs:
       - name: Smoke-test the production autoloader
         run: php -r "require 'include/vendor/autoload.php';"
 
+      - name: Keep extension diagnostics in the Cacti installer
+        run: |
+          set -euo pipefail
+          test "$(composer config platform-check)" = php-only
+          grep -Fq 'PHP_VERSION_ID' include/vendor/composer/platform_check.php
+          if grep -Fq 'extension_loaded(' include/vendor/composer/platform_check.php; then
+            echo 'Composer platform check unexpectedly enforces PHP extensions' >&2
+            exit 1
+          fi
+          php -n -r "require 'include/vendor/autoload.php';"
+
   native-dependencies:
     name: PHP ${{ matrix.php }} native dependencies
     runs-on: ubuntu-24.04

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.x
+-issue: Keep missing PHP extensions visible to the Cacti installer (PR #7747 follow-up)
 -issue: Url encode the base64 regex filter before it reaches the query string (PR #7777)
 -issue: Make 1.2 dependency builds reproducible (PR #7747)
 -issue: Propagate background installation failures (PR #7630)

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "platform": {
             "php": "8.0.0"
         },
-        "platform-check": true,
+        "platform-check": "php-only",
         "sort-packages": true,
         "vendor-dir": "./include/vendor"
     }

--- a/include/vendor/composer/platform_check.php
+++ b/include/vendor/composer/platform_check.php
@@ -8,29 +8,6 @@ if (!(PHP_VERSION_ID >= 80000)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 8.0.0". You are running ' . PHP_VERSION . '.';
 }
 
-$missingExtensions = array();
-extension_loaded('dom') || $missingExtensions[] = 'dom';
-extension_loaded('gd') || $missingExtensions[] = 'gd';
-extension_loaded('gmp') || $missingExtensions[] = 'gmp';
-extension_loaded('intl') || $missingExtensions[] = 'intl';
-extension_loaded('json') || $missingExtensions[] = 'json';
-extension_loaded('ldap') || $missingExtensions[] = 'ldap';
-extension_loaded('mbstring') || $missingExtensions[] = 'mbstring';
-extension_loaded('mysqlnd') || $missingExtensions[] = 'mysqlnd';
-extension_loaded('openssl') || $missingExtensions[] = 'openssl';
-PHP_SAPI !== 'cli' || extension_loaded('pcntl') || $missingExtensions[] = 'pcntl';
-extension_loaded('pdo') || $missingExtensions[] = 'pdo';
-extension_loaded('pdo_mysql') || $missingExtensions[] = 'pdo_mysql';
-extension_loaded('phar') || $missingExtensions[] = 'phar';
-extension_loaded('posix') || $missingExtensions[] = 'posix';
-extension_loaded('sockets') || $missingExtensions[] = 'sockets';
-extension_loaded('sqlite3') || $missingExtensions[] = 'sqlite3';
-extension_loaded('xml') || $missingExtensions[] = 'xml';
-
-if ($missingExtensions) {
-    $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions) . '.';
-}
-
 if ($issues) {
     if (!headers_sent()) {
         header('HTTP/1.1 500 Internal Server Error');

--- a/tests/Unit/Installer/ComposerPlatformCheckContractTest.php
+++ b/tests/Unit/Installer/ComposerPlatformCheckContractTest.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ */
+
+$root = dirname(__DIR__, 3);
+
+test('Composer leaves extension diagnostics to the Cacti installer', function () use ($root) {
+	$composer = json_decode(file_get_contents($root . '/composer.json'), true, flags: JSON_THROW_ON_ERROR);
+	$platformCheck = file_get_contents($root . '/include/vendor/composer/platform_check.php');
+
+	expect($composer['config']['platform-check'])->toBe('php-only')
+		->and($platformCheck)->toContain('PHP_VERSION_ID')
+		->and($platformCheck)->not->toContain('extension_loaded(')
+		->and($platformCheck)->not->toContain('$missingExtensions');
+});


### PR DESCRIPTION
## Summary

- keep Composer's PHP 8.0 version guard while leaving missing-extension diagnostics to Cacti's installer;
- verify the generated Composer bootstrap does not enforce extensions;
- reproduce the affected extension-free path in CI with `php -n`;
- add a focused Pest contract to prevent future Composer regeneration from restoring the regression.

## Related report

Follow-up to #7747. This resolves the installer failure [reported by @olafhering on that PR](https://github.com/Cacti/cacti/pull/7747#issuecomment-5407910994).

The refreshed Composer bootstrap began enforcing every root extension before Cacti could load its installer dependency screen. The fix returns extension diagnostics to the existing installer flow without weakening the PHP runtime requirement.

## Validation

- Composer strict validation
- targeted Pest contract on PHP 8.2
- extension-free autoloader smoke test
- actionlint
- `git diff --check`
- upstream CI matrix: 19 checks passed, 1 expected skip

Signed-off-by: Thomas Vincent <thomasvincent@gmail.com>
