### PR TITLE
hardening: predictable import temp name and unsanitized table-filter search

### DIFF
--- a/graphs.php
+++ b/graphs.php
@@ -3207,7 +3207,7 @@ function create_graphs_filter(string $session_var) : array {
 					'method'         => 'drop_array',
 					'friendly_name'  => __('Template'),
 					'filter'         => FILTER_VALIDATE_REGEXP,
-					'filter_options' => ['options' => ['regexp' => '(cg_[0-9]|dq_[0-9]|[\-0-9])']],
+					'filter_options' => ['options' => ['regexp' => '/^(cg_[0-9]+|dq_[0-9]+|-?[0-9]+)$/']],
 					'default'        => '-1',
 					'pageset'        => true,
 					'array'          => $normalized_templates,

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -5049,7 +5049,7 @@ function check_reset_no_authentication(int $auth_method) : bool {
 
 		$_SESSION[SESS_USER_ID]         = $admin_id;
 		$_SESSION[SESS_CHANGE_PASSWORD] = true;
-		header('Location: ' . CACTI_PATH_URL . 'auth_changepassword.php?action=force&ref=' . ($_SERVER['HTTP_REFERER'] ?? 'index.php'));
+		header('Location: ' . CACTI_PATH_URL . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url($_SERVER['HTTP_REFERER'] ?? 'index.php')));
 
 		exit;
 	}

--- a/lib/html_filter.php
+++ b/lib/html_filter.php
@@ -124,7 +124,8 @@ class CactiTableFilter {
 					'filter' => [
 						'method'         => 'textbox',
 						'friendly_name'  => __('Search'),
-						'filter'         => FILTER_DEFAULT,
+						'filter'         => FILTER_CALLBACK,
+						'options'        => ['options' => 'sanitize_search_string'],
 						'placeholder'    => __('Enter a search term'),
 						'size'           => '30',
 						'default'        => '',

--- a/lib/package.php
+++ b/lib/package.php
@@ -309,7 +309,7 @@ function get_package_contents(string $export_type, int $export_item_id, bool $in
 		$output .= '<div class="formHeader"><div class="formHeaderText">' . __('Graph Templates') . '</div></div>';
 
 		foreach ($graph_templates as $t) {
-			$output .= '<div class="formRow"><div class="formColumnLeft nowrap">' . $t['name'] . '</div></div>';
+			$output .= '<div class="formRow"><div class="formColumnLeft nowrap">' . htmle($t['name']) . '</div></div>';
 		}
 
 		$output .= '</div>';
@@ -320,7 +320,7 @@ function get_package_contents(string $export_type, int $export_item_id, bool $in
 		$output .= '<div class="formHeader"><div class="formHeaderText">' . __('Data Queries') . '</div></div>';
 
 		foreach ($queries as $q) {
-			$output .= '<div class="formRow"><div class="formColumnLeft nowrap">' . $q['name'] . '</div></div>';
+			$output .= '<div class="formRow"><div class="formColumnLeft nowrap">' . htmle($q['name']) . '</div></div>';
 		}
 
 		$output .= '</div>';
@@ -331,7 +331,7 @@ function get_package_contents(string $export_type, int $export_item_id, bool $in
 		$output .= '<div class="formHeader"><div class="formHeaderText">' . __('Data Query Graph Templates') . '</div></div>';
 
 		foreach ($graph_templates as $t) {
-			$output .= '<div class="formRow"><div class="formColumnLeft nowrap">' . $t['name'] . '</div></div>';
+			$output .= '<div class="formRow"><div class="formColumnLeft nowrap">' . htmle($t['name']) . '</div></div>';
 		}
 
 		$output .= '</div>';

--- a/package_import.php
+++ b/package_import.php
@@ -492,7 +492,7 @@ function form_save() : void {
 
 			$_SESSION['sess_import_package'] = file_get_contents($xmlfile);
 		} elseif (isset($_SESSION['sess_import_package'])) {
-			$xmlfile = sys_get_temp_dir() . '/package_import_' . rand();
+			$xmlfile = tempnam(sys_get_temp_dir(), 'package_import_');
 
 			file_put_contents($xmlfile, $_SESSION['sess_import_package']);
 
@@ -637,7 +637,7 @@ function package_file_get_contents(string $package_location, string $package_fil
 			}
 		}
 	} elseif (isset($_SESSION['sess_import_package'])) {
-		$xmlfile = sys_get_temp_dir() . '/package_import_' . rand();
+		$xmlfile = tempnam(sys_get_temp_dir(), 'package_import_');
 
 		$binary_signature = '';
 
@@ -846,7 +846,7 @@ function package_verify_key() : void {
 			}
 		}
 	} elseif (isset($_SESSION['sess_import_package'])) {
-		$xmlfile = sys_get_temp_dir() . '/package_import_' . rand();
+		$xmlfile = tempnam(sys_get_temp_dir(), 'package_import_');
 
 		file_put_contents($xmlfile, $_SESSION['sess_import_package']);
 
@@ -946,7 +946,7 @@ function package_accept_key() : void {
 			}
 		}
 	} elseif (isset($_SESSION['sess_import_package'])) {
-		$xmlfile = sys_get_temp_dir() . '/package_import_' . rand();
+		$xmlfile = tempnam(sys_get_temp_dir(), 'package_import_');
 
 		file_put_contents($xmlfile, $_SESSION['sess_import_package']);
 

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -501,7 +501,7 @@ header_redirect	./lib/auth.php					header('Location: graph_view.php');
 header_redirect	./lib/auth.php					header('Location: index.php');
 header_redirect	./lib/auth.php				header('Location: ' . CACTI_PATH_URL . 'graph_view.php' . ($newtheme ? '?newtheme=1' : ''));
 header_redirect	./lib/auth.php				header('Location: auth_changepassword.php');
-header_redirect	./lib/auth.php			header('Location: ' . CACTI_PATH_URL . 'auth_changepassword.php?action=force&ref=' . ($_SERVER['HTTP_REFERER'] ?? 'index.php'));
+header_redirect	./lib/auth.php			header('Location: ' . CACTI_PATH_URL . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url($_SERVER['HTTP_REFERER'] ?? 'index.php')));
 header_redirect	./lib/clog_webapi.php				header('Location: clog.php?filename=' . basename($logfile));
 header_redirect	./lib/clog_webapi.php			header('Location: ' . get_current_page());
 header_redirect	./lib/functions.php		header('Location: ' . cacti_url(sanitize_redirect_path($path), $params));


### PR DESCRIPTION
Post-auth hardening and regression fixes, each Docker-validated.

- issue#7492: package import wrote to a predictable sys_get_temp_dir()/package_import_<rand()> name (local race/symlink); now uses tempnam().
- issue#7451: the shared CactiTableFilter Search box validated its term with FILTER_DEFAULT; now uses FILTER_CALLBACK + sanitize_search_string.
- issue#7450 / issue#7443: check_reset_no_authentication() reflected raw HTTP_REFERER into the auth_changepassword ref= (open redirect / header injection); wrapped in urlencode(validate_redirect_url()), restoring the guard 1.2.x already has.
- issue#7490: graphs.php template_id filter used an unanchored regex (validation bypass into explode()/SQL); anchored to match the hardened sibling filters.

Fixes #7492.
Addresses the develop side of #7490; the 1.2.x side remains tracked there.

Fixes #7460.
Fixes #7453.
Fixes #7451.
Fixes #7450.
Fixes #7443.