### PR TITLE
fix: functional bug batch (theme, automation sort/filters, device where, REST filters)

### DIFF
--- a/api/include/db_functions.php
+++ b/api/include/db_functions.php
@@ -79,6 +79,16 @@ function get_hosts(array $params = []) : mixed {
 		$values[]     = '%' . $params['snmp_location'] . '%';
 	}
 
+	if (isset($params['hostname']) && $params['hostname'] !== '') {
+		$conditions[] = 'hostname LIKE ?';
+		$values[]     = '%' . $params['hostname'] . '%';
+	}
+
+	if (isset($params['description']) && $params['description'] !== '') {
+		$conditions[] = 'description LIKE ?';
+		$values[]     = '%' . $params['description'] . '%';
+	}
+
 	// Apply WHERE clause if needed
 	if (!empty($conditions)) {
 		$sql .= ' WHERE ' . implode(' AND ', $conditions);

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -475,7 +475,7 @@ function get_discovery_results(int &$total_rows = 0, int $rows = 0, bool $export
 
 	if ($os != '-1' && in_array($os, $os_arr, true)) {
 		$sql_where .= ($sql_where != '' ? ' AND ' : 'WHERE ') . 'os = ?';
-		$sql_params[] = $network;
+		$sql_params[] = $os;
 	}
 
 	if ($filter != '') {

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -1309,6 +1309,13 @@ function display_matching_trees(int $rule_id, int $rule_type, array $item, strin
  * @return bool   Returns true if the column exists in any of the tables, false otherwise.
  */
 function api_automation_column_exists(string $column, array $tables) : bool {
+	// SELECT aliases that are valid in ORDER BY but are not real columns.
+	static $aliases = ['site_name', 'host_template_name'];
+
+	if (in_array($column, $aliases, true)) {
+		return true;
+	}
+
 	$column = str_replace(['h.', 'ht.', 'gt.', 'gl.', 'gtg.'], ['', '', '', '', ''], $column);
 
 	if (cacti_sizeof($tables)) {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -879,6 +879,8 @@ function is_valid_theme(mixed &$theme, int $set_user = 0) : bool {
 		$theme = read_config_option('selected_theme', true);
 
 		if (file_exists(CACTI_PATH_INCLUDE . '/themes/' . $theme . '/main.css')) {
+			$valid = true;
+
 			if ($user_table && $set_user && isset($_SESSION[SESS_USER_ID])) {
 				db_execute_prepared('UPDATE settings_user
 					SET value = ?

--- a/lib/html.php
+++ b/lib/html.php
@@ -2583,7 +2583,7 @@ function html_make_device_where() : string {
 	}
 
 	if (isrv('host_template_id') && gfrv('host_template_id') > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ' : ' (') . 'h.location = ' . grv('host_template_id');
+		$sql_where .= ($sql_where != '' ? ' AND ' : ' (') . 'h.host_template_id = ' . grv('host_template_id');
 	}
 
 	if (isrv('external_id') && gnrv('external_id') != '-1') {

--- a/remote_agent.php
+++ b/remote_agent.php
@@ -185,14 +185,17 @@ function remote_client_authorized() : bool {
 		}
 	}
 
+	// A direct client-IP match against a poller's configured address is
+	// authoritative even when no hostname-based pollers exist, so check it
+	// before the empty-hostname guard.
+	if ($direct_match) {
+		return true;
+	}
+
 	if (!cacti_sizeof($allowed_hostnames)) {
 		cacti_log("Unauthorized remote agent access attempt from $client_addr", false, 'SECURITY');
 
 		return false;
-	}
-
-	if ($direct_match) {
-		return true;
 	}
 
 	foreach ($poller_hostnames as $poller_host) {


### PR DESCRIPTION
Five self-contained functional bugs, each Docker-validated.

- issue#7474: is_valid_theme() returned false even after correcting the theme to selected_theme (never set $valid).
- issue#7462: site_name/host_template_name are SELECT aliases valid in ORDER BY; api_automation_column_exists() rejected them so the site-name sort silently failed.
- issue#7456: automation_devices OS filter bound the network value instead of the OS value.
- issue#7491: html_make_device_where() filtered h.location against the host_template_id value instead of h.host_template_id.
- issue#7479: REST get_hosts() ignored the hostname/description filters callers pass; added as bound LIKE.