### PR TITLE
issue#7355: add a JUNIPER-MIB jnxOperatingTable script data query

### DIFF
--- a/.github/workflows/juniper-operating-coverage.yml
+++ b/.github/workflows/juniper-operating-coverage.yml
@@ -1,0 +1,66 @@
+name: Juniper Operating Coverage
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - '.github/workflows/juniper-operating-coverage.yml'
+      - '.github/actions/setup-php-composer/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'scripts/ss_juniper_operating.php'
+      - 'phpunit-juniper-operating.xml'
+      - 'tests/Unit/DataCollection/Scripts/JuniperOperatingTest.php'
+  pull_request:
+    branches: [develop]
+    paths:
+      - '.github/workflows/juniper-operating-coverage.yml'
+      - '.github/actions/setup-php-composer/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'scripts/ss_juniper_operating.php'
+      - 'phpunit-juniper-operating.xml'
+      - 'tests/Unit/DataCollection/Scripts/JuniperOperatingTest.php'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: juniper-operating-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  COMPOSER_ALLOW_SUPERUSER: 1
+
+jobs:
+  coverage:
+    name: scripts/ss_juniper_operating.php 100% coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Setup locked PHP 8.2 dependencies
+        uses: ./.github/actions/setup-php-composer
+        with:
+          php-version: '8.2'
+          coverage: xdebug
+          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring, snmp
+          dependency-mode: locked
+          install-args: --prefer-dist --no-progress --no-interaction
+
+      - name: Enforce line coverage
+        env:
+          XDEBUG_MODE: coverage
+        run: |
+          set -euo pipefail
+          include/vendor/bin/pest --colors=never \
+            --configuration=phpunit-juniper-operating.xml \
+            --coverage \
+            --coverage-text \
+            --min=100

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -156,6 +156,7 @@ Cacti CHANGELOG
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect
 -issue#7469: Escape path_php_binary before it reaches shell_exec in test_data_source
 -issue#7466: Escape path_stderrlog before it reaches the poller stderr shell redirect
+-issue#7355: Add a JUNIPER-MIB jnxOperatingTable script data query for RE and FPC health
 -feature#7835: Add cacti_snmp_session_from_host() to build SNMP sessions from a device row
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php

--- a/phpunit-juniper-operating.xml
+++ b/phpunit-juniper-operating.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap-unit.php" colors="false" beStrictAboutOutputDuringTests="false">
+	<testsuites>
+		<testsuite name="JuniperOperating">
+			<file>tests/Unit/DataCollection/Scripts/JuniperOperatingTest.php</file>
+		</testsuite>
+	</testsuites>
+	<source>
+		<include>
+			<file>scripts/ss_juniper_operating.php</file>
+		</include>
+	</source>
+</phpunit>

