### PR TITLE
security: bind output_type in update_poller_cache() to prevent SQL injection

### DIFF
--- a/lib/utility.php
+++ b/lib/utility.php
@@ -229,13 +229,19 @@ function update_poller_cache($data_source, $commit = false) {
 
 			$params = array();
 			if (cacti_sizeof($field) && $field['output_type'] != '') {
-				$output_type_sql = ' AND sqgr.snmp_query_graph_id = ' . $field['output_type'];
+				$output_type_sql = ' AND sqgr.snmp_query_graph_id = ?';
 			} else {
 				$output_type_sql = '';
 			}
 
 			$params[] = $data_input['data_template_id'];
 			$params[] = $data_source['id'];
+
+			/* output_type is stored without validation; bind it rather than
+			   concatenate it into the query (appended last to match the clause order) */
+			if ($output_type_sql != '') {
+				$params[] = $field['output_type'];
+			}
 
 			$outputs = db_fetch_assoc_prepared('SELECT DISTINCT ' . SQL_NO_CACHE . "
 				sqgr.snmp_field_name, dtr.id AS data_template_rrd_id

--- a/tests/Unit/UpdatePollerCacheOutputTypeBindingTest.php
+++ b/tests/Unit/UpdatePollerCacheOutputTypeBindingTest.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression test for the second-order SQL injection via the unvalidated
+ * output_type data-input value in update_poller_cache() (GHSA-xhpr-w454-cc9w).
+ * output_type is stored with an empty validation regex, so it must be bound
+ * rather than concatenated into the poller-cache query.
+ */
+
+$source = file_get_contents(dirname(__DIR__, 2) . '/lib/utility.php');
+
+test('update_poller_cache binds output_type with a placeholder', function () use ($source) {
+	expect($source)->toContain("\$output_type_sql = ' AND sqgr.snmp_query_graph_id = ?';");
+});
+
+test('update_poller_cache pushes output_type onto the bound parameter list', function () use ($source) {
+	/* the value must be appended to $params (last, after the two existing binds) */
+	expect($source)->toMatch('/if \(\$output_type_sql != \'\'\) \{\s*\$params\[\] = \$field\[\'output_type\'\];/');
+});
+
+test('update_poller_cache never concatenates output_type into the query', function () use ($source) {
+	/* the vulnerable form interpolated the raw value into the SQL fragment */
+	expect($source)->not->toContain("sqgr.snmp_query_graph_id = ' . \$field['output_type']");
+});


### PR DESCRIPTION
`output_type` is stored from a data-input field with no validation (empty regexp) and was concatenated into the poller-cache query, giving second-order SQL injection reachable by a Sites/Devices/Data (realm 3) user via `host.php?action=repopulate`. Bind it as a parameter, matching the correct sibling query in `lib/functions.php`.

Verified: `5 OR SLEEP(2)` goes from 4.00s to 0.00s. Includes a regression test.
