### PR TITLE
security: verify package signatures with SHA-256, drop the SHA-1 fallback

### DIFF
--- a/package_import.php
+++ b/package_import.php
@@ -656,7 +656,7 @@ function package_file_get_contents(string $package_location, string $package_fil
 				$fdata = base64_decode($file['data'], true);
 
 				// provide two checks against the public key
-				$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA1);
+				$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
 
 				if ($ok != 1) {
 					$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
@@ -704,7 +704,7 @@ function package_file_get_contents(string $package_location, string $package_fil
 					$fdata = base64_decode($file['data'], true);
 
 					// provide two checks against the public key
-					$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA1);
+					$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);
 
 					if ($ok != 1) {
 						$ok = openssl_verify($fdata, $binary_signature, $public_key, OPENSSL_ALGO_SHA256);


### PR DESCRIPTION
issue#7026. package_import.php chose SHA-1 to verify signatures when the public key was short (< 200 chars), so a package signed with the weak, forgeable SHA-1 passed verification. Always verify with SHA-256.

Docker-validated with real RSA keys: a SHA-1 signature is now rejected, a legitimate SHA-256 signature still verifies. Companion 1.2.x fix is in #7863.