--- a/resource/script_server/juniper_operating.xml
+++ b/resource/script_server/juniper_operating.xml
@@ -1,0 +1,49 @@
+<interface>
+	<name>Get Juniper Operating Health</name>
+	<script_path>|path_cacti|/scripts/ss_juniper_operating.php</script_path>
+	<script_function>ss_juniper_operating</script_function>
+	<script_server>php</script_server>
+	<arg_prepend>|host_hostname| |host_id| |host_snmp_version|:|host_snmp_port|:|host_snmp_timeout|:|host_ping_retries|:|host_max_oids|:|host_snmp_community|:|host_snmp_username|:|host_snmp_password|:|host_snmp_auth_protocol|:|host_snmp_priv_passphrase|:|host_snmp_priv_protocol|:|host_snmp_context|</arg_prepend>
+	<arg_index>index</arg_index>
+	<arg_query>query</arg_query>
+	<arg_get>get</arg_get>
+	<arg_num_indexes>num_indexes</arg_num_indexes>
+	<output_delimiter>!</output_delimiter>
+	<index_order>jnxOperatingDescr:jnxOperatingIndex</index_order>
+	<index_order_type>alphabetic</index_order_type>
+	<index_title_format>|chosen_order_field|</index_title_format>
+
+	<fields>
+		<jnxOperatingIndex>
+			<name>Operating Index</name>
+			<direction>input</direction>
+			<query_name>index</query_name>
+		</jnxOperatingIndex>
+		<jnxOperatingDescr>
+			<name>Description</name>
+			<direction>input</direction>
+			<query_name>descr</query_name>
+		</jnxOperatingDescr>
+		<jnxOperatingState>
+			<name>State</name>
+			<direction>input</direction>
+			<query_name>state</query_name>
+		</jnxOperatingState>
+
+		<jnxOperatingCPU>
+			<name>CPU Utilization</name>
+			<direction>output</direction>
+			<query_name>cpu</query_name>
+		</jnxOperatingCPU>
+		<jnxOperatingTemp>
+			<name>Temperature</name>
+			<direction>output</direction>
+			<query_name>temp</query_name>
+		</jnxOperatingTemp>
+		<jnxOperatingBuffer>
+			<name>Buffer Utilization</name>
+			<direction>output</direction>
+			<query_name>buffer</query_name>
+		</jnxOperatingBuffer>
+	</fields>
+</interface>

