### PR TITLE
Make password reset links account-wide and single-use

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-security: Replace sibling password-reset links and revoke authentication state after reset
 -issue#7775: Add plugin-extensible notification API
 -issue#7746: Make PHP 8.1 dependency builds reproducible
 -issue#7672: Block loopback/link-local SSRF targets in call_remote_data_collector

--- a/auth_resetpassword.php
+++ b/auth_resetpassword.php
@@ -76,23 +76,22 @@ switch ($action) {
 		if (cacti_sizeof($user) && $user['email_address'] != '') {
 			$hash = generate_hash();
 
-			db_execute_prepared('INSERT INTO user_auth_reset_hashes
-				(user_id, hash, expiry)
-				VALUES (?, ?, date_add(now(), interval ? minute))',
-				[$user['id'], $hash, read_config_option('secnotify_resetlink_timeout')]);
+			if (auth_reset_token_replace($user['id'], $hash, (int) read_config_option('secnotify_resetlink_timeout'))) {
+				$replacement = [
+					read_config_option('base_url') . CACTI_PATH_URL,
+					$user['username'],
+					read_config_option('base_url') . CACTI_PATH_URL . 'auth_resetpassword.php?action=formreset&hash=' . $hash
+				];
 
-			$replacement = [
-				read_config_option('base_url') . CACTI_PATH_URL,
-				$user['username'],
-				read_config_option('base_url') . CACTI_PATH_URL . 'auth_resetpassword.php?action=formreset&hash=' . $hash
-			];
+				$search = ['<CACTIURL>', '<USERNAME>', '<PWDRESETLINK>'];
 
-			$search = ['<CACTIURL>', '<USERNAME>', '<PWDRESETLINK>'];
+				$body = str_replace($search, $replacement, read_config_option('secnotify_chpass_message'));
 
-			$body = str_replace($search, $replacement, read_config_option('secnotify_chpass_message'));
-
-			send_mail($user['email_address'], null, read_config_option('secnotify_chpass_subject'), $body, [], [],  true);
-			cacti_log(sprintf('NOTE: Reset password request for user %s from IP %s', $user['username'], get_client_addr()), false, 'SYSTEM');
+				send_mail($user['email_address'], null, read_config_option('secnotify_chpass_subject'), $body, [], [],  true);
+				cacti_log(sprintf('NOTE: Reset password request for user %s from IP %s', $user['username'], get_client_addr()), false, 'SYSTEM');
+			} else {
+				cacti_log(sprintf('ERROR: Unable to replace password reset token for user %s', $user['username']), false, 'AUTH');
+			}
 		} else {
 			cacti_log(sprintf('NOTE: Reset password request for unknown user "%s" from IP %s', db_qstr($identity), get_client_addr()), false, 'SYSTEM');
 		}
@@ -172,13 +171,49 @@ switch ($action) {
 
 		// If password isn't blank, password change is good to go
 		if ($password != '') {
+			db_check_password_length();
+
+			if (!db_begin_transaction()) {
+				$errorMessage = "<span class='badpassword_message'>" . __('Unable to securely consume the password reset link.') . '</span>';
+				$action       = 'formidentity';
+
+				break;
+			}
+
+			$locked_user = db_fetch_cell_prepared('SELECT id
+				FROM user_auth
+				WHERE id = ?
+				AND realm = 0
+				AND enabled = "on"
+				FOR UPDATE',
+				[$user['id']]);
+
+			$locked_token_user = db_fetch_cell_prepared('SELECT user_id
+				FROM user_auth_reset_hashes
+				WHERE user_id = ?
+				AND hash = ?
+				AND expiry > NOW()
+				FOR UPDATE',
+				[$user['id'], $user_hash]);
+
+			if ((int) $locked_user !== (int) $user['id'] ||
+				(int) $locked_token_user !== (int) $user['id']) {
+				db_rollback_transaction();
+				$errorMessage = "<span class='badpassword_message'>" . __('Incorrect resetlink hash') . '</span>';
+				$action       = 'formidentity';
+
+				break;
+			}
+
+			$reset_ok = true;
+
 			if (read_config_option('secpass_expirepass') > 0) {
-				db_execute_prepared("UPDATE user_auth
+				$reset_ok = db_execute_prepared("UPDATE user_auth
 					SET lastchange = ?
 					WHERE id = ?
 					AND realm = 0
 					AND enabled = 'on'",
-					[time(), $user['id']]);
+					[time(), $user['id']]) !== false;
 			}
 
 			$history = intval(read_config_option('secpass_history'));
@@ -201,29 +236,37 @@ switch ($action) {
 				$h[] = $op;
 				$h   = implode('|', $h);
 
-				db_execute_prepared("UPDATE user_auth
+				$reset_ok = $reset_ok && db_execute_prepared("UPDATE user_auth
 					SET password_history = ?
 					WHERE id = ?
 					AND realm = 0
 					AND enabled = 'on'",
-					[$h, $user['id']]);
+					[$h, $user['id']]) !== false;
 			}
 
-			db_execute_prepared('INSERT IGNORE INTO user_log
+			$reset_ok = $reset_ok && db_execute_prepared('INSERT IGNORE INTO user_log
 				(username, result, time, ip)
 				VALUES (?, 3, NOW(), ?)',
-				[$user['username'], get_client_addr()]);
+				[$user['username'], get_client_addr()]) !== false;
 
-			db_check_password_length();
-
-			db_execute_prepared("UPDATE user_auth
+			$reset_ok = $reset_ok && db_execute_prepared("UPDATE user_auth
 				SET must_change_password = '', password = ?
 				WHERE id = ?",
-				[compat_password_hash($password,PASSWORD_DEFAULT), $user['id']]);
+				[compat_password_hash($password, PASSWORD_DEFAULT), $user['id']]) !== false;
 
-			db_execute_prepared('DELETE FROM user_auth_reset_hashes
-				WHERE hash = ?',
-				[$user_hash]);
+			$reset_ok = $reset_ok && db_execute_prepared('DELETE FROM user_auth_reset_hashes
+				WHERE user_id = ?',
+				[$user['id']]) !== false;
+			$reset_ok = $reset_ok && db_execute_prepared('DELETE FROM user_auth_cache WHERE user_id = ?', [$user['id']]) !== false;
+			$reset_ok = $reset_ok && db_execute_prepared('DELETE FROM sessions WHERE user_id = ?', [$user['id']]) !== false;
+
+			if (!$reset_ok || !db_commit_transaction()) {
+				db_rollback_transaction();
+				$errorMessage = "<span class='badpassword_message'>" . __('Unable to securely consume the password reset link.') . '</span>';
+				$action       = 'formidentity';
+
+				break;
+			}
 
 			raise_message('password_success');
 

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -670,6 +670,47 @@ function user_enable(int $user_id) : void {
 }
 
 /**
+ * Replace every outstanding password-reset token for a local user.
+ *
+ * Locking the user row serializes the self-service and administrator issuance
+ * paths, so concurrent requests cannot leave multiple valid reset links.
+ *
+ * @param int    $user_id         The local user receiving the token
+ * @param string $hash            Cryptographically random reset-token hash
+ * @param int    $timeout_minutes Token lifetime in minutes
+ *
+ * @return bool True when the replacement token was committed
+ */
+function auth_reset_token_replace(int $user_id, string $hash, int $timeout_minutes) : bool {
+	if ($user_id <= 0 || $hash === '' || $timeout_minutes <= 0 || !db_begin_transaction()) {
+		return false;
+	}
+
+	$locked_user = db_fetch_cell_prepared('SELECT id
+		FROM user_auth
+		WHERE id = ?
+		AND realm = 0
+		AND enabled = "on"
+		FOR UPDATE',
+		[$user_id]);
+
+	$success = (int) $locked_user === $user_id &&
+		db_execute_prepared('DELETE FROM user_auth_reset_hashes WHERE user_id = ?', [$user_id]) !== false &&
+		db_execute_prepared('INSERT INTO user_auth_reset_hashes
+			(user_id, hash, expiry)
+			VALUES (?, ?, date_add(now(), interval ? minute))',
+			[$user_id, $hash, $timeout_minutes]) !== false;
+
+	if ($success && db_commit_transaction()) {
+		return true;
+	}
+
+	db_rollback_transaction();
+
+	return false;
+}
+
+/**
  * Retrieves the authentication realms based on the configured authentication method.
  *
  * @param bool $login Whether the function is being called during a login process. Default is false.

--- a/tests/Unit/Security/Auth/ResetLinkConsumptionTest.php
+++ b/tests/Unit/Security/Auth/ResetLinkConsumptionTest.php
@@ -83,3 +83,23 @@ test('the consumption query in source does not gate on password_change', functio
 		->and($consume)->toContain('AND enabled = "on"')
 		->and($consume)->not->toContain('AND password_change = "on"');
 });
+
+test('issuing a reset link replaces all outstanding links under a user-row lock', function () use ($root) {
+	$auth = file_get_contents($root . '/lib/auth.php');
+
+	expect($auth)->toContain('function auth_reset_token_replace(')
+		->and($auth)->toContain('FOR UPDATE')
+		->and($auth)->toContain('DELETE FROM user_auth_reset_hashes WHERE user_id = ?');
+});
+
+test('successful reset revalidates the token under lock and revokes sibling credentials', function () use ($root) {
+	$reset = file_get_contents($root . '/auth_resetpassword.php');
+	$body  = substr($reset, strpos($reset, "case 'resetpassword'"));
+
+	expect($body)->toContain('AND hash = ?')
+		->and($body)->toContain('FOR UPDATE')
+		->and($body)->toContain("DELETE FROM user_auth_reset_hashes\n\t\t\t\tWHERE user_id = ?")
+		->and($body)->toContain('DELETE FROM user_auth_cache WHERE user_id = ?')
+		->and($body)->toContain('DELETE FROM sessions WHERE user_id = ?')
+		->and($body)->not->toContain("DELETE FROM user_auth_reset_hashes\n\t\t\t\tWHERE hash = ?");
+});

--- a/user_admin.php
+++ b/user_admin.php
@@ -584,28 +584,31 @@ function form_save() : void {
 			$user_id = sql_save($save, 'user_auth');
 
 			if ($user_id) {
+				$reset_link_created = false;
+
 				if (($save['id'] == 0 && read_config_option('secnotify_newuser') == 'on') ||
 					($save['id'] > 0 && read_config_option('secnotify_chpass') == 'on')) {
 					$hash = generate_hash();
 
-					$replacement = [
-						read_config_option('base_url') . CACTI_PATH_URL,
-						$save['username'],
-						read_config_option('base_url') . CACTI_PATH_URL . 'auth_resetpassword.php?action=formreset&hash=' . $hash
-					];
+					if (auth_reset_token_replace($user_id, $hash, (int) read_config_option('secnotify_resetlink_timeout'))) {
+						$replacement = [
+							read_config_option('base_url') . CACTI_PATH_URL,
+							$save['username'],
+							read_config_option('base_url') . CACTI_PATH_URL . 'auth_resetpassword.php?action=formreset&hash=' . $hash
+						];
 
-					$search = ['<CACTIURL>', '<USERNAME>', '<PWDRESETLINK>'];
-
-					db_execute_prepared('INSERT INTO user_auth_reset_hashes
-						(user_id, hash, expiry)
-						VALUES (?, ?, date_add(now(), interval ? minute))',
-						[$user_id, $hash, read_config_option('secnotify_resetlink_timeout')]);
+						$search             = ['<CACTIURL>', '<USERNAME>', '<PWDRESETLINK>'];
+						$reset_link_created = true;
+					} else {
+						$search = $replacement = '';
+						raise_message('reset_token_error', __('Unable to securely issue the password reset link.'), MESSAGE_LEVEL_ERROR);
+					}
 				} else {
 					$search = $replacement = '';
 				}
 
 				if ($save['id'] == 0) {
-					if ($save['email_address'] && read_config_option('secnotify_newuser') == 'on') {
+					if ($reset_link_created && $save['email_address'] && read_config_option('secnotify_newuser') == 'on') {
 						$body = str_replace($search, $replacement, read_config_option('secnotify_newuser_message'));
 
 						send_mail($save['email_address'], null, read_config_option('secnotify_newuser_subject'), $body, [], [],  true);
@@ -615,7 +618,7 @@ function form_save() : void {
 				}
 
 				if ($save['id'] > 0) {
-					if ($save['email_address'] && read_config_option('secnotify_chpass') == 'on') {
+					if ($reset_link_created && $save['email_address'] && read_config_option('secnotify_chpass') == 'on') {
 						$body = str_replace($search, $replacement, read_config_option('secnotify_chpass_message'));
 
 						send_mail($save['email_address'], null, read_config_option('secnotify_chpass_subject'), $body, [], [],  true);


### PR DESCRIPTION
## Summary

- keep only one active password-reset link per account across self-service and administrator issuance
- serialize reset-token issuance and consumption with user-row locks and transactions
- revoke sibling reset links, active sessions, and persistent authentication cache entries after a successful reset

## Validation

- 16 targeted security tests (59 assertions)
- PHP syntax checks
- security sink inventory
- architectural hotspot verification
- `composer validate --strict --no-check-publish`
- `git diff --check`
