### PR TITLE
Harden forced HTTPS redirects against Host spoofing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-security: Build forced-HTTPS redirects from the server-configured name
 -security: Replace sibling password-reset links and revoke authentication state after reset
 -issue#7775: Add plugin-extensible notification API
 -issue#7746: Make PHP 8.1 dependency builds reproducible

--- a/include/global.php
+++ b/include/global.php
@@ -580,8 +580,19 @@ db_cacti_initialized($config['is_web']);
 
 if ($config['is_web']) {
 	if (read_config_option('force_https') == 'on') {
-		if (!cacti_is_https() && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
-			header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+		if (!cacti_is_https()) {
+			$location = cacti_build_https_redirect_url(
+				$_SERVER['SERVER_NAME'] ?? '',
+				$_SERVER['REQUEST_URI'] ?? '',
+				CACTI_PATH_URL
+			);
+
+			if ($location === '') {
+				http_response_code(400);
+				exit;
+			}
+
+			header('Location: ' . $location);
 
 			exit;
 		}

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1578,8 +1578,8 @@ function validate_redirect_url($url = '', $default = 'index.php') {
 	$ref_host = parse_url($url, PHP_URL_HOST);
 	$srv_host = null;
 
-	if (isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST'] != '') {
-		$srv_host = preg_replace('/:\d+$/', '', $_SERVER['HTTP_HOST']);
+	if (isset($_SERVER['SERVER_NAME']) && $_SERVER['SERVER_NAME'] != '') {
+		$srv_host = preg_replace('/:\d+$/', '', $_SERVER['SERVER_NAME']);
 	}
 
 	if ($ref_host === null || ($srv_host !== null && $ref_host === $srv_host)) {
@@ -1592,6 +1592,34 @@ function validate_redirect_url($url = '', $default = 'index.php') {
 	} else {
 		return $default;
 	}
+}
+
+/**
+ * Builds a forced-HTTPS redirect using a server-configured host name.
+ *
+ * @param string $server_name  The web server's configured name.
+ * @param string $request_uri  The requested local path and query string.
+ * @param string $default_path A local fallback when the request URI is invalid.
+ *
+ * @psalm-taint-escape header
+ *
+ * @return string A safe absolute HTTPS URL, or an empty string for an invalid host.
+ */
+function cacti_build_https_redirect_url(string $server_name, string $request_uri, string $default_path = '/') : string {
+	$server_name = trim($server_name);
+	$host        = trim($server_name, '[]');
+
+	if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+		$host = '[' . $host . ']';
+	} elseif (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false &&
+		filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)  === false) {
+		return '';
+	}
+
+	$path = validate_redirect_url($request_uri, $default_path);
+	$path = '/' . ltrim($path, '/');
+
+	return 'https://' . $host . $path;
 }
 
 /**

--- a/tests/Unit/Security/Redirect/ForceHttpsRedirectTest.php
+++ b/tests/Unit/Security/Redirect/ForceHttpsRedirectTest.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 4) . '/lib/functions.php';
+require_once dirname(__DIR__, 4) . '/lib/html_utility.php';
+
+test('forced HTTPS redirects use the server configured name', function () {
+	expect(cacti_build_https_redirect_url(
+		'monitor.example',
+		'/cacti/graph.php?id=1',
+		'/cacti/'
+	))->toBe('https://monitor.example/cacti/graph.php?id=1');
+});
+
+test('forced HTTPS redirects support IPv6 server names', function () {
+	expect(cacti_build_https_redirect_url(
+		'2001:db8::1',
+		'/cacti/',
+		'/cacti/'
+	))->toBe('https://[2001:db8::1]/cacti/');
+});
+
+test('forced HTTPS redirects reject invalid server names', function () {
+	expect(cacti_build_https_redirect_url(
+		"monitor.example\r\nLocation: https://evil.example",
+		'/cacti/',
+		'/cacti/'
+	))->toBe('');
+});
+
+test('redirect validation ignores a spoofed Host header', function () {
+	$server = $_SERVER;
+
+	try {
+		$_SERVER['SERVER_NAME'] = 'monitor.example';
+		$_SERVER['HTTP_HOST']   = 'evil.example';
+
+		expect(validate_redirect_url('https://evil.example/admin', '/cacti/'))->toBe('/cacti/');
+		expect(validate_redirect_url('https://monitor.example/graph.php?id=1', '/cacti/'))->toBe('/graph.php?id=1');
+	} finally {
+		$_SERVER = $server;
+	}
+});
+
+test('forced HTTPS bootstrap does not read the Host header', function () {
+	$source = file_get_contents(dirname(__DIR__, 4) . '/include/global.php');
+
+	expect($source)->not->toContain("\$_SERVER['HTTP_HOST']");
+});

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -457,7 +457,7 @@ header_redirect	./include/fa/svgs/index.php	header('Location:../index.php');
 header_redirect	./include/fa/svgs/regular/index.php	header('Location:../index.php');
 header_redirect	./include/fa/svgs/solid/index.php	header('Location:../index.php');
 header_redirect	./include/fa/webfonts/index.php	header('Location:../index.php');
-header_redirect	./include/global.php				header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
+header_redirect	./include/global.php				header('Location: ' . $location);
 header_redirect	./include/index.php	header('Location:../index.php');
 header_redirect	./include/js/LC_MESSAGES/index.php	header('Location:../index.php');
 header_redirect	./include/js/index.php	header('Location:../index.php');


### PR DESCRIPTION
## Summary
- build forced-HTTPS redirects from the server-configured name instead of the client Host header
- validate redirect hosts and request paths, including IPv6 handling and fail-closed behavior
- use PHP 8.1 typed parameters and return values consistently
- update same-origin redirect validation to ignore spoofed Host headers
- add regression coverage and refresh the security sink inventory

## Validation
- PHP 8.1.34 selected through mise
- clean Composer install from the locked dependencies on PHP 8.1.34
- focused Pest regression tests on PHP 8.1.34
- changed-file PHP syntax checks on PHP 8.1.34
- sink inventory verification
- architectural hotspot verification
- clean range-diff after rebasing onto upstream/develop