--- a/scripts/ss_juniper_operating.php
+++ b/scripts/ss_juniper_operating.php
@@ -1,0 +1,197 @@
+#!/usr/bin/env php
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+error_reporting(0);
+
+// @codeCoverageIgnoreStart
+// Entry-point glue: CLI invocation versus in-process script-server dispatch.
+if (!isset($called_by_script_server)) {
+	include_once(__DIR__ . '/../include/cli_check.php');
+	include_once(__DIR__ . '/../lib/snmp.php');
+
+	array_shift($_SERVER['argv']);
+
+	print call_user_func_array('ss_juniper_operating', $_SERVER['argv']);
+} else {
+	include_once(__DIR__ . '/../lib/snmp.php');
+}
+/** @codeCoverageIgnoreEnd */
+
+/**
+ * Base OIDs for the JUNIPER-MIB jnxOperatingTable (enterprise .2636).
+ *
+ * The table reports the health of each operating subject (Routing Engine, FPC,
+ * PSU, fan). It is multi-indexed by jnxContentsContainerIndex.L1Index.L2Index.
+ * L3Index, so the collector keys rows on the full OID suffix rather than a
+ * single component. The signature Juniper metrics beyond the IF-MIB and
+ * HOST-RESOURCES standards are the per-engine CPU, temperature and buffer use.
+ *
+ * @return array<string,string> Symbolic name to numeric base OID.
+ */
+function ss_juniper_operating_oids() : array {
+	return [
+		'descr'  => '.1.3.6.1.4.1.2636.3.1.13.1.5',  // jnxOperatingDescr
+		'state'  => '.1.3.6.1.4.1.2636.3.1.13.1.6',  // jnxOperatingState
+		'temp'   => '.1.3.6.1.4.1.2636.3.1.13.1.7',  // jnxOperatingTemp (celsius)
+		'cpu'    => '.1.3.6.1.4.1.2636.3.1.13.1.8',  // jnxOperatingCPU (percent)
+		'buffer' => '.1.3.6.1.4.1.2636.3.1.13.1.11', // jnxOperatingBuffer (percent)
+	];
+}
+
+/**
+ * ss_juniper_operating - collect JUNIPER-MIB jnxOperatingTable health metrics.
+ *
+ * Implements Cacti's script-server data-query contract: 'index' lists the
+ * operating-subject indexes, 'num_indexes' counts them, 'query' returns
+ * index!value pairs for a named field, and 'get' returns one field for one
+ * index. The final $walker parameter is a seam for testing; the script server
+ * never passes it, so production runs fall back to cacti_snmp_walk().
+ *
+ * @param string        $hostname  Device hostname.
+ * @param int           $host_id   Cacti host id.
+ * @param mixed         $snmp_auth Colon-joined SNMP auth string from the query.
+ * @param string        $cmd       One of index, num_indexes, query, get.
+ * @param string        $arg1      Field name (query and get).
+ * @param string        $arg2      Operating index (get only).
+ * @param callable|null $walker    Optional walk override: fn(string $oid): array.
+ *
+ * @return mixed Printed lines for index/query, a count for num_indexes, or a
+ *               scalar for get.
+ */
+function ss_juniper_operating(string $hostname = '', int $host_id = 0, mixed $snmp_auth = '', string $cmd = 'index', string $arg1 = '', string $arg2 = '', ?callable $walker = null) : mixed {
+	$oids = ss_juniper_operating_oids();
+
+	if ($walker === null) {
+		$walker = ss_juniper_operating_snmp_walker($hostname, explode(':', (string) $snmp_auth));
+	}
+
+	if ($cmd == 'index') {
+		foreach (array_keys($walker($oids['descr'])) as $index) {
+			print $index . "\n";
+		}
+
+		return '';
+	}
+
+	if ($cmd == 'num_indexes') {
+		return cacti_count($walker($oids['descr']));
+	}
+
+	if ($cmd == 'query') {
+		foreach (ss_juniper_operating_field($walker, $oids, $arg1) as $index => $value) {
+			print $index . '!' . $value . "\n";
+		}
+
+		return '';
+	}
+
+	if ($cmd == 'get') {
+		$rows = ss_juniper_operating_field($walker, $oids, $arg1);
+
+		return $rows[$arg2] ?? 'U';
+	}
+
+	return '';
+}
+
+/**
+ * Build the production SNMP walk callable for ss_juniper_operating().
+ *
+ * The returned closure is the boundary to lib/snmp.php; its body performs live
+ * network I/O and is exercised by integration runs, not unit tests.
+ *
+ * @param string            $hostname Device hostname.
+ * @param array<int,string> $snmp     The colon-split SNMP auth fields.
+ *
+ * @return callable fn(string $oid): array<string,string>
+ */
+function ss_juniper_operating_snmp_walker(string $hostname, array $snmp) : callable {
+	return static function (string $oid) use ($hostname, $snmp) : array {
+		/** @codeCoverageIgnoreStart */
+		$version = $snmp[0] ?? '1';
+		$results = cacti_snmp_walk(
+			$hostname,
+			$version == 3 ? '' : ($snmp[5] ?? ''),
+			$oid,
+			$version,
+			$snmp[6] ?? '', $snmp[7] ?? '', $snmp[8] ?? '', $snmp[9] ?? '', $snmp[10] ?? '', $snmp[11] ?? '',
+			$snmp[1] ?? 161, $snmp[2] ?? 500, $snmp[3] ?? 0, $snmp[4] ?? 10, SNMP_POLLER
+		);
+
+		return ss_juniper_operating_flatten($oid, $results);
+		// @codeCoverageIgnoreEnd
+	};
+}
+
+/**
+ * Normalise a walk result into a jnxOperating-index-keyed map.
+ *
+ * jnxOperatingTable is multi-indexed, so the key is the full OID suffix that
+ * follows the walked base OID, not just its final component.
+ *
+ * @param string                                      $base    The walked base OID.
+ * @param array<int,array{oid?:string,value?:string}> $results Rows from cacti_snmp_walk().
+ *
+ * @return array<string,string> Composite index suffix to value.
+ */
+function ss_juniper_operating_flatten(string $base, array $results) : array {
+	$prefix = rtrim($base, '.') . '.';
+	$map    = [];
+
+	foreach ($results as $row) {
+		$oid = '.' . ltrim(trim($row['oid'] ?? ''), '.');
+
+		if (str_starts_with($oid, $prefix)) {
+			$index = substr($oid, strlen($prefix));
+
+			if ($index !== '') {
+				$map[$index] = trim((string) ($row['value'] ?? ''));
+			}
+		}
+	}
+
+	return $map;
+}
+
+/**
+ * Resolve one query field into an index-keyed map.
+ *
+ * Every field is a direct walk of a jnxOperatingTable column; an unknown field
+ * yields an empty map so the data query degrades cleanly.
+ *
+ * @param callable             $walker Walk callable: fn(string $oid): array.
+ * @param array<string,string> $oids   The base OID map from ss_juniper_operating_oids().
+ * @param string               $field  Requested field name.
+ *
+ * @return array<string,string> Composite index to field value.
+ */
+function ss_juniper_operating_field(callable $walker, array $oids, string $field) : array {
+	if ($field == 'index') {
+		$rows = $walker($oids['descr']);
+
+		return array_combine(array_keys($rows), array_keys($rows));
+	}
+
+	if (isset($oids[$field])) {
+		return $walker($oids[$field]);
+	}
+
+	return [];
+}

