### PR TITLE
fix(html_tree): escape data query index in graph tree title

### DIFF
--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -941,7 +941,7 @@ function grow_right_pane_tree($tree_id, $leaf_id, $host_group_data) {
 			WHERE id = ?',
 			array($host_group_data_array[1]));
 
-		$host_group_data_name = '<strong>' . __('Graph Template:') . '</strong> ' . (empty($host_group_data_array[1]) ? __('Non Query Based') : html_escape($name)) . '-> ' . (empty($host_group_data_array[2]) ? __('Template Based') : get_formatted_data_query_index($leaf['host_id'], $host_group_data_array[1], $host_group_data_array[2]));
+		$host_group_data_name = '<strong>' . __('Graph Template:') . '</strong> ' . (empty($host_group_data_array[1]) ? __('Non Query Based') : html_escape($name)) . '-> ' . (empty($host_group_data_array[2]) ? __('Template Based') : html_escape(get_formatted_data_query_index($leaf['host_id'], $host_group_data_array[1], $host_group_data_array[2])));
 		$data_query_id    = $host_group_data_array[1];
 		$data_query_index = $host_group_data_array[2];
 	}


### PR DESCRIPTION
The graph tree node title runs the tree, site, leaf, device and graph-template names through `html_escape()`, but the data query index part is concatenated without it. That value is substituted from device SNMP data (`host_snmp_cache`), so it should be escaped the same way as the sibling parts before it reaches the title.