### PR TITLE
feat: build SNMP sessions from a device row with cacti_snmp_session_from_host()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -153,6 +153,7 @@ Cacti CHANGELOG
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect
 -issue#7469: Escape path_php_binary before it reaches shell_exec in test_data_source
 -issue#7466: Escape path_stderrlog before it reaches the poller stderr shell redirect
+-feature#7835: Add cacti_snmp_session_from_host() to build SNMP sessions from a device row
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php
 -feature#1361: UI should update alternate row colors

--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -1079,11 +1079,7 @@ function query_snmp_host(int $host_id, int $snmp_query_id) : bool {
 		query_debug_timer_offset('data_query', __('Auto Bulk Walk Size Selected.'));
 
 		foreach ($walk_sizes as $size) {
-			$session = cacti_snmp_session($host['hostname'], $host['snmp_community'],
-				$host['snmp_version'], $host['snmp_username'], $host['snmp_password'],
-				$host['snmp_auth_protocol'], $host['snmp_priv_passphrase'], $host['snmp_priv_protocol'],
-				$host['snmp_context'], $host['snmp_engine_id'],  $host['snmp_port'],
-				$host['snmp_timeout'], $host['ping_retries'], $host['max_oids'], $size);
+			$session = cacti_snmp_session_from_host($host, $size);
 
 			if ($session === false) {
 				debug_log_insert('data_query', __esc('Failed to load SNMP session.'));
@@ -1125,11 +1121,7 @@ function query_snmp_host(int $host_id, int $snmp_query_id) : bool {
 
 		query_debug_timer_offset('data_query', __esc('Bulk Walk Size is fixed at %d.', $walk_size));
 
-		$session = cacti_snmp_session($host['hostname'], $host['snmp_community'],
-			$host['snmp_version'], $host['snmp_username'], $host['snmp_password'],
-			$host['snmp_auth_protocol'], $host['snmp_priv_passphrase'], $host['snmp_priv_protocol'],
-			$host['snmp_context'], $host['snmp_engine_id'],  $host['snmp_port'],
-			$host['snmp_timeout'], $host['ping_retries'], $host['max_oids'], $walk_size);
+		$session = cacti_snmp_session_from_host($host, $walk_size);
 
 		if ($session === false) {
 			debug_log_insert('data_query', __esc('Failed to load SNMP session.'));

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -441,6 +441,41 @@ function cacti_get_snmpv3_auth(mixed $auth_proto, mixed $auth_user, mixed $auth_
 }
 
 /**
+ * cacti_snmp_session_from_host - build an SNMP session from a device row.
+ *
+ * cacti_snmp_session() takes fifteen positional arguments. Callers across the
+ * poller, data queries, and automation each spelled out the same mapping from
+ * a $host row, which is where SNMPv3 credential handling drifted between them.
+ * This assembles the arguments once. Missing keys fall back to the same
+ * defaults cacti_snmp_session() already applies, so a partial row behaves as
+ * the explicit-argument calls did.
+ *
+ * @param array $host           A device row with the snmp_* and ping_retries columns.
+ * @param mixed $bulk_walk_size Optional bulk walk size override.
+ *
+ * @return mixed The SNMP session object, or false on failure.
+ */
+function cacti_snmp_session_from_host(array $host, mixed $bulk_walk_size = 10) : mixed {
+	return cacti_snmp_session(
+		$host['hostname'] ?? '',
+		$host['snmp_community'] ?? '',
+		$host['snmp_version'] ?? '',
+		$host['snmp_username'] ?? '',
+		$host['snmp_password'] ?? '',
+		$host['snmp_auth_protocol'] ?? '',
+		$host['snmp_priv_passphrase'] ?? '',
+		$host['snmp_priv_protocol'] ?? '',
+		$host['snmp_context'] ?? '',
+		$host['snmp_engine_id'] ?? '',
+		$host['snmp_port'] ?? 161,
+		$host['snmp_timeout'] ?? 500,
+		$host['ping_retries'] ?? 0,
+		$host['max_oids'] ?? 10,
+		$bulk_walk_size
+	);
+}
+
+/**
  * Calls a native SNMP session method and captures its suppressed warning.
  *
  * Some PHP SNMP failures emit their only useful diagnostic as a warning while

--- a/tests/Unit/DataCollection/Snmp/DataQueryWalkSizeTest.php
+++ b/tests/Unit/DataCollection/Snmp/DataQueryWalkSizeTest.php
@@ -191,6 +191,11 @@ test('the walk size is normalized before the output_format walk reads it', funct
 test('max_oids is still passed to the session calls that take it', function () {
 	$source = file_get_contents(dirname(__DIR__, 4) . '/lib/data_query.php');
 
-	// the fix must not have swapped every max_oids in the file
-	expect(substr_count($source, "\$host['max_oids']"))->toBeGreaterThan(0);
+	// the #7493 fix must not have swapped every max_oids for the walk size.
+	// max_oids reaches the session either directly or through
+	// cacti_snmp_session_from_host(), which forwards $host['max_oids'].
+	$direct  = substr_count($source, "\$host['max_oids']");
+	$wrapped = substr_count($source, 'cacti_snmp_session_from_host(');
+
+	expect($direct + $wrapped)->toBeGreaterThan(0);
 });

--- a/tests/Unit/DataCollection/Snmp/SnmpCoverageTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpCoverageTest.php
@@ -327,6 +327,17 @@ test('native sessions cover versions and security levels without network I/O', f
 		->and(cacti_snmp_session('127.0.0.1', '', '3', 'user', 'secretpass', 'SHA', 'privatepass', 'AES'))->toBeObject()
 		->and(cacti_snmp_session('127.0.0.1', '', '3', 'user', 'secretpass', 'INVALID', '', '[None]'))->toBeFalse()
 		->and(cacti_snmp_session('127.0.0.1', 'public', 'invalid'))->toBeFalse();
+
+	// cacti_snmp_session_from_host maps a device row onto the arguments above (#7835).
+	expect(cacti_snmp_session_from_host(array(
+		'hostname' => '127.0.0.1', 'snmp_community' => 'public', 'snmp_version' => '2',
+	)))->toBeObject()
+		->and(cacti_snmp_session_from_host(array(
+			'hostname' => '127.0.0.1', 'snmp_version' => '3', 'snmp_username' => 'user',
+			'snmp_password' => 'secretpass', 'snmp_auth_protocol' => 'SHA',
+			'snmp_priv_passphrase' => 'privatepass', 'snmp_priv_protocol' => 'AES',
+		)))->toBeObject()
+		->and(cacti_snmp_session_from_host(array('hostname' => '127.0.0.1', 'snmp_community' => 'public', 'snmp_version' => 'invalid')))->toBeFalse();
 });
 
 test('native and binary get operations cover success and failure results', function () : void {

--- a/tests/Unit/DataCollection/Snmp/SnmpSessionFromHostTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpSessionFromHostTest.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Guards cacti_snmp_session_from_host()'s mapping from a $host row to the
+ * positional cacti_snmp_session() arguments. Source-scan (no DB): a drift in
+ * the field order or a dropped default would silently change SNMPv3 sessions.
+ */
+
+function _snmp_source() {
+	$src = file_get_contents(dirname(__DIR__, 4) . '/lib/snmp.php');
+	expect($src)->not->toBeFalse('Failed to read lib/snmp.php');
+
+	return $src;
+}
+
+function _from_host_body() {
+	$src   = _snmp_source();
+	$start = strpos($src, 'function cacti_snmp_session_from_host(');
+	expect($start)->not->toBeFalse('cacti_snmp_session_from_host() must exist');
+
+	$end = strpos($src, "\nfunction ", $start + 1);
+
+	return substr($src, $start, ($end === false ? strlen($src) : $end) - $start);
+}
+
+test('maps the host columns in cacti_snmp_session parameter order', function () {
+	$body = _from_host_body();
+
+	$order = array(
+		'hostname', 'snmp_community', 'snmp_version', 'snmp_username', 'snmp_password',
+		'snmp_auth_protocol', 'snmp_priv_passphrase', 'snmp_priv_protocol',
+		'snmp_context', 'snmp_engine_id', 'snmp_port', 'snmp_timeout',
+		'ping_retries', 'max_oids',
+	);
+
+	$pos = -1;
+	foreach ($order as $key) {
+		$at = strpos($body, "\$host['$key']");
+		expect($at)->not->toBeFalse("mapping must reference \$host['$key']");
+		expect($at)->toBeGreaterThan($pos, "\$host['$key'] must appear after the previous column");
+		$pos = $at;
+	}
+});
+
+test('falls back to the cacti_snmp_session defaults for optional columns', function () {
+	$body = _from_host_body();
+
+	// The default numbers must match cacti_snmp_session()'s own defaults.
+	expect($body)->toContain("?? 161");   // snmp_port
+	expect($body)->toContain("?? 500");   // snmp_timeout
+	expect($body)->toContain("?? 0");     // ping_retries
+	expect($body)->toContain("?? 10");    // max_oids
+});
+
+test('delegates to cacti_snmp_session rather than reimplementing it', function () {
+	$body = _from_host_body();
+	expect($body)->toContain('return cacti_snmp_session(');
+});


### PR DESCRIPTION
`cacti_snmp_session()` takes fifteen positional arguments. The poller, data queries, and automation each spell out the same mapping from a `$host` row (24 field references in `data_query.php`, 33 in `api_automation.php`, 15 in `snmpagent.php`). That repetition is where SNMPv3 credential handling drifts between callers.

This adds one wrapper, `cacti_snmp_session_from_host(array $host, $bulk_walk_size = 10)`, that assembles the arguments once, and converts the two `data_query.php` call sites as the first adopters. The remaining callers can move over one at a time.

Missing keys fall back to the same defaults `cacti_snmp_session()` already applies (port 161, timeout 500, retries 0, max_oids 10), so a partial row behaves exactly as the explicit-argument calls did. Additive and behavior-preserving.

## Test
`tests/Unit/DataCollection/Snmp/SnmpSessionFromHostTest.php` (source-scan, no DB) guards:
- the host columns are passed in `cacti_snmp_session()` parameter order (drift here would silently change v3 sessions)
- the optional-column defaults match `cacti_snmp_session()`'s own
- the wrapper delegates rather than reimplementing

3 passed. The `data_query.php` unit suite (22 tests) still passes. `phpstan --level 6` clean on both changed files.

## Risk
Low. New function plus two call-site swaps that produce identical arguments. Revert is mechanical.