--- a/tests/Unit/DataCollection/Scripts/JuniperOperatingTest.php
+++ b/tests/Unit/DataCollection/Scripts/JuniperOperatingTest.php
@@ -1,0 +1,103 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Unit tests for the JUNIPER-MIB jnxOperatingTable collector (issue #7355).
+ * The SNMP walk is injected through the $walker seam so every branch runs
+ * without a device. jnxOperatingTable is multi-indexed, so the fixture uses
+ * composite index suffixes.
+ */
+
+$called_by_script_server = true;
+if (!defined('SNMP_POLLER')) {
+	define('SNMP_POLLER', 'SNMP');
+}
+if (!function_exists('cacti_count')) {
+	function cacti_count(mixed $a): int { return is_array($a) ? count($a) : 0; }
+}
+require_once dirname(__DIR__, 4) . '/scripts/ss_juniper_operating.php';
+
+function _jnx_walker(array $fixture): callable {
+	return static function (string $oid) use ($fixture): array {
+		return $fixture[$oid] ?? [];
+	};
+}
+
+$OIDS = ss_juniper_operating_oids();
+
+// Two operating subjects: Routing Engine 0 (9.1.0.0) and FPC 0 (7.1.0.0).
+$FIXTURE = [
+	$OIDS['descr'] => ['9.1.0.0' => 'Routing Engine 0', '7.1.0.0' => 'FPC: 0'],
+	$OIDS['cpu']   => ['9.1.0.0' => '12', '7.1.0.0' => '5'],
+	$OIDS['temp']  => ['9.1.0.0' => '41', '7.1.0.0' => '38'],
+	$OIDS['state'] => ['9.1.0.0' => '2',  '7.1.0.0' => '2'],
+];
+
+test('index prints one line per operating subject', function () use ($FIXTURE) {
+	ob_start();
+	ss_juniper_operating('h', 1, '', 'index', '', '', _jnx_walker($FIXTURE));
+	expect(trim(ob_get_clean()))->toBe("9.1.0.0\n7.1.0.0");
+});
+
+test('num_indexes counts the subjects', function () use ($FIXTURE) {
+	expect(ss_juniper_operating('h', 1, '', 'num_indexes', '', '', _jnx_walker($FIXTURE)))->toBe(2);
+});
+
+test('query cpu returns composite-index!value pairs', function () use ($FIXTURE) {
+	ob_start();
+	ss_juniper_operating('h', 1, '', 'query', 'cpu', '', _jnx_walker($FIXTURE));
+	expect(trim(ob_get_clean()))->toBe("9.1.0.0!12\n7.1.0.0!5");
+});
+
+test('query descr returns the subject label', function () use ($FIXTURE) {
+	ob_start();
+	ss_juniper_operating('h', 1, '', 'query', 'descr', '', _jnx_walker($FIXTURE));
+	expect(trim(ob_get_clean()))->toBe("9.1.0.0!Routing Engine 0\n7.1.0.0!FPC: 0");
+});
+
+test('query index maps each subject index to itself', function () use ($FIXTURE) {
+	ob_start();
+	ss_juniper_operating('h', 1, '', 'query', 'index', '', _jnx_walker($FIXTURE));
+	expect(trim(ob_get_clean()))->toBe("9.1.0.0!9.1.0.0\n7.1.0.0!7.1.0.0");
+});
+
+test('query of an unknown field yields nothing', function () use ($FIXTURE) {
+	ob_start();
+	ss_juniper_operating('h', 1, '', 'query', 'bogus', '', _jnx_walker($FIXTURE));
+	expect(ob_get_clean())->toBe('');
+});
+
+test('get returns one field for one index', function () use ($FIXTURE) {
+	expect(ss_juniper_operating('h', 1, '', 'get', 'temp', '9.1.0.0', _jnx_walker($FIXTURE)))->toBe('41');
+});
+
+test('get for a missing index returns U', function () use ($FIXTURE) {
+	expect(ss_juniper_operating('h', 1, '', 'get', 'cpu', '3.1.0.0', _jnx_walker($FIXTURE)))->toBe('U');
+});
+
+test('an unknown command returns empty', function () use ($FIXTURE) {
+	expect(ss_juniper_operating('h', 1, '', 'restart', '', '', _jnx_walker($FIXTURE)))->toBe('');
+});
+
+test('with no injected walker the default SNMP walker is constructed', function () {
+	expect(ss_juniper_operating('127.0.0.1', 1, '2:161:500:0:10:public', 'noop'))->toBe('');
+});
+
+test('the SNMP walker factory returns a callable', function () {
+	expect(ss_juniper_operating_snmp_walker('127.0.0.1', ['2', '161']))->toBeCallable();
+});
+
+test('flatten keys rows by the full suffix after the base and skips foreign rows', function () use ($OIDS) {
+	$rows = [
+		['oid' => $OIDS['cpu'] . '.9.1.0.0', 'value' => ' 12 '],
+		['oid' => '.1.3.6.1.2.1.1.3.0',      'value' => 'x'],   // outside the base, dropped
+		['oid' => $OIDS['cpu'],              'value' => 'y'],   // exactly the base, no suffix, dropped
+	];
+	expect(ss_juniper_operating_flatten($OIDS['cpu'], $rows))->toBe(['9.1.0.0' => '12']);
+});


### PR DESCRIPTION
Part of #7355 (add modern SNMP device templates). Follows #7839 (ENTITY-SENSOR) with the same collector and coverage pattern.

Junos routers and switches (EX / MX / SRX) expose per-subject health through `JUNIPER-MIB jnxOperatingTable` (enterprise `.2636`) — one row per Routing Engine, FPC, PSU and fan. That table is the signature Juniper data beyond the IF-MIB and HOST-RESOURCES standards; no Juniper template ships today.

## What this adds
- `scripts/ss_juniper_operating.php` — script-server collector for `jnxOperatingCPU`, `jnxOperatingTemp`, `jnxOperatingBuffer`, `jnxOperatingState`, labelled by `jnxOperatingDescr`.
- `resource/script_server/juniper_operating.xml` — the data-query definition.
- Tests and a CI gate enforcing 100% line coverage.

## Multi-index handling
`jnxOperatingTable` is indexed by `jnxContentsContainerIndex.L1.L2.L3`, so `ss_juniper_operating_flatten()` keys each row on the full OID suffix after the walked base rather than a single component, and drops rows outside the base.

## Testing / style
SNMP walks sit behind an injectable `$walker`; `scripts/ss_juniper_operating.php 100% coverage` runs `pest --coverage --min=100`. Only the live `cacti_snmp_walk()` boundary and the CLI dispatch are `@codeCoverageIgnore`. PHPStan level 6 and php-cs-fixer clean. Typed signatures/returns and PHPDoc throughout, following the existing `ss_host_disk.php` pattern.

## Scope / follow-up
Collector + data query. The graph and host-template packaging (`.xml.gz`) is GUI-authored against a live device and follows separately.
