### PR TITLE
Refactor RRDtool execution for idiomatic PHP 8.1

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -202,6 +202,10 @@ jobs:
       run: composer run-script phpstan
       working-directory: .
 
+    - name: Run PHPStan at Level 8 on RRD code
+      run: composer run-script phpstan-rrd
+      working-directory: .
+
     - name: Run Pest Unit Tests
       run: composer run-script test
       working-directory: .

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "symfony/http-foundation": "^7.4",
         "symfony/mailer": "^7.4",
         "symfony/notifier": "^7.4",
+        "symfony/process": "^7.4",
         "symfony/validator": "^7.4"
     },
     "require-dev": {
@@ -74,6 +75,7 @@
     "scripts": {
         "lint": "phplint --no-cache --exclude=include/vendor --exclude=plugins ",
         "phpstan": "phpstan analyse --level 6 ",
+        "phpstan-rrd": "phpstan analyse --level 8 lib/rrd.php lib/Rrd ",
         "php-cs-fixer": "php-cs-fixer fix --allow-unsupported-php-version=yes --dry-run --diff --config=./.php-cs-fixer.php ",
         "phpcsfixer": "@php-cs-fixer",
         "hardening-patterns": "php tests/tools/check_hardening_patterns.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b11d855049443d645aa8a3cdfb2ed37",
+    "content-hash": "ae4bc4ea760feb92d4c530a51c2670d4",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -3123,6 +3123,71 @@
                 }
             ],
             "time": "2026-07-01T12:47:55+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.4.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "058d17fc284cce14efb2385783b55014a461b176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/058d17fc284cce14efb2385783b55014a461b176",
+                "reference": "058d17fc284cce14efb2385783b55014a461b176",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.4.17"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-21T17:40:08+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -8024,71 +8089,6 @@
                 }
             ],
             "time": "2026-05-26T12:51:13+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v7.4.17",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "058d17fc284cce14efb2385783b55014a461b176"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/058d17fc284cce14efb2385783b55014a461b176",
-                "reference": "058d17fc284cce14efb2385783b55014a461b176",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.17"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-08-21T17:40:08+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/lib/Rrd/LocalRrdTransport.php
+++ b/lib/Rrd/LocalRrdTransport.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+use Symfony\Component\Process\Process;
+use Throwable;
+
+/**
+ * Executes a structured RRDtool command without invoking an operating-system
+ * shell. Symfony owns process lifecycle and concurrent output collection.
+ */
+final class LocalRrdTransport implements RrdTransport {
+	public function __construct(
+		private readonly string $binary,
+	) {
+	}
+
+	public function execute(RrdCommand $command): RrdProcessResult {
+		try {
+			$process = new Process($command->toArgv($this->binary));
+
+			// Preserve the previous RRDtool execution contract, which had no timeout.
+			$process->setTimeout(null);
+			$exitCode = $process->run();
+		} catch (Throwable $exception) {
+			throw new RrdTransportException(
+				'Unable to execute RRDtool: ' . $exception->getMessage(),
+				(int) $exception->getCode(),
+				$exception
+			);
+		}
+
+		return new RrdProcessResult(
+			$process->getOutput(),
+			$process->getErrorOutput(),
+			$exitCode
+		);
+	}
+}

--- a/lib/Rrd/RrdCommand.php
+++ b/lib/Rrd/RrdCommand.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+use InvalidArgumentException;
+
+/**
+ * An RRDtool operation and its unescaped argument values.
+ *
+ * Keeping arguments separate allows local execution to bypass the shell. A
+ * transport that uses RRDtool's line protocol can serialize the same command
+ * with the quoting rules required by that protocol.
+ */
+final class RrdCommand {
+	/**
+	 * @param list<string> $arguments
+	 */
+	public function __construct(
+		public readonly string $operation,
+		public readonly array $arguments = [],
+	) {
+		$this->assertValidToken($operation, 'operation', false);
+
+		if (!array_is_list($arguments)) {
+			throw new InvalidArgumentException('RRDtool arguments must be a list.');
+		}
+
+		foreach ($arguments as $argument) {
+			$this->assertValidToken($argument, 'argument', true);
+		}
+	}
+
+	/**
+	 * @param array<array-key, scalar|null> $tokens
+	 */
+	public static function fromList(array $tokens): self {
+		$tokens = array_values(array_map(
+			static fn (mixed $token): string => (string) $token,
+			$tokens
+		));
+
+		$operation = array_shift($tokens);
+
+		if ($operation === null) {
+			throw new InvalidArgumentException('An RRDtool command requires an operation.');
+		}
+
+		return new self($operation, $tokens);
+	}
+
+	/**
+	 * @return non-empty-list<string>
+	 */
+	public function toArgv(string $binary): array {
+		$this->assertValidToken($binary, 'binary path', false);
+
+		return [$binary, $this->operation, ...$this->arguments];
+	}
+
+	private function assertValidToken(string $token, string $description, bool $allowEmpty): void {
+		if (!$allowEmpty && $token === '') {
+			throw new InvalidArgumentException("RRDtool $description cannot be empty.");
+		}
+
+		if (!$allowEmpty && preg_match('/\s/', $token) === 1) {
+			throw new InvalidArgumentException("RRDtool $description cannot contain whitespace.");
+		}
+
+		if (preg_match('/[\x00-\x1f\x7f]/', $token) === 1) {
+			throw new InvalidArgumentException("RRDtool $description contains a control character.");
+		}
+	}
+}

--- a/lib/Rrd/RrdCommandSerializer.php
+++ b/lib/Rrd/RrdCommandSerializer.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+final class RrdCommandSerializer {
+	/**
+	 * Serialize a command for RRDtool's line-oriented stdin/proxy protocol.
+	 *
+	 * @param callable(string): string $escapeArgument
+	 */
+	public function forLineProtocol(RrdCommand $command, callable $escapeArgument): string {
+		if ($command->arguments === []) {
+			return $command->operation;
+		}
+
+		return $command->operation . ' ' . implode(' ', array_map(
+			$escapeArgument,
+			$command->arguments
+		));
+	}
+}

--- a/lib/Rrd/RrdProcessResult.php
+++ b/lib/Rrd/RrdProcessResult.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+final class RrdProcessResult {
+	public function __construct(
+		public readonly string $stdout,
+		public readonly string $stderr,
+		public readonly int $exitCode,
+	) {
+	}
+
+	public function succeeded(): bool {
+		return $this->exitCode === 0;
+	}
+
+	public function outputWithErrors(): string {
+		return $this->stdout . $this->stderr;
+	}
+}

--- a/lib/Rrd/RrdTransport.php
+++ b/lib/Rrd/RrdTransport.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+interface RrdTransport {
+	public function execute(RrdCommand $command): RrdProcessResult;
+}

--- a/lib/Rrd/RrdTransportException.php
+++ b/lib/Rrd/RrdTransportException.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+use RuntimeException;
+
+final class RrdTransportException extends RuntimeException {
+}

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -23,6 +23,12 @@
 */
 
 require_once(__DIR__ . '/rrd_graph_item.php');
+require_once(__DIR__ . '/Rrd/RrdCommand.php');
+require_once(__DIR__ . '/Rrd/RrdCommandSerializer.php');
+require_once(__DIR__ . '/Rrd/RrdProcessResult.php');
+require_once(__DIR__ . '/Rrd/RrdTransport.php');
+require_once(__DIR__ . '/Rrd/RrdTransportException.php');
+require_once(__DIR__ . '/Rrd/LocalRrdTransport.php');
 
 define('RRD_NL', " \\\n");
 define('MAX_FETCH_CACHE_SIZE', 5);
@@ -248,11 +254,11 @@ function __rrd_proxy_init(string $logopt = 'WEBLOG') : mixed {
 
 		// set the rrdtool default font
 		if (read_config_option('path_rrdtool_default_font')) {
-			rrdtool_execute("setenv RRD_DEFAULT_FONT '" . read_config_option('path_rrdtool_default_font') . "'", false, RRDTOOL_OUTPUT_NULL, $rrdproxy, $logopt = 'WEBLOG');
+			rrdtool_execute(new \Cacti\Rrd\RrdCommand('setenv', ['RRD_DEFAULT_FONT', read_config_option('path_rrdtool_default_font')]), false, RRDTOOL_OUTPUT_NULL, $rrdproxy, 'WEBLOG');
 		}
 
 		// disable encryption
-		$encryption = rrdtool_execute('setcnn encryption off', false, RRDTOOL_OUTPUT_BOOLEAN, $rrdproxy, $logopt = 'WEBLOG') ? false : true;
+		$encryption = !rrdtool_execute(new \Cacti\Rrd\RrdCommand('setcnn', ['encryption', 'off']), false, RRDTOOL_OUTPUT_BOOLEAN, $rrdproxy, 'WEBLOG');
 
 		return $rrdproxy;
 	}
