### PR TITLE
[1.2.x] Harden forced HTTPS redirects against Host spoofing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.x
+-security: Build forced-HTTPS redirects from the server-configured name
 -security: Constrain external-link includes to regular files inside the configured content directory
 -security: Harden advisory command execution and database DDL sink validation
 -security: Restrict graph input fields across the template, graph and import handoffs

--- a/include/global.php
+++ b/include/global.php
@@ -419,8 +419,19 @@ if ($config['is_web']) {
 	if (read_config_option('force_https') == 'on') {
 		$is_https = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== '' && strtolower($_SERVER['HTTPS']) !== 'off');
 
-		if (!$is_https && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
-			header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+		if (!$is_https) {
+			$location = cacti_build_https_redirect_url(
+				$_SERVER['SERVER_NAME'] ?? '',
+				$_SERVER['REQUEST_URI'] ?? '',
+				$config['url_path']
+			);
+
+			if ($location === '') {
+				http_response_code(400);
+				exit;
+			}
+
+			header('Location: ' . $location);
 			exit;
 		}
 	}

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1070,12 +1070,9 @@ function validate_redirect_url($url = '', $default = 'index.php') {
 
 	$srv_host = null;
 
-	/* Prefer SERVER_NAME (set by server config) over HTTP_HOST (client-supplied)
-	   to prevent open redirect via Host header spoofing */
+	/* Use the server-configured name rather than the client-supplied Host header. */
 	if (isset($_SERVER['SERVER_NAME']) && $_SERVER['SERVER_NAME'] != '') {
 		$srv_host = preg_replace('/:\d+$/', '', $_SERVER['SERVER_NAME']);
-	} elseif (isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST'] != '') {
-		$srv_host = preg_replace('/:\d+$/', '', $_SERVER['HTTP_HOST']);
 	}
 
 	if ($ref_host !== null) {
@@ -1109,6 +1106,34 @@ function validate_redirect_url($url = '', $default = 'index.php') {
 	}
 
 	return $safe;
+}
+
+/**
+ * Builds a forced-HTTPS redirect using a server-configured host name.
+ *
+ * @param string $server_name  The web server's configured name.
+ * @param string $request_uri  The requested local path and query string.
+ * @param string $default_path A local fallback when the request URI is invalid.
+ *
+ * @psalm-taint-escape header
+ *
+ * @return string A safe absolute HTTPS URL, or an empty string for an invalid host.
+ */
+function cacti_build_https_redirect_url(string $server_name, string $request_uri, string $default_path = '/') : string {
+	$server_name = trim($server_name);
+	$host         = trim($server_name, '[]');
+
+	if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+		$host = '[' . $host . ']';
+	} elseif (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false &&
+		filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)  === false) {
+		return '';
+	}
+
+	$path = validate_redirect_url($request_uri, $default_path);
+	$path = '/' . ltrim($path, '/');
+
+	return 'https://' . $host . $path;
 }
 
 /**

--- a/tests/Unit/Security/Misc/SecurityHardening1_2xTest.php
+++ b/tests/Unit/Security/Misc/SecurityHardening1_2xTest.php
@@ -39,17 +39,15 @@ test('sanitize_uri does not call urldecode', function () use ($functionsSource) 
 	expect($body)->not->toContain('urldecode(');
 });
 
-// M-3/M-4: validate_redirect_url prefers SERVER_NAME over HTTP_HOST
+// M-3/M-4: validate_redirect_url does not trust HTTP_HOST
 
-test('validate_redirect_url prefers SERVER_NAME over HTTP_HOST', function () use ($htmlUtilitySource) {
+test('validate_redirect_url does not trust HTTP_HOST', function () use ($htmlUtilitySource) {
 	$start = strpos($htmlUtilitySource, 'function validate_redirect_url(');
 	expect($start)->not->toBeFalse();
 
 	$body = substr($htmlUtilitySource, $start, 3000);
-	// SERVER_NAME check must appear before HTTP_HOST fallback
-	$posServerName = strpos($body, "SERVER_NAME");
-	$posHttpHost   = strpos($body, "HTTP_HOST");
-	expect($posServerName)->toBeLessThan($posHttpHost);
+	expect($body)->toContain('SERVER_NAME');
+	expect($body)->not->toContain('HTTP_HOST');
 });
 
 test('validate_redirect_url rejects protocol-relative URLs after sanitize_uri', function () use ($htmlUtilitySource) {

--- a/tests/Unit/Security/Redirect/ForceHttpsRedirectTest.php
+++ b/tests/Unit/Security/Redirect/ForceHttpsRedirectTest.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 4) . '/lib/functions.php';
+require_once dirname(__DIR__, 4) . '/lib/html_utility.php';
+
+test('forced HTTPS redirects use the server configured name', function () {
+	expect(cacti_build_https_redirect_url(
+		'monitor.example',
+		'/cacti/graph.php?id=1',
+		'/cacti/'
+	))->toBe('https://monitor.example/cacti/graph.php?id=1');
+});
+
+test('forced HTTPS redirects support IPv6 server names', function () {
+	expect(cacti_build_https_redirect_url(
+		'2001:db8::1',
+		'/cacti/',
+		'/cacti/'
+	))->toBe('https://[2001:db8::1]/cacti/');
+});
+
+test('forced HTTPS redirects reject invalid server names', function () {
+	expect(cacti_build_https_redirect_url(
+		"monitor.example\r\nLocation: https://evil.example",
+		'/cacti/',
+		'/cacti/'
+	))->toBe('');
+});
+
+test('redirect validation ignores a spoofed Host header', function () {
+	$server = $_SERVER;
+
+	try {
+		$_SERVER['SERVER_NAME'] = 'monitor.example';
+		$_SERVER['HTTP_HOST']   = 'evil.example';
+
+		expect(validate_redirect_url('https://evil.example/admin', '/cacti/'))->toBe('/cacti/');
+		expect(validate_redirect_url('https://monitor.example/graph.php?id=1', '/cacti/'))->toBe('/graph.php?id=1');
+	} finally {
+		$_SERVER = $server;
+	}
+});
+
+test('forced HTTPS bootstrap does not read the Host header', function () {
+	$source = file_get_contents(dirname(__DIR__, 4) . '/include/global.php');
+
+	expect($source)->not->toContain("\$_SERVER['HTTP_HOST']");
+});

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -834,7 +834,7 @@ header_redirect	./include/fa/svgs/brands/index.php:25	header("Location:../index.
 header_redirect	./include/fa/svgs/regular/index.php:25	header("Location:../index.php");
 header_redirect	./include/fa/svgs/solid/index.php:25	header("Location:../index.php");
 header_redirect	./include/fa/webfonts/index.php:25	header("Location:../index.php");
-header_redirect	./include/global.php:423				header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+header_redirect	./include/global.php:434				header('Location: ' . $location);
 header_redirect	./include/index.php:25	header("Location:../index.php");
 header_redirect	./include/js/LC_MESSAGES/index.php:25	header("Location:../index.php");
 header_redirect	./include/js/index.php:25	header("Location:../index.php");

--- a/tests/security/build_architectural_helper_report.sh
+++ b/tests/security/build_architectural_helper_report.sh
@@ -49,7 +49,7 @@ hotspots() {
 	done
 
 	# Host header trust boundaries.
-	rg -n --pcre2 "${RG_COMMON[@]}" '\$_SERVER\s*\[\s*["'"'"']HTTP_HOST["'"'"']\s*\]' "${EXCLUDE[@]}" --glob '*.php' . | while IFS= read -r line; do
+	(rg -n --pcre2 "${RG_COMMON[@]}" '\$_SERVER\s*\[\s*["'"'"']HTTP_HOST["'"'"']\s*\]' "${EXCLUDE[@]}" --glob '*.php' . || true) | while IFS= read -r line; do
 		file="${line%%:*}"
 		rest="${line#*:}"
 		lineno="${rest%%:*}"


### PR DESCRIPTION
## Summary
- build forced-HTTPS redirects from the server-configured name instead of the client Host header
- validate redirect hosts and request paths, including IPv6 handling and fail-closed behavior
- use typed parameters and return values plus null coalescing consistently
- preserve the 1.2.x declared PHP 8.0 compatibility floor
- add regression coverage and keep security inventories current
- make the 1.2 architectural scan accept zero Host-header findings

## Validation
- PHP 8.1.34 selected through mise
- focused Pest regression tests on PHP 8.1.34
- changed-file PHP syntax checks on PHP 8.1.34
- sink inventory verification
- architectural hotspot verification
- clean range-diff after rebasing onto upstream/1.2.x