### PR TITLE
security: 1.2.x hardening batch (clog filenames, dsstats/aggregate escaping, auth)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 Cacti CHANGELOG
 
 1.2.x
--security: Substitute query data before escaping graph titles and axis labels
+-security: Reject Windows-special log filename forms in the clog purge validation
 -security: Build forced-HTTPS redirects from the server-configured name
 -security: Constrain external-link includes to regular files inside the configured content directory
 -security: Harden advisory command execution and database DDL sink validation

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 Cacti CHANGELOG
 
 1.2.x
+-security: Escape path_dsstats_log before logging
+-security: Escape aggregate graph local_graph_id before SQL use
 -security: Reject Windows-special log filename forms in the clog purge validation
 -security: Build forced-HTTPS redirects from the server-configured name
 -security: Constrain external-link includes to regular files inside the configured content directory

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,13 @@
 Cacti CHANGELOG
 
 1.2.x
+-security: Revoke anonymous access when the guest account is disabled
+-security: Cast graph and device ids to int in get_allowed_* permission filters
+-security: Set the Secure session cookie behind a trusted TLS-terminating proxy
 -security: Escape path_dsstats_log before logging
 -security: Escape aggregate graph local_graph_id before SQL use
 -security: Reject Windows-special log filename forms in the clog purge validation
