### PR TITLE
fix: prevent cookie domain login loops

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@ Cacti CHANGELOG
 -issue: Correct octet carry in automation_get_next_host for wide ranges (PR #7410)
 -issue: Commit transaction check uses the passed connection (PR #7409)
 -issue: Memoize db_get_table_column_types to cut redundant SHOW COLUMNS (1.2.x backport) (PR #7382)
+-issue#7829: Fall back to host-only cookies when the configured session cookie domain cannot match
 -feature#7246: It should be possible to change the Device of a Graph if both Devices include the Data Query
 -feature#7364: Allow Users to Choose to Hide Graph Template on Site Trees
 -feature#7388: Allow admin to pass CSV file to change device script for bulk changes

--- a/include/config.php.dist
+++ b/include/config.php.dist
@@ -79,7 +79,9 @@ $url_path = '/cacti/';
 $cacti_session_name = 'Cacti';
 
 /**
- * Default Cookie domain - The cookie domain to be used for Cacti
+ * Optional cookie domain. This must match the browser-visible host or one of
+ * its parent domains. Leave it unset for a host-only cookie. Use $url_path and
+ * $cacti_session_name, not the cookie domain, to isolate Cacti installations.
  */
 
 //$cacti_cookie_domain = 'cacti.net';

--- a/include/global.php
+++ b/include/global.php
@@ -442,6 +442,7 @@ if ($config['is_web']) {
 	/* add additional cookie directives */
 	ini_set('session.cookie_httponly', true);
 	ini_set('session.cookie_path', $config['url_path']);
+	ini_set('session.cookie_domain', '');
 	ini_set('session.use_strict_mode', true);
 	ini_set('session.use_only_cookies', true);
 
@@ -452,8 +453,14 @@ if ($config['is_web']) {
 	);
 
 	if (isset($cacti_cookie_domain) && $cacti_cookie_domain != '') {
-		ini_set('session.cookie_domain', $cacti_cookie_domain);
-		$options['cookie_domain'] = $cacti_cookie_domain;
+		$server_name = $_SERVER['SERVER_NAME'] ?? '';
+
+		if (cacti_cookie_domain_matches_host($cacti_cookie_domain, $server_name)) {
+			ini_set('session.cookie_domain', $cacti_cookie_domain);
+			$options['cookie_domain'] = $cacti_cookie_domain;
+		} elseif (!isset($_COOKIE[$cacti_session_name])) {
+			cacti_log('WARNING: Ignoring configured session cookie domain ' . cacti_log_safe_value($cacti_cookie_domain) . ' because it does not match the configured server name; using a host-only cookie.', false, 'AUTH');
+		}
 	}
 
 	// SameSite php7.3+ behavior

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -7768,13 +7768,12 @@ function cacti_session_start($regenerate = false) {
 function cacti_session_regenerate() {
 	if (session_status() === PHP_SESSION_ACTIVE) {
 		$session_data = $_SESSION;
-	} else {
-		$session_data = array();
+		session_regenerate_id(true);
+
+		return $session_data;
 	}
 
-	session_regenerate_id(true);
-
-	return $session_data;
+	return array();
 }
 
 /**

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1137,6 +1137,53 @@ function cacti_build_https_redirect_url(string $server_name, string $request_uri
 }
 
 /**
+ * Checks whether a configured cookie domain can domain-match a host.
+ *
+ * A leading dot on the cookie domain is ignored by modern clients. Host names
+ * are compared case-insensitively, while IP addresses must match exactly.
+ *
+ * @param string $cookie_domain The configured Domain attribute.
+ * @param string $host          The web server's configured host name.
+ *
+ * @return bool True when a browser can accept the Domain attribute for the host.
+ */
+function cacti_cookie_domain_matches_host(string $cookie_domain, string $host) : bool {
+	if (preg_match('/[\x00-\x20\x7f]/', $cookie_domain) || preg_match('/[\x00-\x20\x7f]/', $host)) {
+		return false;
+	}
+
+	$cookie_domain = strtolower(trim($cookie_domain));
+	$host          = strtolower(trim($host));
+
+	if ($cookie_domain === '' || $host === '' || substr($cookie_domain, -1) === '.') {
+		return false;
+	}
+
+	$cookie_domain = ltrim($cookie_domain, '.');
+	$host          = rtrim($host, '.');
+
+	if (filter_var($cookie_domain, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false ||
+		filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+		return false;
+	}
+
+	$domain_is_ip = filter_var($cookie_domain, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+	$host_is_ip   = filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false;
+
+	if ($domain_is_ip || $host_is_ip) {
+		return $domain_is_ip && $host_is_ip && $cookie_domain === $host;
+	}
+
+	if (filter_var($cookie_domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false ||
+		filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false) {
+		return false;
+	}
+
+	return $host === $cookie_domain ||
+		substr($host, -(strlen($cookie_domain) + 1)) === '.' . $cookie_domain;
+}
+
+/**
  * Validates if the given string is a valid regular expression.
  *
  * This function checks if the provided regular expression is valid and safe to use.

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1179,8 +1179,20 @@ function cacti_cookie_domain_matches_host(string $cookie_domain, string $host) :
 		return false;
 	}
 
-	return $host === $cookie_domain ||
-		substr($host, -(strlen($cookie_domain) + 1)) === '.' . $cookie_domain;
+	if ($host === $cookie_domain) {
+		return true;
+	}
+
+	/* A single-label domain that is not the host itself is a public suffix as
+	 * far as the browser is concerned, so it would be discarded. 'localhost'
+	 * still works because it matches the host exactly above. This does not
+	 * catch multi-label suffixes such as co.uk, which would need the public
+	 * suffix list. */
+	if (strpos($cookie_domain, '.') === false) {
+		return false;
+	}
+
+	return substr($host, -(strlen($cookie_domain) + 1)) === '.' . $cookie_domain;
 }
 
 /**

--- a/tests/Unit/Security/Session/CookieDomainTest.php
+++ b/tests/Unit/Security/Session/CookieDomainTest.php
@@ -27,6 +27,15 @@ test('cookie domains reject mismatched or malformed hosts', function () {
 		->and(cacti_cookie_domain_matches_host('2001:db8::1', '2001:db8::1'))->toBeFalse();
 });
 
+test('a single label domain is only accepted as the host itself', function () {
+	/* Domain=localhost on host localhost is stored by the browser, while
+	 * Domain=com on host foo.com is discarded as a public suffix. Both were
+	 * confirmed against a real client before this rule was written. */
+	expect(cacti_cookie_domain_matches_host('localhost', 'localhost'))->toBeTrue()
+		->and(cacti_cookie_domain_matches_host('com', 'foo.com'))->toBeFalse()
+		->and(cacti_cookie_domain_matches_host('example', 'host.example'))->toBeFalse();
+});
+
 test('invalid configured domains use host-only session cookies', function () {
 	$global = file_get_contents(dirname(__DIR__, 4) . '/include/global.php');
 

--- a/tests/Unit/Security/Session/CookieDomainTest.php
+++ b/tests/Unit/Security/Session/CookieDomainTest.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ */
+
+require_once dirname(__DIR__, 4) . '/lib/functions.php';
+require_once dirname(__DIR__, 4) . '/lib/html_utility.php';
+
+test('cookie domains match the configured server name', function () {
+	expect(cacti_cookie_domain_matches_host('monitor.example', 'monitor.example'))->toBeTrue()
+		->and(cacti_cookie_domain_matches_host('.example.com', 'monitor.example.com'))->toBeTrue()
+		->and(cacti_cookie_domain_matches_host('EXAMPLE.COM', 'Monitor.Example.Com'))->toBeTrue()
+		->and(cacti_cookie_domain_matches_host('127.0.0.1', '127.0.0.1'))->toBeTrue();
+});
+
+test('cookie domains reject mismatched or malformed hosts', function () {
+	expect(cacti_cookie_domain_matches_host('cacti13_test', '127.0.0.1'))->toBeFalse()
+		->and(cacti_cookie_domain_matches_host('example.com', '127.0.0.1'))->toBeFalse()
+		->and(cacti_cookie_domain_matches_host('localhost', '127.0.0.1'))->toBeFalse()
+		->and(cacti_cookie_domain_matches_host('example.com', 'notexample.com'))->toBeFalse()
+		->and(cacti_cookie_domain_matches_host("example.com\r\n", 'example.com'))->toBeFalse()
+		->and(cacti_cookie_domain_matches_host('example.com.', 'example.com'))->toBeFalse()
+		->and(cacti_cookie_domain_matches_host('2001:db8::1', '2001:db8::1'))->toBeFalse();
+});
+
+test('invalid configured domains use host-only session cookies', function () {
+	$global = file_get_contents(dirname(__DIR__, 4) . '/include/global.php');
+
+	expect($global)->toContain("ini_set('session.cookie_domain', '');")
+		->and($global)->toContain('cacti_cookie_domain_matches_host($cacti_cookie_domain, $server_name)')
+		->and($global)->toContain('using a host-only cookie.');
+});
+
+test('session regeneration only runs for an active session', function () {
+	$functions = file_get_contents(dirname(__DIR__, 4) . '/lib/functions.php');
+	$start     = strpos($functions, 'function cacti_session_regenerate()');
+	$body      = substr($functions, $start, 400);
+
+	expect($start)->not->toBeFalse()
+		->and($body)->toContain('if (session_status() === PHP_SESSION_ACTIVE) {')
+		->and(strpos($body, 'session_regenerate_id(true);'))->toBeGreaterThan(strpos($body, 'PHP_SESSION_ACTIVE'));
+});


### PR DESCRIPTION
Refs #7829.

A configured session-cookie `Domain` that does not domain-match the browser-visible host is rejected by the client. Each request then starts a new session, producing a login loop.

This merged change:

- validated `cacti_cookie_domain` against `SERVER_NAME` and fell back to a host-only cookie when it did not match
- guarded session-ID regeneration so it only runs for an active session
- documented that cookie domain is not an installation-isolation setting
- added focused regression coverage

Risk discovered during final Docker validation: automatically changing cookie scope can break intentional cross-subdomain sessions, and `SERVER_NAME` can differ from the browser-visible hostname behind proxies or aliases.

Follow-up #7871 removes that automatic scope rewrite. It preserves configured cookie behavior and instead returns an actionable HTTP 403 and log entry when CSRF validation detects that the browser did not return Cacti's session cookie. The follow-up includes a full-stack Docker login/CSRF regression.
