### PR TITLE
security: escape external link titles and the tree data query index

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -4509,7 +4509,7 @@ function draw_navigation_text(string $type = 'url') : string {
 		}
 	} elseif (preg_match('#link.php\?id=(\d+)#', $_SERVER['REQUEST_URI'], $matches)) {
 		$externalLinks = db_fetch_row_prepared('SELECT title, style FROM external_links WHERE id = ?', [$matches[1]]);
-		$title         = is_array($externalLinks) ? $externalLinks['title'] : '';
+		$title         = is_array($externalLinks) ? htmle($externalLinks['title']) : '';
 		$style         = is_array($externalLinks) ? $externalLinks['style'] : '';
 
 		if ($style == 'CONSOLE') {
@@ -4518,9 +4518,9 @@ function draw_navigation_text(string $type = 'url') : string {
 					<a id='nav_0' href='" . CACTI_PATH_URL . "index.php'>" . __('Console') . '</a>' .
 				'</li>';
 
-			$current_nav .= "<li><a id='nav_1' href='#'>" . __('Link %s', htmle($title)) . '</a></li>';
+			$current_nav .= "<li><a id='nav_1' href='#'>" . __('Link %s', $title) . '</a></li>';
 		} else {
-			$current_nav = "<ul id='breadcrumbs'><li><a id='nav_0'>" . htmle($title) . '</a></li>';
+			$current_nav = "<ul id='breadcrumbs'><li><a id='nav_0'>" . $title . '</a></li>';
 		}
 
 		$tree_title = '';

--- a/lib/html_tree.php
+++ b/lib/html_tree.php
@@ -1285,7 +1285,7 @@ function grow_right_pane_tree(int $tree_id, int $leaf_id, string $host_group_dat
 			WHERE id = ?',
 			[$host_group_data_array[1]]);
 
-		$host_group_data_name = '<i class="bold">' . __('Graph Template:') . '</i> ' . (empty($host_group_data_array[1]) ? __('Non Query Based') : htmle($name)) . '-> ' . (empty($host_group_data_array[2]) ? __('Template Based') : get_formatted_data_query_index($leaf['host_id'], intval($host_group_data_array[1]), $host_group_data_array[2]));
+		$host_group_data_name = '<i class="bold">' . __('Graph Template:') . '</i> ' . (empty($host_group_data_array[1]) ? __('Non Query Based') : htmle($name)) . '-> ' . (empty($host_group_data_array[2]) ? __('Template Based') : htmle(get_formatted_data_query_index($leaf['host_id'], intval($host_group_data_array[1]), $host_group_data_array[2])));
 		$data_query_id        = intval($host_group_data_array[1]);
 		$data_query_index     = $host_group_data_array[2];
 	}


### PR DESCRIPTION
Two display values reach HTML sinks without escaping.

`external_links.title` is stored with an empty validation regex in `links.php`, and the
`title` branch of `draw_navigation_text()` returned it raw. It is printed unescaped into
the `<title>` element by the three `top_*_header.php` files and by `html_common_header()`.
Escaping now happens where the column enters the accumulator, matching what the normal
navigation path already does one branch below. The two `htmle($title)` calls in the same
branch became redundant and were removed so breadcrumb titles are not double-encoded.

`get_formatted_data_query_index()` in the tree graph header is the only part of that
concatenation not escaped; the sibling `$name` on the same line already is. SNMP-collected
values are stripped of `<>"'` by `format_snmp_string()`, so this is not reachable through
the SNMP path, but script-query output reaches `host_snmp_cache.field_value` at
`lib/data_query.php:743` without that filter.

Verification: `php -l` on both files, and a before/after harness driving the real
`form_input_validate()` and `draw_navigation_text()` title branch on PHP 8.4.24.
