### PR TITLE
fix(database): restore qualified plugin table metadata lookup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,7 @@ Cacti CHANGELOG
 -issue#7728: Fail closed during Boost handoff and preserve the direct-RRD fallback
 -issue#7801: Harden CSRF secret storage and state-changing browser request handoffs
 -issue: Keep missing PHP extensions visible to the Cacti installer (PR #7747 follow-up)
+-issue: Restore qualified plugin table metadata lookups (plugin_syslog#331)
 -issue: Restore RRDproxy encryption with Composer-managed phpseclib 3
 -issue: Url encode the base64 regex filter before it reaches the query string (PR #7777)
 -issue: Make 1.2 dependency builds reproducible (PR #7747)

--- a/lib/database.php
+++ b/lib/database.php
@@ -900,6 +900,41 @@ function db_is_safe_identifier($identifier) {
 }
 
 /**
+ * db_format_qualified_identifier - validate and quote a table identifier
+ *
+ * @param  (string) $identifier - A table name, optionally qualified by a database
+ *
+ * @return (string|bool) The safely quoted identifier or false when invalid
+ */
+function db_format_qualified_identifier($identifier) {
+	if (!is_string($identifier)) {
+		return false;
+	}
+
+	$parts = explode('.', $identifier);
+
+	if (count($parts) < 1 || count($parts) > 2) {
+		return false;
+	}
+
+	$quoted_parts = array();
+
+	foreach ($parts as $part) {
+		if (preg_match('/^`([A-Za-z0-9_]+)`$/D', $part, $matches) === 1) {
+			$part = $matches[1];
+		}
+
+		if (!db_is_safe_identifier($part)) {
+			return false;
+		}
+
+		$quoted_parts[] = "`$part`";
+	}
+
+	return implode('.', $quoted_parts);
+}
+
+/**
  * db_is_safe_column_type - validate column type clauses used in DDL
  *
  * @param  (string) $type - Column type clause
@@ -1484,7 +1519,9 @@ function db_get_table_column_types($table, $db_conn = false) {
 		}
 	}
 
-	if (!db_is_safe_identifier($table)) {
+	$table_identifier = db_format_qualified_identifier($table);
+
+	if ($table_identifier === false) {
 		return false;
 	}
 
@@ -1492,13 +1529,13 @@ function db_get_table_column_types($table, $db_conn = false) {
 	 * lookup. sql_save() calls this for every write, and a bulk operation (e.g.
 	 * creating many graphs) otherwise re-queries the same tables hundreds of
 	 * times. The cache is cleared by the DDL helpers whenever a column changes. */
-	$key = spl_object_id($db_conn) . ':' . $table;
+	$key = spl_object_id($db_conn) . ':' . $table_identifier;
 
 	if (isset($db_column_type_cache[$key])) {
 		return $db_column_type_cache[$key];
 	}
 
-	$columns = db_fetch_assoc("SHOW COLUMNS FROM `$table`", false, $db_conn);
+	$columns = db_fetch_assoc("SHOW COLUMNS FROM $table_identifier", false, $db_conn);
 	$cols    = [];
 	if (cacti_sizeof($columns)) {
 		foreach ($columns as $col) {

--- a/tests/Unit/Database/DbColumnTypeCacheTest.php
+++ b/tests/Unit/Database/DbColumnTypeCacheTest.php
@@ -38,7 +38,7 @@ test('db_get_table_column_types memoizes the SHOW COLUMNS lookup', function () u
 
 	expect($body)->not->toBe('');
 	// it still issues the SHOW COLUMNS query when uncached
-	expect($body)->toContain('SHOW COLUMNS FROM $table');
+	expect($body)->toContain('SHOW COLUMNS FROM $table_identifier');
 	// but reads from and writes to the request-scoped cache
 	expect($body)->toContain('global $database_sessions, $database_default, $database_hostname, $database_port, $db_column_type_cache');
 	expect($body)->toContain('if (isset($db_column_type_cache[$key])) {');

--- a/tests/Unit/Database/DbQualifiedIdentifierTest.php
+++ b/tests/Unit/Database/DbQualifiedIdentifierTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 3) . '/lib/database.php';
+
+test('qualified table identifiers are validated and quoted per component', function () {
+	expect(db_format_qualified_identifier('syslog_logs'))->toBe('`syslog_logs`')
+		->and(db_format_qualified_identifier('syslog_prod.syslog_logs'))->toBe('`syslog_prod`.`syslog_logs`')
+		->and(db_format_qualified_identifier('`syslog_prod`.`syslog_logs`'))->toBe('`syslog_prod`.`syslog_logs`');
+});
+
+test('unsafe qualified table identifiers are rejected', function () {
+	foreach (array(
+		'',
+		'syslog_prod.',
+		'.syslog_logs',
+		'syslog_prod..syslog_logs',
+		'`syslog_prod`.syslog_logs`',
+		'syslog_prod.syslog_logs; DROP TABLE users',
+	) as $identifier) {
+		expect(db_format_qualified_identifier($identifier))->toBeFalse();
+	}
+});
+
+test('column metadata uses the canonical qualified identifier', function () {
+	$source = file_get_contents(dirname(__DIR__, 3) . '/lib/database.php');
+	$start  = strpos($source, 'function db_get_table_column_types(');
+	$end    = strpos($source, "\nfunction ", $start + 1);
+	$body   = substr($source, $start, $end - $start);
+
+	expect($body)->toContain('$table_identifier = db_format_qualified_identifier($table);')
+		->and($body)->toContain('SHOW COLUMNS FROM $table_identifier')
+		->and($body)->not->toContain('SHOW COLUMNS FROM `$table`');
+});


### PR DESCRIPTION
## Summary

- restore `sql_save()` metadata lookup for plugin tables qualified as `database.table`
- validate each database/table component independently before canonical backtick quoting
- retain request-local column metadata caching under the canonical identifier
- add regression coverage for Syslog's quoted table form and malformed/injected identifiers

Syslog uses a separate PDO connection and passes table names such as `` `syslog_prod`.`syslog_logs` ``. The 1.2.x DDL hardening treated that qualified name as one identifier, rejected it, and caused `sql_save()` to report every submitted column as missing.

Current `develop` is not affected: its metadata lookup still supports the qualified form. This correction is therefore scoped to the declared `1.2.x` base.

## Validation

- 14 focused Pest tests passed (87 assertions)
- `composer validate --strict`
- PHP syntax checks for the implementation and regression test
- `git diff --check upstream/1.2.x...HEAD`

Fixes Cacti/plugin_syslog#331
