### PR TITLE
Fix obsolete PHP compatibility branches on 1.2.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Cacti CHANGELOG
 -security: Harden advisory command execution and database DDL sink validation
 -security: Restrict graph input fields across the template, graph and import handoffs
 -security: Treat a non-boolean signature result as a failure in import_package
+-issue#7819: Remove obsolete pre-PHP 8 compatibility branches
 -issue#5679: Attempt SNMP in Ping-OR-SNMP availability checks when ping fails
 -issue#6609: Return a controlled empty export when RRDtool XPORT omits metadata
 -issue#6684: Prevent VDEF-backed aggregate graph items from being emitted as XPORT data sources

--- a/include/global.php
+++ b/include/global.php
@@ -476,25 +476,6 @@ if ($config['is_web']) {
 
 	cacti_session_start();
 
-	/* we never run with magic quotes on */
-	if (version_compare(PHP_VERSION, '5.4', '<=')) {
-		if (get_magic_quotes_gpc()) {
-			$process = array(&$_GET, &$_POST, &$_COOKIE, &$_REQUEST);
-			foreach ($process as $key => $val) {
-				foreach ($val as $k => $v) {
-					unset($process[$key][$k]);
-					if (is_array($v)) {
-						$process[$key][stripslashes($k)] = $v;
-						$process[] = &$process[$key][stripslashes($k)];
-					} else {
-						$process[$key][stripslashes($k)] = stripslashes($v);
-					}
-				}
-			}
-			unset($process);
-		}
-	}
-
 	/* make sure to start only Cacti session at a time */
 	if (!isset($_SESSION['cacti_cwd'])) {
 		$_SESSION['cacti_cwd'] = $config['base_path'];
@@ -508,31 +489,6 @@ if ($config['is_web']) {
 	if (isset($_SERVER['HTTP_REFERER'])) {
 		$_SERVER['HTTP_REFERER'] = sanitize_uri($_SERVER['HTTP_REFERER']);
 	}
-}
-
-/* emulate 'register_globals' = 'off' if turned on */
-if ((bool)ini_get('register_globals')) {
-	$not_unset = array('_GET', '_POST', '_COOKIE', '_SERVER', '_SESSION', '_ENV', '_FILES', 'database_type', 'database_default', 'database_hostname', 'database_username', 'database_password', 'config', 'colors');
-
-	/* Not only will array_merge give a warning if a parameter is not an array, it will
-	* actually fail. So we check if HTTP_SESSION_VARS has been initialised. */
-	if (!isset($_SESSION)) {
-		$_SESSION = array();
-	}
-
-	/* Merge all into one extremely huge array; unset this later */
-	$input = array_merge($_GET, $_POST, $_COOKIE, $_SERVER, $_SESSION, $_ENV, $_FILES);
-
-	unset($input['input']);
-	unset($input['not_unset']);
-
-	foreach ($input as $var => $val) {
-		if (!in_array($var, $not_unset)) {
-			unset($$var);
-		}
-	}
-
-	unset($input);
 }
 
 define('CACTI_DATE_TIME_FORMAT', date_time_format());

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1138,17 +1138,7 @@ function clear_messages() {
  * kill_session_var - kills a session variable using unset()
  */
 function kill_session_var($var_name) {
-	/* register_global = on: reset local settings cache so the user sees the new settings */
 	unset($_SESSION[$var_name]);
-
-	/* register_global = off: reset local settings cache so the user sees the new settings */
-	/* session_unregister is deprecated in PHP 5.3.0, unset is sufficient */
-
-	if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-		session_unregister($var_name);
-	} else {
-		unset($var_name);
-	}
 }
 
 /**
@@ -7704,8 +7694,7 @@ function cacti_count($array) {
 
 function is_function_enabled($name) {
 	return function_exists($name) &&
-		!in_array($name, array_map('trim', explode(', ', ini_get('disable_functions')))) &&
-		strtolower(ini_get('safe_mode')) != 1;
+		!in_array($name, array_map('trim', explode(',', (string) ini_get('disable_functions'))), true);
 }
 
 function is_page_ajax() {

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1142,19 +1142,15 @@ function validate_is_regex($regex) {
 
 	restore_error_handler();
 
-	$track_errors = ini_get('track_errors');
-	ini_set('track_errors', 1);
-
-    if (@preg_match("'" . $regex . "'", NULL) !== false) {
-		ini_set('track_errors', $track_errors);
+	if (@preg_match("'" . $regex . "'", '') !== false) {
 		return true;
 	}
 
 	$last_error = error_get_last();
 
-	$php_error = trim(str_replace('preg_match():', '', $last_error['message']));
-
-	ini_set('track_errors', $track_errors);
+	$php_error = isset($last_error['message'])
+		? trim(str_replace('preg_match():', '', $last_error['message']))
+		: __('Invalid regular expression.');
 
 	$errors = array(
 		PREG_INTERNAL_ERROR         => __('There was an internal error!'),

--- a/tests/Unit/PhpLegacyCompatibilityCleanupTest.php
+++ b/tests/Unit/PhpLegacyCompatibilityCleanupTest.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ */
+
+$base = dirname(__DIR__, 2);
+
+test('removed PHP runtime compatibility branches do not return', function () use ($base) {
+	$global    = file_get_contents($base . '/include/global.php');
+	$functions = file_get_contents($base . '/lib/functions.php');
+
+	expect($global)
+		->not->toContain('get_magic_quotes_gpc')
+		->not->toContain("ini_get('register_globals')")
+		->and($functions)
+		->not->toContain('session_unregister')
+		->not->toContain("ini_get('safe_mode')");
+});
+
+test('regex validation does not rely on removed track_errors state', function () use ($base) {
+	$source = file_get_contents($base . '/lib/html_utility.php');
+
+	expect($source)
+		->not->toContain("ini_get('track_errors')")
+		->not->toContain("ini_set('track_errors'")
+		->not->toContain('preg_match("\'" . $regex . "\'", NULL)')
+		->toContain('error_get_last()');
+});
+
+test('function availability uses the current disabled-functions contract', function () use ($base) {
+	$source = file_get_contents($base . '/lib/functions.php');
+
+	expect($source)
+		->toContain("explode(',', (string) ini_get('disable_functions'))")
+		->toContain("), true);");
+});


### PR DESCRIPTION
## Summary

- remove unreachable magic-quotes and register-globals compatibility branches
- simplify session invalidation and function availability checks for supported PHP runtimes
- stop using the removed track_errors directive during regular-expression validation
- pass an empty string rather than null to preg_match and guard missing error details
- add regression coverage for the removed APIs and directives

Fixes #7819.

## Validation

- focused Pest regression test: 3 passed, 10 assertions
- PHPCompatibility removed-functions and removed-INI-directives scan targeting PHP 8.1: clean
- broad PHPCompatibility scan: 0 errors; only 29 pre-existing double-underscore API and test-closure warnings remain
- PHP syntax checks for every changed PHP file
- Composer validation
- security sink inventory and architectural hotspot checks
