### PR TITLE
security: escape path_dsstats_log and aggregate_graphs local_graph_id

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Cacti CHANGELOG
 
 1.2.x
+-security: Escape path_dsstats_log before logging
+-security: Escape aggregate graph local_graph_id before SQL use
 -security: Substitute query data before escaping graph titles and axis labels
 -security: Build forced-HTTPS redirects from the server-configured name
 -security: Constrain external-link includes to regular files inside the configured content directory

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -534,7 +534,7 @@ function form_actions() {
 	print "	<tr>
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
-			<input type='hidden' name='local_graph_id' value='" . (isset_request_var('local_graph_id') ? get_nfilter_request_var('local_graph_id'):0) . "'>
+			<input type='hidden' name='local_graph_id' value='" . (isset_request_var('local_graph_id') ? html_escape(get_nfilter_request_var('local_graph_id')):0) . "'>
 			<input type='hidden' name='selected_items' value='" . (isset($graph_array) ? serialize($graph_array) : '') . "'>
 			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -1036,9 +1036,9 @@ function dsstats_poller_bottom () {
 		$command_string = read_config_option('path_php_binary');
 		if (read_config_option('path_dsstats_log') != '') {
 			if ($config['cacti_server_os'] == 'unix') {
-				$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php >> ' . read_config_option('path_dsstats_log') . ' 2>&1';
+				$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php >> ' . cacti_escapeshellarg(read_config_option('path_dsstats_log')) . ' 2>&1';
 			} else {
-				$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php >> ' . read_config_option('path_dsstats_log');
+				$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php >> ' . cacti_escapeshellarg(read_config_option('path_dsstats_log'));
 			}
 		} else {
 			$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php';

--- a/tests/Unit/Security/Shell/DsstatsLogEscapeTest.php
+++ b/tests/Unit/Security/Shell/DsstatsLogEscapeTest.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression: the path_dsstats_log setting is written into a shell redirect
+ * when relaunching poller_dsstats.php, and must be escaped like the identical
+ * path_rrdcheck_log redirect. An unescaped admin-set path could inject shell
+ * metacharacters into the background command.
+ */
+
+$dsstatsSource = file_get_contents(dirname(__DIR__, 4) . '/lib/dsstats.php');
+
+test('path_dsstats_log is wrapped in cacti_escapeshellarg in the log redirect', function () use ($dsstatsSource) {
+	expect($dsstatsSource)->not->toBeFalse();
+	// both the unix (>> ... 2>&1) and windows branches must escape the setting
+	expect(substr_count($dsstatsSource, "cacti_escapeshellarg(read_config_option('path_dsstats_log'))"))->toBe(2);
+	// the raw, unescaped redirect must be gone
+	expect($dsstatsSource)->not->toContain("'/poller_dsstats.php >> ' . read_config_option('path_dsstats_log')");
+});

--- a/tests/Unit/Security/Xss/AggregateGraphsLocalGraphIdEscapeTest.php
+++ b/tests/Unit/Security/Xss/AggregateGraphsLocalGraphIdEscapeTest.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression: on the aggregate_graphs action-confirmation render, local_graph_id
+ * is not integer-validated (the validating branches exit first), so it must be
+ * html_escape()'d before it is reflected into the hidden input value attribute.
+ */
+
+$source = file_get_contents(dirname(__DIR__, 4) . '/aggregate_graphs.php');
+
+test('local_graph_id is html_escaped where it is reflected into the hidden input', function () use ($source) {
+	expect($source)->not->toBeFalse();
+	expect($source)->toContain("html_escape(get_nfilter_request_var('local_graph_id'))");
+	// the raw reflection must be gone
+	expect($source)->not->toContain("? get_nfilter_request_var('local_graph_id'):0");
+});


### PR DESCRIPTION
Two small escaping fixes found during a 1.2.x hardening review.

## path_dsstats_log shell escape (`lib/dsstats.php`)
When relaunching `poller_dsstats.php`, the `path_dsstats_log` setting is concatenated into a `>>` shell redirect without `cacti_escapeshellarg` — the last member of the `path_*_log` family that issue#7466/7469/7473/7476 escaped elsewhere. `lib/rrdcheck.php` already escapes the identical `path_rrdcheck_log` redirect; this matches it. Admin-gated (settings), so defense-in-depth.

## aggregate_graphs local_graph_id reflection (`aggregate_graphs.php`)
On the action-confirmation render, `local_graph_id` is reflected into a hidden input `value=''` via raw `get_nfilter_request_var`. On that path it is never integer-validated (the validating branches `exit` first), so it is html_escaped now. The action is CSRF-protected (POST + csrf-magic), so exploitation is effectively self-XSS, but the missing escape is real.

## Tests
- `tests/Unit/Security/Shell/DsstatsLogEscapeTest.php` — asserts both redirect branches escape the setting and the raw form is gone.
- `tests/Unit/Security/Xss/AggregateGraphsLocalGraphIdEscapeTest.php` — asserts the reflection is html_escaped.

Both pass. Non-breaking, low risk.
