### PR TITLE
Fix #7617: allow graph tree sidebar to shrink (1.2.x)

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -35,8 +35,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  installer-javascript:
-    name: Installer JavaScript contracts
+  javascript-contracts:
+    name: JavaScript contracts
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
@@ -47,8 +47,8 @@ jobs:
       with:
         node-version: '22'
 
-    - name: Test installer state handoff
-      run: node --test tests/js/installer_selection.test.js
+    - name: Test JavaScript contracts
+      run: node --test tests/js/*.test.js
 
   check:
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Cacti CHANGELOG
 -security: Treat a non-boolean signature result as a failure in import_package
 -issue#7809: Undefined array key "source" warning reindexing SNMP data queries with output-only fields
 -issue#7819: Remove obsolete pre-PHP 8 compatibility branches
+-issue#7617: Allow the graph tree sidebar to shrink with collapsed content
 -issue#5679: Attempt SNMP in Ping-OR-SNMP availability checks when ping fails
 -issue#6609: Return a controlled empty export when RRDtool XPORT omits metadata
 -issue#6684: Prevent VDEF-backed aggregate graph items from being emitted as XPORT data sources

--- a/include/layout.js
+++ b/include/layout.js
@@ -1621,8 +1621,9 @@ function resizeTreePanel() {
 		$('#jstree').height(jsTreeHeight + 30);
 		$('.cactiTreeNavigationArea').height(treeAreaHeight+searchHeight);
 
-		var visWidth = Math.max.apply(Math, $('#jstree').children(':visible').map(function() {
-			return $(this).width();
+		var treeLeft = $('#jstree').offset().left;
+		var visWidth = Math.max.apply(Math, $('#jstree').find('.jstree-anchor:visible').map(function() {
+			return this.getBoundingClientRect().right - treeLeft;
 		}).get());
 
 		if (visWidth < 0) {
@@ -1642,18 +1643,18 @@ function resizeTreePanel() {
 			$('.cactiGraphContentArea').css('margin-left', visWidth+5);
 			$('.cactiTreeNavigationArea').css('overflow-x', 'auto');
 		} else {
-			$('.cactiTreeNavigationArea').css('width', navWidth);
-			$('.cactiGraphContentArea').css('margin-left', navWidth+5);
+			$('.cactiTreeNavigationArea').css('width', visWidth);
+			$('.cactiGraphContentArea').css('margin-left', visWidth+5);
 			$('.cactiTreeNavigationArea').css('overflow-x', '');
 		}
 	}
 
 	var navWidth = $('#navigation').width();
-	if (navWidth > 220) {
-		$('#searcher').css('width', navWidth-70);
-	} else {
-		$('#searcher').css('width', 150);
-	}
+	$('#searcher').css('width', getTreeSearchWidth(navWidth));
+}
+
+function getTreeSearchWidth(navWidth) {
+	return Math.max(navWidth-70, 40);
 }
 
 function countHiddenCols(object) {
@@ -3301,11 +3302,7 @@ function keepWindowSize() {
 			}
 
 			var navWidth = $('#navigation').width();
-			if (navWidth > 220) {
-				$('#searcher').css('width', navWidth-70);
-			} else {
-				$('#searcher').css('width', 150);
-			}
+			$('#searcher').css('width', getTreeSearchWidth(navWidth));
 
 			responsiveResizeGraphs();
 

--- a/tests/js/layout_tree_resize.test.js
+++ b/tests/js/layout_tree_resize.test.js
@@ -1,0 +1,193 @@
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const layoutSource = fs.readFileSync(
+	path.join(__dirname, '..', '..', 'include', 'layout.js'),
+	'utf8'
+);
+
+function extractFunction(name) {
+	const start = layoutSource.indexOf(`function ${name}(`);
+
+	assert.notEqual(start, -1, `${name}() must exist`);
+
+	const bodyStart = layoutSource.indexOf('{', start);
+	let depth = 0;
+
+	for (let offset = bodyStart; offset < layoutSource.length; offset++) {
+		if (layoutSource[offset] === '{') {
+			depth++;
+		} else if (layoutSource[offset] === '}') {
+			depth--;
+
+			if (depth === 0) {
+				return layoutSource.slice(start, offset + 1);
+			}
+		}
+	}
+
+	throw new Error(`Unable to extract ${name}()`);
+}
+
+function loadTreeFunctions(state) {
+	const windowObject = {};
+	const anchors = state.anchorRightEdges.map((right) => ({
+		getBoundingClientRect: () => ({ right }),
+	}));
+
+	function collection(methods = {}) {
+		return {
+			length: 1,
+			css: () => undefined,
+			height: () => undefined,
+			outerHeight: () => 0,
+			width: () => 0,
+			...methods,
+		};
+	}
+
+	function jquery(selector) {
+		if (selector === windowObject) {
+			return collection({ outerHeight: () => 800 });
+		}
+
+		if (selector === '.cactiTreeNavigationArea') {
+			return collection({
+				width: () => state.navWidth,
+				css: (property, value) => {
+					if (property === 'width') {
+						state.navWidth = value;
+					} else if (property === 'overflow-x') {
+						state.overflowX = value;
+					}
+				},
+			});
+		}
+
+		if (selector === '.cactiGraphContentArea') {
+			return collection({
+				css: (property, value) => {
+					if (property === 'margin-left') {
+						state.graphMargin = value;
+					}
+				},
+			});
+		}
+
+		if (selector === '#navigation') {
+			return collection({ width: () => state.navWidth });
+		}
+
+		if (selector === '#searcher') {
+			return collection({
+				css: (property, value) => {
+					if (property === 'width') {
+						state.searchWidth = value;
+					}
+				},
+			});
+		}
+
+		if (selector === '#jstree') {
+			return collection({
+				offset: () => ({ left: state.treeLeft }),
+				children: () => ({
+					map: (callback) => ({
+						get: () => [callback.call({})],
+					}),
+				}),
+				find: (query) => {
+					assert.equal(query, '.jstree-anchor:visible');
+
+					return {
+						map: (callback) => ({
+							get: () => anchors.map((anchor) => callback.call(anchor)),
+						}),
+					};
+				},
+			});
+		}
+
+		return collection();
+	}
+
+	const context = vm.createContext({
+		$: jquery,
+		console,
+		Math,
+		maxTreeWidth: 300,
+		minTreeWidth: 170,
+		theme: 'modern',
+		window: windowObject,
+	});
+
+	vm.runInContext(
+		`${extractFunction('getTreeSearchWidth')}\n${extractFunction('resizeTreePanel')}`,
+		context,
+		{ filename: 'include/layout.js' }
+	);
+
+	return context;
+}
+
+test('collapsed anchors shrink the sidebar to their current footprint', () => {
+	const state = {
+		anchorRightEdges: [130, 220],
+		navWidth: 260,
+		treeLeft: 10,
+	};
+
+	loadTreeFunctions(state).resizeTreePanel();
+
+	assert.equal(state.navWidth, 210);
+	assert.equal(state.graphMargin, 215);
+	assert.equal(state.overflowX, '');
+});
+
+test('anchor depth is included by measuring right edge from the tree origin', () => {
+	const state = {
+		anchorRightEdges: [190, 290],
+		navWidth: 170,
+		treeLeft: 10,
+	};
+
+	loadTreeFunctions(state).resizeTreePanel();
+
+	assert.equal(state.navWidth, 280);
+	assert.equal(state.graphMargin, 285);
+	assert.equal(state.overflowX, 'auto');
+});
+
+test('tree and search widths retain their lower bounds', () => {
+	const state = {
+		anchorRightEdges: [40],
+		navWidth: 260,
+		treeLeft: 10,
+	};
+
+	const context = loadTreeFunctions(state);
+	context.resizeTreePanel();
+
+	assert.equal(state.navWidth, 170);
+	assert.equal(state.graphMargin, 175);
+	assert.equal(state.searchWidth, 100);
+	assert.equal(context.getTreeSearchWidth(70), 40);
+});


### PR DESCRIPTION
Addresses #7617.

The jsTree whole-row wrapper has min-width: 100%, so measuring that wrapper creates a circular width dependency after the sidebar grows. Measure the visible anchors' right edges from the tree origin instead, then use that current footprint in the shrink branch.

Also keep the search field inside narrow sidebars and use the same width calculation during window resize.

Tests:
- mise exec node@22 -- node --test tests/js/*.test.js (8 passing)
- git diff --check upstream/1.2.x...HEAD

The new behavioral contract covers shrinking, nested-anchor depth, growth, and lower bounds. The JavaScript workflow now runs every tests/js contract.
