### PR TITLE
fix: poller overrun cleanup and CSV export row cap

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1671,7 +1671,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 		$graph_opts =
 			'--start=' . cacti_escapeshellarg($graph_start) . RRD_NL .
 			'--end=' . cacti_escapeshellarg($graph_end) . RRD_NL .
-			'--maxrows=10000' . RRD_NL;
+			'--maxrows=' . max(10000, intval(($graph_end - $graph_start) / 60) + 10) . RRD_NL;
 	}
 
 	/* +++++++++++++++++++++++ LEGEND: MAGIC +++++++++++++++++++++++ */

--- a/poller.php
+++ b/poller.php
@@ -549,8 +549,9 @@ while ($poller_runs_completed < $poller_runs) {
 		admin_email(__('Cacti System Warning'), __('WARNING: There are %d processes detected as overrunning a polling cycle for poller id %d, please investigate.', $running_processes, $poller_id));
 	}
 
-	db_execute_prepared('DELETE FROM poller_time
-		WHERE poller_id = ?',
+	db_execute_prepared("DELETE FROM poller_time
+		WHERE poller_id = ?
+		AND end_time != '0000-00-00 00:00:00'",
 		array($poller_id), true, $poller_db_cnn_id);
 
 	/**

--- a/poller.php
+++ b/poller.php
@@ -633,7 +633,13 @@ while ($poller_runs_completed < $poller_runs) {
 		db_execute('CREATE TABLE IF NOT EXISTS po LIKE poller_output');
 		db_execute('RENAME TABLE poller_output TO poold, po TO poller_output');
 		db_execute('DROP TABLE IF EXISTS poold');
-		db_execute('ALTER TABLE poller_output ENGINE=MEMORY');
+
+		// The swapped-in copy inherits the engine, so only convert when it is
+		// not already MEMORY. This drops a metadata-locking ALTER from every
+		// poll cycle in the steady state.
+		if (db_fetch_cell("SELECT ENGINE FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'poller_output'") != 'MEMORY') {
+			db_execute('ALTER TABLE poller_output ENGINE=MEMORY');
+		}
 
 		// catch the unlikely event that the poller_output_boost is missing
 		if (!db_table_exists('poller_output_boost')) {


### PR DESCRIPTION
Three confirmed bugs present on 1.2.x, each validated in a Cacti Docker container.

- issue#7024: the overrun cleanup deleted still-running poller_time rows, breaking process tracking. Restricted to completed rows.
- issue#7030: the poller_output refresh ran ALTER TABLE ... ENGINE=MEMORY every cycle. Now guarded by an engine probe so the steady state skips it.
- issue#7341: the CSV export hardcoded --maxrows=10000, truncating wide date ranges. Sized to the span now.

Companion develop PR (which also restores three develop-only regressions): #7861. The 1.2.x package-signature fix is in #7863.

Fixes #7341.