### PR TITLE
security: forward-port 1.2.x hardening (dsstats, guest, permissions, cookie)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-security: Escape path_dsstats_log before it reaches the dsstats poller shell redirect
+-security: Revoke anonymous access when the guest account is disabled
+-security: Cast graph and device ids to int in get_allowed_* permission filters
+-security: Honour a trusted forwarded proto when setting the Secure session cookie
 -security: Build forced-HTTPS redirects from the server-configured name
 -security: Replace sibling password-reset links and revoke authentication state after reset
 -issue: Fail closed when OAuth callback state is absent or mismatched

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -1745,7 +1745,7 @@ function get_allowed_aggregate_graphs(string $sql_where = '', string $sql_order 
 	}
 
 	if ($graph_id > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . " gl.id = $graph_id";
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . ' gl.id = ' . (int) $graph_id;
 	}
 
 	if (read_user_setting('hide_disabled', false, false, $user_id) == 'on') {
@@ -2913,7 +2913,7 @@ function get_allowed_devices(string $sql_where = '', string $sql_order = 'descri
 	}
 
 	if ($device_id > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . " h.id = $device_id";
+		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . ' h.id = ' . (int) $device_id;
 	}
 
 	$graph_auth_method = read_config_option('graph_auth_method');

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -1235,9 +1235,9 @@ function dsstats_poller_bottom() : void {
 
 		if (read_config_option('path_dsstats_log') != '') {
 			if (CACTI_SERVER_OS == 'unix') {
-				$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_dsstats.php >> ' . read_config_option('path_dsstats_log') . ' 2>&1';
+				$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_dsstats.php >> ' . cacti_escapeshellarg(read_config_option('path_dsstats_log')) . ' 2>&1';
 			} else {
-				$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_dsstats.php >> ' . read_config_option('path_dsstats_log');
+				$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_dsstats.php >> ' . cacti_escapeshellarg(read_config_option('path_dsstats_log'));
 			}
 		} else {
 			$extra_args = '-q ' . CACTI_PATH_BASE . '/poller_dsstats.php';

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3442,9 +3442,10 @@ function get_graph_title(int $local_graph_id) : string {
  * @return int The guest account if greater than 0
  */
 function get_guest_account() : int {
-	$user = db_fetch_cell_prepared('SELECT id
+	$user = db_fetch_cell_prepared("SELECT id
 		FROM user_auth
-		WHERE username = ? OR id = ?',
+		WHERE (username = ? OR id = ?)
+		AND enabled = 'on'",
 		[read_config_option('guest_user'), read_config_option('guest_user')]);
 
 	if (empty($user)) {
@@ -9091,11 +9092,24 @@ function get_client_addr() : string|false {
  * @return bool True when the connection is HTTPS, false otherwise.
  */
 function cacti_is_https() : bool {
-	if (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === '' || $_SERVER['HTTPS'] === '0') {
-		return false;
+	global $config;
+
+	if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== '' && $_SERVER['HTTPS'] !== '0' && strtolower($_SERVER['HTTPS']) !== 'off') {
+		return true;
 	}
 
-	return strtolower($_SERVER['HTTPS']) !== 'off';
+	// Honour a forwarded proto only when we are configured to trust proxy
+	// headers, so a client cannot force the Secure flag on a plaintext request.
+	if (!empty($config['proxy_headers'])) {
+		$fwd_proto = isset($_SERVER['HTTP_X_FORWARDED_PROTO']) ? strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) : '';
+		$fwd_ssl   = isset($_SERVER['HTTP_X_FORWARDED_SSL']) ? strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) : '';
+
+		if ($fwd_proto === 'https' || $fwd_ssl === 'on') {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /**

--- a/tests/Unit/Security/Auth/HardeningForwardportTest.php
+++ b/tests/Unit/Security/Auth/HardeningForwardportTest.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Forward-port of the 1.2.x hardening fixes. cacti_is_https() is exercised
+ * directly (it has no DB dependency); the remaining three are source-scan
+ * guards because they sit inside DB/shell code paths.
+ */
+
+$functions = file_get_contents(dirname(__DIR__, 4) . '/lib/functions.php');
+$auth      = file_get_contents(dirname(__DIR__, 4) . '/lib/auth.php');
+$dsstats   = file_get_contents(dirname(__DIR__, 4) . '/lib/dsstats.php');
+
+require_once dirname(__DIR__, 4) . '/lib/functions.php';
+
+beforeEach(function () {
+	unset($_SERVER['HTTPS'], $_SERVER['HTTP_X_FORWARDED_PROTO'], $_SERVER['HTTP_X_FORWARDED_SSL']);
+	$GLOBALS['config']['proxy_headers'] = [];
+});
+
+test('cacti_is_https is true on direct TLS and false on plain http', function () {
+	$_SERVER['HTTPS'] = 'on';
+	expect(cacti_is_https())->toBeTrue();
+
+	$_SERVER['HTTPS'] = 'off';
+	expect(cacti_is_https())->toBeFalse();
+
+	unset($_SERVER['HTTPS']);
+	expect(cacti_is_https())->toBeFalse();
+});
+
+test('a forwarded proto is honoured only when proxy trust is enabled', function () {
+	$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+	// proxy trust off: a client-supplied header must NOT force https
+	$GLOBALS['config']['proxy_headers'] = [];
+	expect(cacti_is_https())->toBeFalse();
+
+	// proxy trust on: the forwarded proto is honoured
+	$GLOBALS['config']['proxy_headers'] = ['REMOTE_ADDR'];
+	expect(cacti_is_https())->toBeTrue();
+});
+
+test('X-Forwarded-SSL on is honoured under proxy trust', function () {
+	$GLOBALS['config']['proxy_headers'] = true;
+	$_SERVER['HTTP_X_FORWARDED_SSL'] = 'on';
+	expect(cacti_is_https())->toBeTrue();
+});
+
+test('get_guest_account requires the guest user to be enabled', function () use ($functions) {
+	$start = strpos($functions, 'function get_guest_account(');
+	expect(substr($functions, $start, 400))->toContain("enabled = 'on'");
+});
+
+test('permission where-clauses cast ids to int', function () use ($auth) {
+	expect($auth)->not->toContain('" gl.id = $graph_id"');
+	expect($auth)->not->toContain('" h.id = $device_id"');
+	expect($auth)->toContain('(int) $graph_id');
+	expect($auth)->toContain('(int) $device_id');
+});
+
+test('path_dsstats_log is escaped in the shell redirect', function () use ($dsstats) {
+	expect(substr_count($dsstats, "cacti_escapeshellarg(read_config_option('path_dsstats_log'))"))->toBe(2);
+});


### PR DESCRIPTION
Forward-port to develop of the 1.2.x hardening in #7842 and #7843. Four of the five fixes apply here (the aggregate_graphs `local_graph_id` reflection was restructured away on develop).

## Fixes
- **`lib/dsstats.php`** — escape `path_dsstats_log` in the poller shell redirect (last of the `path_*_log` family).
- **`lib/functions.php` `get_guest_account()`** — require `enabled='on'`, so disabling the guest user revokes anonymous access.
- **`lib/auth.php`** — cast `$graph_id`/`$device_id` to int in the `get_allowed_*` permission filters (defense-in-depth).
- **`lib/functions.php` `cacti_is_https()`** — honour `X-Forwarded-Proto`/`X-Forwarded-SSL`, but only when `$config['proxy_headers']` trust is enabled, so the Secure cookie is set behind a TLS-terminating proxy without a client being able to force it. Fixed centrally in the helper so every caller benefits.

## Tests
`tests/Unit/Security/Auth/HardeningForwardportTest.php` — `cacti_is_https()` is exercised directly (direct TLS, forwarded-proto with and without proxy trust, X-Forwarded-SSL); the other three are source-scan guards. 6 passing. PHPStan level 6 and php-cs-fixer clean. Non-breaking.
