### PR TITLE
issue#7809: stop reading a missing source key on output-only data query fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Cacti CHANGELOG
 -security: Harden advisory command execution and database DDL sink validation
 -security: Restrict graph input fields across the template, graph and import handoffs
 -security: Treat a non-boolean signature result as a failure in import_package
+-issue#7809: Undefined array key "source" warning reindexing SNMP data queries with output-only fields
 -issue#7819: Remove obsolete pre-PHP 8 compatibility branches
 -issue#5679: Attempt SNMP in Ping-OR-SNMP availability checks when ping fails
 -issue#6609: Return a controlled empty export when RRDtool XPORT omits metadata

--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -1007,7 +1007,7 @@ function query_snmp_host($host_id, $snmp_query_id) {
 	rewrite_snmp_enum_value(null);
 
 	foreach ($snmp_queries['fields'] as $field_name => $field_array) {
-		if ($field_array['source'] != 'index' && ($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') && $field_array['method'] != 'get' &&
+		if (($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') && $field_array['source'] != 'index' && $field_array['method'] != 'get' &&
 			(isset($field_array['rewrite_index']) || isset($field_array['oid_suffix']))) {
 			$field_array['method'] = 'get';
 			debug_log_insert('data_query', __esc('Fixing wrong \'method\' field for \'%s\' since \'rewrite_index\' or \'oid_suffix\' is defined',$field_name));

--- a/tests/Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php
+++ b/tests/Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression test for #7809.
+ *
+ * query_snmp_host() iterates every data query field, including output-only
+ * fields that carry no 'source' key. The pre-processing guard read
+ * $field_array['source'] as its left-most term, so PHP raised
+ * "Undefined array key source" for every output field before the direction
+ * test could short-circuit. Testing the direction first reads 'source' only
+ * for input fields, which always define it.
+ */
+
+function _data_query_source_7809() {
+	$path = dirname(__DIR__, 4) . '/lib/data_query.php';
+	$src  = file_get_contents($path);
+
+	expect($src)->not->toBeFalse('Failed to read lib/data_query.php');
+
+	return $src;
+}
+
+test('#7809: the method-fix guard tests direction before reading source', function () {
+	$src = _data_query_source_7809();
+
+	$needle = 'if ((' . '$field_array' . "['direction'] == 'input' || " . '$field_array' . "['direction'] == 'input-output') && " . '$field_array' . "['source'] != 'index'";
+	$start  = strpos($src, $needle);
+
+	expect($start)->not->toBeFalse(
+		"query_snmp_host() must test direction before reading \$field_array['source'] so output-only fields short-circuit"
+	);
+
+	// The old ordering (source first) must be gone.
+	$oldNeedle = 'if (' . '$field_array' . "['source'] != 'index' && (" . '$field_array' . "['direction'] == 'input'";
+	$old       = strpos($src, $oldNeedle);
+	expect($old)->toBeFalse('the source-first ordering must not remain');
+});
+
+test('#7809: an output-only field does not read a missing source key', function () {
+	// Mirrors the real guard. An output field carries direction=output and no source.
+	$field_array = array(
+		'direction' => 'output',
+		'method'    => 'walk',
+	);
+
+	$warned = false;
+	set_error_handler(function ($errno, $errstr) use (&$warned) {
+		if (stripos($errstr, 'source') !== false) {
+			$warned = true;
+		}
+		return true;
+	});
+
+	$hit =
+		($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') &&
+		$field_array['source'] != 'index' &&
+		$field_array['method'] != 'get' &&
+		(isset($field_array['rewrite_index']) || isset($field_array['oid_suffix']));
+
+	restore_error_handler();
+
+	expect($warned)->toBeFalse('output-only field must not trigger an undefined source-key warning');
+	expect($hit)->toBeFalse('output-only field must not enter the input method-fix branch');
+});
+
+test('#7809: an input field still enters the branch when it should', function () {
+	$field_array = array(
+		'direction'     => 'input',
+		'source'        => 'value',
+		'method'        => 'walk',
+		'rewrite_index' => '.1',
+	);
+
+	$hit =
+		($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') &&
+		$field_array['source'] != 'index' &&
+		$field_array['method'] != 'get' &&
+		(isset($field_array['rewrite_index']) || isset($field_array['oid_suffix']));
+
+	expect($hit)->toBeTrue('input field with rewrite_index must still be corrected to method=get');
+});


### PR DESCRIPTION
Fixes #7809.

`query_snmp_host()` iterates every data query field. Output-only fields carry no `source` key, but the method-fix guard read `$field_array['source']` as its left-most term, so PHP raised `Undefined array key "source"` for each output field before the `&&` could short-circuit on direction. The reporter saw it flood the log during device creation and forced reindex (`api_device_save` -> `api_device_update_host_template` -> `run_data_query` -> `query_snmp_host`), e.g. the Dell iDRAC query, whose XML has output-only fields.

The fix tests direction first, so `source` is read only for input / input-output fields, which always define it. `&&` is commutative in its result, so the branch condition is unchanged; only the read order is.

## Test
`tests/Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php` (source-scan bootstrap, no DB):
- asserts the guard tests direction before reading source, and the old ordering is gone
- an output-only field (direction=output, no source) triggers no source-key warning and does not enter the input branch
- an input field with rewrite_index still enters the branch

Run: `cd tests && vendor/bin/pest Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php --bootstrap=bootstrap-unit.php` -> 3 passed.

## Risk
One reordered boolean term, no behavior change. Reverting is a one-line change.