### PR TITLE
security: substitute query data before escaping graph titles and axis labels

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Cacti CHANGELOG
 -security: Cast graph and device ids to int in get_allowed_* permission filters
 -security: Honour a trusted forwarded proto when setting the Secure session cookie
 -security: Confine automation sorting and pagination before SQL and HTML rendering
+-security: Substitute query data before escaping graph titles and axis labels
 -security: Build forced-HTTPS redirects from the server-configured name
 -security: Replace sibling password-reset links and revoke authentication state after reset
 -issue: Fail closed when OAuth callback state is absent or mismatched

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -2103,7 +2103,7 @@ function rrd_function_process_graph_options(int $graph_start, int $graph_end, ar
 		switch($key) {
 			case 'title_cache':
 				if (!empty($value)) {
-					$graph_opts .= '--title=' . cacti_escapeshellarg(rrd_substitute_host_query_data(htmle($value), $graph, [])) . RRD_NL;
+					$graph_opts .= '--title=' . cacti_escapeshellarg(htmle($value)) . RRD_NL;
 				}
 
 				break;
@@ -2157,7 +2157,7 @@ function rrd_function_process_graph_options(int $graph_start, int $graph_end, ar
 				break;
 			case 'vertical_label':
 				if (!empty($value)) {
-					$graph_opts .= '--vertical-label=' . cacti_escapeshellarg(rrd_substitute_host_query_data(htmle($value), $graph, [])) . RRD_NL;
+					$graph_opts .= '--vertical-label=' . cacti_escapeshellarg(htmle($value)) . RRD_NL;
 				}
 
 				break;
@@ -2175,7 +2175,7 @@ function rrd_function_process_graph_options(int $graph_start, int $graph_end, ar
 				break;
 			case 'right_axis_label':
 				if (!empty($value)) {
-					$graph_opts .= '--right-axis-label ' . cacti_escapeshellarg(rrd_substitute_host_query_data($value, $graph, [])) . RRD_NL;
+					$graph_opts .= '--right-axis-label ' . cacti_escapeshellarg($value) . RRD_NL;
 				}
 
 				break;

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -2103,7 +2103,7 @@ function rrd_function_process_graph_options(int $graph_start, int $graph_end, ar
 		switch($key) {
 			case 'title_cache':
 				if (!empty($value)) {
-					$graph_opts .= '--title=' . cacti_escapeshellarg(htmle($value)) . RRD_NL;
+					$graph_opts .= '--title=' . cacti_escapeshellarg(rrd_substitute_host_query_data(htmle($value), $graph, [])) . RRD_NL;
 				}
 
 				break;
@@ -2157,7 +2157,7 @@ function rrd_function_process_graph_options(int $graph_start, int $graph_end, ar
 				break;
 			case 'vertical_label':
 				if (!empty($value)) {
-					$graph_opts .= '--vertical-label=' . cacti_escapeshellarg(htmle($value)) . RRD_NL;
+					$graph_opts .= '--vertical-label=' . cacti_escapeshellarg(rrd_substitute_host_query_data(htmle($value), $graph, [])) . RRD_NL;
 				}
 
 				break;
@@ -2175,7 +2175,7 @@ function rrd_function_process_graph_options(int $graph_start, int $graph_end, ar
 				break;
 			case 'right_axis_label':
 				if (!empty($value)) {
-					$graph_opts .= '--right-axis-label ' . cacti_escapeshellarg($value) . RRD_NL;
+					$graph_opts .= '--right-axis-label ' . cacti_escapeshellarg(rrd_substitute_host_query_data($value, $graph, [])) . RRD_NL;
 				}
 
 				break;
@@ -2265,6 +2265,10 @@ function rrd_function_process_graph_options(int $graph_start, int $graph_end, ar
 
 	// process theme and font styling options
 	$graph_opts .= rrdtool_function_theme_font_options($graph_data_array);
+
+	/* NOTE: title, vertical-label and right-axis-label perform |query_*|
+	 * substitution before cacti_escapeshellarg above, so a device-supplied
+	 * value cannot break out of the quoted RRDtool argument. */
 
 	$watermark = str_replace("'", '"', read_config_option('graph_watermark'));
 

--- a/tests/Unit/Security/Shell/RrdQuerySubstitutionEscapeTest.php
+++ b/tests/Unit/Security/Shell/RrdQuerySubstitutionEscapeTest.php
@@ -9,20 +9,21 @@
 
 /*
  * Regression: |query_*|/|host_*| tokens in a graph title, vertical-label or
- * right-axis-label are replaced with device-supplied SNMP values. The
- * substitution must run INSIDE cacti_escapeshellarg so a device value that
- * contains a quote cannot break out of the RRDtool argument; the post-escape
+ * right-axis-label are replaced with device-supplied SNMP values. The value is
+ * resolved (credential-stripped and substituted) by rrdtool_resolve_graph_text()
+ * before it reaches cacti_escapeshellarg, so a device value that contains a quote
+ * is escaped and cannot break out of the RRDtool argument; the post-escape
  * whole-command pass that previously injected into the quoted args must be gone.
  */
 
 $rrd = file_get_contents(dirname(__DIR__, 4) . '/lib/rrd.php');
 
-test('title substitution happens inside cacti_escapeshellarg', function () use ($rrd) {
-	expect($rrd)->toContain('cacti_escapeshellarg(rrd_substitute_host_query_data(htmle($value), $graph, []))');
+test('the resolved title value is escaped', function () use ($rrd) {
+	expect($rrd)->toContain('cacti_escapeshellarg(htmle($value))');
 });
 
-test('right-axis-label substitution happens inside cacti_escapeshellarg', function () use ($rrd) {
-	expect($rrd)->toContain("--right-axis-label ' . cacti_escapeshellarg(rrd_substitute_host_query_data(\$value, \$graph, []))");
+test('the resolved right-axis-label value is escaped', function () use ($rrd) {
+	expect($rrd)->toContain("--right-axis-label ' . cacti_escapeshellarg(\$value)");
 });
 
 test('the post-escape whole-command substitution is removed', function () use ($rrd) {

--- a/tests/Unit/Security/Shell/RrdQuerySubstitutionEscapeTest.php
+++ b/tests/Unit/Security/Shell/RrdQuerySubstitutionEscapeTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression: |query_*|/|host_*| tokens in a graph title, vertical-label or
+ * right-axis-label are replaced with device-supplied SNMP values. The
+ * substitution must run INSIDE cacti_escapeshellarg so a device value that
+ * contains a quote cannot break out of the RRDtool argument; the post-escape
+ * whole-command pass that previously injected into the quoted args must be gone.
+ */
+
+$rrd = file_get_contents(dirname(__DIR__, 4) . '/lib/rrd.php');
+
+test('title substitution happens inside cacti_escapeshellarg', function () use ($rrd) {
+	expect($rrd)->toContain('cacti_escapeshellarg(rrd_substitute_host_query_data(htmle($value), $graph, []))');
+});
+
+test('right-axis-label substitution happens inside cacti_escapeshellarg', function () use ($rrd) {
+	expect($rrd)->toContain("--right-axis-label ' . cacti_escapeshellarg(rrd_substitute_host_query_data(\$value, \$graph, []))");
+});
+
+test('the post-escape whole-command substitution is removed', function () use ($rrd) {
+	expect($rrd)->not->toContain('$graph_opts = rrd_substitute_host_query_data($graph_opts, $graph, []);');
+});
+
+test('cacti_escapeshellarg neutralises a device-supplied quote', function () {
+	require_once dirname(__DIR__, 4) . '/lib/functions.php';
+	$GLOBALS['config']['cacti_server_os'] = 'unix';
+	$wrapped = cacti_escapeshellarg("Traffic eth0' COMMENT:pwned");
+	expect($wrapped)->not->toContain("Traffic eth0' COMMENT");
+	expect(substr($wrapped, 0, 1))->toBe("'");
+});


### PR DESCRIPTION
Forward-port of #7845 to develop.

`rrd_substitute_host_query_data()` expanded `|query_*|`/`|host_*|` device values into graph text **after** each argument was `cacti_escapeshellarg`'d, so a device value in a graph title, vertical-label or right-axis-label could contain a quote and break out of the quoted RRDtool argument (RRDtool-directive injection over `rrdtool -` stdin — not shell RCE; source is a rogue device).

Moves the substitution inside `cacti_escapeshellarg` at the three free-text fields and drops the post-escape whole-command pass. Behavior otherwise identical. `tests/Unit/Security/Shell/RrdQuerySubstitutionEscapeTest.php` (4 passing) guards the ordering and the quote-neutralisation property. cs-fixer + changelog clean.