### PR TITLE
hardening: confine external-link content includes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.x
+-security: Constrain external-link includes to regular files inside the configured content directory
 -security: Harden advisory command execution and database DDL sink validation
 -security: Restrict graph input fields across the template, graph and import handoffs
 -security: Treat a non-boolean signature result as a failure in import_package

--- a/link.php
+++ b/link.php
@@ -66,10 +66,10 @@ if (!cacti_sizeof($page)) {
 		} else {
 			print '<div id="content">';
 
-			$basepath = $config['base_path'] . '/include/content';
-			$file     = realpath($basepath . '/' . $page['contentfile']);
+			$basepath = realpath($config['base_path'] . '/include/content');
+			$file     = ($basepath !== false) ? realpath($basepath . '/' . $page['contentfile']) : false;
 
-			if ($file !== false && substr($file, 0, strlen($basepath)) == $basepath) {
+			if ($file !== false && is_file($file) && cacti_path_is_within($file, $basepath)) {
 				include_once($file);
 			} else {
 				print '<h1>The file \'' . html_escape($page['contentfile']) . '\' does not exist!!</h1>';

--- a/tests/Unit/Security/Misc/DefenseInDepthFollowupTest.php
+++ b/tests/Unit/Security/Misc/DefenseInDepthFollowupTest.php
@@ -13,6 +13,7 @@ $boostSource = file_get_contents(__DIR__ . '/../../../../poller_boost.php');
 $importSource = file_get_contents(__DIR__ . '/../../../../package_import.php');
 $indexSource = file_get_contents(__DIR__ . '/../../../../index.php');
 $ssSource    = file_get_contents(__DIR__ . '/../../../../script_server.php');
+$linkSource  = file_get_contents(__DIR__ . '/../../../../link.php');
 
 // --- cacti_csv_safe ---
 
@@ -70,6 +71,14 @@ test('index.php uses cacti_path_is_within for include path validation', function
 
 test('script_server.php uses cacti_path_is_within for include path validation', function () use ($ssSource) {
 	expect($ssSource)->toContain('cacti_path_is_within(');
+});
+
+// --- link.php uses cacti_path_is_within ---
+
+test('link.php confines local content includes to regular files inside include/content', function () use ($linkSource) {
+	expect($linkSource)->toContain('cacti_path_is_within($file, $basepath)')
+		->and($linkSource)->toContain('is_file($file)')
+		->and($linkSource)->not->toContain('substr($file, 0, strlen($basepath)) == $basepath');
 });
 
 // --- db_replace redaction ---


### PR DESCRIPTION
## Summary

- resolve the configured external-link content directory before use
- require included external-link content to be a regular file
- enforce normalized path containment with the shared path-boundary helper

## Validation

- targeted containment regression assertion
- PHP syntax checks
- security sink inventory
- architectural hotspot verification
- `composer validate --strict --no-check-publish`
- `git diff --check`
