### PR TITLE
hardening: user_admin sort column, sites LIKE filter, package temp dir

### DIFF
--- a/package_import.php
+++ b/package_import.php
@@ -372,10 +372,12 @@ function package_get_details() {
 			$data = get_repo_file($package_location, $filename, false);
 
 			if ($data !== false) {
-				$tmp_dir = sys_get_temp_dir() . '/package' . $_SESSION['sess_user_id'];
+				/* use an unpredictable, private per-run directory so a local
+				   co-tenant cannot pre-plant a symlink at a guessable path */
+				$tmp_dir = sys_get_temp_dir() . '/cacti_pkg_' . $_SESSION['sess_user_id'] . '_' . bin2hex(random_bytes(8));
 
 				if (!is_dir($tmp_dir)) {
-					mkdir($tmp_dir);
+					mkdir($tmp_dir, 0700);
 				}
 
 				$xmlfile = $tmp_dir . '/' . $filename;

--- a/sites.php
+++ b/sites.php
@@ -577,7 +577,7 @@ function sites() {
 
 	/* form the 'where' clause for our main sql query */
 	if (get_request_var('filter') != '') {
-		$sql_where = 'WHERE name LIKE ' . db_qstr('%' . get_request_var('filter') . '%');
+		$sql_where = 'WHERE name LIKE ' . db_qstr('%' . str_replace(array('\\', '%', '_'), array('\\\\', '\\%', '\\_'), get_request_var('filter')) . '%');
 	} else {
 		$sql_where = '';
 	}

--- a/user_admin.php
+++ b/user_admin.php
@@ -2116,6 +2116,12 @@ function user() {
 	);
 
 	validate_store_request_vars($filters, 'sess_usera');
+
+	/* constrain sort_column to the displayed columns so it cannot pivot ORDER BY
+	   onto sensitive user_auth columns such as password or tfa_secret */
+	set_request_var('sort_column', cacti_validate_sort_column(get_request_var('sort_column'),
+		array('username', 'id', 'full_name', 'enabled', 'realm', 'policy_graphs', 'policy_hosts', 'policy_graph_templates', 'dtime'),
+		'username'));
 	/* ================= input validation ================= */
 
 	?>


### PR DESCRIPTION
Three low-severity defense-in-depth items surfaced while validating draft advisories against a live 1.2.31. None is a high-impact vulnerability on its own; grouping them since each is a small, mechanical hardening a reviewer can evaluate at once.

**user_admin.php sort_column** — `sort_column` was validated only by `sanitize_search_string`, so `get_order_string()` would accept `password`/`tfa_secret`/`locked` and emit `ORDER BY \`password\``, leaking the relative ordering of those columns by row position. Constrained to the displayed columns via the existing `cacti_validate_sort_column()` allowlist. Verified: `password`/`tfa_secret`/`locked` now fall back to `username`.

**sites.php name filter** — user-supplied `%` and `_` passed straight into `name LIKE`, so a wildcard filter could force expensive scans (small impact given the table size and LIMIT, but the pattern matches the plugins.php sibling). Escape the wildcards so they are treated literally.

**package_import.php temp dir** — a guessable `/tmp/package<user_id>` with check-then-mkdir let a local co-tenant pre-plant a symlink. Use an unpredictable name with `0700`. Note this branch is currently unreachable (`get_repo_file()` returns false), so the change is defensive.

Verification: `php -l` clean on all three; the sort_column allowlist tested live on 1.2.31.