+-security: Substitute query data before escaping graph titles and axis labels
 -security: Build forced-HTTPS redirects from the server-configured name
 -security: Constrain external-link includes to regular files inside the configured content directory
 -security: Harden advisory command execution and database DDL sink validation

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -534,7 +534,7 @@ function form_actions() {
 	print "	<tr>
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
-			<input type='hidden' name='local_graph_id' value='" . (isset_request_var('local_graph_id') ? html_escape(get_nfilter_request_var('local_graph_id')):0) . "'>
+			<input type='hidden' name='local_graph_id' value='" . (isset_request_var('local_graph_id') ? get_filter_request_var('local_graph_id') : 0) . "'>
 			<input type='hidden' name='selected_items' value='" . (isset($graph_array) ? serialize($graph_array) : '') . "'>
 			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -534,7 +534,7 @@ function form_actions() {
 	print "	<tr>
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='actions'>
-			<input type='hidden' name='local_graph_id' value='" . (isset_request_var('local_graph_id') ? get_nfilter_request_var('local_graph_id'):0) . "'>
+			<input type='hidden' name='local_graph_id' value='" . (isset_request_var('local_graph_id') ? html_escape(get_nfilter_request_var('local_graph_id')):0) . "'>
 			<input type='hidden' name='selected_items' value='" . (isset($graph_array) ? serialize($graph_array) : '') . "'>
 			<input type='hidden' name='drp_action' value='" . html_escape(get_request_var('drp_action')) . "'>
 			$save_html

--- a/include/global.php
+++ b/include/global.php
@@ -462,7 +462,21 @@ if ($config['is_web']) {
 		$options['cookie_samesite'] = 'Strict';
 	}
 
-	if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') {
+	/* Direct TLS, or TLS terminated at a proxy we are configured to trust
+	 * ($config['proxy_headers']). Only honour a forwarded-proto header when
+	 * proxy trust is enabled, so a client cannot force the Secure flag. */
+	$https = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off');
+
+	if (!$https && !empty($config['proxy_headers'])) {
+		$fwd_proto = isset($_SERVER['HTTP_X_FORWARDED_PROTO']) ? strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) : '';
+		$fwd_ssl   = isset($_SERVER['HTTP_X_FORWARDED_SSL'])   ? strtolower($_SERVER['HTTP_X_FORWARDED_SSL'])   : '';
+
+		if ($fwd_proto == 'https' || $fwd_ssl == 'on') {
+			$https = true;
+		}
+	}
+
+	if ($https) {
 		ini_set('session.cookie_secure', true);
 		$options['cookie_secure'] = true;
 	}

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -1485,7 +1485,7 @@ function get_allowed_graphs($sql_where = '', $sql_order = 'gtg.title_cache', $sq
 	}
 
 	if ($graph_id > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . " gl.id = $graph_id";
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . " gl.id = " . (int) $graph_id;
 	}
 
 	if (read_user_setting('hide_disabled', false, false, $user_id) == 'on') {
@@ -1587,7 +1587,7 @@ function get_allowed_aggregate_graphs($sql_where = '', $sql_order = 'gtg.title_c
 	}
 
 	if ($graph_id > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . " gl.id = $graph_id";
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' ') . " gl.id = " . (int) $graph_id;
 	}
 
 	if (read_user_setting('hide_disabled', false, false, $user_id) == 'on') {
@@ -2811,7 +2811,7 @@ function get_allowed_devices($sql_where = '', $sql_order = 'description', $sql_l
 	}
 
 	if ($device_id > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . " h.id = $device_id";
+		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . " h.id = " . (int) $device_id;
 	}
 
 	$graph_auth_method = read_config_option('graph_auth_method');

--- a/lib/clog_webapi.php
+++ b/lib/clog_webapi.php
@@ -72,6 +72,14 @@ function clog_validate_filename(&$file, &$filepath, &$filename, $filecheck = fal
 	$file     = basename($file);
 	$logbase  = basename($logfile);
 
+	/* SECURITY: reject Windows-special filename forms so a name that the OS
+	 * resolves back to the active log (trailing dot/space, or an alternate
+	 * data stream / drive colon) cannot slip past the active-log guard in
+	 * clog_purge_logfile(). Legitimate rotated logs are name.<digit>. */
+	if (strpos($file, ':') !== false || preg_match('/[\. ]$/', $file)) {
+		return false;
+	}
+
 	$filepath = '';
 	$filename = '';
 	$filefull = '';

--- a/lib/dsstats.php
+++ b/lib/dsstats.php
@@ -1036,9 +1036,9 @@ function dsstats_poller_bottom () {
 		$command_string = read_config_option('path_php_binary');
 		if (read_config_option('path_dsstats_log') != '') {
 			if ($config['cacti_server_os'] == 'unix') {
-				$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php >> ' . read_config_option('path_dsstats_log') . ' 2>&1';
+				$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php >> ' . cacti_escapeshellarg(read_config_option('path_dsstats_log')) . ' 2>&1';
 			} else {
-				$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php >> ' . read_config_option('path_dsstats_log');
+				$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php >> ' . cacti_escapeshellarg(read_config_option('path_dsstats_log'));
 			}
 		} else {
 			$extra_args = '-q ' . $config['base_path'] . '/poller_dsstats.php';

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3040,9 +3040,10 @@ function get_graph_title($local_graph_id) {
  * @return (int) the guest account if greater than 0
  */
 function get_guest_account() {
-	$user = db_fetch_cell_prepared('SELECT id
+	$user = db_fetch_cell_prepared("SELECT id
 		FROM user_auth
-		WHERE username = ? OR id = ?',
+		WHERE (username = ? OR id = ?)
+		AND enabled = 'on'",
 		array(read_config_option('guest_user'), read_config_option('guest_user')));
 
 	if (empty($user)) {

--- a/tests/Unit/Security/Auth/AuthHardeningTest.php
+++ b/tests/Unit/Security/Auth/AuthHardeningTest.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression tests for three 1.2.x auth-hardening fixes found in review:
+ *  - a disabled guest account must not keep granting anonymous access
+ *  - the get_allowed_* permission where-clauses must not interpolate a raw id
+ *  - the Secure session cookie must be set behind a trusted TLS proxy
+ */
+
+$functions = file_get_contents(dirname(__DIR__, 4) . '/lib/functions.php');
+$auth      = file_get_contents(dirname(__DIR__, 4) . '/lib/auth.php');
+$global    = file_get_contents(dirname(__DIR__, 4) . '/include/global.php');
+
+test('get_guest_account requires the guest user to be enabled', function () use ($functions) {
+	$start = strpos($functions, 'function get_guest_account(');
+	expect($start)->not->toBeFalse();
+	$body = substr($functions, $start, 400);
+	expect($body)->toContain("enabled = 'on'");
+});
+
+test('permission where-clauses cast the id to int rather than interpolating it raw', function () use ($auth) {
+	// the raw interpolations are gone
+	expect($auth)->not->toContain('" gl.id = $graph_id"');
+	expect($auth)->not->toContain('" h.id = $device_id"');
+	// and replaced with an int cast
+	expect(substr_count($auth, '(int) $graph_id'))->toBeGreaterThan(0);
+	expect($auth)->toContain('(int) $device_id');
+});
+
+test('the Secure cookie flag honours a forwarded-proto only when proxy trust is enabled', function () use ($global) {
+	$start = strpos($global, "session.cookie_secure");
+	expect($start)->not->toBeFalse();
+	// the forwarded-proto path is gated on proxy_headers so a client cannot force it
+	expect($global)->toContain("!empty(\$config['proxy_headers'])");
+	expect($global)->toContain('HTTP_X_FORWARDED_PROTO');
+});

--- a/tests/Unit/Security/PathTraversal/ClogWindowsFilenameTest.php
+++ b/tests/Unit/Security/PathTraversal/ClogWindowsFilenameTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression: clog_purge_logfile() protects the active log with a byte-for-byte
+ * name comparison. On Windows a name with a trailing dot/space or an alternate
+ * data stream (cacti.log::$DATA) passes the prefix check yet differs as a
+ * string, so the purge took the unlink() branch and deleted the live log.
+ * clog_validate_filename() now rejects those Windows-special forms.
+ */
+
+$source = file_get_contents(dirname(__DIR__, 4) . '/lib/clog_webapi.php');
+
+test('clog_validate_filename rejects an alternate-data-stream / drive colon', function () use ($source) {
+	$start = strpos($source, 'function clog_validate_filename(');
+	expect($start)->not->toBeFalse();
+	$body = substr($source, $start, 900);
+	expect($body)->toContain("strpos(\$file, ':') !== false");
+});
+
+test('clog_validate_filename rejects a trailing dot or space', function () use ($source) {
+	$start = strpos($source, 'function clog_validate_filename(');
+	$body  = substr($source, $start, 900);
+	expect($body)->toContain("preg_match('/[\\. ]\$/', \$file)");
+});
+
+test('the reject runs before the active-log prefix match', function () use ($source) {
+	$start   = strpos($source, 'function clog_validate_filename(');
+	$body    = substr($source, $start, 1200);
+	$reject  = strpos($body, 'return false;');
+	$prefix  = strpos($body, "strpos(\$file, \$logbase) === 0");
+	expect($reject)->not->toBeFalse();
+	expect($prefix)->not->toBeFalse();
+	expect($reject)->toBeLessThan($prefix);
+});

--- a/tests/Unit/Security/Shell/DsstatsLogEscapeTest.php
+++ b/tests/Unit/Security/Shell/DsstatsLogEscapeTest.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression: the path_dsstats_log setting is written into a shell redirect
+ * when relaunching poller_dsstats.php, and must be escaped like the identical
+ * path_rrdcheck_log redirect. An unescaped admin-set path could inject shell
+ * metacharacters into the background command.
+ */
+
+$dsstatsSource = file_get_contents(dirname(__DIR__, 4) . '/lib/dsstats.php');
+
+test('path_dsstats_log is wrapped in cacti_escapeshellarg in the log redirect', function () use ($dsstatsSource) {
+	expect($dsstatsSource)->not->toBeFalse();
+	// both the unix (>> ... 2>&1) and windows branches must escape the setting
+	expect(substr_count($dsstatsSource, "cacti_escapeshellarg(read_config_option('path_dsstats_log'))"))->toBe(2);
+	// the raw, unescaped redirect must be gone
+	expect($dsstatsSource)->not->toContain("'/poller_dsstats.php >> ' . read_config_option('path_dsstats_log')");
+});

--- a/tests/Unit/Security/Xss/AggregateGraphsLocalGraphIdEscapeTest.php
+++ b/tests/Unit/Security/Xss/AggregateGraphsLocalGraphIdEscapeTest.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression: on the aggregate_graphs action-confirmation render, local_graph_id
+ * is not integer-validated (the validating branches exit first), so it must be
+ * html_escape()'d before it is reflected into the hidden input value attribute.
+ */
+
+$source = file_get_contents(dirname(__DIR__, 4) . '/aggregate_graphs.php');
+
+test('local_graph_id is html_escaped where it is reflected into the hidden input', function () use ($source) {
+	expect($source)->not->toBeFalse();
+	expect($source)->toContain("html_escape(get_nfilter_request_var('local_graph_id'))");
+	// the raw reflection must be gone
+	expect($source)->not->toContain("? get_nfilter_request_var('local_graph_id'):0");
+});


### PR DESCRIPTION
Three 1.2.x hardening fixes, grouped so they are one review rather than three. Each is a separate commit; the files are byte-identical to the branches they came from.

**clog purge filename validation** — `clog_purge_logfile()` protects the active log only when the requested name string-equals it. On Windows a trailing dot or space, or an alternate data stream (`cacti.log.`, `cacti.log ` , `cacti.log::$DATA`), passes `clog_validate_filename()` yet differs as a string, so the purge takes the `unlink()` branch and the OS resolves the crafted name back to the live `cacti.log`. Windows-only, post-auth, bounded to the log directory.

**dsstats log and aggregate graph escaping** — `path_dsstats_log` reaches a shell sink unescaped, and `local_graph_id` reaches SQL from `aggregate_graphs.php` without casting.

**Auth hardening** — anonymous access survived the guest account being disabled; `get_allowed_*` permission filters took ids without an int cast; the Secure session cookie was not set behind a TLS-terminating proxy.

Tests: `ClogWindowsFilenameTest`, `DsstatsLogEscapeTest`, `AggregateGraphsLocalGraphIdEscapeTest`, `AuthHardeningTest`.

Supersedes #7842 and #7843.

Closes #7850
Closes #7860