### PR TITLE
issue#7355: add an F5-BIGIP-SYSTEM-MIB per-CPU utilization script data query

### DIFF
--- a/.github/workflows/f5-cpu-coverage.yml
+++ b/.github/workflows/f5-cpu-coverage.yml
@@ -1,0 +1,66 @@
+name: F5 Cpu Coverage
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - '.github/workflows/f5-cpu-coverage.yml'
+      - '.github/actions/setup-php-composer/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'scripts/ss_f5_cpu.php'
+      - 'phpunit-f5-cpu.xml'
+      - 'tests/Unit/DataCollection/Scripts/F5CpuTest.php'
+  pull_request:
+    branches: [develop]
+    paths:
+      - '.github/workflows/f5-cpu-coverage.yml'
+      - '.github/actions/setup-php-composer/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'scripts/ss_f5_cpu.php'
+      - 'phpunit-f5-cpu.xml'
+      - 'tests/Unit/DataCollection/Scripts/F5CpuTest.php'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: f5-cpu-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  COMPOSER_ALLOW_SUPERUSER: 1
+
+jobs:
+  coverage:
+    name: scripts/ss_f5_cpu.php 100% coverage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Setup locked PHP 8.2 dependencies
+        uses: ./.github/actions/setup-php-composer
+        with:
+          php-version: '8.2'
+          coverage: xdebug
+          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring, snmp
+          dependency-mode: locked
+          install-args: --prefer-dist --no-progress --no-interaction
+
+      - name: Enforce line coverage
+        env:
+          XDEBUG_MODE: coverage
+        run: |
+          set -euo pipefail
+          include/vendor/bin/pest --colors=never \
+            --configuration=phpunit-f5-cpu.xml \
+            --coverage \
+            --coverage-text \
+            --min=100

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -156,6 +156,7 @@ Cacti CHANGELOG
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect
 -issue#7469: Escape path_php_binary before it reaches shell_exec in test_data_source
 -issue#7466: Escape path_stderrlog before it reaches the poller stderr shell redirect
+-issue#7355: Add an F5-BIGIP-SYSTEM-MIB script data query for per-CPU utilization
 -feature#7835: Add cacti_snmp_session_from_host() to build SNMP sessions from a device row
 -feature#412: Import Export for Graph and Tree rules
 -feature#1214: Move Tree Create/Remove/Modify Functions to lib/api_tree.php

--- a/phpunit-f5-cpu.xml
+++ b/phpunit-f5-cpu.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap-unit.php" colors="false" beStrictAboutOutputDuringTests="false">
+	<testsuites>
+		<testsuite name="F5Cpu">
+			<file>tests/Unit/DataCollection/Scripts/F5CpuTest.php</file>
+		</testsuite>
+	</testsuites>
+	<source>
+		<include>
+			<file>scripts/ss_f5_cpu.php</file>
+		</include>
+	</source>
+</phpunit>

