### PR TITLE
fix(user_admin): validate group filter as an integer

### DIFF
--- a/tests/Unit/Security/SqlInjection/UserAdminGroupFilterTest.php
+++ b/tests/Unit/Security/SqlInjection/UserAdminGroupFilterTest.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$source = file_get_contents(dirname(__DIR__, 4) . '/user_admin.php');
+
+if ($source === false) {
+	throw new RuntimeException('Unable to read user_admin.php');
+}
+
+test('the user group filter is validated and constrained again at the SQL boundary', function () use ($source) {
+	expect($source)
+		->toContain("'group' => array(\n\t\t\t'filter' => FILTER_VALIDATE_INT,")
+		->toContain("\$group_id = (int) get_request_var('group');")
+		->toContain("' ug.group_id = ' . \$group_id;")
+		->not->toContain("' ug.group_id = ' . get_request_var('group');")
+		->not->toContain("'options' => array('options' => 'sanitize_search_string')\n\t\t),\n\t\t'sort_column'");
+});
+
+test('integer validation rejects SQL expressions accepted by the old search sanitizer', function () {
+	expect(filter_var('0 OR 1', FILTER_VALIDATE_INT))->toBeFalse()
+		->and(filter_var('1 UNION SELECT 1', FILTER_VALIDATE_INT))->toBeFalse()
+		->and(filter_var('-1', FILTER_VALIDATE_INT))->toBe(-1)
+		->and(filter_var('42', FILTER_VALIDATE_INT))->toBe(42);
+});

--- a/user_admin.php
+++ b/user_admin.php
@@ -2099,10 +2099,9 @@ function user() {
 			'default' => ''
 		),
 		'group' => array(
-			'filter' => FILTER_CALLBACK,
+			'filter' => FILTER_VALIDATE_INT,
 			'default' => '-1',
-			'pageset' => true,
-			'options' => array('options' => 'sanitize_search_string')
+			'pageset' => true
 		),
 		'sort_column' => array(
 			'filter' => FILTER_CALLBACK,

--- a/user_admin.php
+++ b/user_admin.php
@@ -2273,8 +2273,10 @@ function user() {
 		}
 	}
 
-	if (get_request_var('group') > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . ' ug.group_id = ' . get_request_var('group');
+	$group_id = (int) get_request_var('group');
+
+	if ($group_id > 0) {
+		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . ' ug.group_id = ' . $group_id;
 	}
 
 	if (get_request_var('login') > 0) {


### PR DESCRIPTION
## Problem

The `group` filter on the user list is a numeric group ID, but it was validated as free text through `sanitize_search_string` while sibling numeric filters use `FILTER_VALIDATE_INT`. The value is later concatenated into the `ug.group_id` predicate.

`validate_store_request_vars()` restores session-backed filter values without reapplying the declared filter. Request-level validation alone therefore does not protect an existing `sess_usera_group` value saved before an upgrade.

## Changes

- validate new `group` values with `FILTER_VALIDATE_INT`
- cast the restored value to an integer again at the SQL boundary
- add regression coverage for SQL-expression payloads and the sink-level constraint

## Related and duplicate review

- No other open pull request changes `user_admin.php`, `user_group_admin.php`, or `lib/html_utility.php`.
- The equivalent protection is already present on `develop` through commit `8355366e9`; this pull request is the focused `1.2.x` backport.
- Closed pull request #7101 and open pull request #7701 address adjacent SQL hardening but do not cover this filter.
- Adjacent callback-filtered values in the user/group administration paths are either quoted, parameterized, allowlisted, or select fixed SQL fragments; no second instance of this issue was found.

## Validation

- `UserAdminGroupFilterTest.php`: 2 tests passed
- PHP syntax checks passed for the changed production and test files
- `tests/security/verify_sink_inventory.sh`: passed
- `tests/security/verify_architectural_hotspots.sh`: passed
- `git diff --check`: passed