@@ -339,37 +345,53 @@ function decrypt(string $input) : string {
 	}
 }
 
-function rrdtool_execute() : mixed {
+function rrdtool_execute(
+	string|array|\Cacti\Rrd\RrdCommand $command_line,
+	bool $log_to_stdout,
+	int $output_flag = RRDTOOL_OUTPUT_STDOUT,
+	mixed $rrdtool_pipe = null,
+	string $logopt = 'WEBLOG'
+) : mixed {
 	global $config;
-
-	$args = func_get_args();
 
 	$local_storage = (isset($config['local_storage']) && $config['local_storage'] === true) ? true : false;
 
-	$function = ($local_storage === false && read_config_option('storage_location')) ? '__rrd_proxy_execute' : '__rrd_execute';
+	if ($local_storage === false && read_config_option('storage_location')) {
+		return __rrd_proxy_execute($command_line, $log_to_stdout, $output_flag, $rrdtool_pipe, $logopt);
+	}
 
-	return call_user_func_array($function, $args);
+	return __rrd_execute($command_line, $log_to_stdout, $output_flag, $rrdtool_pipe, $logopt);
 }
 
 /**
  * Execute an RRDtool command and return the output.
  *
- * @param string|array $command_line  The RRDtool command to execute.  An array is quoted here,
- *                                    one element per argument.  A caller passing a string quotes
- *                                    each variable argument with cacti_escapeshellarg() as it
- *                                    builds the line; the assembled line is never quoted
- * @param bool         $log_to_stdout Whether to echo output to stdout
- * @param int          $output_flag   Output format constant (RRDTOOL_OUTPUT_*)
- * @param mixed        $rrdtool_pipe  An open RRDtool pipe resource, or null
- * @param string       $logopt        Logging context identifier
+ * @param string|array|\Cacti\Rrd\RrdCommand $command_line  The RRDtool command to execute. New
+ *                                                          code should pass an RrdCommand so local execution bypasses
+ *                                                          the operating-system shell. Arrays remain supported as a
+ *                                                          compatibility shorthand. A caller passing a legacy string
+ *                                                          quotes each variable argument with cacti_escapeshellarg().
+ * @param bool                               $log_to_stdout Whether to echo output to stdout
+ * @param int                                $output_flag   Output format constant (RRDTOOL_OUTPUT_*)
+ * @param mixed                              $rrdtool_pipe  An open RRDtool pipe resource, or null
+ * @param string                             $logopt        Logging context identifier
  *
  * @return mixed The command output in the requested format
  */
-function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdtool_pipe = null, string $logopt = 'WEBLOG') : mixed {
+function __rrd_execute(string|array|\Cacti\Rrd\RrdCommand $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdtool_pipe = null, string $logopt = 'WEBLOG') : mixed {
 	static $last_command;
 
 	if (is_array($command_line)) {
-		$command_line = implode(' ', array_map('cacti_escapeshellarg', $command_line));
+		$command_line = \Cacti\Rrd\RrdCommand::fromList($command_line);
+	}
+
+	$structured_command = $command_line instanceof \Cacti\Rrd\RrdCommand ? $command_line : null;
+
+	if ($structured_command !== null) {
+		$command_line = (new \Cacti\Rrd\RrdCommandSerializer())->forLineProtocol(
+			$structured_command,
+			'cacti_escapeshellarg'
+		);
 	}
 
 	/**
@@ -399,13 +421,6 @@ function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $out
 		}
 	}
 
-	// use popen to eliminate the zombie issue
-	if (CACTI_SERVER_OS == 'unix') {
-		$pipe_mode = 'r';
-	} else {
-		$pipe_mode = 'rb';
-	}
-
 	// an empty $rrdtool_pipe array means no fp is available
 	if ($rrdtool_pipe === null || $rrdtool_pipe === false || !is_resource($rrdtool_pipe)) {
 		if (str_starts_with($command_line, 'fetch') || str_starts_with($command_line, 'info') || str_starts_with($command_line, 'xport')) {
@@ -419,11 +434,6 @@ function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $out
 		cacti_session_close();
 
 		if (is_file(read_config_option('path_rrdtool')) && is_executable(read_config_option('path_rrdtool'))) {
-			$descriptorspec = [
-				0 => ['pipe', 'r'],
-				1 => ['pipe', 'w']
-			];
-
 			if (CACTI_WEB) {
 				cacti_time_zone_set();
 			}
@@ -433,44 +443,18 @@ function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $out
 			$full_commandline = read_config_option('path_rrdtool') . $debug . ' ' . $command_line;
 
 			while ($attempts < 5) {
-				if (0 == 1) { // @phpstan-ignore-line
-					/**
-					 * For debugging issue associated with RRDtool, for now I'm commenting out this line
-					 * There are issues processing graphv output with the --add-jsontime option when
-					 * rrdtool is launched in the background.
-					 *
-					 * The reason for this difference is still to be determined.
-					 *
-					 * cacti_log($command_line);
-					 */
-					$process = proc_open(read_config_option('path_rrdtool') . ' - ' . $debug, $descriptorspec, $pipes);
+				if ($structured_command !== null) {
+					try {
+						$result = (new \Cacti\Rrd\LocalRrdTransport(
+							read_config_option('path_rrdtool')
+						))->execute($structured_command);
 
-					if (!is_resource($process)) {
-						$attempts++;
-
-						unset($process);
-					} else {
-						fwrite($pipes[0], $command_line . "\r\nquit\r\n");
-						fclose($pipes[0]);
-						$fp = $pipes[1];
-					}
-
-					if (!isset($fp)) {
-						rrdtool_reset_language();
-
-						return 'Error';
-					}
-
-					// get the output regardless of the output type
-					$output = '';
-
-					while (!feof($fp)) {
-						$output .= fgets($fp, 10000);
-					}
-
-					if (isset($process)) {
-						fclose($fp);
-						proc_close($process);
+						$output = ($output_flag == RRDTOOL_OUTPUT_STDERR || $output_flag == RRDTOOL_OUTPUT_RETURN_STDERR)
+							? $result->outputWithErrors()
+							: $result->stdout;
+					} catch (\Cacti\Rrd\RrdTransportException $exception) {
+						cacti_log('ERROR: ' . $exception->getMessage(), false, 'RRDTOOL');
+						$output = null;
 					}
 				} else {
 					$output = shell_exec($full_commandline);
@@ -628,12 +612,23 @@ function rrdtool_trim_output(string &$output) : void {
 	}
 }
 
-function __rrd_proxy_execute(string $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdp = '', string $logopt = 'WEBLOG') : mixed {
+function __rrd_proxy_execute(string|array|\Cacti\Rrd\RrdCommand $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdp = '', string $logopt = 'WEBLOG') : mixed {
 	global $encryption;
 
 	static $last_command;
 	$end_of_packet   = "_EOP_\r\n";
 	$end_of_sequence = "_EOT_\r\n";
+
+	if (is_array($command_line)) {
+		$command_line = \Cacti\Rrd\RrdCommand::fromList($command_line);
+	}
+
+	if ($command_line instanceof \Cacti\Rrd\RrdCommand) {
+		$command_line = (new \Cacti\Rrd\RrdCommandSerializer())->forLineProtocol(
+			$command_line,
+			'cacti_escapeshellarg'
+		);
+	}
 
 	/**
 	 * WIN32: before sending this command off to rrdtool, get rid
@@ -955,8 +950,8 @@ function rrdtool_function_create(int $local_data_id, bool $show_source, mixed $r
 	 */
 	if (read_config_option('extended_paths') == 'on') {
 		if (read_config_option('storage_location')) {
-			if (rrdtool_execute('is_dir ' . cacti_escapeshellarg(dirname($data_source_path)), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER') === false) {
-				if (rrdtool_execute('mkdir ' . cacti_escapeshellarg(dirname($data_source_path)), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER') === false) {
+			if (rrdtool_execute(new \Cacti\Rrd\RrdCommand('is_dir', [dirname($data_source_path)]), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER') === false) {
+				if (rrdtool_execute(new \Cacti\Rrd\RrdCommand('mkdir', [dirname($data_source_path)]), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER') === false) {
 					cacti_log("ERROR: Unable to create directory '" . dirname($data_source_path) . "'", false);
 				}
 			}
@@ -1060,13 +1055,23 @@ function rrdtool_function_update(array $update_cache_array, mixed $rrdtool_pipe 
 					$rrd_update_values .= $value;
 				}
 
+				$arguments = [$rrd_path];
+
 				if (cacti_version_compare(get_rrdtool_version(), '1.5', '>=')) {
-					$update_options = '--skip-past-updates';
-				} else {
-					$update_options = '';
+					$arguments[] = '--skip-past-updates';
 				}
 
-				rrdtool_execute('update ' . cacti_escapeshellarg($rrd_path) . " $update_options --template $rrd_update_template $rrd_update_values", true, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'POLLER');
+				$arguments[] = '--template';
+				$arguments[] = $rrd_update_template;
+				$arguments[] = $rrd_update_values;
+
+				rrdtool_execute(
+					new \Cacti\Rrd\RrdCommand('update', $arguments),
+					true,
+					RRDTOOL_OUTPUT_STDOUT,
+					$rrdtool_pipe,
+					'POLLER'
+				);
 				$rrds_processed++;
 			}
 		}
@@ -1168,7 +1173,7 @@ function rrdtool_function_fetch(int $local_data_id, int $start_time, int $end_ti
 
 	$time = time();
 
-	// initialize fetch array
+	// Keep error responses empty; successful RRDtool responses use a stable shape.
 	$fetch_array = [];
 
 	// check if we have been passed a file instead of local data source to look up
@@ -1191,18 +1196,37 @@ function rrdtool_function_fetch(int $local_data_id, int $start_time, int $end_ti
 		$cf = 'AVERAGE';
 	}
 
-	// build and run the rrdtool fetch command with all of our data
-	$cmd_line = 'fetch ' . cacti_escapeshellarg($data_source_path) . " $cf -s $start_time -e $end_time";
+	// Build and run the RRDtool fetch command with structured arguments.
+	$arguments = [
+		$data_source_path,
+		$cf,
+		'-s',
+		(string) $start_time,
+		'-e',
+		(string) $end_time,
+	];
 
 	if ($resolution > 0) {
-		$cmd_line .= " -r $resolution";
+		$arguments[] = '-r';
+		$arguments[] = (string) $resolution;
 	}
 
-	$output = rrdtool_execute($cmd_line, false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe);
+	$output = rrdtool_execute(
+		new \Cacti\Rrd\RrdCommand('fetch', $arguments),
+		false,
+		RRDTOOL_OUTPUT_STDOUT,
+		$rrdtool_pipe
+	);
 
 	if (!is_string($output)) {
 		return $fetch_array;
 	}
+
+	$fetch_array = [
+		'data_source_names' => [],
+		'timestamp'         => [],
+		'values'            => [],
+	];
 
 	$output = explode("\n", $output);
 
@@ -1218,15 +1242,20 @@ function rrdtool_function_fetch(int $local_data_id, int $start_time, int $end_ti
 
 			if ($first) {
 				// get the data source names
-				$fetch_array['data_source_names'] = preg_split('/\s+/', $line);
+				$fetch_array['data_source_names'] = preg_split('/\s+/', $line) ?: [];
 				$first                            = false;
 			} elseif ($line != '') {
 				// process the data sources into an array
-				$parts     = explode(':', $line);
+				$parts     = explode(':', $line, 2);
+
+				if (count($parts) !== 2) {
+					continue;
+				}
+
 				$timestamp = $parts[0];
 				$data      = explode(' ', trim($parts[1]));
 
-				if (!isset($fetch_array['timestamp']['start_time'])) { // @phpstan-ignore-line
+				if (!isset($fetch_array['timestamp']['start_time'])) {
 					$fetch_array['timestamp']['start_time'] = $timestamp;
 				}
 
@@ -1733,7 +1762,7 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 	);
 
 	// handle the case where the graph has been deleted
-	if (!cacti_sizeof($graph)) {
+	if (!is_array($graph) || $graph === []) {
 		return false;
 	}
 
@@ -1825,7 +1854,12 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 	$last_graph_cf   = [];
 	$legends         = [];
 	$defs            = [];
-	$graph_variables = [];
+	$graph_variables = [
+		'text_format' => [],
+		'value'       => [],
+		'cdef_cache'  => [],
+		'vdef_cache'  => [],
+	];
 	$cf_ds_cache     = [];
 	$cdef_cache      = [];
 	$vdef_cache      = [];
@@ -1977,7 +2011,8 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 					continue;
 				}
 
-				$graph_variables[$field_name][$graph_item_id] = $graph_item[$field_name];
+				$field_value                                  = $graph_item[$field_name] ?? '';
+				$graph_variables[$field_name][$graph_item_id] = is_scalar($field_value) ? (string) $field_value : '';
 
 				$search  = [];
 				$replace = [];
@@ -2068,7 +2103,7 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 				if ($graph['auto_padding'] == 'on') {
 					// only applies to AREA, STACK and LINEs
 					if (preg_match('/(AREA|STACK|LINE[123])/', $graph_item_types[$graph_item['graph_type_id']])) {
-						$text_format_length = mb_strlen(trim($graph_variables['text_format'][$graph_item_id]), 'UTF-8');
+						$text_format_length = mb_strlen(trim($graph_variables['text_format'][$graph_item_id] ?? ''), 'UTF-8');
 
 						if ($text_format_length > $pad_number) {
 							$pad_number = $text_format_length;
@@ -2129,8 +2164,7 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 			$cdef_cache_key = "{$graph_item['cdef_id']}:{$graph_item['data_template_rrd_id']}:{$cf_id}";
 
 			if ($graph_item['cdef_id'] > 0 && !isset($cdef_cache[$cdef_cache_key])) {
-				/** @var string $cdef_string */
-				$cdef_string  = $graph_variables['cdef_cache'][$graph_item['graph_templates_item_id']];
+				$cdef_string  = $graph_variables['cdef_cache'][$graph_item['graph_templates_item_id']] ?? '';
 				$magic_item   = [];
 				$already_seen = [];
 				$sources_seen = [];
@@ -2282,7 +2316,8 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 
 				// allow automatic rate calculations on raw gauge data
 				if (isset($graph_item['local_data_id'])) {
-					$cdef_string = str_replace('CURRENT_DATA_SOURCE_PI', db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]), $cdef_string);
+					$rrd_step    = db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]);
+					$cdef_string = str_replace('CURRENT_DATA_SOURCE_PI', is_scalar($rrd_step) ? (string) $rrd_step : '', $cdef_string);
 				} else {
 					$cdef_string = str_replace('CURRENT_DATA_SOURCE_PI', read_config_option('poller_interval'), $cdef_string);
 				}
@@ -2291,7 +2326,8 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 
 				// allow automatic rate calculations on raw gauge data
 				if (isset($graph_item['local_data_id'])) {
-					$cdef_string = str_replace('ALL_DATA_SOURCES_DUPS_PI', db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]), $cdef_string);
+					$rrd_step    = db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]);
+					$cdef_string = str_replace('ALL_DATA_SOURCES_DUPS_PI', is_scalar($rrd_step) ? (string) $rrd_step : '', $cdef_string);
 				} else {
 					$cdef_string = str_replace('ALL_DATA_SOURCES_DUPS_PI', read_config_option('poller_interval'), $cdef_string);
 				}
@@ -2303,7 +2339,8 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 
 				// allow automatic rate calculations on raw gauge data
 				if (isset($graph_item['local_data_id'])) {
-					$cdef_string = str_replace('ALL_DATA_SOURCES_NODUPS_PI', db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]), $cdef_string);
+					$rrd_step    = db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]);
+					$cdef_string = str_replace('ALL_DATA_SOURCES_NODUPS_PI', is_scalar($rrd_step) ? (string) $rrd_step : '', $cdef_string);
 				} else {
 					$cdef_string = str_replace('ALL_DATA_SOURCES_NODUPS_PI', read_config_option('poller_interval'), $cdef_string);
 				}
@@ -2314,7 +2351,8 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 
 				// allow automatic rate calculations on raw gauge data
 				if (isset($graph_item['local_data_id'])) {
-					$cdef_string = str_replace('SIMILAR_DATA_SOURCES_DUPS_PI', db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]), $cdef_string);
+					$rrd_step    = db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]);
+					$cdef_string = str_replace('SIMILAR_DATA_SOURCES_DUPS_PI', is_scalar($rrd_step) ? (string) $rrd_step : '', $cdef_string);
 				} else {
 					$cdef_string = str_replace('SIMILAR_DATA_SOURCES_DUPS_PI', read_config_option('poller_interval'), $cdef_string);
 				}
@@ -2324,7 +2362,8 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 				}
 
 				if (isset($graph_item['local_data_id'])) {
-					$cdef_string = str_replace('SIMILAR_DATA_SOURCES_NODUPS_PI', db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]), $cdef_string);
+					$rrd_step    = db_fetch_cell_prepared('SELECT rrd_step FROM data_template_data WHERE local_data_id = ?', [$graph_item['local_data_id']]);
+					$cdef_string = str_replace('SIMILAR_DATA_SOURCES_NODUPS_PI', is_scalar($rrd_step) ? (string) $rrd_step : '', $cdef_string);
 				} else {
 					$cdef_string = str_replace('SIMILAR_DATA_SOURCES_NODUPS_PI', read_config_option('poller_interval'), $cdef_string);
 				}
