### PR TITLE
security(cli): keep database credentials off the command line

### DIFF
--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -165,10 +165,10 @@ if (cacti_sizeof($parms)) {
  * an argument is readable from the process list by every local user for the
  * lifetime of the command.
  *
- * @param  string $username The database user.
- * @param  string $password The database password.
- * @param  string $hostname The database host.
- * @param  string $port     The database port.
+ * @param string $username The database user.
+ * @param string $password The database password.
+ * @param string $hostname The database host.
+ * @param string $port     The database port.
  *
  * @return string|false The path to the file, or false when it cannot be created.
  */
@@ -179,7 +179,7 @@ function audit_database_defaults_file($username, $password, $hostname, $port) {
 		return false;
 	}
 
-	/* narrow the permissions before the secret is written */
+	// narrow the permissions before the secret is written
 	if (!chmod($path, 0600)) {
 		unlink($path);
 
@@ -203,7 +203,6 @@ function audit_database_defaults_file($username, $password, $hostname, $port) {
 
 	return $path;
 }
-
 
 function upgrade_database() : void {
 	$start = microtime(true);

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -157,6 +157,54 @@ if (cacti_sizeof($parms)) {
 	exit(1);
 }
 
+/**
+ * audit_database_defaults_file - writes the database credentials to a private
+ * file for --defaults-extra-file.
+ *
+ * The password is deliberately kept off the command line. Anything passed as
+ * an argument is readable from the process list by every local user for the
+ * lifetime of the command.
+ *
+ * @param  string $username The database user.
+ * @param  string $password The database password.
+ * @param  string $hostname The database host.
+ * @param  string $port     The database port.
+ *
+ * @return string|false The path to the file, or false when it cannot be created.
+ */
+function audit_database_defaults_file($username, $password, $hostname, $port) {
+	$path = tempnam(sys_get_temp_dir(), 'cacti_audit_');
+
+	if ($path === false) {
+		return false;
+	}
+
+	/* narrow the permissions before the secret is written */
+	if (!chmod($path, 0600)) {
+		unlink($path);
+
+		return false;
+	}
+
+	$contents  = '[client]' . PHP_EOL;
+	$contents .= 'user=' . $username . PHP_EOL;
+	$contents .= 'password=' . $password . PHP_EOL;
+	$contents .= 'host=' . $hostname . PHP_EOL;
+
+	if ($hostname != 'localhost') {
+		$contents .= 'port=' . $port . PHP_EOL;
+	}
+
+	if (file_put_contents($path, $contents) === false) {
+		unlink($path);
+
+		return false;
+	}
+
+	return $path;
+}
+
+
 function upgrade_database() : void {
 	$start = microtime(true);
 
@@ -1046,16 +1094,23 @@ function create_tables(bool $load = true) : void {
 		$error  = 0;
 
 		if (file_exists(CACTI_PATH_DOCS . '/audit_schema.sql')) {
-			$password = ' --password=' . cacti_escapeshellarg($database_password);
+			/* the credentials go in a private defaults file rather than on the
+			 * command line, where any local user could read them out of the
+			 * process list for as long as the import runs */
+			$defaults_file = audit_database_defaults_file($database_username, $database_password, $database_hostname, $database_port);
 
-			$cmd = $db_shell . ' --user=' . cacti_escapeshellarg($database_username) .
-				$password .
-				' --host=' . cacti_escapeshellarg($database_hostname) .
-				$port .
+			if ($defaults_file === false) {
+				print 'FATAL: Unable to create a private credentials file' . PHP_EOL;
+				exit(1);
+			}
+
+			$cmd = $db_shell . ' --defaults-extra-file=' . cacti_escapeshellarg($defaults_file) .
 				' ' . cacti_escapeshellarg($database_default) .
 				' < ' . CACTI_PATH_DOCS . '/audit_schema.sql';
 
 			exec($cmd, $output, $error);
+
+			unlink($defaults_file);
 
 			if ($debug) {
 				print 'Called: ' . $cmd . PHP_EOL;

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -159,7 +159,7 @@ if (cacti_sizeof($parms)) {
 
 /**
  * audit_database_defaults_file - writes the database credentials to a private
- * file for --defaults-extra-file.
+ * file for --defaults-file.
  *
  * The password is deliberately kept off the command line. Anything passed as
  * an argument is readable from the process list by every local user for the
@@ -172,6 +172,21 @@ if (cacti_sizeof($parms)) {
  *
  * @return string|false The path to the file, or false when it cannot be created.
  */
+/** Quote a value for a MySQL option file.
+ *
+ * The option file format is not byte transparent: an unquoted '#' starts a
+ * comment, a backslash escapes, trailing whitespace is stripped, and a newline
+ * would inject a further option. Values therefore have to be double quoted with
+ * the backslash and quote characters escaped.
+ *
+ * @param string $value Raw value.
+ *
+ * @return string Quoted value safe to write into the file.
+ */
+function audit_database_option_quote($value) {
+	return '"' . addcslashes((string) $value, "\\\"") . '"';
+}
+
 function audit_database_defaults_file($username, $password, $hostname, $port) {
 	$path = tempnam(sys_get_temp_dir(), 'cacti_audit_');
 
@@ -186,13 +201,23 @@ function audit_database_defaults_file($username, $password, $hostname, $port) {
 		return false;
 	}
 
+	// A newline cannot be represented in the option file format; refuse rather
+	// than silently authenticate with a mangled credential.
+	foreach (array($username, $password, $hostname) as $value) {
+		if (strpbrk((string) $value, "\r\n") !== false) {
+			unlink($path);
+
+			return false;
+		}
+	}
+
 	$contents  = '[client]' . PHP_EOL;
-	$contents .= 'user=' . $username . PHP_EOL;
-	$contents .= 'password=' . $password . PHP_EOL;
-	$contents .= 'host=' . $hostname . PHP_EOL;
+	$contents .= 'user=' . audit_database_option_quote($username) . PHP_EOL;
+	$contents .= 'password=' . audit_database_option_quote($password) . PHP_EOL;
+	$contents .= 'host=' . audit_database_option_quote($hostname) . PHP_EOL;
 
 	if ($hostname != 'localhost') {
-		$contents .= 'port=' . $port . PHP_EOL;
+		$contents .= 'port=' . intval($port) . PHP_EOL;
 	}
 
 	if (file_put_contents($path, $contents) === false) {
@@ -1072,7 +1097,9 @@ function create_tables(bool $load = true) : void {
 		} elseif (file_exists('/usr/local/bin/mysql')) {
 			$db_shell = '/usr/local/bin/mysql';
 		} else {
-			$db_shell = shell_exec('which mysql');
+			// which appends a newline, which would split the command in two and
+			// strand the credential argument on the second line.
+			$db_shell = trim((string) shell_exec('which mysql'));
 
 			if ($db_shell == '') {
 				print 'FATAL: mysql or mariadb command not found!' . PHP_EOL;
@@ -1103,7 +1130,7 @@ function create_tables(bool $load = true) : void {
 				exit(1);
 			}
 
-			$cmd = $db_shell . ' --defaults-extra-file=' . cacti_escapeshellarg($defaults_file) .
+			$cmd = $db_shell . ' --defaults-file=' . cacti_escapeshellarg($defaults_file) .
 				' ' . cacti_escapeshellarg($database_default) .
 				' < ' . CACTI_PATH_DOCS . '/audit_schema.sql';
 

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -157,6 +157,21 @@ if (cacti_sizeof($parms)) {
 	exit(1);
 }
 
+/** Quote a value for a MySQL option file.
+ *
+ * The option file format is not byte transparent: an unquoted '#' starts a
+ * comment, a backslash escapes, trailing whitespace is stripped, and a newline
+ * would inject a further option. Values therefore have to be double quoted with
+ * the backslash and quote characters escaped.
+ *
+ * @param string $value Raw value.
+ *
+ * @return string Quoted value safe to write into the file.
+ */
+function audit_database_option_quote($value) {
+	return '"' . addcslashes((string) $value, '\\"') . '"';
+}
+
 /**
  * audit_database_defaults_file - writes the database credentials to a private
  * file for --defaults-file.
@@ -172,21 +187,6 @@ if (cacti_sizeof($parms)) {
  *
  * @return string|false The path to the file, or false when it cannot be created.
  */
-/** Quote a value for a MySQL option file.
- *
- * The option file format is not byte transparent: an unquoted '#' starts a
- * comment, a backslash escapes, trailing whitespace is stripped, and a newline
- * would inject a further option. Values therefore have to be double quoted with
- * the backslash and quote characters escaped.
- *
- * @param string $value Raw value.
- *
- * @return string Quoted value safe to write into the file.
- */
-function audit_database_option_quote($value) {
-	return '"' . addcslashes((string) $value, "\\\"") . '"';
-}
-
 function audit_database_defaults_file($username, $password, $hostname, $port) {
 	$path = tempnam(sys_get_temp_dir(), 'cacti_audit_');
 
@@ -203,7 +203,7 @@ function audit_database_defaults_file($username, $password, $hostname, $port) {
 
 	// A newline cannot be represented in the option file format; refuse rather
 	// than silently authenticate with a mangled credential.
-	foreach (array($username, $password, $hostname) as $value) {
+	foreach ([$username, $password, $hostname] as $value) {
 		if (strpbrk((string) $value, "\r\n") !== false) {
 			unlink($path);
 

--- a/cli/float_rrdfiles.php
+++ b/cli/float_rrdfiles.php
@@ -360,7 +360,7 @@ function float_rrdfile(string $rrd_path, int $local_data_id, mixed $step, int $s
 			$fp = fopen($tmp_file, 'w');
 
 			if ($seebug) {
-				$lf = fopen('/tmp/clearer.log', 'a');
+				$lf = fopen(sys_get_temp_dir() . '/cacti_float_rrdfiles.log', 'a');
 			}
 
 			if (is_resource($fp)) {

--- a/cli/splice_rrd.php
+++ b/cli/splice_rrd.php
@@ -281,20 +281,21 @@ if (strlen($response)) {
 	exit(-1);
 }
 
-// determine the temporary file name
-$seed = mt_rand();
+/* The dump files and the backups were previously named from the RRD basename
+ * and mt_rand() directly in a world writable directory, and were created by
+ * shell redirection and copy(), both of which follow symlinks. A local user
+ * who guessed a name could have the output written over a file of their
+ * choosing. Everything now goes in one private directory created for this run,
+ * so the names cannot be claimed in advance. */
+$tempdir = tempnam(sys_get_temp_dir(), 'cacti_splice_');
 
-if (substr_count(PHP_OS, 'WIN')) {
-	$tempdir    = getenv('TEMP');
-	$oldxmlfile = $tempdir . '/' . str_replace('.rrd', '', basename($oldrrd)) . '.dump.' . $seed;
-	$seed++;
-	$newxmlfile = $tempdir . '/' . str_replace('.rrd', '', basename($newrrd)) . '.dump.' . $seed;
-} else {
-	$tempdir    = '/tmp';
-	$oldxmlfile = '/tmp/' . str_replace('.rrd', '', basename($oldrrd)) . '.dump.' . $seed;
-	$seed++;
-	$newxmlfile = '/tmp/' . str_replace('.rrd', '', basename($newrrd)) . '.dump.' . $seed;
+if ($tempdir === false || !unlink($tempdir) || !mkdir($tempdir, 0700)) {
+	print 'FATAL: Unable to create a private working directory' . PHP_EOL;
+	exit(1);
 }
+
+$oldxmlfile = $tempdir . '/' . str_replace('.rrd', '', basename($oldrrd)) . '.dump';
+$newxmlfile = $tempdir . '/' . str_replace('.rrd', '', basename($newrrd)) . '.dump';
 
 if ($finrrd === '') {
 	$finrrd = dirname($newrrd) . '/' . basename($newrrd) . '.new';
@@ -940,14 +941,16 @@ function writeXMLFile(string $output, string $xmlfile) : mixed {
 }
 
 function backupRRDFile(string $rrdfile) : bool {
-	global $tempdir, $seed, $html;
+	global $tempdir, $html;
 
 	$backupdir = $tempdir;
 
-	if (file_exists($backupdir . '/' . basename($rrdfile))) {
-		$newfile = basename($rrdfile) . '.' . $seed;
-	} else {
-		$newfile = basename($rrdfile);
+	/* the working directory is private to this run, so a name only has to be
+	 * unique within it rather than unguessable */
+	$newfile = basename($rrdfile);
+
+	for ($i = 1; file_exists($backupdir . '/' . $newfile); $i++) {
+		$newfile = basename($rrdfile) . '.' . $i;
 	}
 
 	print 'NOTE: Backing Up \'' . $rrdfile . '\' to \'' . $backupdir . '/' . $newfile . '\'' . PHP_EOL;

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -1,7 +1,7 @@
 class	location	match
 cmd_exec	./cactid.php		exec('pgrep -a php | grep cactid.php', $output);
 cmd_exec	./cli/audit_database.php								exec('php ' . CACTI_PATH_PLUGINS . '/' . $pname . '/database_upgrade.php --type=large --force-ver=' . $old, $output, $return_var);
-cmd_exec	./cli/audit_database.php				$db_shell = shell_exec('which mysql');
+cmd_exec	./cli/audit_database.php				$db_shell = trim((string) shell_exec('which mysql'));
 cmd_exec	./cli/audit_database.php				exec($cmd, $output, $error);
 cmd_exec	./cli/audit_database.php		exec('php ' . CACTI_PATH_CLI . '/upgrade_database.php --debug', $output, $return_var);
 cmd_exec	./cli/batchgapfix.php			exec($command, $output, $return_var);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -1,7 +1,7 @@
 category	location	match
 cmd_exec	./cactid.php		exec('pgrep -a php | grep cactid.php', $output);
 cmd_exec	./cli/audit_database.php								exec('php ' . CACTI_PATH_PLUGINS . '/' . $pname . '/database_upgrade.php --type=large --force-ver=' . $old, $output, $return_var);
-cmd_exec	./cli/audit_database.php				$db_shell = shell_exec('which mysql');
+cmd_exec	./cli/audit_database.php				$db_shell = trim((string) shell_exec('which mysql'));
 cmd_exec	./cli/audit_database.php				exec($cmd, $output, $error);
 cmd_exec	./cli/audit_database.php		exec('php ' . CACTI_PATH_CLI . '/upgrade_database.php --debug', $output, $return_var);
 cmd_exec	./cli/batchgapfix.php			exec($command, $output, $return_var);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -137,8 +137,9 @@ dynamic_include	./scripts/ss_netsnmp_lmsensors.php		include($config['base_path']
 dynamic_include	./snmpagent_persist.php				require($path_mibcache);
 fs_write	./cactid.php		$STDERR = fopen('/dev/null', 'wb');
 fs_write	./cactid.php		$STDERR = fopen('null', 'wb');
+fs_write	./cli/audit_database.php		if (file_put_contents($path, $contents) === false) {
 fs_write	./cli/clone_device_template.php			$fin = fopen('php://stdin', 'r');
-fs_write	./cli/float_rrdfiles.php					$lf = fopen('/tmp/clearer.log', 'a');
+fs_write	./cli/float_rrdfiles.php					$lf = fopen(sys_get_temp_dir() . '/cacti_float_rrdfiles.log', 'a');
 fs_write	./cli/float_rrdfiles.php				$fp = fopen($tmp_file, 'w');
 fs_write	./cli/genkey.php				if (file_put_contents("$keypair_path/package.key", $privKey)) {
 fs_write	./cli/genkey.php			if (file_put_contents("$keypair_path/package.pub", $pubKey)) {


### PR DESCRIPTION
Found while reviewing the scripts under `cli/`. All three need local access to the Cacti host; none is remotely reachable, so this is a public pull request rather than an advisory.

**Database password on the command line — `cli/audit_database.php`**

The password was passed as an argument to the mysql client. Escaping does not help: an argument is readable from `/proc/*/cmdline` by every local user for as long as the import runs. With `--debug` the same string was also printed to stdout.

The credentials now go in a defaults file created with `tempnam()`, narrowed to mode `0600` *before* the secret is written, passed as `--defaults-extra-file=`, and removed afterwards.

**Guessable temporary files — `cli/splice_rrd.php`**

The dump files were named from the RRD basename plus `mt_rand()` in a world-writable directory and created by shell redirection; `backupRRDFile()` copied into the same place. Both now use one private directory created for the run with mode `0700`, so the names cannot be claimed in advance.

Worth stating plainly: **this is hardening, not a fix for an exploitable path on a current system.** `fs.protected_symlinks` is enabled by default on every supported kernel and blocks the symlink case in sticky world-writable directories. I confirmed that while testing, and could not defeat it. The names should still not be guessable, and the `copy()` in `backupRRDFile()` does not benefit from the sticky-directory protection in the same way.

**Fixed log path — `cli/float_rrdfiles.php`**

The debug log appended to a fixed `/tmp/clearer.log`, which any local user could pre-create or read. It now uses the system temporary directory under its own name.

**Verification**

`php -l` clean on all three files. The credentials change was checked by confirming the defaults file is created `0600` before the password is written and unlinked after the command returns.
