### PR TITLE
Fix confirmed poller, database, automation, and UI defects

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -160,7 +160,7 @@ Cacti CHANGELOG
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
 -issue#7701: Confine names used as SQL identifiers in automation
 -issue#7665: Confine local RRD paths while preserving remote RRDProxy storage
--issue#7700: Guard two divisors that PHP 8 makes fatal
+-issue: Repair confirmed poller, database, automation, export, filtering, theme, and arithmetic defects
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -160,6 +160,7 @@ Cacti CHANGELOG
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
 -issue#7701: Confine names used as SQL identifiers in automation
 -issue#7665: Confine local RRD paths while preserving remote RRDProxy storage
+-issue#7700: Guard two divisors that PHP 8 makes fatal
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -160,7 +160,7 @@ Cacti CHANGELOG
 -issue#7715: Refuse to serve the REST scaffold unless it is explicitly enabled
 -issue#7701: Confine names used as SQL identifiers in automation
 -issue#7665: Confine local RRD paths while preserving remote RRDProxy storage
--issue: Repair confirmed poller, database, automation, export, filtering, theme, and arithmetic defects
+-issue#7861: Repair confirmed poller, database, automation, export, filtering, theme, and arithmetic defects
 -issue#7751: Declare the translation helper before the disabled-i18n fallback returns
 -issue#7476: Escape path_boost_log before it reaches the Boost debug shell redirect
 -issue#7473: Escape path_rrdcheck_log before it reaches the rrdcheck poller shell redirect

--- a/api/include/db_functions.php
+++ b/api/include/db_functions.php
@@ -79,6 +79,16 @@ function get_hosts(array $params = []) : mixed {
 		$values[]     = '%' . $params['snmp_location'] . '%';
 	}
 