--- a/resource/script_server/f5_cpu.xml
+++ b/resource/script_server/f5_cpu.xml
@@ -1,0 +1,44 @@
+<interface>
+	<name>Get F5 BIG-IP Per-CPU Utilization</name>
+	<script_path>|path_cacti|/scripts/ss_f5_cpu.php</script_path>
+	<script_function>ss_f5_cpu</script_function>
+	<script_server>php</script_server>
+	<arg_prepend>|host_hostname| |host_id| |host_snmp_version|:|host_snmp_port|:|host_snmp_timeout|:|host_ping_retries|:|host_max_oids|:|host_snmp_community|:|host_snmp_username|:|host_snmp_password|:|host_snmp_auth_protocol|:|host_snmp_priv_passphrase|:|host_snmp_priv_protocol|:|host_snmp_context|</arg_prepend>
+	<arg_index>index</arg_index>
+	<arg_query>query</arg_query>
+	<arg_get>get</arg_get>
+	<arg_num_indexes>num_indexes</arg_num_indexes>
+	<output_delimiter>!</output_delimiter>
+	<index_order>sysMultiHostCpuId:sysMultiHostCpuIndex</index_order>
+	<index_order_type>alphabetic</index_order_type>
+	<index_title_format>|chosen_order_field|</index_title_format>
+
+	<fields>
+		<sysMultiHostCpuIndex>
+			<name>CPU Index</name>
+			<direction>input</direction>
+			<query_name>index</query_name>
+		</sysMultiHostCpuIndex>
+		<sysMultiHostCpuId>
+			<name>CPU Id</name>
+			<direction>input</direction>
+			<query_name>name</query_name>
+		</sysMultiHostCpuId>
+
+		<sysMultiHostCpuUsageRatio5s>
+			<name>Utilization (5s)</name>
+			<direction>output</direction>
+			<query_name>avg5s</query_name>
+		</sysMultiHostCpuUsageRatio5s>
+		<sysMultiHostCpuUsageRatio1m>
+			<name>Utilization (1m)</name>
+			<direction>output</direction>
+			<query_name>avg1m</query_name>
+		</sysMultiHostCpuUsageRatio1m>
+		<sysMultiHostCpuUsageRatio5m>
+			<name>Utilization (5m)</name>
+			<direction>output</direction>
+			<query_name>avg5m</query_name>
+		</sysMultiHostCpuUsageRatio5m>
+	</fields>
+</interface>