@@ -2460,7 +2499,7 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 			$vdef_cache_key  = "{$graph_item['vdef_id']}:{$graph_item['cdef_id']}:{$graph_item['data_template_rrd_id']}:{$cf_id}";
 
 			if ($graph_item['vdef_id'] > 0 && !isset($vdef_cache[$vdef_cache_key])) {
-				$vdef_string = $graph_variables['vdef_cache'][$graph_item['graph_templates_item_id']];
+				$vdef_string = $graph_variables['vdef_cache'][$graph_item['graph_templates_item_id']] ?? '';
 
 				// do we refer to a CDEF within this VDEF?
 				if ($graph_item['cdef_id'] > 0) {
@@ -2824,7 +2863,7 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 						break;
 					case GRAPH_ITEM_TYPE_HRULE:
 						// perform variable substitution; if this does not return a number, rrdtool will FAIL!
-						$substitute = strip_alpha(rrd_substitute_host_query_data($graph_variables['value'][$graph_item_id], $graph, $graph_item));
+						$substitute = strip_alpha(rrd_substitute_host_query_data($graph_variables['value'][$graph_item_id] ?? '', $graph, $graph_item));
 
 						$text_format = rrdtool_escape_string(htmle(rrd_substitute_host_query_data($graph_variables['text_format'][$graph_item_id], $graph, $graph_item)));
 
@@ -3076,8 +3115,6 @@ function rrdtool_function_theme_font_options(array &$graph_data_array) : string 
 	// implement theme colors
 	$graph_opts  = '';
 	$themefonts  = [];
-	$themecolors = 'rrdcolors';
-	$themeborder = 'rrdborder';
 
 	if (isset($graph_data_array['graph_theme'])) {
 		$theme = cacti_validate_theme((string) $graph_data_array['graph_theme']);
@@ -3091,24 +3128,31 @@ function rrdtool_function_theme_font_options(array &$graph_data_array) : string 
 		$rrdversion = get_rrdtool_version();
 		include($rrdtheme);
 
-		if (isset($_COOKIE['CactiColorMode']) && in_array($_COOKIE['CactiColorMode'], ['dark', 'light', 'dark-dimmed'], true)) {
-			$themecolors = 'rrdcolors_' . $_COOKIE['CactiColorMode'];
-			$themeborder = 'rrdborder_' . $_COOKIE['CactiColorMode'];
+		$color_mode = $_COOKIE['CactiColorMode'] ?? null;
+		$colors     = match ($color_mode) {
+			'dark'  => $rrdcolors_dark ?? null,
+			'light' => $rrdcolors_light ?? null,
+			default => null,
+		};
+		$border = match ($color_mode) {
+			'dark'  => $rrdborder_dark ?? null,
+			'light' => $rrdborder_light ?? null,
+			default => null,
+		};
 
-			if (!isset(${$themecolors}) || !is_array(${$themecolors})) { // @phpstan-ignore-line
-				$themecolors = 'rrdcolors';
-				$themeborder = 'rrdborder';
-			}
+		if (!is_array($colors)) {
+			$colors = is_array($rrdcolors) ? $rrdcolors : [];
+			$border = $rrdborder ?? null;
 		}
 
-		if (isset(${$themecolors}) && is_array(${$themecolors})) { // @phpstan-ignore-line
-			foreach (${$themecolors} as $colortag => $color) { // @phpstan-ignore-line
+		foreach ($colors as $colortag => $color) {
+			if (is_string($colortag) && is_string($color)) {
 				$graph_opts .= '--color ' . cacti_strtoupper($colortag) . '#' . cacti_strtoupper($color) . RRD_NL;
 			}
 		}
 
-		if (isset(${$themeborder}) && cacti_version_compare($rrdversion, '1.4', '>=')) { // @phpstan-ignore-line
-			$graph_opts .= '--border ' . ${$themeborder} . RRD_NL; // @phpstan-ignore-line
+		if (is_scalar($border) && cacti_version_compare($rrdversion, '1.4', '>=')) {
+			$graph_opts .= '--border ' . $border . RRD_NL;
 		}
 
 		if (isset($rrdfonts)) {
@@ -3287,7 +3331,7 @@ function rrdtool_function_get_resstep(mixed $local_data_ids, int $graph_start, i
  */
 function rrdtool_file_exists(string $data_source_path, mixed $rrdtool_pipe = null) : bool {
 	if (read_config_option('storage_location')) {
-		if (!rrdtool_execute('file_exists ' . cacti_escapeshellarg($data_source_path), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER')) {
+		if (!rrdtool_execute(new \Cacti\Rrd\RrdCommand('file_exists', [$data_source_path]), true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'POLLER')) {
 			return false;
 		}
 	} elseif (!file_exists($data_source_path)) {
@@ -3314,8 +3358,12 @@ function rrdtool_function_info(int $local_data_id, mixed $rrdtool_pipe = null) :
 	}
 
 	// Execute rrdtool info command
-	$cmd_line = ' info ' . cacti_escapeshellarg($data_source_path);
-	$output   = rrdtool_execute($cmd_line, RRDTOOL_OUTPUT_NULL, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe);
+	$output = rrdtool_execute(
+		new \Cacti\Rrd\RrdCommand('info', [$data_source_path]),
+		false,
+		RRDTOOL_OUTPUT_STDOUT,
+		$rrdtool_pipe
+	);
 
 	if (!is_string($output) || $output == '') {
 		return false;
@@ -3393,7 +3441,7 @@ function rrdtool_function_info_from_ds(int $data_source_id) : array {
 			[$data_source_id]);
 	}
 
-	if (cacti_sizeof($cacti_header_array) && cacti_sizeof($cacti_ds_array)) {
+	if (is_array($cacti_header_array) && $cacti_header_array !== [] && $cacti_ds_array !== []) {
 		$info_array['step'] = $cacti_header_array['rrd_step'];
 
 		// get cacti RRA information
@@ -3994,9 +4042,15 @@ function rrd_datasource_add(array $file_array, array $ds_array, bool $debug) : m
 	// iterate all given rrd files
 	foreach ($file_array as $file) {
 		// create a DOM object from an rrdtool dump
-		$dom = new domDocument;
-
-		$success = $dom->loadXML(rrdtool_execute("dump $file", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'UTIL'));
+		$dom         = new DOMDocument;
+		$dump_output = rrdtool_execute(
+			new \Cacti\Rrd\RrdCommand('dump', [$file]),
+			false,
+			RRDTOOL_OUTPUT_STDOUT,
+			$rrdtool_pipe,
+			'UTIL'
+		);
+		$success = is_string($dump_output) && $dom->loadXML($dump_output);
 
 		if (!$success) {
 			$check['err_msg'] = __('Error while parsing the XML of rrdtool dump');
@@ -4009,7 +4063,11 @@ function rrd_datasource_add(array $file_array, array $ds_array, bool $debug) : m
 		 * version 0003 => RRDtool 1.2.x, 1.3.x, 1.4.x, 1.5.x, 1.6.x
 		 */
 		$version_node = $dom->getElementsByTagName('version')->item(0);
-		$version      = $version_node !== null ? trim($version_node->nodeValue) : RRD_FILE_VERSION3;
+		$version      = $version_node !== null ? trim($version_node->nodeValue ?? '') : RRD_FILE_VERSION3;
+
+		if ($version === '') {
+			$version = RRD_FILE_VERSION3;
+		}
 
 		// now start XML processing
 		foreach ($ds_array as $ds) {
@@ -4041,7 +4099,7 @@ function rrd_datasource_add(array $file_array, array $ds_array, bool $debug) : m
 				// are we allowed to write the rrd file?
 				if (is_writable($file)) {
 					// restore the modified XML to rrd
-					rrdtool_execute("restore -f $xml_file $file", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'UTIL');
+					rrdtool_execute(new \Cacti\Rrd\RrdCommand('restore', ['-f', $xml_file, $file]), false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'UTIL');
 					// scratch that XML file to avoid filling up the disk
 					unlink($xml_file);
 					cacti_log('Added Data Source(s) to RRDfile: ' . $file, false, 'UTIL');
@@ -4074,9 +4132,15 @@ function rrd_rra_delete(array $file_array, array $rra_array, bool $debug) : mixe
 	// iterate all given rrd files
 	foreach ($file_array as $file) {
 		// create a DOM document from an rrdtool dump
-		$dom = new domDocument;
-
-		$success = $dom->loadXML(rrdtool_execute("dump $file", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'UTIL'));
+		$dom         = new DOMDocument;
+		$dump_output = rrdtool_execute(
+			new \Cacti\Rrd\RrdCommand('dump', [$file]),
+			false,
+			RRDTOOL_OUTPUT_STDOUT,
+			$rrdtool_pipe,
+			'UTIL'
+		);
+		$success = is_string($dump_output) && $dom->loadXML($dump_output);
 
 		if (!$success) {
 			$check['err_msg'] = __('Error while parsing the XML of RRDtool dump');
@@ -4105,7 +4169,7 @@ function rrd_rra_delete(array $file_array, array $rra_array, bool $debug) : mixe
 				// are we allowed to write the rrd file?
 				if (is_writable($file)) {
 					// restore the modified XML to rrd
-					rrdtool_execute("restore -f $xml_file $file", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'UTIL');
+					rrdtool_execute(new \Cacti\Rrd\RrdCommand('restore', ['-f', $xml_file, $file]), false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'UTIL');
 					// scratch that XML file to avoid filling up the disk
 					unlink($xml_file);
 					cacti_log('Deleted RRA(s) from RRDfile: ' . $file, false, 'UTIL');
@@ -4139,9 +4203,15 @@ function rrd_rra_clone(array $file_array, string $cf, array $rra_array, bool $de
 	// iterate all given rrd files
 	foreach ($file_array as $file) {
 		// create a DOM document from an rrdtool dump
-		$dom = new domDocument;
-
-		$success = $dom->loadXML(rrdtool_execute("dump $file", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'UTIL'));
+		$dom         = new DOMDocument;
+		$dump_output = rrdtool_execute(
+			new \Cacti\Rrd\RrdCommand('dump', [$file]),
+			false,
+			RRDTOOL_OUTPUT_STDOUT,
+			$rrdtool_pipe,
+			'UTIL'
+		);
+		$success = is_string($dump_output) && $dom->loadXML($dump_output);
 
 		if (!$success) {
 			$check['err_msg'] = __('Error while parsing the XML of RRDtool dump');
@@ -4170,7 +4240,7 @@ function rrd_rra_clone(array $file_array, string $cf, array $rra_array, bool $de
 				// are we allowed to write the rrd file?
 				if (is_writable($file)) {
 					// restore the modified XML to rrd
-					rrdtool_execute("restore -f $xml_file $file", false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'UTIL');
+					rrdtool_execute(new \Cacti\Rrd\RrdCommand('restore', ['-f', $xml_file, $file]), false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'UTIL');
 					// scratch that XML file to avoid filling up the disk
 					unlink($xml_file);
 					cacti_log('Deleted RRA(s) from RRDfile: ' . $file, false, 'UTIL');
@@ -4191,17 +4261,17 @@ function rrd_rra_clone(array $file_array, string $cf, array $rra_array, bool $de
 /**
  * rrd_append_ds - appends a <DS> subtree to an RRD XML structure
  *
- * @param object $dom     The DOM object, where the RRD XML is stored
- * @param string $version The rrd file version
- * @param string $name    Name of the new ds
- * @param string $type    Type of the new ds
- * @param int    $min_hb  Heartbeat of the new ds
- * @param string $min     Min value of the new ds or [NaN|U]
- * @param string $max     Max value of the new ds or [NaN|U]
+ * @param DOMDocument $dom     The DOM object where the RRD XML is stored
+ * @param string      $version The rrd file version
+ * @param string      $name    Name of the new ds
+ * @param string      $type    Type of the new ds
+ * @param int         $min_hb  Heartbeat of the new ds
+ * @param string      $min     Min value of the new ds or [NaN|U]
+ * @param string      $max     Max value of the new ds or [NaN|U]
  *
- * @return object Modified DOM
+ * @return DOMDocument Modified DOM
  */
-function rrd_append_ds(object $dom, string $version, string $name, string $type, int $min_hb, string $min, string $max) : object {
+function rrd_append_ds(DOMDocument $dom, string $version, string $name, string $type, int $min_hb, string $min, string $max) : DOMDocument {
 	// rrdtool version dependencies
 	if ($version === RRD_FILE_VERSION1) {
 		$last_ds = 'U';
@@ -4241,7 +4311,7 @@ function rrd_append_ds(object $dom, string $version, string $name, string $type,
 	// $insert = $xpath->query('/rrd/rra')->item(0);
 	$insert = $dom->getElementsByTagName('rra')->item(0);
 
-	if ($insert !== null && $new_node !== null) {
+	if ($insert !== null && $insert->parentNode !== null && $new_node !== null) {
 		// import the new node
 		$new_node = $dom->importNode($new_node, true);
 		// and insert it at the correct place
@@ -4254,15 +4324,15 @@ function rrd_append_ds(object $dom, string $version, string $name, string $type,
 /**
  * rrd_append_compute_ds - COMPUTE DS: appends a <DS> subtree to an RRD XML structure
  *
- * @param object $dom     The DOM object, where the RRD XML is stored
- * @param string $version The rrd file version
- * @param string $name    Name of the new ds
- * @param string $type    Type of the new ds
- * @param int    $cdef    The cdef rpn used for COMPUTE
+ * @param DOMDocument $dom     The DOM object where the RRD XML is stored
+ * @param string      $version The rrd file version
+ * @param string      $name    Name of the new ds
+ * @param string      $type    Type of the new ds
+ * @param int         $cdef    The cdef rpn used for COMPUTE
  *
- * @return object Modified DOM
+ * @return DOMDocument Modified DOM
  */
-function rrd_append_compute_ds(object $dom, string $version, string $name, string $type, int $cdef) : object {
+function rrd_append_compute_ds(DOMDocument $dom, string $version, string $name, string $type, int $cdef) : DOMDocument {
 	// rrdtool version dependencies
 	if ($version === RRD_FILE_VERSION1) {
 		$last_ds = 'U';
@@ -4299,7 +4369,7 @@ function rrd_append_compute_ds(object $dom, string $version, string $name, strin
 	// $insert = $xpath->query('/rrd/rra')->item(0);
 	$insert = $dom->getElementsByTagName('rra')->item(0);
 
-	if ($insert !== null && $new_node !== null) {
+	if ($insert !== null && $insert->parentNode !== null && $new_node !== null) {
 		// import the new node
 		$new_node = $dom->importNode($new_node, true);
 		// and insert it at the correct place
@@ -4312,12 +4382,12 @@ function rrd_append_compute_ds(object $dom, string $version, string $name, strin
 /**
  * rrd_append_cdp_prep_ds - append a <DS> subtree to the <CDP_PREP> subtrees of a RRD XML structure
  *
- * @param object $dom     The DOM object, where the RRD XML is stored
- * @param string $version The rrd file version
+ * @param DOMDocument $dom     The DOM object where the RRD XML is stored
+ * @param string      $version The rrd file version
  *
- * @return object The modified DOM object
+ * @return DOMDocument The modified DOM object
  */
-function rrd_append_cdp_prep_ds(object $dom, string $version) : object {
+function rrd_append_cdp_prep_ds(DOMDocument $dom, string $version) : DOMDocument {
 	// get all <cdp_prep><ds> entries
 	// $cdp_prep_list = $xpath->query('/rrd/rra/cdp_prep');
 	$rra_node = $dom->getElementsByTagName('rra')->item(0);
@@ -4349,14 +4419,33 @@ function rrd_append_cdp_prep_ds(object $dom, string $version) : object {
 	$new_ds = $src_ds->cloneNode(true);
 
 	// rrdtool version dependencies
-	if ($version === RRD_FILE_VERSION3) {
-		$new_ds->getElementsByTagName('primary_value')->item(0)->nodeValue   = ' NaN ';
-		$new_ds->getElementsByTagName('secondary_value')->item(0)->nodeValue = ' NaN ';
+	if (!$new_ds instanceof DOMElement) {
+		return $dom;
 	}
 
-	// the new node always has default entries
-	$new_ds->getElementsByTagName('value')->item(0)->nodeValue              = ' NaN ';
-	$new_ds->getElementsByTagName('unknown_datapoints')->item(0)->nodeValue = ' 0 ';
+	if ($version === RRD_FILE_VERSION3) {
+		$primary_value   = $new_ds->getElementsByTagName('primary_value')->item(0);
+		$secondary_value = $new_ds->getElementsByTagName('secondary_value')->item(0);
+
+		if ($primary_value !== null) {
+			$primary_value->nodeValue = ' NaN ';
+		}
+
+		if ($secondary_value !== null) {
+			$secondary_value->nodeValue = ' NaN ';
+		}
+	}
+
+	$value              = $new_ds->getElementsByTagName('value')->item(0);
+	$unknown_datapoints = $new_ds->getElementsByTagName('unknown_datapoints')->item(0);
+
+	if ($value !== null) {
+		$value->nodeValue = ' NaN ';
+	}
+
+	if ($unknown_datapoints !== null) {
+		$unknown_datapoints->nodeValue = ' 0 ';
+	}
 
 	// iterate all entries found, equals 'number of <rra>' times 'number of <ds>'
 	if ($cdp_prep_list->length) {
@@ -4373,15 +4462,11 @@ function rrd_append_cdp_prep_ds(object $dom, string $version) : object {
 /**
  * rrd_append_value - append a <V>alue element to the <DATABASE> subtrees of a RRD XML structure
  *
- * @param object $dom The DOM object, where the RRD XML is stored
+ * @param DOMDocument $dom The DOM object where the RRD XML is stored
  *
- * @return object The modified DOM object
+ * @return DOMDocument The modified DOM object
  */
-function rrd_append_value(object $dom) : object {
-	if (!$dom instanceof DOMDocument) {
-		return $dom;
-	}
-
+function rrd_append_value(DOMDocument $dom) : DOMDocument {
 	// get XPATH notation required for positioning
 	// $xpath = new DOMXPath($dom);
 
@@ -4407,16 +4492,12 @@ function rrd_append_value(object $dom) : object {
 /**
  * rrd_delete_rra - delete an <RRA> subtree from the <RRD> XML structure
  *
- * @param object $dom      The DOM document, where the RRD XML is stored
- * @param array  $rra_parm A single rra parameter set, given by the user
+ * @param DOMDocument $dom      The DOM document where the RRD XML is stored
+ * @param array       $rra_parm A single rra parameter set, given by the user
  *
- * @return object The modified DOM object
+ * @return DOMDocument The modified DOM object
  */
-function rrd_delete_rra(object $dom, array $rra_parm) : object {
-	if (!$dom instanceof DOMDocument) {
-		return $dom;
-	}
-
+function rrd_delete_rra(DOMDocument $dom, array $rra_parm) : DOMDocument {
 	// find all RRA DOMNodes
 	$rras = $dom->getElementsByTagName('rra');
 
@@ -4425,10 +4506,23 @@ function rrd_delete_rra(object $dom, array $rra_parm) : object {
 
 	for ($pos = 0; $pos < $nb; $pos++) {
 		// retrieve all RRA DOMNodes one by one
-		$rra         = $rras->item($pos);
-		$cf          = $rra->getElementsByTagName('cf')->item(0)->nodeValue;
-		$pdp_per_row = $rra->getElementsByTagName('pdp_per_row')->item(0)->nodeValue;
-		$xff         = $rra->getElementsByTagName('xff')->item(0)->nodeValue;
+		$rra = $rras->item($pos);
+
+		if ($rra === null) {
+			continue;
+		}
+
+		$cf_node          = $rra->getElementsByTagName('cf')->item(0);
+		$pdp_per_row_node = $rra->getElementsByTagName('pdp_per_row')->item(0);
+		$xff_node         = $rra->getElementsByTagName('xff')->item(0);
+
+		if ($cf_node === null || $pdp_per_row_node === null || $xff_node === null) {
+			continue;
+		}
+
+		$cf          = $cf_node->nodeValue;
+		$pdp_per_row = $pdp_per_row_node->nodeValue;
+		$xff         = $xff_node->nodeValue;
 		$rows        = $rra->getElementsByTagName('row')->length;
 
 		if ($cf == $rra_parm['cf'] &&
@@ -4438,7 +4532,10 @@ function rrd_delete_rra(object $dom, array $rra_parm) : object {
 			print (__('RRA (CF=%s, ROWS=%d, PDP_PER_ROW=%d, XFF=%1.2f) removed from RRD file', $cf, $rows, $pdp_per_row, $xff)) . PHP_EOL;
 			// we need the parentNode for removal operation
 			$parent = $rra->parentNode;
-			$parent->removeChild($rra);
+
+			if ($parent !== null) {
+				$parent->removeChild($rra);
+			}
 
 			break; // do NOT accidentally remove more than one element, else loop back to forth
 		}
@@ -4450,17 +4547,13 @@ function rrd_delete_rra(object $dom, array $rra_parm) : object {
 /**
  * rrd_copy_rra - clone an <RRA> subtree of the <RRD> XML structure, replacing cf
  *
- * @param object $dom      The DOM document, where the RRD XML is stored
- * @param string $cf       New consolidation function
- * @param array  $rra_parm A single rra parameter set, given by the user
+ * @param DOMDocument $dom      The DOM document where the RRD XML is stored
+ * @param string      $cf       New consolidation function
+ * @param array       $rra_parm A single rra parameter set, given by the user
  *
- * @return object The modified DOM object
+ * @return DOMDocument The modified DOM object
  */
-function rrd_copy_rra(object $dom, string $cf, array $rra_parm) : object {
-	if (!$dom instanceof DOMDocument) {
-		return $dom;
-	}
-
+function rrd_copy_rra(DOMDocument $dom, string $cf, array $rra_parm) : DOMDocument {
 	// find all RRA DOMNodes
 	$rras = $dom->getElementsByTagName('rra');
 
@@ -4469,10 +4562,23 @@ function rrd_copy_rra(object $dom, string $cf, array $rra_parm) : object {
 
 	for ($pos = 0; $pos < $nb; $pos++) {
 		// retrieve all RRA DOMNodes one by one
-		$rra          = $rras->item($pos);
-		$_cf          = $rra->getElementsByTagName('cf')->item(0)->nodeValue;
-		$_pdp_per_row = $rra->getElementsByTagName('pdp_per_row')->item(0)->nodeValue;
-		$_xff         = $rra->getElementsByTagName('xff')->item(0)->nodeValue;
+		$rra = $rras->item($pos);
+
+		if ($rra === null) {
+			continue;
+		}
+
+		$cf_node          = $rra->getElementsByTagName('cf')->item(0);
+		$pdp_per_row_node = $rra->getElementsByTagName('pdp_per_row')->item(0);
+		$xff_node         = $rra->getElementsByTagName('xff')->item(0);
+
+		if ($cf_node === null || $pdp_per_row_node === null || $xff_node === null) {
+			continue;
+		}
+
+		$_cf          = $cf_node->nodeValue;
+		$_pdp_per_row = $pdp_per_row_node->nodeValue;
+		$_xff         = $xff_node->nodeValue;
 		$_rows        = $rra->getElementsByTagName('row')->length;
 
 		if ($_cf == $rra_parm['cf'] &&
@@ -4490,9 +4596,17 @@ function rrd_copy_rra(object $dom, string $cf, array $rra_parm) : object {
 			// $old_cf = $new_rra->getElementsByTagName('cf')->item(0);
 			// now replace old cf with new one
 			// $old_cf->childNodes->item(0)->replaceData(0,20,$cf);
-			if ($new_rra instanceof DOMElement) {
-				$new_rra->getElementsByTagName('cf')->item(0)->nodeValue = $cf;
+			if (!$new_rra instanceof DOMElement) {
+				continue;
 			}
+
+			$new_cf = $new_rra->getElementsByTagName('cf')->item(0);
+
+			if ($new_cf === null || $parent === null) {
+				continue;
+			}
+
+			$new_cf->nodeValue = $cf;
 
 			// append new rra entry at end of the list
 			$parent->appendChild($new_rra);

--- a/tests/Unit/Core/Rrd/LocalRrdTransportTest.php
+++ b/tests/Unit/Core/Rrd/LocalRrdTransportTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Cacti\Rrd\LocalRrdTransport;
+use Cacti\Rrd\RrdCommand;
+
+$rrdRoot = dirname(__DIR__, 4) . '/lib/Rrd';
+
+require_once "$rrdRoot/RrdCommand.php";
+require_once "$rrdRoot/RrdProcessResult.php";
+require_once "$rrdRoot/RrdTransport.php";
+require_once "$rrdRoot/RrdTransportException.php";
+require_once "$rrdRoot/LocalRrdTransport.php";
+
+test('local transport captures stdout stderr and exit status', function () {
+	$transport = new LocalRrdTransport(PHP_BINARY);
+	$command   = new RrdCommand('-r', [
+		'fwrite(STDOUT, $argv[1]); fwrite(STDERR, $argv[2]); exit(7);',
+		'standard output',
+		'standard error',
+	]);
+
+	$result = $transport->execute($command);
+
+	expect($result->stdout)->toBe('standard output')
+		->and($result->stderr)->toBe('standard error')
+		->and($result->exitCode)->toBe(7)
+		->and($result->succeeded())->toBeFalse()
+		->and($result->outputWithErrors())->toBe('standard outputstandard error');
+});
+
+test('local transport passes metacharacters as data without a shell', function () {
+	$payload   = 'value; printf injected | $(whoami)';
+	$transport = new LocalRrdTransport(PHP_BINARY);
+	$command   = new RrdCommand('-r', ['fwrite(STDOUT, $argv[1]);', $payload]);
+
+	$result = $transport->execute($command);
+
+	expect($result->succeeded())->toBeTrue()
+		->and($result->stdout)->toBe($payload)
+		->and($result->stderr)->toBe('');
+});
+
+test('rrd updates use the structured command path', function () {
+	$source = file_get_contents(dirname(__DIR__, 4) . '/lib/rrd.php');
+	$start  = strpos($source, 'function rrdtool_function_update(');
+	$end    = strpos($source, 'function rrdtool_function_tune(', $start);
+
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+
+	expect($function)->toContain("new \\Cacti\\Rrd\\RrdCommand('update', \$arguments)")
+		->not->toContain("rrdtool_execute('update '");
+});
+
+test('rrd fetches use the structured command path', function () {
+	$source = file_get_contents(dirname(__DIR__, 4) . '/lib/rrd.php');
+	$start  = strpos($source, 'function rrdtool_function_fetch(');
+	$end    = strpos($source, 'function rrd_function_process_graph_options(', $start);
+
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+
+	expect($function)->toContain("new \\Cacti\\Rrd\\RrdCommand('fetch', \$arguments)")
+		->not->toContain("\$cmd_line = 'fetch '");
+});

--- a/tests/Unit/Core/Rrd/RrdCommandTest.php
+++ b/tests/Unit/Core/Rrd/RrdCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Cacti\Rrd\RrdCommand;
+use Cacti\Rrd\RrdCommandSerializer;
+
+require_once dirname(__DIR__, 4) . '/lib/Rrd/RrdCommand.php';
+require_once dirname(__DIR__, 4) . '/lib/Rrd/RrdCommandSerializer.php';
+
+test('a command preserves raw arguments for shellless execution', function () {
+	$command = new RrdCommand('update', [
+		'/var/lib/cacti/a file.rrd',
+		'--template',
+		'traffic_in:traffic_out',
+		'100:1; echo not-a-command',
+	]);
+
+	expect($command->toArgv('/usr/bin/rrdtool'))->toBe([
+		'/usr/bin/rrdtool',
+		'update',
+		'/var/lib/cacti/a file.rrd',
+		'--template',
+		'traffic_in:traffic_out',
+		'100:1; echo not-a-command',
+	]);
+});
+
+test('line protocol serialization escapes arguments but not the operation', function () {
+	$command    = new RrdCommand('fetch', ['/var/lib/cacti/a file.rrd', 'AVERAGE']);
+	$serializer = new RrdCommandSerializer();
+
+	expect($serializer->forLineProtocol($command, 'escapeshellarg'))
+		->toBe("fetch '/var/lib/cacti/a file.rrd' 'AVERAGE'");
+});
+
+test('the compatibility list constructor normalizes scalar arguments', function () {
+	$command = RrdCommand::fromList(['fetch', '/tmp/test.rrd', 'AVERAGE', -300, null]);
+
+	expect($command->operation)->toBe('fetch')
+		->and($command->arguments)->toBe(['/tmp/test.rrd', 'AVERAGE', '-300', '']);
+});
+
+test('commands reject line protocol control characters', function (string $token) {
+	expect(fn () => new RrdCommand('update', [$token]))
+		->toThrow(InvalidArgumentException::class);
+})->with([
+	'line feed'       => "value\nfetch other.rrd AVERAGE",
+	'carriage return' => "value\rquit",
+	'null byte'       => "value\0suffix",
+]);
+
+test('commands reject operations containing whitespace', function () {
+	expect(fn () => new RrdCommand('fetch another-command'))
+		->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Unit/Security/Shell/RrdEscapeCommandRemovalTest.php
+++ b/tests/Unit/Security/Shell/RrdEscapeCommandRemovalTest.php
@@ -41,23 +41,31 @@ test('escape_command is not redefined elsewhere under lib', function () {
 	expect($found)->toBe([]);
 });
 
-test('__rrd_execute escapes array arguments one at a time', function () use ($rrdPath) {
+test('__rrd_execute normalizes array commands into structured commands', function () use ($rrdPath) {
 	$source = file_get_contents($rrdPath);
 
-	expect($source)->toContain("\$command_line = implode(' ', array_map('cacti_escapeshellarg', \$command_line));");
+	expect($source)->toContain('$command_line = \\Cacti\\Rrd\\RrdCommand::fromList($command_line);')
+		->and($source)->toContain("'cacti_escapeshellarg'");
 });
 
-test('the shell_exec command line is assembled without a whole-command escape', function () use ($rrdPath) {
+test('structured commands use a shellless local transport', function () use ($rrdPath) {
 	$source = file_get_contents($rrdPath);
 
-	expect($source)->toContain("\$full_commandline = read_config_option('path_rrdtool') . \$debug . ' ' . \$command_line;");
-	expect($source)->toContain('$output = shell_exec($full_commandline);');
+	expect($source)->toContain('$structured_command = $command_line instanceof \\Cacti\\Rrd\\RrdCommand')
+		->and($source)->toContain('new \\Cacti\\Rrd\\LocalRrdTransport(')
+		->and($source)->toContain('))->execute($structured_command);');
 });
 
-test('the pipe writers pass the command line through untouched', function () use ($rrdPath) {
+test('legacy string commands retain their compatibility execution path', function () use ($rrdPath) {
 	$source = file_get_contents($rrdPath);
 
-	expect($source)->toContain('fwrite($pipes[0], $command_line . "\r\nquit\r\n");');
+	expect($source)->toContain("\$full_commandline = read_config_option('path_rrdtool') . \$debug . ' ' . \$command_line;")
+		->and($source)->toContain('$output = shell_exec($full_commandline);');
+});
+
+test('the persistent pipe writer passes the command line through untouched', function () use ($rrdPath) {
+	$source = file_get_contents($rrdPath);
+
 	expect($source)->toContain('if (fwrite($rrdtool_pipe, " $command_line\r\n") === false) {');
 });
 

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -95,7 +95,37 @@ cmd_exec	./lib/utility.php			exec('wmic os get TotalVirtualMemorySize', $memInfo
 cmd_exec	./lib/utility.php			exec('wmic os get TotalVisibleMemorySize', $memInfo['TotalVisibleMemorySize']);
 cmd_exec	./lib/utility.php		$json       = shell_exec($php . ' -q ' . $php_file);
 cmd_exec	./lib/utility.php		$json     = shell_exec($php . ' -q ' . $php_file);
-cmd_exec	./lib/utility.php		$json     = shell_exec($php . ' -q ' . $php_file);
+cmd_exec	./lib/dsstats.php		$process = proc_open($command, $fds, $pipes);
+cmd_exec	./lib/installer.php						$output = shell_exec(
+cmd_exec	./lib/installer.php						$output = shell_exec(cacti_escapeshellcmd(str_replace('\\', '/', $path)) . ' --version 2>&1');
+cmd_exec	./lib/installer.php			$check    = shell_exec("$composer install --dry-run --no-interaction --working-dir=$base 2>&1");
+cmd_exec	./lib/installer.php			$output = shell_exec("$composer install --no-interaction --no-progress --working-dir=$base 2>&1");
+cmd_exec	./lib/installer.php				$last_line = exec($command, $output, $return);
+cmd_exec	./lib/installer.php						shell_exec(cacti_escapeshellcmd((string) read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php						$results = shell_exec(cacti_escapeshellcmd((string) read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/database.php			exec("$dump_esc $options $credentials_string " . cacti_escapeshellarg($database) . ($tables_esc !== '' ? ' ' . $tables_esc : '') . " > $output_esc", $output, $retval);
+cmd_exec	./lib/database.php			exec("$dump_esc $options $credentials_string " . cacti_escapeshellarg($database) . ' version >/dev/null 2>&1', $output, $retval);
+cmd_exec	./lib/database.php				exec("$dump_esc $options $credentials_string --user=" . cacti_escapeshellarg($username) . ' --password=' . cacti_escapeshellarg($password) . ' ' . cacti_escapeshellarg($database) . ($tables_esc !== '' ? ' ' . $tables_esc : '') . " > $output_esc", $output, $retval);
+cmd_exec	./lib/database.php				exec("$dump_esc $options $credentials_string " . cacti_escapeshellarg($database) . ($tables_esc !== '' ? ' ' . $tables_esc : '') . " > $output_esc", $output, $retval);
+cmd_exec	./lib/ping.php					$result = shell_exec(cacti_escapeshellarg($fping) . ' -q -t ' . $this->timeout . ' -c 1 -r ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']) . ' 2>&1');
+cmd_exec	./lib/ping.php						$result = shell_exec('ping ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php						$result = shell_exec('ping -m ' . ceil($this->timeout / 1000) . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php						$result = shell_exec('ping -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php							$result = shell_exec('ping6 -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php							$result = shell_exec('ping -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php						$result = shell_exec('ping -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php						$result = shell_exec('ping -w ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php						$result = shell_exec('ping -i ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php						$result = shell_exec('chcp 437 && ping -w ' . $this->timeout . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php							$result = shell_exec('ping -6 -W ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . cacti_escapeshellarg($this->host['hostname']));
+cmd_exec	./lib/ping.php							$result = shell_exec('ping -W ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . cacti_escapeshellarg($this->host['hostname']) . ' 2>&1');
+cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
+cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
+cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
+cmd_exec	./lib/rrd.php		$process = popen($command, 'w');
+cmd_exec	./lib/rrd.php						$output = shell_exec($full_commandline);
+cmd_exec	./lib/rrd.php					$fp = popen($rrd_cmd, 'r');
+cmd_exec	./poller_realtime.php	shell_exec("$command_string $extra_args");
 cmd_exec	./poller_realtime.php					shell_exec($command);
 cmd_exec	./poller_realtime.php	shell_exec("$command_string $extra_args");
 cmd_exec	./poller_spikekill.php				$response = exec(cacti_escapeshellcmd((string) read_config_option('path_php_binary')) . ' -q ' .

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -75,7 +75,6 @@ cmd_exec	./lib/poller.php	 *                                    of the proc_open
 cmd_exec	./lib/poller.php	 * @param array  $pipes               The array of r/w pipes returned from proc_open()
 cmd_exec	./lib/poller.php	 * @param mixed  $proc_fd             The file descriptor returned from proc_open()
 cmd_exec	./lib/rrd.php						$output = shell_exec($full_commandline);
-cmd_exec	./lib/rrd.php						$process = proc_open(read_config_option('path_rrdtool') . ' - ' . $debug, $descriptorspec, $pipes);
 cmd_exec	./lib/rrd.php					$fp = popen($rrd_cmd, 'r');
 cmd_exec	./lib/rrd.php		$process = popen($command, 'w');
 cmd_exec	./lib/rrdcheck.php		$process = proc_open($command, $fds, $pipes);
@@ -95,37 +94,7 @@ cmd_exec	./lib/utility.php			exec('wmic os get TotalVirtualMemorySize', $memInfo
 cmd_exec	./lib/utility.php			exec('wmic os get TotalVisibleMemorySize', $memInfo['TotalVisibleMemorySize']);
 cmd_exec	./lib/utility.php		$json       = shell_exec($php . ' -q ' . $php_file);
 cmd_exec	./lib/utility.php		$json     = shell_exec($php . ' -q ' . $php_file);
-cmd_exec	./lib/dsstats.php		$process = proc_open($command, $fds, $pipes);
-cmd_exec	./lib/installer.php						$output = shell_exec(
-cmd_exec	./lib/installer.php						$output = shell_exec(cacti_escapeshellcmd(str_replace('\\', '/', $path)) . ' --version 2>&1');
-cmd_exec	./lib/installer.php			$check    = shell_exec("$composer install --dry-run --no-interaction --working-dir=$base 2>&1");
-cmd_exec	./lib/installer.php			$output = shell_exec("$composer install --no-interaction --no-progress --working-dir=$base 2>&1");
-cmd_exec	./lib/installer.php				$last_line = exec($command, $output, $return);
-cmd_exec	./lib/installer.php						shell_exec(cacti_escapeshellcmd((string) read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php						$results = shell_exec(cacti_escapeshellcmd((string) read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/database.php			exec("$dump_esc $options $credentials_string " . cacti_escapeshellarg($database) . ($tables_esc !== '' ? ' ' . $tables_esc : '') . " > $output_esc", $output, $retval);
-cmd_exec	./lib/database.php			exec("$dump_esc $options $credentials_string " . cacti_escapeshellarg($database) . ' version >/dev/null 2>&1', $output, $retval);
-cmd_exec	./lib/database.php				exec("$dump_esc $options $credentials_string --user=" . cacti_escapeshellarg($username) . ' --password=' . cacti_escapeshellarg($password) . ' ' . cacti_escapeshellarg($database) . ($tables_esc !== '' ? ' ' . $tables_esc : '') . " > $output_esc", $output, $retval);
-cmd_exec	./lib/database.php				exec("$dump_esc $options $credentials_string " . cacti_escapeshellarg($database) . ($tables_esc !== '' ? ' ' . $tables_esc : '') . " > $output_esc", $output, $retval);
-cmd_exec	./lib/ping.php					$result = shell_exec(cacti_escapeshellarg($fping) . ' -q -t ' . $this->timeout . ' -c 1 -r ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']) . ' 2>&1');
-cmd_exec	./lib/ping.php						$result = shell_exec('ping ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php						$result = shell_exec('ping -m ' . ceil($this->timeout / 1000) . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php						$result = shell_exec('ping -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php							$result = shell_exec('ping6 -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php							$result = shell_exec('ping -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php						$result = shell_exec('ping -t ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php						$result = shell_exec('ping -w ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php						$result = shell_exec('ping -i ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php						$result = shell_exec('chcp 437 && ping -w ' . $this->timeout . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php							$result = shell_exec('ping -6 -W ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . cacti_escapeshellarg($this->host['hostname']));
-cmd_exec	./lib/ping.php							$result = shell_exec('ping -W ' . ceil($this->timeout / 1000) . ' -c ' . $this->retries . ' -p ' . $pattern . ' ' . cacti_escapeshellarg($this->host['hostname']) . ' 2>&1');
-cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
-cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
-cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
-cmd_exec	./lib/rrd.php		$process = popen($command, 'w');
-cmd_exec	./lib/rrd.php						$output = shell_exec($full_commandline);
-cmd_exec	./lib/rrd.php					$fp = popen($rrd_cmd, 'r');
-cmd_exec	./poller_realtime.php	shell_exec("$command_string $extra_args");
+cmd_exec	./lib/utility.php		$json     = shell_exec($php . ' -q ' . $php_file);
 cmd_exec	./poller_realtime.php					shell_exec($command);
 cmd_exec	./poller_realtime.php	shell_exec("$command_string $extra_args");
 cmd_exec	./poller_spikekill.php				$response = exec(cacti_escapeshellcmd((string) read_config_option('path_php_binary')) . ' -q ' .


### PR DESCRIPTION
## Summary

- introduce typed PHP 8.1 RRDtool command, transport, result, and exception objects
- use Symfony Process with argv arrays for shellless local execution
- migrate update, fetch, info, dump, restore, and proxy utility operations to structured commands
- harden fetch parsing, graph data handling, theme selection, and DOM mutation contracts
- enforce PHPStan level 8 for `lib/rrd.php` and `lib/Rrd` in Composer and CI
- remove the unreachable legacy `proc_open` branch and refresh the generated sink inventory

## Compatibility

Complex graph and create command builders remain on RRDtool's line protocol because their values are RRDtool DSL expressions. Persistent-pipe and proxy execution retain their existing transport behavior. Local structured commands use Symfony Process without a shell.

The project Composer platform remains PHP 8.1.0 and Symfony Process 6.4 requires PHP 8.1 or newer.

## Validation

- `composer run-script phpstan-rrd` — passed at level 8 with no suppressions in the RRD scope
- `composer run-script phpstan` — repository-wide level 6 passed
- focused RRD/security suite — 91 tests passed, 218 assertions
- configured Pest suite — 1,925 passed, 26 skipped; two unrelated Orb integration tests failed because Orb was unavailable or misdetected in the local environment
- PHP lint — 739 files passed
- Composer validation — passed
- PHP CS Fixer — passed for changed PHP files
- Actionlint — passed
- sink inventory and architectural hotspot checks — passed

## Environment note

An exact local PHP 8.1 runtime could not be installed through mise because its build failed on the local libiconv configuration. The implementation is constrained to PHP 8.1 syntax and Composer continues to resolve dependencies against its PHP 8.1.0 platform setting.

Closes #7859