### PR TITLE
security: substitute query data before escaping graph titles and axis labels

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.x
+-security: Substitute query data before escaping graph titles and axis labels
 -security: Build forced-HTTPS redirects from the server-configured name
 -security: Constrain external-link includes to regular files inside the configured content directory
 -security: Harden advisory command execution and database DDL sink validation

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1294,7 +1294,7 @@ function rrd_function_process_graph_options($graph_start, $graph_end, &$graph, &
 		switch($key) {
 		case 'title_cache':
 			if (!empty($value)) {
-				$graph_opts .= '--title=' . cacti_escapeshellarg(html_escape($value)) . RRD_NL;
+				$graph_opts .= '--title=' . cacti_escapeshellarg(rrd_substitute_host_query_data(html_escape($value), $graph, array())) . RRD_NL;
 			}
 
 			break;
@@ -1348,7 +1348,7 @@ function rrd_function_process_graph_options($graph_start, $graph_end, &$graph, &
 			break;
 		case 'vertical_label':
 			if (!empty($value)) {
-				$graph_opts .= '--vertical-label=' . cacti_escapeshellarg(html_escape($value)) . RRD_NL;
+				$graph_opts .= '--vertical-label=' . cacti_escapeshellarg(rrd_substitute_host_query_data(html_escape($value), $graph, array())) . RRD_NL;
 			}
 
 			break;
@@ -1366,7 +1366,7 @@ function rrd_function_process_graph_options($graph_start, $graph_end, &$graph, &
 			break;
 		case 'right_axis_label':
 			if (!empty($value)) {
-				$graph_opts .= '--right-axis-label ' . cacti_escapeshellarg($value) . RRD_NL;
+				$graph_opts .= '--right-axis-label ' . cacti_escapeshellarg(rrd_substitute_host_query_data($value, $graph, array())) . RRD_NL;
 			}
 
 			break;
@@ -1450,8 +1450,9 @@ function rrd_function_process_graph_options($graph_start, $graph_end, &$graph, &
 	/* process theme and font styling options */
 	$graph_opts .= rrdtool_function_theme_font_options($graph_data_array);
 
-	/* Replace "|query_*|" in the graph command to replace e.g. vertical_label.  */
-	$graph_opts = rrd_substitute_host_query_data($graph_opts, $graph, array());
+	/* NOTE: title, vertical-label and right-axis-label perform |query_*|
+	 * substitution before cacti_escapeshellarg above, so a device-supplied
+	 * value cannot break out of the quoted RRDtool argument. */
 
 	/* if the user desires a watermark set it */
 	$watermark = str_replace("'", '"', read_config_option('graph_watermark'));

--- a/tests/Unit/Security/Shell/RrdQuerySubstitutionEscapeTest.php
+++ b/tests/Unit/Security/Shell/RrdQuerySubstitutionEscapeTest.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression: |query_*|/|host_*| tokens in a graph title, vertical-label or
+ * right-axis-label are replaced with device-supplied SNMP values. Previously
+ * the substitution ran over the whole graph command AFTER each argument was
+ * cacti_escapeshellarg'd, so a device value containing a quote could break out
+ * of the quoted RRDtool argument and inject directives. The substitution must
+ * run INSIDE cacti_escapeshellarg, and the post-escape global pass must be gone.
+ */
+
+$rrd = file_get_contents(dirname(__DIR__, 4) . '/lib/rrd.php');
+
+test('title substitution happens inside cacti_escapeshellarg', function () use ($rrd) {
+	expect($rrd)->toContain(
+		"cacti_escapeshellarg(rrd_substitute_host_query_data(html_escape(\$value), \$graph, array()))"
+	);
+});
+
+test('right-axis-label substitution happens inside cacti_escapeshellarg', function () use ($rrd) {
+	expect($rrd)->toContain(
+		"--right-axis-label ' . cacti_escapeshellarg(rrd_substitute_host_query_data(\$value, \$graph, array()))"
+	);
+});
+
+test('the post-escape whole-command substitution is removed', function () use ($rrd) {
+	// this line injected the raw device value into already-quoted arguments
+	expect($rrd)->not->toContain('$graph_opts = rrd_substitute_host_query_data($graph_opts, $graph, array());');
+});
+
+test('cacti_escapeshellarg neutralises a device-supplied quote (property this relies on)', function () {
+	require_once dirname(__DIR__, 4) . '/lib/functions.php';
+	$GLOBALS['config']['cacti_server_os'] = 'unix';
+	// a substituted value with a quote, once wrapped, cannot terminate the arg
+	$evil    = "eth0' COMMENT:pwned";
+	$wrapped = cacti_escapeshellarg('Traffic ' . $evil);
+	// the inner single quote must be escaped, not left bare-closing the argument
+	expect($wrapped)->not->toContain("Traffic eth0' COMMENT");
+	expect(substr($wrapped, 0, 1))->toBe("'");
+});


### PR DESCRIPTION
Follow-up to the 1.2.x hardening review (residual R1 from #7842/#7843).

`rrd_substitute_host_query_data()` expands `|query_*|` / `|host_*|` tokens in graph text with device-supplied SNMP values (from `host_snmp_cache`). It ran over the whole graph command **after** each argument had already been `cacti_escapeshellarg`'d, so a device value expanded into a graph title, vertical-label or right-axis-label could contain a quote and break out of the quoted RRDtool argument, injecting RRDtool directives.

This is RRDtool-directive injection over `rrdtool -`'s stdin, **not** shell RCE (the command is written to stdin via `proc_open`, never a shell), and the graph is rendered by an authenticated user — but the source is a rogue/compromised device (effectively pre-auth), so it is worth closing.

## Fix
Move the substitution **inside** `cacti_escapeshellarg` at the three free-text fields (title, vertical-label, right-axis-label), and drop the post-escape whole-command pass. The device value is now expanded before the argument is quoted, so `cacti_escapeshellarg` escapes any quote it contains. Behavior is otherwise identical: static title text is still html-escaped, device values are still not html-escaped.

Only those three fields carry `|query_*|` tokens; the other escaped options (y-grid, formatters, legend position) are settings-derived enums/format strings.

## Test
`tests/Unit/Security/Shell/RrdQuerySubstitutionEscapeTest.php` — asserts the substitution is inside `cacti_escapeshellarg` at title and right-axis-label, that the post-escape global pass is gone, and (behavioral) that `cacti_escapeshellarg` neutralizes a device-supplied quote. 4 passing. Non-breaking.
