### PR TITLE
security: guest revocation, permission id casting, proxy-aware Secure cookie

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 Cacti CHANGELOG
 
 1.2.x
+-security: Revoke anonymous access when the guest account is disabled
+-security: Cast graph and device ids to int in get_allowed_* permission filters
+-security: Set the Secure session cookie behind a trusted TLS-terminating proxy
 -security: Substitute query data before escaping graph titles and axis labels
 -security: Build forced-HTTPS redirects from the server-configured name
 -security: Constrain external-link includes to regular files inside the configured content directory

--- a/include/global.php
+++ b/include/global.php
@@ -462,7 +462,21 @@ if ($config['is_web']) {
 		$options['cookie_samesite'] = 'Strict';
 	}
 
-	if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') {
+	/* Direct TLS, or TLS terminated at a proxy we are configured to trust
+	 * ($config['proxy_headers']). Only honour a forwarded-proto header when
+	 * proxy trust is enabled, so a client cannot force the Secure flag. */
+	$https = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off');
+
+	if (!$https && !empty($config['proxy_headers'])) {
+		$fwd_proto = isset($_SERVER['HTTP_X_FORWARDED_PROTO']) ? strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) : '';
+		$fwd_ssl   = isset($_SERVER['HTTP_X_FORWARDED_SSL'])   ? strtolower($_SERVER['HTTP_X_FORWARDED_SSL'])   : '';
+
+		if ($fwd_proto == 'https' || $fwd_ssl == 'on') {
+			$https = true;
+		}
+	}
+
+	if ($https) {
 		ini_set('session.cookie_secure', true);
 		$options['cookie_secure'] = true;
 	}

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -1485,7 +1485,7 @@ function get_allowed_graphs($sql_where = '', $sql_order = 'gtg.title_cache', $sq
 	}
 
 	if ($graph_id > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . " gl.id = $graph_id";
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . " gl.id = " . (int) $graph_id;
 	}
 
 	if (read_user_setting('hide_disabled', false, false, $user_id) == 'on') {
@@ -1587,7 +1587,7 @@ function get_allowed_aggregate_graphs($sql_where = '', $sql_order = 'gtg.title_c
 	}
 
 	if ($graph_id > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . " gl.id = $graph_id";
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . " gl.id = " . (int) $graph_id;
 	}
 
 	if (read_user_setting('hide_disabled', false, false, $user_id) == 'on') {
@@ -2811,7 +2811,7 @@ function get_allowed_devices($sql_where = '', $sql_order = 'description', $sql_l
 	}
 
 	if ($device_id > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . " h.id = $device_id";
+		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . " h.id = " . (int) $device_id;
 	}
 
 	$graph_auth_method = read_config_option('graph_auth_method');

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3040,9 +3040,10 @@ function get_graph_title($local_graph_id) {
  * @return (int) the guest account if greater than 0
  */
 function get_guest_account() {
-	$user = db_fetch_cell_prepared('SELECT id
+	$user = db_fetch_cell_prepared("SELECT id
 		FROM user_auth
-		WHERE username = ? OR id = ?',
+		WHERE (username = ? OR id = ?)
+		AND enabled = 'on'",
 		array(read_config_option('guest_user'), read_config_option('guest_user')));
 
 	if (empty($user)) {

--- a/tests/Unit/Security/Auth/AuthHardeningTest.php
+++ b/tests/Unit/Security/Auth/AuthHardeningTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression tests for three 1.2.x auth-hardening fixes found in review:
+ *  - a disabled guest account must not keep granting anonymous access
+ *  - the get_allowed_* permission where-clauses must not interpolate a raw id
+ *  - the Secure session cookie must be set behind a trusted TLS proxy
+ */
+
+$functions = file_get_contents(dirname(__DIR__, 4) . '/lib/functions.php');
+$auth      = file_get_contents(dirname(__DIR__, 4) . '/lib/auth.php');
+$global    = file_get_contents(dirname(__DIR__, 4) . '/include/global.php');
+
+test('get_guest_account requires the guest user to be enabled', function () use ($functions) {
+	$start = strpos($functions, 'function get_guest_account(');
+	expect($start)->not->toBeFalse();
+	$body = substr($functions, $start, 400);
+	expect($body)->toContain("enabled = 'on'");
+});
+
+test('permission where-clauses cast the id to int rather than interpolating it raw', function () use ($auth) {
+	// the raw interpolations are gone
+	expect($auth)->not->toContain('" gl.id = $graph_id"');
+	expect($auth)->not->toContain('" h.id = $device_id"');
+	// and replaced with an int cast
+	expect(substr_count($auth, '(int) $graph_id'))->toBeGreaterThan(0);
+	expect($auth)->toContain('(int) $device_id');
+});
+
+test('the Secure cookie flag honours a forwarded-proto only when proxy trust is enabled', function () use ($global) {
+	$start = strpos($global, "session.cookie_secure");
+	expect($start)->not->toBeFalse();
+	// the forwarded-proto path is gated on proxy_headers so a client cannot force it
+	expect($global)->toContain("!empty(\$config['proxy_headers'])");
+	expect($global)->toContain('HTTP_X_FORWARDED_PROTO');
+});


### PR DESCRIPTION
Three auth defense-in-depth fixes from a 1.2.x review. None is pre-auth exploitable; all close real gaps.

## Disabled guest still grants access (`lib/functions.php`)
`get_guest_account()` selected the guest id with no `enabled='on'` predicate, and the guest id is exempt from the disabled-session kill. So disabling the guest user did not stop anonymous browsing — an admin had to clear the `guest_user` setting instead. Now requires `enabled='on'`.

## Raw id in permission filters (`lib/auth.php`)
`get_allowed_graphs()` and `get_allowed_devices()` interpolated `$graph_id`/`$device_id` into the permission `WHERE` clause unbound. Reachable web callers pre-validate as int today, so this is latent, but cast to int as defense-in-depth for any future or plugin caller.

## Secure cookie behind a TLS proxy (`include/global.php`)
The Secure session/remember-me cookie flag was set only on direct `$_SERVER['HTTPS']`. Behind a TLS-terminating proxy the cookies were issued without Secure and could leak over a downgraded request. Now honours `X-Forwarded-Proto`/`X-Forwarded-SSL` — but only when `$config['proxy_headers']` trust is configured (the same gate `get_client_addr()` uses), so a client cannot force the flag. HttpOnly and SameSite=Strict were already correct.

## Tests
`tests/Unit/Security/Auth/AuthHardeningTest.php` covers all three. Non-breaking, low risk.

Closes #7860