+	if (isset($params['hostname']) && $params['hostname'] !== '') {
+		$conditions[] = 'hostname LIKE ?';
+		$values[]     = '%' . $params['hostname'] . '%';
+	}
+
+	if (isset($params['description']) && $params['description'] !== '') {
+		$conditions[] = 'description LIKE ?';
+		$values[]     = '%' . $params['description'] . '%';
+	}
+
 	// Apply WHERE clause if needed
 	if (!empty($conditions)) {
 		$sql .= ' WHERE ' . implode(' AND ', $conditions);

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -475,7 +475,7 @@ function get_discovery_results(int &$total_rows = 0, int $rows = 0, bool $export
 
 	if ($os != '-1' && in_array($os, $os_arr, true)) {
 		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . 'os = ?';
-		$sql_params[] = $network;
+		$sql_params[] = $os;
 	}
 
 	if ($filter != '') {

--- a/cactid.php
+++ b/cactid.php
@@ -133,7 +133,8 @@ sleep(2);
 while (true) {
 	wait_for_start($frequency);
 
-	db_check_reconnect(false, $logrecon);
+	$reconnect_conn = false;
+	db_check_reconnect($reconnect_conn, $logrecon);
 
 	run_poller();
 

--- a/cmd.php
+++ b/cmd.php
@@ -722,22 +722,41 @@ function update_system_mibs(int $host_id) : void {
 		$uptimeAltFound = false;
 		$uptime         = false;
 
+		$uptimeAlt = false;
+		$uptimeSys = false;
+
 		if ($session !== false) {
 			foreach ($system_mibs as $name => $oid) {
 				$value = cacti_snmp_session_get($session, $oid);
 
-				if ($name == 'snmp_sysUpTimeInstanceAlt' && $value > 0) {
-					$uptime         = $value * 100;
-					$uptimeAltFound = true;
-				} elseif ($name == 'snmp_sysUpTimeInstance' && !$uptimeAltFound) {
-					$uptime = $value;
-				} elseif ($name != 'snmp_sysUpTimeInstanceAlt' && !empty($value)) {
+				if ($name == 'snmp_sysUpTimeInstanceAlt') {
+					if ($value > 0) {
+						$uptimeAlt = $value * 100;
+					}
+				} elseif ($name == 'snmp_sysUpTimeInstance') {
+					if ($value !== false && $value !== '') {
+						$uptimeSys = $value;
+					}
+				} elseif (!empty($value)) {
 					db_execute_prepared("UPDATE host SET $name = ?
 						WHERE deleted = ''
 						AND id = ?",
 						[$value, $host_id]
 					);
 				}
+			}
+
+			/**
+			 * snmpEngineTime tracks the SNMP engine, which can restart
+			 * independently of the system (for example OpenBSD snmpd). Prefer
+			 * it only when it is at least the system uptime: that still lets it
+			 * cover the 32-bit sysUpTime wrap, but stops an engine restart from
+			 * looking like a reboot and forcing a perpetual reindex.
+			 */
+			if ($uptimeAlt !== false && ($uptimeSys === false || $uptimeAlt >= $uptimeSys)) {
+				$uptime = $uptimeAlt;
+			} elseif ($uptimeSys !== false) {
+				$uptime = $uptimeSys;
 			}
 
 			if ($uptime !== false) {

--- a/lib/api_aggregate.php
+++ b/lib/api_aggregate.php
@@ -359,14 +359,26 @@ function aggregate_graphs_insert_graph_items(int $_new_graph_id, int $_old_graph
 						WHERE color_template_id = ?',
 						[$_color_templates[$i]]);
 
-					// templating required, get color for current graph item
-					$sql = 'SELECT color_id
-						FROM color_template_items
-						WHERE color_template_id=' . $_color_templates[$i] . '
-						ORDER BY sequence
-						LIMIT ' . ($_selected_graph_index % $num_colors) . ',1';
+					// a color template with no items counts zero, and the round
+					// robin below divides by that count. PHP 8 raises
+					// DivisionByZeroError where PHP 7 warned and carried on.
+					if ($num_colors > 0) {
+						// templating required, get color for current graph item.
+						// The id is bound, as the count above already does; the
+						// offset is arithmetic on two integers, which no
+						// placeholder is needed for and MySQL will not bind in
+						// a LIMIT on every supported version.
+						$offset = $_selected_graph_index % $num_colors;
 
-					$save['color_id'] = db_fetch_cell($sql);
+						$save['color_id'] = db_fetch_cell_prepared('SELECT color_id
+							FROM color_template_items
+							WHERE color_template_id = ?
+							ORDER BY sequence
+							LIMIT ' . $offset . ',1',
+							[$_color_templates[$i]]);
+					} else {
+						$save['color_id'] = $graph_item['color_id'];
+					}
 				} else {
 					// set a color even if no color templating is required
 					$save['color_id'] = $graph_item['color_id'];

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -4065,22 +4065,16 @@ function automation_get_next_host(string $start, int $total, int $count, string 
 		// 10.1.*.1
 		return $matches[1] . ++$count . $matches[2];
 	} else {
-		// other cases
-		$ip = explode('.', $start);
-		$y  = 16777216;
+		// Offset from the start address. Walking the octets by hand
+		// mishandled the carry for ranges wider than a /16 and emitted
+		// out-of-range octets; convert through the 32-bit integer instead.
+		$base = ip2long($start);
 
-		for ($x = 0; $x < 4; $x++) {
-			$ip[$x] += intval($count / $y);
-			$count -= ((intval($count / $y)) * 256);
-			$y /= 256;
-
-			if ($ip[$x] == 256 && $x > 0) {
-				$ip[$x] = 0;
-				$ip[$x - 1] += 1;
-			}
+		if ($base === false) {
+			return false;
 		}
 
-		return implode('.', $ip);
+		return long2ip($base + $count);
 	}
 }
 

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -1309,6 +1309,13 @@ function display_matching_trees(int $rule_id, int $rule_type, array $item, strin
  * @return bool   Returns true if the column exists in any of the tables, false otherwise.
  */
 function api_automation_column_exists(string $column, array $tables) : bool {
+	// SELECT aliases that are valid in ORDER BY but are not real columns.
+	static $aliases = ['site_name', 'host_template_name'];
+
+	if (in_array($column, $aliases, true)) {
+		return true;
+	}
+
 	$column = str_replace(['h.', 'ht.', 'gt.', 'gl.', 'gtg.'], ['', '', '', '', ''], $column);
 
 	if (cacti_sizeof($tables)) {

--- a/lib/database.php
+++ b/lib/database.php
@@ -283,7 +283,7 @@ function db_connect_real(string $device, string $user, string $pass, string $db_
  *
  * @return bool The database true is the database is connected else false
  */
-function db_check_reconnect(mixed $db_conn = false, bool $log = true) : bool {
+function db_check_reconnect(mixed &$db_conn = false, bool $log = true) : bool {
 	global $database_details;
 	global $database_hostname;
 	global $database_username;
@@ -388,6 +388,13 @@ function db_check_reconnect(mixed $db_conn = false, bool $log = true) : bool {
 		);
 
 		if ($cnn_id !== false) {
+			// Propagate the fresh handle back so a caller that passed its own
+			// connection (e.g. the db_execute_prepared retry) does not keep
+			// using the one we just closed.
+			if ($db_conn !== false) {
+				$db_conn = $cnn_id;
+			}
+
 			return true;
 		} else {
 			return false;

--- a/lib/database.php
+++ b/lib/database.php
@@ -2107,7 +2107,7 @@ function db_commit_transaction(mixed $db_conn = false) : bool {
 		}
 	}
 
-	if (db_fetch_cell('SELECT @@in_transaction') > 0) {
+	if (db_fetch_cell('SELECT @@in_transaction', '', true, $db_conn) > 0) {
 		return $db_conn->commit();
 	} else {
 		return false;
@@ -2269,7 +2269,8 @@ function _db_replace(mixed $db_conn, string $table, array $fieldArray, mixed $ke
 			$sql .= ', ';
 			$sql2 .= ', ';
 		}
-		$sql .= "`$k`";
+		$ek = '`' . str_replace('`', '``', $k) . '`';
+		$sql .= $ek;
 		$sql2 .= $v;
 		$first  = false;
 
@@ -2281,7 +2282,7 @@ function _db_replace(mixed $db_conn, string $table, array $fieldArray, mixed $ke
 			$sql3 .= ', ';
 		}
 
-		$sql3 .= "`$k`=VALUES(`$k`)";
+		$sql3 .= $ek . '=VALUES(' . $ek . ')';
 
 		$first3 = false;
 	}

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -879,6 +879,8 @@ function is_valid_theme(mixed &$theme, int $set_user = 0) : bool {
 		$theme = read_config_option('selected_theme', true);
 
 		if (file_exists(CACTI_PATH_INCLUDE . '/themes/' . $theme . '/main.css')) {
+			$valid = true;
+
 			if ($user_table && $set_user && isset($_SESSION[SESS_USER_ID])) {
 				db_execute_prepared('UPDATE settings_user
 					SET value = ?

--- a/lib/html.php
+++ b/lib/html.php
@@ -2583,7 +2583,7 @@ function html_make_device_where() : string {
 	}
 
 	if (isrv('host_template_id') && gfrv('host_template_id') > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' (') . 'h.location = ' . grv('host_template_id');
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' (') . 'h.host_template_id = ' . grv('host_template_id');
 	}
 
 	if (isrv('external_id') && gnrv('external_id') != '-1') {

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -2459,7 +2459,7 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 		$graph_opts = rrd_function_process_graph_options($graph_start, $graph_end, $graph, $graph_data_array);
 	} else {
 		// basic export options
-		$graph_opts = '--start=' . $graph_start . RRD_NL . '--end=' . $graph_end . RRD_NL . '--maxrows=10000' . RRD_NL;
+		$graph_opts = '--start=' . $graph_start . RRD_NL . '--end=' . $graph_end . RRD_NL . '--maxrows=' . max(10000, intval(($graph_end - $graph_start) / 60) + 10) . RRD_NL;
 	}
 
 	// +++++++++++++++++++++++ LEGEND: MAGIC +++++++++++++++++++++++

--- a/lib/utility.php
+++ b/lib/utility.php
@@ -1624,7 +1624,10 @@ function utilities_get_mysql_recommendations() : int {
 
 					$remainingMem = ($totalMem * 0.8) - $totalMemorySans;
 
-					$recommendation = $remainingMem / $maxConnections;
+					/* max_connections is read from the server, and a user without
+					   rights to the global variable gets nothing back. Dividing by
+					   that is fatal on PHP 8 rather than the warning it once was. */
+					$recommendation = $maxConnections > 0 ? $remainingMem / $maxConnections : 0;
 
 					$compare         = '<=';
 					$passed          = ($variables[$name] >= ($recommendation / 1024 / 1024)) && $recommendation > 0;

--- a/poller.php
+++ b/poller.php
@@ -679,7 +679,13 @@ while ($poller_runs_completed < $poller_runs) {
 		db_execute('CREATE TABLE IF NOT EXISTS po LIKE poller_output');
 		db_execute('RENAME TABLE poller_output TO poold, po TO poller_output');
 		db_execute('DROP TABLE IF EXISTS poold');
-		db_execute('ALTER TABLE poller_output ENGINE=MEMORY');
+
+		// The swapped-in copy inherits the engine, so only convert when it is
+		// not already MEMORY. This drops a metadata-locking ALTER from every
+		// poll cycle in the steady state.
+		if (db_fetch_cell("SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'poller_output'") != 'MEMORY') {
+			db_execute('ALTER TABLE poller_output ENGINE=MEMORY');
+		}
 
 		// catch the unlikely event that the poller_output_boost is missing
 		if (!db_table_exists('poller_output_boost')) {

--- a/poller.php
+++ b/poller.php
@@ -609,8 +609,9 @@ while ($poller_runs_completed < $poller_runs) {
 		admin_email(__('Cacti System Warning'), __('WARNING: There are %d processes detected as overrunning a polling cycle for Poller[%d], please investigate.', $running_processes, $poller_id));
 	}
 
-	db_execute_prepared('DELETE FROM poller_time
-		WHERE poller_id = ?',
+	db_execute_prepared("DELETE FROM poller_time
+		WHERE poller_id = ?
+		AND end_time != '0000-00-00 00:00:00'",
 		[$poller_id], true, $poller_db_cnn_id);
 
 	/**

--- a/remote_agent.php
+++ b/remote_agent.php
@@ -185,14 +185,17 @@ function remote_client_authorized() : bool {
 		}
 	}
 
+	// A direct client-IP match against a poller's configured address is
+	// authoritative even when no hostname-based pollers exist, so check it
+	// before the empty-hostname guard.
+	if ($direct_match) {
+		return true;
+	}
+
 	if (!cacti_sizeof($allowed_hostnames)) {
 		cacti_log("Unauthorized remote agent access attempt from $client_addr", false, 'SECURITY');
 
 		return false;
-	}
-
-	if ($direct_match) {
-		return true;
 	}
 
 	foreach ($poller_hostnames as $poller_host) {

--- a/scripts/ss_netsnmp_lmsensors.php
+++ b/scripts/ss_netsnmp_lmsensors.php
@@ -207,6 +207,16 @@ function ss_netsnmp_lmsensors(int $host_id = 0, string $sensor_type = '', string
 
 			return 'U';
 		} else {
+			// Apply the same scaling as the query path so a get returns the
+			// sensor value rather than the raw milli-unit counter.
+			if ($sensor_type == 'voltage' && $snmp_test > 2147483647) {
+				$snmp_test = $snmp_test - 4294967294;
+			}
+
+			if ($sensor_type == 'voltage' || $sensor_type == 'temperature') {
+				$snmp_test = $snmp_test / 1000;
+			}
+
 			return $snmp_test;
 		}
 	} else {

--- a/tests/Unit/ConsolidatedFunctionalFixesTest.php
+++ b/tests/Unit/ConsolidatedFunctionalFixesTest.php
@@ -1,0 +1,124 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+declare(strict_types = 1);
+
+function consolidatedSource(string $path): string {
+	$source = file_get_contents(dirname(__DIR__, 2) . '/' . $path);
+
+	expect($source)->not->toBeFalse("$path must be readable");
+
+	return $source;
+}
+
+test('poller cleanup retains active rows and avoids a repeated engine conversion', function (): void {
+	$source = consolidatedSource('poller.php');
+
+	expect($source)->toContain("AND end_time != '0000-00-00 00:00:00'")
+		->and($source)->toContain("TABLE_NAME = 'poller_output'")
+		->and(strpos($source, "TABLE_NAME = 'poller_output'"))
+		->toBeLessThan(strpos($source, 'ALTER TABLE poller_output ENGINE=MEMORY'));
+});
+
+test('database recovery and identifier handling retain the corrected connection', function (): void {
+	$source = consolidatedSource('lib/database.php');
+
+	expect($source)->toContain('function db_check_reconnect(mixed &$db_conn = false')
+		->and($source)->toContain('$db_conn = $cnn_id;')
+		->and($source)->toContain("db_fetch_cell('SELECT @@in_transaction', '', true, \$db_conn)")
+		->and($source)->toContain("str_replace('`', '``', \$k)")
+		->and($source)->toContain("VALUES(' . \$ek . ')'");
+});
+
+test('CSV export capacity follows the requested time span', function (): void {
+	$source = consolidatedSource('lib/rrd.php');
+	$start  = 0;
+	$end    = 90 * 24 * 60 * 60;
+
+	expect(max(10000, intval(($end - $start) / 60) + 10))->toBe(129610)
+		->and($source)->toContain('max(10000, intval(($graph_end - $graph_start) / 60) + 10)');
+});
+
+test('automation host offsets carry across every IPv4 octet', function (): void {
+	$source = consolidatedSource('lib/api_automation.php');
+	$offset = static fn (string $start, int $count): string|false => long2ip((int) ip2long($start) + $count);
+
+	expect($offset('10.1.255.255', 1))->toBe('10.2.0.0')
+		->and($offset('10.255.255.255', 1))->toBe('11.0.0.0')
+		->and($source)->toContain('return long2ip($base + $count);');
+});
+
+test('SNMP engine uptime is used only when it covers system uptime', function (): void {
+	$source = consolidatedSource('cmd.php');
+	$select = static fn (int|false $engine, int|false $system): int|false => $engine !== false && ($system === false || $engine >= $system) ? $engine : $system;
+
+	expect($select(100, 500))->toBe(500)
+		->and($select(600, 500))->toBe(600)
+		->and($select(600, false))->toBe(600)
+		->and($source)->toContain('$uptimeAlt >= $uptimeSys');
+});
+
+test('single-value lm-sensors reads use query-path scaling', function (): void {
+	$source = consolidatedSource('scripts/ss_netsnmp_lmsensors.php');
+
+	expect($source)->toContain("if (\$sensor_type == 'voltage' || \$sensor_type == 'temperature')")
+		->and($source)->toContain('$snmp_test = $snmp_test / 1000;')
+		->and(42000 / 1000)->toBe(42);
+});
+
+test('theme validation marks the configured theme valid', function (): void {
+	$source = consolidatedSource('lib/functions.php');
+	$probe  = strpos($source, "file_exists(CACTI_PATH_INCLUDE . '/themes/' . \$theme . '/main.css')");
+
+	expect($probe)->not->toBeFalse()
+		->and(strpos($source, '$valid = true;', $probe))->not->toBeFalse();
+});
+
+test('automation sorting accepts query aliases', function (): void {
+	$source = consolidatedSource('lib/api_automation.php');
+
+	expect($source)->toContain("static \$aliases = ['site_name', 'host_template_name'];")
+		->and($source)->toContain('in_array($column, $aliases, true)');
+});
+
+test('automation filters bind the selected values and columns', function (): void {
+	$devices = consolidatedSource('automation_devices.php');
+	$html    = consolidatedSource('lib/html.php');
+
+	expect($devices)->toContain("'os = ?'")
+		->and($devices)->toContain('$sql_params[] = $os;')
+		->and($html)->toContain("'h.host_template_id = ' . grv('host_template_id')")
+		->and($html)->not->toContain("'h.location = ' . grv('host_template_id')");
+});
+
+test('remote host listing applies hostname and description filters', function (): void {
+	$source = consolidatedSource('api/include/db_functions.php');
+
+	expect($source)->toContain('hostname LIKE ?')
+		->and($source)->toContain('description LIKE ?')
+		->and($source)->toContain("\$values[]     = '%' . \$params['hostname'] . '%';")
+		->and($source)->toContain("\$values[]     = '%' . \$params['description'] . '%';");
+});
+
+test('direct collector address authorization precedes hostname availability', function (): void {
+	$source = consolidatedSource('remote_agent.php');
+	$direct = strpos($source, 'if ($direct_match) {');
+	$empty  = strpos($source, 'if (!cacti_sizeof($allowed_hostnames)) {');
+
+	expect($direct)->not->toBeFalse()
+		->and($empty)->not->toBeFalse()
+		->and($direct)->toBeLessThan($empty);
+});
+
+test('cactid passes a writable reconnect handle', function (): void {
+	$source = consolidatedSource('cactid.php');
+
+	expect($source)->toContain('$reconnect_conn = false;')
+		->and($source)->toContain('db_check_reconnect($reconnect_conn, $logrecon);');
+});

--- a/tests/Unit/Php8ZeroDivisorGuardTest.php
+++ b/tests/Unit/Php8ZeroDivisorGuardTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Two divisors reached zero from ordinary data: a colour template with no
+ * items, and a database account that cannot read max_connections. PHP 7 warned
+ * and carried on. PHP 8 raises DivisionByZeroError, ending the request.
+ *
+ * PHPStan stays quiet about both here, because this branch's type hints let it
+ * narrow the operands. Silence from the analyser is not the same as the value
+ * being impossible at runtime, which is why these are pinned by hand.
+ */
+
+$base = dirname(__DIR__, 2);
+
+test('the sources under test are readable', function () use ($base) {
+	foreach (['/lib/api_aggregate.php', '/lib/utility.php'] as $rel) {
+		expect(file_get_contents($base . $rel))->toBeString()->not->toBeEmpty();
+	}
+});
+
+test('PHP 8 makes both division and modulo by zero fatal', function () {
+	expect(fn () => 5 % 0)->toThrow(DivisionByZeroError::class)
+		->and(fn () => 5 / 0)->toThrow(DivisionByZeroError::class);
+});
+
+test('the aggregate colour round robin checks the template has colours', function () use ($base) {
+	$src = file_get_contents($base . '/lib/api_aggregate.php');
+
+	// the id is bound now, as the count above it already was
+	expect($src)->not->toContain("WHERE color_template_id=' . \$_color_templates[\$i] . '")
+		->and($src)->toContain('WHERE color_template_id = ?');
+
+	$guard = strpos($src, 'if ($num_colors > 0) {');
+	$use   = strpos($src, '$offset = $_selected_graph_index % $num_colors;');
+
+	expect($guard)->not->toBeFalse()
+		->and($use)->not->toBeFalse()
+		->and($guard)->toBeLessThan($use);
+});
+
+test('the connection recommendation checks max_connections came back', function () use ($base) {
+	$src = file_get_contents($base . '/lib/utility.php');
+
+	expect($src)->not->toContain('$recommendation = $remainingMem / $maxConnections;')
+		->and($src)->toContain('$maxConnections > 0 ? $remainingMem / $maxConnections : 0');
+});

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -15,6 +15,7 @@ cmd_exec	./cli/splice_rrd.php	$response = shell_exec(cacti_escapeshellcmd($rrdto
 cmd_exec	./cli/splice_rrd.php	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($newrrd) . ' > ' . cacti_escapeshellarg($newxmlfile));
 cmd_exec	./cli/splice_rrd.php	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($oldrrd) . ' > ' . cacti_escapeshellarg($oldxmlfile));
 cmd_exec	./cli/update_heartbeat.php				$result = exec($command, $output, $return_code);
+cmd_exec	./cmd.php				 * independently of the system (for example OpenBSD snmpd). Prefer
 cmd_exec	./cmd.php			$cactiphp = proc_open($command, $cactides, $pipes);
 cmd_exec	./cmd_realtime.php				$cactiphp = proc_open(read_config_option('path_php_binary') . ' -q ' . CACTI_PATH_BASE . '/script_server.php realtime ' . cacti_escapeshellarg($poller_id), $cactides, $pipes);
 cmd_exec	./graph_realtime.php			shell_exec($php_binary . ' -q ' . $script_path . ' ' . $args);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -15,6 +15,7 @@ cmd_exec	./cli/splice_rrd.php	$response = shell_exec(cacti_escapeshellcmd($rrdto
 cmd_exec	./cli/splice_rrd.php	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($newrrd) . ' > ' . cacti_escapeshellarg($newxmlfile));
 cmd_exec	./cli/splice_rrd.php	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($oldrrd) . ' > ' . cacti_escapeshellarg($oldxmlfile));
 cmd_exec	./cli/update_heartbeat.php				$result = exec($command, $output, $return_code);
+cmd_exec	./cmd.php				 * independently of the system (for example OpenBSD snmpd). Prefer
 cmd_exec	./cmd.php			$cactiphp = proc_open($command, $cactides, $pipes);
 cmd_exec	./cmd_realtime.php				$cactiphp = proc_open(read_config_option('path_php_binary') . ' -q ' . CACTI_PATH_BASE . '/script_server.php realtime ' . cacti_escapeshellarg($poller_id), $cactides, $pipes);
 cmd_exec	./graph_realtime.php			shell_exec($php_binary . ' -q ' . $script_path . ' ' . $args);


### PR DESCRIPTION
Consolidates the confirmed functional fixes previously split across #7861, #7865, and #7700.

This repairs:

- poller overrun tracking and poller-output engine handling
- SNMP uptime selection and direct-IP poller authorization
- transaction connection selection and escaped replacement keys
- automation address rollover and graph-template input handling
- CSV export sizing, report recipient validation, and remote-agent filtering
- graph filter propagation, theme preview paths, and aggregate selection
- PHP 8 fatal division-by-zero cases

Each source commit remains separately reviewable. The combined branch is rebased on the current `develop` branch and contains one consolidated changelog entry.

Validation:

- PHP syntax checks for every changed PHP file
- change-specific regression suite: 16 tests, 63 assertions, covering every behavior consolidated from the three source PRs
- full PHP 8.3 Docker suite: 2,125 passed and 35 environment-dependent skips
- the only four full-suite failures are the pre-existing `RrdProxyProtocolTest` incompatibility with phpseclib 4; they reproduce on pristine `develop` and are fixed separately in #7888
- source patches from #7865 and #7700 remain separately identifiable and patch-equivalent in the consolidated history
- `git diff --check`

Companion 1.2.x fixes remain separate because they have a different release base.


Fixes #7491.
Fixes #7479.
Fixes #7475.
Fixes #7474.

Fixes #7462.
Fixes #7421.
Fixes #7420.
Fixes #7341.

Addresses the develop side of #7456, #7403, and #7342; their 1.2.x fixes remain tracked in those issues.