--- a/scripts/ss_f5_cpu.php
+++ b/scripts/ss_f5_cpu.php
@@ -1,0 +1,196 @@
+#!/usr/bin/env php
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+error_reporting(0);
+
+// @codeCoverageIgnoreStart
+// Entry-point glue: CLI invocation versus in-process script-server dispatch.
+if (!isset($called_by_script_server)) {
+	include_once(__DIR__ . '/../include/cli_check.php');
+	include_once(__DIR__ . '/../lib/snmp.php');
+
+	array_shift($_SERVER['argv']);
+
+	print call_user_func_array('ss_f5_cpu', $_SERVER['argv']);
+} else {
+	include_once(__DIR__ . '/../lib/snmp.php');
+}
+/** @codeCoverageIgnoreEnd */
+
+/**
+ * Base OIDs for the F5-BIGIP-SYSTEM-MIB sysMultiHostCpuTable (enterprise .3375).
+ *
+ * BIG-IP reports per-CPU utilisation as sliding averages in this table, which
+ * is the signature F5 metric beyond the IF-MIB and HOST-RESOURCES standards.
+ * The table is multi-indexed by sysMultiHostCpuHostId and sysMultiHostCpuIndex,
+ * so the collector keys rows on the full OID suffix. Every OID here was
+ * resolved from the published F5-BIGIP-SYSTEM-MIB, not inferred.
+ *
+ * @return array<string,string> Symbolic name to numeric base OID.
+ */
+function ss_f5_cpu_oids() : array {
+	return [
+		'name'  => '.1.3.6.1.4.1.3375.2.1.7.5.2.1.3',  // sysMultiHostCpuId
+		'avg5s' => '.1.3.6.1.4.1.3375.2.1.7.5.2.1.19', // sysMultiHostCpuUsageRatio5s
+		'avg1m' => '.1.3.6.1.4.1.3375.2.1.7.5.2.1.27', // sysMultiHostCpuUsageRatio1m
+		'avg5m' => '.1.3.6.1.4.1.3375.2.1.7.5.2.1.35', // sysMultiHostCpuUsageRatio5m
+	];
+}
+
+/**
+ * ss_f5_cpu - collect F5 BIG-IP per-CPU utilisation from sysMultiHostCpuTable.
+ *
+ * Implements Cacti's script-server data-query contract: 'index' lists the CPU
+ * indexes, 'num_indexes' counts them, 'query' returns index!value pairs for a
+ * named field, and 'get' returns one field for one index. The final $walker
+ * parameter is a seam for testing; the script server never passes it, so
+ * production runs fall back to cacti_snmp_walk().
+ *
+ * @param string        $hostname  Device hostname.
+ * @param int           $host_id   Cacti host id.
+ * @param mixed         $snmp_auth Colon-joined SNMP auth string from the query.
+ * @param string        $cmd       One of index, num_indexes, query, get.
+ * @param string        $arg1      Field name (query and get).
+ * @param string        $arg2      CPU index (get only).
+ * @param callable|null $walker    Optional walk override: fn(string $oid): array.
+ *
+ * @return mixed Printed lines for index/query, a count for num_indexes, or a
+ *               scalar for get.
+ */
+function ss_f5_cpu(string $hostname = '', int $host_id = 0, mixed $snmp_auth = '', string $cmd = 'index', string $arg1 = '', string $arg2 = '', ?callable $walker = null) : mixed {
+	$oids = ss_f5_cpu_oids();
+
+	if ($walker === null) {
+		$walker = ss_f5_cpu_snmp_walker($hostname, explode(':', (string) $snmp_auth));
+	}
+
+	if ($cmd == 'index') {
+		foreach (array_keys($walker($oids['name'])) as $index) {
+			print $index . "\n";
+		}
+
+		return '';
+	}
+
+	if ($cmd == 'num_indexes') {
+		return cacti_count($walker($oids['name']));
+	}
+
+	if ($cmd == 'query') {
+		foreach (ss_f5_cpu_field($walker, $oids, $arg1) as $index => $value) {
+			print $index . '!' . $value . "\n";
+		}
+
+		return '';
+	}
+
+	if ($cmd == 'get') {
+		$rows = ss_f5_cpu_field($walker, $oids, $arg1);
+
+		return $rows[$arg2] ?? 'U';
+	}
+
+	return '';
+}
+
+/**
+ * Build the production SNMP walk callable for ss_f5_cpu().
+ *
+ * The returned closure is the boundary to lib/snmp.php; its body performs live
+ * network I/O and is exercised by integration runs, not unit tests.
+ *
+ * @param string            $hostname Device hostname.
+ * @param array<int,string> $snmp     The colon-split SNMP auth fields.
+ *
+ * @return callable fn(string $oid): array<string,string>
+ */
+function ss_f5_cpu_snmp_walker(string $hostname, array $snmp) : callable {
+	return static function (string $oid) use ($hostname, $snmp) : array {
+		/** @codeCoverageIgnoreStart */
+		$version = $snmp[0] ?? '1';
+		$results = cacti_snmp_walk(
+			$hostname,
+			$version == 3 ? '' : ($snmp[5] ?? ''),
+			$oid,
+			$version,
+			$snmp[6] ?? '', $snmp[7] ?? '', $snmp[8] ?? '', $snmp[9] ?? '', $snmp[10] ?? '', $snmp[11] ?? '',
+			$snmp[1] ?? 161, $snmp[2] ?? 500, $snmp[3] ?? 0, $snmp[4] ?? 10, SNMP_POLLER
+		);
+
+		return ss_f5_cpu_flatten($oid, $results);
+		// @codeCoverageIgnoreEnd
+	};
+}
+
+/**
+ * Normalise a walk result into a sysMultiHostCpu-index-keyed map.
+ *
+ * sysMultiHostCpuTable is multi-indexed, so the key is the full OID suffix that
+ * follows the walked base OID, not just its final component.
+ *
+ * @param string                                      $base    The walked base OID.
+ * @param array<int,array{oid?:string,value?:string}> $results Rows from cacti_snmp_walk().
+ *
+ * @return array<string,string> Composite index suffix to value.
+ */
+function ss_f5_cpu_flatten(string $base, array $results) : array {
+	$prefix = rtrim($base, '.') . '.';
+	$map    = [];
+
+	foreach ($results as $row) {
+		$oid = '.' . ltrim(trim($row['oid'] ?? ''), '.');
+
+		if (str_starts_with($oid, $prefix)) {
+			$index = substr($oid, strlen($prefix));
+
+			if ($index !== '') {
+				$map[$index] = trim((string) ($row['value'] ?? ''));
+			}
+		}
+	}
+
+	return $map;
+}
+
+/**
+ * Resolve one query field into an index-keyed map.
+ *
+ * Every field is a direct walk of a sysMultiHostCpuTable column; an unknown
+ * field yields an empty map so the data query degrades cleanly.
+ *
+ * @param callable             $walker Walk callable: fn(string $oid): array.
+ * @param array<string,string> $oids   The base OID map from ss_f5_cpu_oids().
+ * @param string               $field  Requested field name.
+ *
+ * @return array<string,string> Composite index to field value.
+ */
+function ss_f5_cpu_field(callable $walker, array $oids, string $field) : array {
+	if ($field == 'index') {
+		$rows = $walker($oids['name']);
+
+		return array_combine(array_keys($rows), array_keys($rows));
+	}
+
+	if (isset($oids[$field])) {
+		return $walker($oids[$field]);
+	}
+
+	return [];
+}

