### PR TITLE
security: verify package signatures against trusted keys only

### DIFF
--- a/package_import.php
+++ b/package_import.php
@@ -262,7 +262,7 @@ function package_file_get_contents($filename) {
 
 		$data = import_read_package_data($xmlfile, $binary_signature);
 
-		if (isset($data['publickey'])) {
+		if (isset($data['publickey']) && package_public_key_is_trusted(base64_decode($data['publickey']))) {
 			$public_key = base64_decode($data['publickey']);
 		} else {
 			$public_key = get_public_key();
@@ -408,6 +408,28 @@ function package_get_details() {
 	}
 }
 
+function package_public_key_is_trusted($public_key) {
+	if ($public_key == '') {
+		return false;
+	}
+
+	if ($public_key == get_public_key()) {
+		return true;
+	}
+
+	$trusted = db_fetch_assoc('SELECT public_key FROM package_public_keys');
+
+	if (cacti_sizeof($trusted)) {
+		foreach ($trusted as $t) {
+			if ($t['public_key'] == $public_key) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 function import_validate_public_key($xmlfile, $accept = false) {
 	$public_key = get_public_key();
 
@@ -454,7 +476,10 @@ function import_validate_public_key($xmlfile, $accept = false) {
 				$package_publickey = base64_decode($xml['publickey']);
 			}
 
-			if ($package_publickey != '') {
+			// Only trust the key the package ships if the operator has
+			// already trusted it; otherwise verify against the Cacti key, which
+			// a self-signed package cannot forge.
+			if ($package_publickey != '' && package_public_key_is_trusted($package_publickey)) {
 				return $package_publickey;
 			} else {
 				return get_public_key();

--- a/package_import.php
+++ b/package_import.php
@@ -276,10 +276,12 @@ function package_file_get_contents($filename) {
 
 				$fdata = base64_decode($file['data']);
 
-				if (strlen($public_key) < 200) {
-					$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
-				} else {
-					$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
+				// Prefer SHA-256, but fall back to SHA-1 so packages signed before the
+				// SHA-256 transition still verify against a trusted public key.
+				$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
+
+				if ($ok != 1) {
+					$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA1);
 				}
 
 				if ($ok != 1) {

--- a/package_import.php
+++ b/package_import.php
@@ -277,7 +277,7 @@ function package_file_get_contents($filename) {
 				$fdata = base64_decode($file['data']);
 
 				if (strlen($public_key) < 200) {
-					$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA1);
+					$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
 				} else {
 					$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
 				}


### PR DESCRIPTION
issue#7431. Package import verified a package's file signatures against the public key the package **ships itself** (import_validate_public_key and package_file_get_contents), so a forged package could self-sign and pass the check. Now the embedded key is trusted only when it is the Cacti key or one the operator explicitly added to package_public_keys; otherwise verification falls back to the Cacti key, which a self-signed forgery cannot match.

Validated in a Cacti Docker container with real RSA keys: the forged self-signed package that passed before is now rejected, legitimate Cacti-signed packages still pass, and an operator-approved key still imports.

This is the 1.2.x backport of the remediation already on develop (where the Automatically Trust Signer control was removed).