### PR TITLE
security: authorize tree ownership for node AJAX actions

### DIFF
--- a/tests/Unit/Security/Auth/TreeNodeActionAuthorizationTest.php
+++ b/tests/Unit/Security/Auth/TreeNodeActionAuthorizationTest.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression test for the tree node-action IDOR (GHSA-73qf / GHSA-fchr): the
+ * AJAX node actions (copy/create/delete/move/rename/get_node) operate on a
+ * request tree_id and must be gated by cacti_authorize_resource so a non-owner
+ * cannot read or modify another user's tree.
+ */
+
+$source = file_get_contents(dirname(__DIR__, 3) . '/tree.php');
+
+test('tree.php gates every node action on tree ownership before dispatch', function () use ($source) {
+	foreach (array('copy_node', 'create_node', 'delete_node', 'move_node', 'rename_node', 'get_node') as $action) {
+		expect($source)->toContain("'$action'");
+	}
+	/* the guard must run before the action switch, keyed on tree_id */
+	expect($source)->toContain("cacti_authorize_resource(\$_SESSION['sess_user_id'], (int) get_request_var('tree_id'), 'graph_tree')");
+
+	$guard_pos  = strpos($source, "\$tree_node_actions = array(");
+	$switch_pos = strpos($source, "switch (get_request_var('action')) {");
+	expect($guard_pos)->toBeInt()->and($switch_pos)->toBeInt()->and($guard_pos)->toBeLessThan($switch_pos);
+});
+
+test('the node-action guard denies with 403 and exits', function () use ($source) {
+	expect($source)->toMatch('/in_array\(get_nfilter_request_var\(\'action\'\), \$tree_node_actions.*?header\(\'HTTP\/1\.1 403 Forbidden\'\);\s*print[^\n]*\s*exit;/s');
+});

--- a/tree.php
+++ b/tree.php
@@ -84,6 +84,19 @@ if (get_request_var('action') != '') {
 	/* ================= input validation ================= */
 }
 
+/* the node AJAX actions all operate on tree_id; block callers who do not own the
+   tree, covering both the write handlers and the copy_node/get_node read path
+   (admin realm 1 bypasses inside cacti_authorize_resource) */
+$tree_node_actions = array('copy_node', 'create_node', 'delete_node', 'move_node', 'rename_node', 'get_node');
+
+if (in_array(get_nfilter_request_var('action'), $tree_node_actions, true)
+	&& isset_request_var('tree_id')
+	&& !cacti_authorize_resource($_SESSION['sess_user_id'], (int) get_request_var('tree_id'), 'graph_tree')) {
+	header('HTTP/1.1 403 Forbidden');
+	print __('You do not have permission to access this tree.');
+	exit;
+}
+
 switch (get_request_var('action')) {
 	case 'save':
 		form_save();


### PR DESCRIPTION
The `tree.php` node actions (copy_node/create_node/delete_node/move_node/rename_node/get_node) dispatched on a request `tree_id` with no ownership check, letting a realm-4 non-owner read (get_node) or modify another user's tree. Gate all six on `cacti_authorize_resource(..., 'graph_tree')` before the switch, matching the save/bulk paths (admin realm 1 bypasses).

Verified live: non-owner -> 403; owner and admin allowed. Includes a regression test.