--- a/tests/Unit/DataCollection/Scripts/F5CpuTest.php
+++ b/tests/Unit/DataCollection/Scripts/F5CpuTest.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Unit tests for the F5 BIG-IP sysMultiHostCpuTable collector (issue #7355).
+ * The SNMP walk is injected through the $walker seam so every branch runs
+ * without a device. The table is multi-indexed, so the fixture uses composite
+ * index suffixes (host id . cpu index).
+ */
+
+$called_by_script_server = true;
+if (!defined('SNMP_POLLER')) {
+	define('SNMP_POLLER', 'SNMP');
+}
+if (!function_exists('cacti_count')) {
+	function cacti_count(mixed $a): int { return is_array($a) ? count($a) : 0; }
+}
+require_once dirname(__DIR__, 4) . '/scripts/ss_f5_cpu.php';
+
+function _f5_walker(array $fixture): callable {
+	return static function (string $oid) use ($fixture): array {
+		return $fixture[$oid] ?? [];
+	};
+}
+
+$OIDS = ss_f5_cpu_oids();
+
+// Two CPUs on host 0: index 0 and 1.
+$FIXTURE = [
+	$OIDS['name']  => ['0.0' => 'cpu0', '0.1' => 'cpu1'],
+	$OIDS['avg1m'] => ['0.0' => '18', '0.1' => '22'],
+	$OIDS['avg5s'] => ['0.0' => '25', '0.1' => '30'],
+];
+
+test('index prints one line per cpu', function () use ($FIXTURE) {
+	ob_start();
+	ss_f5_cpu('h', 1, '', 'index', '', '', _f5_walker($FIXTURE));
+	expect(trim(ob_get_clean()))->toBe("0.0\n0.1");
+});
+
+test('num_indexes counts the cpus', function () use ($FIXTURE) {
+	expect(ss_f5_cpu('h', 1, '', 'num_indexes', '', '', _f5_walker($FIXTURE)))->toBe(2);
+});
+
+test('query avg1m returns composite-index!value pairs', function () use ($FIXTURE) {
+	ob_start();
+	ss_f5_cpu('h', 1, '', 'query', 'avg1m', '', _f5_walker($FIXTURE));
+	expect(trim(ob_get_clean()))->toBe("0.0!18\n0.1!22");
+});
+
+test('query name returns the cpu label', function () use ($FIXTURE) {
+	ob_start();
+	ss_f5_cpu('h', 1, '', 'query', 'name', '', _f5_walker($FIXTURE));
+	expect(trim(ob_get_clean()))->toBe("0.0!cpu0\n0.1!cpu1");
+});
+
+test('query index maps each cpu index to itself', function () use ($FIXTURE) {
+	ob_start();
+	ss_f5_cpu('h', 1, '', 'query', 'index', '', _f5_walker($FIXTURE));
+	expect(trim(ob_get_clean()))->toBe("0.0!0.0\n0.1!0.1");
+});
+
+test('query of an unknown field yields nothing', function () use ($FIXTURE) {
+	ob_start();
+	ss_f5_cpu('h', 1, '', 'query', 'bogus', '', _f5_walker($FIXTURE));
+	expect(ob_get_clean())->toBe('');
+});
+
+test('get returns one field for one index', function () use ($FIXTURE) {
+	expect(ss_f5_cpu('h', 1, '', 'get', 'avg1m', '0.1', _f5_walker($FIXTURE)))->toBe('22');
+});
+
+test('get for a missing index returns U', function () use ($FIXTURE) {
+	expect(ss_f5_cpu('h', 1, '', 'get', 'avg1m', '9.9', _f5_walker($FIXTURE)))->toBe('U');
+});
+
+test('an unknown command returns empty', function () use ($FIXTURE) {
+	expect(ss_f5_cpu('h', 1, '', 'reload', '', '', _f5_walker($FIXTURE)))->toBe('');
+});
+
+test('with no injected walker the default SNMP walker is constructed', function () {
+	expect(ss_f5_cpu('127.0.0.1', 1, '2:161:500:0:10:public', 'noop'))->toBe('');
+});
+
+test('the SNMP walker factory returns a callable', function () {
+	expect(ss_f5_cpu_snmp_walker('127.0.0.1', ['2', '161']))->toBeCallable();
+});
+
+test('flatten keys rows by the full suffix and skips foreign rows', function () use ($OIDS) {
+	$rows = [
+		['oid' => $OIDS['avg1m'] . '.0.0', 'value' => ' 18 '],
+		['oid' => '.1.3.6.1.2.1.1.3.0',    'value' => 'x'],
+		['oid' => $OIDS['avg1m'],          'value' => 'y'],
+	];
+	expect(ss_f5_cpu_flatten($OIDS['avg1m'], $rows))->toBe(['0.0' => '18']);
+});


### PR DESCRIPTION
Part of #7355 (add modern SNMP device templates). Follows #7839 (ENTITY-SENSOR) and #7840 (Juniper) with the same collector and coverage pattern.

BIG-IP reports per-CPU utilization as sliding 5s / 1m / 5m averages in `F5-BIGIP-SYSTEM-MIB sysMultiHostCpuTable` (enterprise `.3375`) — the signature F5 metric beyond the IF-MIB and HOST-RESOURCES standards. No F5 template ships today.

## OID provenance
Every OID was resolved from the published `F5-BIGIP-SYSTEM-MIB` with `snmptranslate`, not inferred:
- `sysMultiHostCpuId` `.1.3.6.1.4.1.3375.2.1.7.5.2.1.3`
- `sysMultiHostCpuUsageRatio5s` `…2.1.19`
- `sysMultiHostCpuUsageRatio1m` `…2.1.27`
- `sysMultiHostCpuUsageRatio5m` `…2.1.35`

## What this adds
- `scripts/ss_f5_cpu.php` — script-server collector over the multi-indexed CPU table.
- `resource/script_server/f5_cpu.xml` — the data-query definition.
- Tests and a CI gate enforcing 100% line coverage.

`sysMultiHostCpuTable` is indexed by host id and CPU index, so `ss_f5_cpu_flatten()` keys each row on the full OID suffix after the walked base and drops rows outside it.

## Testing / style
SNMP walks sit behind an injectable `$walker`; `scripts/ss_f5_cpu.php 100% coverage` runs `pest --coverage --min=100`. Only the live `cacti_snmp_walk()` boundary and the CLI dispatch are `@codeCoverageIgnore`. PHPStan level 6 and php-cs-fixer clean; typed signatures/returns and PHPDoc throughout.

## Scope / follow-up
Collector + data query. F5's scalar signature metrics (client/server current connections) are a simple SNMP-get data template, and the graph/host-template packaging (`.xml.gz`) is GUI-authored against a live device — both follow separately.
