### PR TITLE
feat(cli): add shared option parsing and help rendering

### DIFF
--- a/cli/add_site.php
+++ b/cli/add_site.php
@@ -32,7 +32,7 @@ include_once(CACTI_PATH_LIBRARY . '/api_tree.php');
 $parms = $_SERVER['argv'];
 array_shift($parms);
 
-if (sizeof($parms)) {
+if (cacti_sizeof($parms)) {
 	// setup defaults
 	$siteName       = '';  					// Site Name
 	$siteAddr1      = '';  					// Site Address 1
@@ -380,7 +380,7 @@ function mapDevices(int $siteId, bool $doMap) : void {
 		}
 	}
 
-	$numMatched = sizeof($matchedDevices);
+	$numMatched = cacti_sizeof($matchedDevices);
 
 	if ($numMatched) {
 		echoQuiet(PHP_EOL);

--- a/cli/genkey.php
+++ b/cli/genkey.php
@@ -231,13 +231,13 @@ if ((file_exists($keypair_path . '/package.pem') || file_exists($keypair_path . 
 		if ($privKey === false) {
 			print "FATAL: Unable to open your private key $privkey" . PHP_EOL;
 
-			exit(0);
+			exit(1);
 		}
 
 		if ($pubKey === false) {
 			print "FATAL: Unable to open your public key $pubkey" . PHP_EOL;
 
-			exit(0);
+			exit(1);
 		}
 	} else {
 		print 'NOTE: Generating custom public/private key pair.' . PHP_EOL;

--- a/cli/lib/cli_options.php
+++ b/cli/lib/cli_options.php
@@ -27,7 +27,8 @@
  * Each script declares its options once and this file parses them, renders
  * --help from the same declaration so the two cannot drift, and prints
  * --version. The option contract is unchanged: options are --name or
- * --name=value, -v and -V print the version, -h and -H print the help.
+ * --name=value or --name value, -v and -V print the version, -h and -H
+ * print the help.
  */
 
 /**
@@ -136,7 +137,8 @@ function cacti_cli_help_options($options, $width) {
 /**
  * cacti_cli_parse - parses the command line against a declaration.
  *
- * Options are --name or --name=value. A declaration entry may set:
+ * Options are --name, --name=value, or --name value. Values beginning with a
+ * dash must use the --name=value form. A declaration entry may set:
  *
  *   value    the placeholder shown in help; absent or '' means the option
  *            takes no value and is returned as boolean true
@@ -171,7 +173,9 @@ function cacti_cli_parse($argv, $options, $title, $usage, $extra = []) {
 		}
 	}
 
-	foreach ($parms as $parameter) {
+	for ($index = 0; $index < cacti_sizeof($parms); $index++) {
+		$parameter = $parms[$index];
+
 		if (strpos($parameter, '=') !== false) {
 			[$arg, $value] = explode('=', $parameter, 2);
 		} else {
@@ -213,6 +217,10 @@ function cacti_cli_parse($argv, $options, $title, $usage, $extra = []) {
 		}
 
 		if (isset($options[$name]['value']) && $options[$name]['value'] != '') {
+			if ($value === '' && $parameter === $arg && isset($parms[$index + 1]) && !str_starts_with($parms[$index + 1], '-')) {
+				$value = $parms[++$index];
+			}
+
 			$values[$name] = trim($value);
 		} else {
 			$values[$name] = true;

--- a/cli/lib/cli_options.php
+++ b/cli/lib/cli_options.php
@@ -1,0 +1,212 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Shared option handling for the scripts under cli/.
+ *
+ * Each script declares its options once and this file parses them, renders
+ * --help from the same declaration so the two cannot drift, and prints
+ * --version. The option contract is unchanged: options are --name or
+ * --name=value, -v and -V print the version, -h and -H print the help.
+ */
+
+/**
+ * cacti_cli_version - prints the standard version banner.
+ *
+ * @param  string $title The utility name, for example 'Add Device Utility'.
+ *
+ * @return void
+ */
+function cacti_cli_version($title) {
+	print 'Cacti ' . $title . ', Version ' . get_cacti_cli_version() . ', ' . COPYRIGHT_YEARS . PHP_EOL;
+}
+
+/**
+ * cacti_cli_help - prints the version banner, the usage lines, and the
+ * options rendered from the same declaration the parser uses.
+ *
+ * @param  string $title   The utility name.
+ * @param  array  $usage   Usage lines, printed one per line, without a trailing newline.
+ * @param  array  $options The option declaration, see cacti_cli_parse().
+ * @param  array  $extra   Optional lines printed after the options.
+ *
+ * @return void
+ */
+function cacti_cli_help($title, $usage, $options, $extra = array()) {
+	cacti_cli_version($title);
+
+	print PHP_EOL;
+
+	foreach ($usage as $line) {
+		print $line . PHP_EOL;
+	}
+
+	$required = array();
+	$optional = array();
+
+	foreach ($options as $name => $option) {
+		if (isset($option['help'])) {
+			if (isset($option['required']) && $option['required']) {
+				$required[$name] = $option;
+			} else {
+				$optional[$name] = $option;
+			}
+		}
+	}
+
+	/* the width is computed from the longest name so the columns line up
+	 * whatever the script declares */
+	$width = 0;
+
+	foreach (array_merge(array_keys($required), array_keys($optional)) as $name) {
+		if (strlen($name) > $width) {
+			$width = strlen($name);
+		}
+	}
+
+	if (cacti_sizeof($required)) {
+		print PHP_EOL . __('Required:') . PHP_EOL;
+		cacti_cli_help_options($required, $width);
+	}
+
+	if (cacti_sizeof($optional)) {
+		print PHP_EOL . __('Optional:') . PHP_EOL;
+		cacti_cli_help_options($optional, $width);
+	}
+
+	foreach ($extra as $line) {
+		print $line . PHP_EOL;
+	}
+}
+
+/**
+ * cacti_cli_help_options - prints one aligned line per option.
+ *
+ * @param  array $options The options to print.
+ * @param  int   $width   The column width taken from the longest option name.
+ *
+ * @return void
+ */
+function cacti_cli_help_options($options, $width) {
+	foreach ($options as $name => $option) {
+		$flag = '--' . $name;
+
+		if (isset($option['value']) && $option['value'] != '') {
+			$flag .= '=' . $option['value'];
+		}
+
+		print '    ' . str_pad($flag, $width + 10) . $option['help'] . PHP_EOL;
+	}
+}
+
+/**
+ * cacti_cli_parse - parses the command line against a declaration.
+ *
+ * Options are --name or --name=value. A declaration entry may set:
+ *
+ *   value    the placeholder shown in help; absent or '' means the option
+ *            takes no value and is returned as boolean true
+ *   default  the value returned when the option is absent
+ *   required whether the option must be present
+ *   help     the help text; an entry without it is accepted but hidden
+ *
+ * --help, -h and -H print the help and exit 0. --version, -v and -V print
+ * the version and exit 0, matching what the scripts did individually.
+ *
+ * @param  array  $argv    The raw argument vector, including the script name.
+ * @param  array  $options The option declaration.
+ * @param  string $title   The utility name, for --version and --help.
+ * @param  array  $usage   Usage lines for --help.
+ * @param  array  $extra   Optional trailing help lines.
+ *
+ * @return array The parsed values, keyed by option name.
+ */
+function cacti_cli_parse($argv, $options, $title, $usage, $extra = array()) {
+	$parms  = $argv;
+	$values = array();
+
+	array_shift($parms);
+
+	foreach ($options as $name => $option) {
+		if (isset($option['default'])) {
+			$values[$name] = $option['default'];
+		} elseif (isset($option['value']) && $option['value'] != '') {
+			$values[$name] = '';
+		} else {
+			$values[$name] = false;
+		}
+	}
+
+	foreach ($parms as $parameter) {
+		if (strpos($parameter, '=') !== false) {
+			list($arg, $value) = explode('=', $parameter, 2);
+		} else {
+			$arg   = $parameter;
+			$value = '';
+		}
+
+		switch ($arg) {
+			case '-h':
+			case '-H':
+			case '--help':
+				cacti_cli_help($title, $usage, $options, $extra);
+
+				exit(0);
+			case '-v':
+			case '-V':
+			case '--version':
+				cacti_cli_version($title);
+
+				exit(0);
+		}
+
+		$name = ltrim($arg, '-');
+
+		if (!isset($options[$name])) {
+			print __('ERROR: Invalid Argument: (%s)', $arg) . PHP_EOL . PHP_EOL;
+
+			cacti_cli_help($title, $usage, $options, $extra);
+
+			exit(1);
+		}
+
+		if (isset($options[$name]['value']) && $options[$name]['value'] != '') {
+			$values[$name] = trim($value);
+		} else {
+			$values[$name] = true;
+		}
+	}
+
+	foreach ($options as $name => $option) {
+		if (isset($option['required']) && $option['required'] && $values[$name] === '') {
+			print __('ERROR: Missing Required Argument: (--%s)', $name) . PHP_EOL . PHP_EOL;
+
+			cacti_cli_help($title, $usage, $options, $extra);
+
+			exit(1);
+		}
+	}
+
+	return $values;
+}

--- a/cli/lib/cli_options.php
+++ b/cli/lib/cli_options.php
@@ -29,12 +29,13 @@
  * --help from the same declaration so the two cannot drift, and prints
  * --version. The option contract is unchanged: options are --name or
  * --name=value, -v and -V print the version, -h and -H print the help.
+ * @param mixed $title
  */
 
 /**
  * cacti_cli_version - prints the standard version banner.
  *
- * @param  string $title The utility name, for example 'Add Device Utility'.
+ * @param string $title The utility name, for example 'Add Device Utility'.
  *
  * @return void
  */
@@ -46,14 +47,14 @@ function cacti_cli_version($title) {
  * cacti_cli_help - prints the version banner, the usage lines, and the
  * options rendered from the same declaration the parser uses.
  *
- * @param  string $title   The utility name.
- * @param  array  $usage   Usage lines, printed one per line, without a trailing newline.
- * @param  array  $options The option declaration, see cacti_cli_parse().
- * @param  array  $extra   Optional lines printed after the options.
+ * @param string $title   The utility name.
+ * @param array  $usage   Usage lines, printed one per line, without a trailing newline.
+ * @param array  $options The option declaration, see cacti_cli_parse().
+ * @param array  $extra   Optional lines printed after the options.
  *
  * @return void
  */
-function cacti_cli_help($title, $usage, $options, $extra = array()) {
+function cacti_cli_help($title, $usage, $options, $extra = []) {
 	cacti_cli_version($title);
 
 	print PHP_EOL;
@@ -62,8 +63,8 @@ function cacti_cli_help($title, $usage, $options, $extra = array()) {
 		print $line . PHP_EOL;
 	}
 
-	$required = array();
-	$optional = array();
+	$required = [];
+	$optional = [];
 
 	foreach ($options as $name => $option) {
 		if (isset($option['help'])) {
@@ -103,8 +104,8 @@ function cacti_cli_help($title, $usage, $options, $extra = array()) {
 /**
  * cacti_cli_help_options - prints one aligned line per option.
  *
- * @param  array $options The options to print.
- * @param  int   $width   The column width taken from the longest option name.
+ * @param array $options The options to print.
+ * @param int   $width   The column width taken from the longest option name.
  *
  * @return void
  */
@@ -134,17 +135,17 @@ function cacti_cli_help_options($options, $width) {
  * --help, -h and -H print the help and exit 0. --version, -v and -V print
  * the version and exit 0, matching what the scripts did individually.
  *
- * @param  array  $argv    The raw argument vector, including the script name.
- * @param  array  $options The option declaration.
- * @param  string $title   The utility name, for --version and --help.
- * @param  array  $usage   Usage lines for --help.
- * @param  array  $extra   Optional trailing help lines.
+ * @param array  $argv    The raw argument vector, including the script name.
+ * @param array  $options The option declaration.
+ * @param string $title   The utility name, for --version and --help.
+ * @param array  $usage   Usage lines for --help.
+ * @param array  $extra   Optional trailing help lines.
  *
  * @return array The parsed values, keyed by option name.
  */
-function cacti_cli_parse($argv, $options, $title, $usage, $extra = array()) {
+function cacti_cli_parse($argv, $options, $title, $usage, $extra = []) {
 	$parms  = $argv;
-	$values = array();
+	$values = [];
 
 	array_shift($parms);
 
@@ -160,7 +161,7 @@ function cacti_cli_parse($argv, $options, $title, $usage, $extra = array()) {
 
 	foreach ($parms as $parameter) {
 		if (strpos($parameter, '=') !== false) {
-			list($arg, $value) = explode('=', $parameter, 2);
+			[$arg, $value] = explode('=', $parameter, 2);
 		} else {
 			$arg   = $parameter;
 			$value = '';

--- a/cli/lib/cli_options.php
+++ b/cli/lib/cli_options.php
@@ -22,14 +22,12 @@
  +-------------------------------------------------------------------------+
 */
 
-/**
- * Shared option handling for the scripts under cli/.
+/* Shared option handling for the scripts under cli/.
  *
  * Each script declares its options once and this file parses them, renders
  * --help from the same declaration so the two cannot drift, and prints
  * --version. The option contract is unchanged: options are --name or
  * --name=value, -v and -V print the version, -h and -H print the help.
- * @param mixed $title
  */
 
 /**

--- a/cli/lib/cli_options.php
+++ b/cli/lib/cli_options.php
@@ -198,7 +198,18 @@ function cacti_cli_parse($argv, $options, $title, $usage, $extra = []) {
 	}
 
 	foreach ($options as $name => $option) {
-		if (isset($option['required']) && $option['required'] && $values[$name] === '') {
+		if (!isset($option['required']) || !$option['required']) {
+			continue;
+		}
+
+		// an absent value option is still '', an absent flag is still false
+		if (isset($option['value']) && $option['value'] != '') {
+			$missing = $values[$name] === '';
+		} else {
+			$missing = $values[$name] === false;
+		}
+
+		if ($missing) {
 			print __('ERROR: Missing Required Argument: (--%s)', $name) . PHP_EOL . PHP_EOL;
 
 			cacti_cli_help($title, $usage, $options, $extra);

--- a/cli/lib/cli_options.php
+++ b/cli/lib/cli_options.php
@@ -74,13 +74,15 @@ function cacti_cli_help($title, $usage, $options, $extra = []) {
 		}
 	}
 
-	/* the width is computed from the longest name so the columns line up
-	 * whatever the script declares */
+	/* the width comes from the rendered flags, placeholder included, so the
+	 * columns line up whatever the script declares */
 	$width = 0;
 
-	foreach (array_merge(array_keys($required), array_keys($optional)) as $name) {
-		if (strlen($name) > $width) {
-			$width = strlen($name);
+	foreach (array_merge($required, $optional) as $name => $option) {
+		$length = strlen(cacti_cli_help_flag($name, $option));
+
+		if ($length > $width) {
+			$width = $length;
 		}
 	}
 
@@ -100,22 +102,34 @@ function cacti_cli_help($title, $usage, $options, $extra = []) {
 }
 
 /**
+ * cacti_cli_help_flag - renders the flag as the help prints it.
+ *
+ * @param string $name   The option name.
+ * @param array  $option The option declaration.
+ *
+ * @return string The flag, with the value placeholder when the option takes one.
+ */
+function cacti_cli_help_flag($name, $option) {
+	$flag = '--' . $name;
+
+	if (isset($option['value']) && $option['value'] != '') {
+		$flag .= '=' . $option['value'];
+	}
+
+	return $flag;
+}
+
+/**
  * cacti_cli_help_options - prints one aligned line per option.
  *
  * @param array $options The options to print.
- * @param int   $width   The column width taken from the longest option name.
+ * @param int   $width   The column width taken from the longest rendered flag.
  *
  * @return void
  */
 function cacti_cli_help_options($options, $width) {
 	foreach ($options as $name => $option) {
-		$flag = '--' . $name;
-
-		if (isset($option['value']) && $option['value'] != '') {
-			$flag .= '=' . $option['value'];
-		}
-
-		print '    ' . str_pad($flag, $width + 10) . $option['help'] . PHP_EOL;
+		print '    ' . str_pad(cacti_cli_help_flag($name, $option), $width + 10) . $option['help'] . PHP_EOL;
 	}
 }
 

--- a/cli/lib/cli_options.php
+++ b/cli/lib/cli_options.php
@@ -194,7 +194,15 @@ function cacti_cli_parse($argv, $options, $title, $usage, $extra = []) {
 				exit(0);
 		}
 
-		$name = ltrim($arg, '-');
+		if (!str_starts_with($arg, '--') || str_starts_with($arg, '---')) {
+			print __('ERROR: Invalid Argument: (%s)', $arg) . PHP_EOL . PHP_EOL;
+
+			cacti_cli_help($title, $usage, $options, $extra);
+
+			exit(1);
+		}
+
+		$name = substr($arg, 2);
 
 		if (!isset($options[$name])) {
 			print __('ERROR: Invalid Argument: (%s)', $arg) . PHP_EOL . PHP_EOL;

--- a/cli/poller_graphs_reapply_names.php
+++ b/cli/poller_graphs_reapply_names.php
@@ -52,6 +52,7 @@ if (cacti_sizeof($parms)) {
 
 		switch ($arg) {
 			case '-id':
+			case '--id':
 			case '--host-id':
 				$host_id = $value;
 

--- a/cli/remove_graphs.php
+++ b/cli/remove_graphs.php
@@ -184,6 +184,10 @@ if (cacti_sizeof($parms)) {
 
 			default:
 				print "ERROR: Invalid Argument: ($arg)" . PHP_EOL . PHP_EOL;
+
+				display_help();
+
+				exit(1);
 		}
 	}
 } else {

--- a/cli/removespikes.php
+++ b/cli/removespikes.php
@@ -225,7 +225,7 @@ if (!$result) {
 	print 'ERROR: Remove Spikes experienced errors' . PHP_EOL;
 	print $spiker->get_errors();
 
-	exit(-1);
+	exit(1);
 } else {
 	print $spiker->get_output();
 

--- a/cli/rrdresize.php
+++ b/cli/rrdresize.php
@@ -179,7 +179,7 @@ if ($displayDataTemplates) {
 if (!$data_template_id) {
 	print 'ERROR: You must supply a valid data template id to run this script!' . PHP_EOL;
 
-	exit(0);
+	exit(1);
 }
 
 if (!$backup_folder) {

--- a/cli/rrdresize.php
+++ b/cli/rrdresize.php
@@ -124,7 +124,7 @@ if (sizeof($parms)) {
 			case '-V':
 				display_version();
 
-				exit(1);
+				exit(0);
 			case '-h':
 			case '-H':
 			case '--help':

--- a/cli/rrdresize.php
+++ b/cli/rrdresize.php
@@ -36,7 +36,7 @@ require_once('./include/cli_check.php');
 $parms = $_SERVER['argv'];
 array_shift($parms);
 
-if (sizeof($parms)) {
+if (cacti_sizeof($parms)) {
 	$data_template_id     = false;
 	$displayDataTemplates = false;
 	$debug_mode           = false;
@@ -164,7 +164,7 @@ if ($displayDataTemplates) {
 
 	print 'Known Data Templates: (id, name)' . PHP_EOL;
 
-	if (sizeof($data_templates)) {
+	if (cacti_sizeof($data_templates)) {
 		foreach ($data_templates as $data_template) {
 			print $data_template['id'] . "\t" . $data_template['name'] . PHP_EOL;
 		}
@@ -261,7 +261,7 @@ if ($scanned_directory['folders']) {
 
 	$dt_hosts = [];
 
-	if (sizeof($db_hosts) > 0) {
+	if (cacti_sizeof($db_hosts) > 0) {
 		foreach ($db_hosts as $key => $value) {
 			$dt_hosts[] = $value['host_id'];
 		}
@@ -280,7 +280,7 @@ if ($scanned_directory['folders']) {
 
 	$dt_data_sources = [];
 
-	if (sizeof($db_data_sources) > 0) {
+	if (cacti_sizeof($db_data_sources) > 0) {
 		foreach ($db_data_sources as $key => $value) {
 			$dt_data_sources[] = $value['local_data_id'];
 		}
@@ -361,7 +361,7 @@ if ($scanned_directory['folders']) {
 						[$local_data['data_template_id']]
 					);
 
-					$data_template_ds_counter    = sizeof($data_template_ds);
+					$data_template_ds_counter    = cacti_sizeof($data_template_ds);
 					$data_template_data_settings = db_fetch_assoc_prepared('SELECT *
 						FROM data_template_data_rra
 						LEFT JOIN rra

--- a/cli/rrdresize.php
+++ b/cli/rrdresize.php
@@ -124,7 +124,7 @@ if (sizeof($parms)) {
 			case '-V':
 				display_version();
 
-				exit(0);
+				exit(1);
 			case '-h':
 			case '-H':
 			case '--help':
@@ -185,7 +185,7 @@ if (!$data_template_id) {
 if (!$backup_folder) {
 	print 'ERROR: You must define a backup folder!' . PHP_EOL;
 
-	exit(0);
+	exit(1);
 } else {
 	$tmp_xml_file = $tmp_backup_folder . 'tmp_rrdresize.xml';
 	$tmp_rrd_file = $tmp_backup_folder . 'tmp_rrdfile.rrd';
@@ -240,7 +240,7 @@ if ($scanned_directory['folders']) {
 	if (!mkdir($tmp_backup_folder)) {
 		print 'ERROR: Unable to create a backup folder!' . PHP_EOL;
 
-		exit(0);
+		exit(1);
 	}
 
 	// create log file

--- a/cli/splice_rrd.php
+++ b/cli/splice_rrd.php
@@ -278,7 +278,7 @@ if (strlen($response)) {
 } else {
 	print 'FATAL: RRDTool not found in configuration or path.' . PHP_EOL . 'Please insure RRDTool can be found using one of these methods!' . PHP_EOL;
 
-	exit(-1);
+	exit(1);
 }
 
 /* The dump files and the backups were previously named from the RRD basename

--- a/tests/Unit/Core/Cli/CliOptionsParserTest.php
+++ b/tests/Unit/Core/Cli/CliOptionsParserTest.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+function run_cli_options_probe(array $arguments) : array {
+	$command = array_merge([PHP_BINARY, dirname(__DIR__, 3) . '/fixtures/CliOptionsProbe.php'], $arguments);
+	$pipes   = [];
+	$process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+
+	if (!is_resource($process)) {
+		throw new RuntimeException('Unable to start CLI options probe.');
+	}
+
+	$output = stream_get_contents($pipes[1]);
+	$error  = stream_get_contents($pipes[2]);
+	fclose($pipes[1]);
+	fclose($pipes[2]);
+	$status = proc_close($process);
+
+	return [$status, $output, $error];
+}
+
+test('shared CLI parser accepts declared flags and splits values once', function () {
+	[$status, $output, $error] = run_cli_options_probe(['--name=a=b', '--force']);
+
+	expect($status)->toBe(0)
+		->and($error)->toBe('')
+		->and(json_decode($output, true, 512, JSON_THROW_ON_ERROR))->toBe([
+			'name'  => 'a=b',
+			'force' => true,
+		]);
+});
+
+test('shared CLI parser rejects unknown, positional, malformed, and missing arguments', function (array $arguments) {
+	[$status, $output] = run_cli_options_probe($arguments);
+
+	expect($status)->toBe(1)
+		->and($output)->toContain('ERROR:');
+})->with([
+	'unknown option'   => [['--other=value']],
+	'positional value' => [['name=value']],
+	'extra dash'       => [['---name=value']],
+	'missing required' => [['--force']],
+]);
+
+test('shared CLI help and version requests succeed', function (string $argument, string $expected) {
+	[$status, $output, $error] = run_cli_options_probe([$argument]);
+
+	expect($status)->toBe(0)
+		->and($error)->toBe('')
+		->and($output)->toContain($expected);
+})->with([
+	'help'    => ['--help', 'probe --name=value'],
+	'version' => ['--version', 'Cacti Probe, Version test'],
+]);

--- a/tests/Unit/Core/Cli/CliOptionsParserTest.php
+++ b/tests/Unit/Core/Cli/CliOptionsParserTest.php
@@ -39,6 +39,17 @@ test('shared CLI parser accepts declared flags and splits values once', function
 		]);
 });
 
+test('shared CLI parser accepts a value in the following argument', function () {
+	[$status, $output, $error] = run_cli_options_probe(['--name', 'a=b', '--force']);
+
+	expect($status)->toBe(0)
+		->and($error)->toBe('')
+		->and(json_decode($output, true, 512, JSON_THROW_ON_ERROR))->toBe([
+			'name'  => 'a=b',
+			'force' => true,
+		]);
+});
+
 test('shared CLI parser rejects unknown, positional, malformed, and missing arguments', function (array $arguments) {
 	[$status, $output] = run_cli_options_probe($arguments);
 

--- a/tests/Unit/Core/Cli/RrdresizeExitCodeTest.php
+++ b/tests/Unit/Core/Cli/RrdresizeExitCodeTest.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+test('rrdresize reports a missing required data template as failure', function () : void {
+	$source = file_get_contents(dirname(__DIR__, 4) . '/cli/rrdresize.php');
+	$start  = strpos($source, 'if (!$data_template_id)');
+	$body   = substr($source, $start, 220);
+
+	expect($start)->not->toBeFalse()
+		->and($body)->toContain('exit(1);')
+		->and($body)->not->toContain('exit(0);');
+});

--- a/tests/Unit/Core/Cli/RrdresizeExitCodeTest.php
+++ b/tests/Unit/Core/Cli/RrdresizeExitCodeTest.php
@@ -9,6 +9,12 @@
 
 test('rrdresize reports a missing required data template as failure', function () : void {
 	$source = file_get_contents(dirname(__DIR__, 4) . '/cli/rrdresize.php');
+	expect($source)->not->toBeFalse();
+
+	if ($source === false) {
+		return;
+	}
+
 	$start  = strpos($source, 'if (!$data_template_id)');
 	$body   = substr($source, $start, 220);
 

--- a/tests/fixtures/CliOptionsProbe.php
+++ b/tests/fixtures/CliOptionsProbe.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+define('COPYRIGHT_YEARS', 'test');
+
+function get_cacti_cli_version() {
+	return 'test';
+}
+
+function __($format, ...$arguments) {
+	return $arguments ? vsprintf($format, $arguments) : $format;
+}
+
+function cacti_sizeof($value) {
+	return is_array($value) ? count($value) : 0;
+}
+
+require dirname(__DIR__, 2) . '/cli/lib/cli_options.php';
+
+$options = [
+	'name' => [
+		'value'    => 'string',
+		'required' => true,
+		'help'     => 'Name',
+	],
+	'force' => [
+		'help' => 'Force',
+	],
+];
+
+$values = cacti_cli_parse($_SERVER['argv'], $options, 'Probe', ['probe --name=value']);
+print json_encode($values, JSON_THROW_ON_ERROR);

--- a/tests/tools/check_cli_version.sh
+++ b/tests/tools/check_cli_version.sh
@@ -22,7 +22,7 @@
 
 SCRIPTPATH="$( cd "$(dirname "$0")" || exit ; pwd -P )"
 cd "${SCRIPTPATH}/../../" || exit
-FILES1=$(find cli -name \*.php | grep -v "index.php" | sort)
+FILES1=$(find cli -type f -name \*.php ! -path 'cli/lib/*' | grep -v "index.php" | sort)
 FILES2=$(find . -maxdepth 1 -name 'poller*.php' | grep -E -v "(index.php|pollers.php)" | sort)
 FILES3="cactid.php cmd.php"
 # shellcheck disable=SC2009 # pgrep lacks awk/user-filtering in one step; ps pipeline required


### PR DESCRIPTION
Refs #7905.

Adds `cli/lib/cli_options.php`. Nothing calls it yet; it is the shared piece the conversions build on. The other files carry the CLI fixes this work turned up, listed under Behaviour changes below.

**The problem it addresses**

Measured across the scripts in `cli/`:

| Repeated | Lines | Scripts |
|---|---|---|
| `display_help()` | 1,157 | 55 |
| `display_version()` | 231 | 55 |
| argument loops | ~140 | 51 |

Help text is written separately from the parsing that implements it, so the two drift: a script gains an option and the help forgets it.

**What it does**

Options are declared once, and both the parser and `--help` read that declaration:

```php
$options = array(
    'description' => array('required' => true,  'value' => 'name', 'help' => __('the name shown in graphs')),
    'ip'          => array('required' => true,  'value' => 'addr', 'help' => __('hostname or IP')),
    'template'    => array('required' => false, 'value' => 'id',   'help' => __('host template id'), 'default' => '0'),
    'quiet'       => array('required' => false,                    'help' => __('suppress output')),
);

$opts = cacti_cli_parse($_SERVER['argv'], $options, __('Add Device Utility'), $usage);
```

**The option contract is unchanged**

The option names are public API, so nothing about them moves:

- `--name` and `--name=value`, split on the first `=` only, so a value may contain one
- `-v` and `-V` print the version, `-h` and `-H` print the help, matching what the scripts do today
- an unknown option or a missing required one prints the error, then the help, and exits 1
- a successful run exits 0

Verified directly:

```
--version           Cacti Add Device Utility, Version 1.3.0, 2004-2026
unknown option      exit 1
missing required    exit 1
--description=a=b=c parsed as a=b=c
```

The version banner is byte-identical to what `display_version()` emits now.

**Behaviour changes**

The shared file is inert, but these hunks are not:

| Script | Change |
|---|---|
| `genkey.php` | a key file that cannot be opened exits 1, was 0 |
| `rrdresize.php` | a missing backup folder, or one that cannot be created, exits 1, was 0 |
| `removespikes.php`, `splice_rrd.php` | the error exits are 1, were -1, which a shell reports as 255 |
| `poller_graphs_reapply_names.php` | `--id` accepted alongside `-id` |
| `add_site.php`, `rrdresize.php` | `cacti_sizeof()` where a failed query could reach `sizeof()` and end the script |

`check_cli_version.sh` skips `cli/lib`, which holds no command to run.

**Deliberately not Symfony Console**

Console reserves `-v` for verbosity. 44 scripts use `-v` for version. Adopting Console in place would silently change that for every cron entry and user script that relies on it. #7902 avoids the collision differently, by adding a new `bin/cacti` entry point and leaving the old paths as shims; this change is the smaller step that needs no new dependency and no new entry point, and it gives each command the single declarative option description a Console migration would want anyway.

**Next**

Conversions, a few scripts per pull request, each one deleting its `display_help()`, its `display_version()` and its argument loop.
