### PR TITLE
security: escape template and report names in raise_message (stored XSS)

### DIFF
--- a/graph_templates.php
+++ b/graph_templates.php
@@ -314,9 +314,9 @@ function form_actions() {
 						array($selected_items[$i]));
 
 					if (isset($_SESSION['sess_gt_repairs']) && $_SESSION['sess_gt_repairs'] > 0) {
-						raise_message('gt_repair' . $selected_items[$i], __('Sync of Graph Template \'%s\' Resulted in %s Repairs!', $graph_template_name, $_SESSION['sess_gt_repairs']), MESSAGE_LEVEL_WARN);
+						raise_message('gt_repair' . $selected_items[$i], __esc('Sync of Graph Template \'%s\' Resulted in %s Repairs!', $graph_template_name, $_SESSION['sess_gt_repairs']), MESSAGE_LEVEL_WARN);
 					} else {
-						raise_message('gt_repair' . $selected_items[$i], __('Sync of Graph Template \'%s\' Resulted in no Repairs.', $graph_template_name), MESSAGE_LEVEL_INFO);
+						raise_message('gt_repair' . $selected_items[$i], __esc('Sync of Graph Template \'%s\' Resulted in no Repairs.', $graph_template_name), MESSAGE_LEVEL_INFO);
 					}
 				}
 			} elseif (get_request_var('drp_action') == '5') { // resequence graphs with sequences off
@@ -329,9 +329,9 @@ function form_actions() {
 						array($selected_items[$i]));
 
 					if (isset($_SESSION['sess_gt_repairs']) && $_SESSION['sess_gt_repairs'] > 0) {
-						raise_message('gt_repair' . $selected_items[$i], __('Sync of Graph Template \'%s\' Resulted in %s Repairs!', $graph_template_name, $_SESSION['sess_gt_repairs']), MESSAGE_LEVEL_WARN);
+						raise_message('gt_repair' . $selected_items[$i], __esc('Sync of Graph Template \'%s\' Resulted in %s Repairs!', $graph_template_name, $_SESSION['sess_gt_repairs']), MESSAGE_LEVEL_WARN);
 					} else {
-						raise_message('gt_repair' . $selected_items[$i], __('Sync of Graph Template \'%s\' Resulted in no Repairs.', $graph_template_name), MESSAGE_LEVEL_INFO);
+						raise_message('gt_repair' . $selected_items[$i], __esc('Sync of Graph Template \'%s\' Resulted in no Repairs.', $graph_template_name), MESSAGE_LEVEL_INFO);
 					}
 				}
 			}

--- a/host.php
+++ b/host.php
@@ -331,7 +331,7 @@ function form_actions() {
 						WHERE id = ?',
 						array(get_request_var('report_id')));
 
-					raise_message('reports_add_error', __('Unable to add some Devices to Report \'%s\'', $name), MESSAGE_LEVEL_WARN);
+					raise_message('reports_add_error', __esc('Unable to add some Devices to Report \'%s\'', $name), MESSAGE_LEVEL_WARN);
 				}
 			} elseif (get_request_var('drp_action') == '1') { // delete
 				if (!isset_request_var('delete_type')) {

--- a/tests/Unit/Security/Xss/RaiseMessageNameEscapingTest.php
+++ b/tests/Unit/Security/Xss/RaiseMessageNameEscapingTest.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression test for the raise_message stored-XSS cluster (GHSA-9737): name
+ * values embedded in raise_message() reach $('body').append() as HTML, so they
+ * must use __esc() (which escapes the formatted string), not __().
+ */
+
+test('graph_templates sync messages escape the template name', function () {
+	$s = file_get_contents(dirname(__DIR__, 3) . '/graph_templates.php');
+	expect(substr_count($s, "__esc('Sync of Graph Template"))->toBe(4)
+		->and($s)->not->toContain("__('Sync of Graph Template");
+});
+
+test('host device-to-report message escapes the report name', function () {
+	$s = file_get_contents(dirname(__DIR__, 3) . '/host.php');
+	expect($s)->toContain("__esc('Unable to add some Devices to Report")
+		->and($s)->not->toContain("__('Unable to add some Devices to Report");
+});


### PR DESCRIPTION
`graph_templates.name` and `reports.name` are stored raw and embedded via `__()` into `raise_message`, which renders through `$('body').append()` as HTML. Switch these sinks to `__esc()`.

Verified: a name containing markup renders escaped. Includes a regression test. (`color_templates`/`data_templates` in the same family are not exploitable: input sanitization and varchar(19) width respectively.)
