### PR TITLE
security(cli): keep database credentials off the command line

### DIFF
--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -138,6 +138,54 @@ if (cacti_sizeof($parms)) {
 	exit(1);
 }
 
+
+/**
+ * audit_database_defaults_file - writes the database credentials to a private
+ * file for --defaults-extra-file.
+ *
+ * The password is deliberately kept off the command line. Anything passed as
+ * an argument is readable from the process list by every local user for the
+ * lifetime of the command.
+ *
+ * @param  string $username The database user.
+ * @param  string $password The database password.
+ * @param  string $hostname The database host.
+ * @param  string $port     The database port.
+ *
+ * @return string|false The path to the file, or false when it cannot be created.
+ */
+function audit_database_defaults_file($username, $password, $hostname, $port) {
+	$path = tempnam(sys_get_temp_dir(), 'cacti_audit_');
+
+	if ($path === false) {
+		return false;
+	}
+
+	/* narrow the permissions before the secret is written */
+	if (!chmod($path, 0600)) {
+		unlink($path);
+
+		return false;
+	}
+
+	$contents  = '[client]' . PHP_EOL;
+	$contents .= 'user=' . $username . PHP_EOL;
+	$contents .= 'password=' . $password . PHP_EOL;
+	$contents .= 'host=' . $hostname . PHP_EOL;
+
+	if ($hostname != 'localhost') {
+		$contents .= 'port=' . $port . PHP_EOL;
+	}
+
+	if (file_put_contents($path, $contents) === false) {
+		unlink($path);
+
+		return false;
+	}
+
+	return $path;
+}
+
 function upgrade_database() {
 	global $config;
 
@@ -1043,13 +1091,22 @@ function create_tables($load = true) {
 		}
 
 		if (file_exists($config['base_path'] . '/docs/audit_schema.sql')) {
+			/* the credentials go in a private defaults file rather than on the
+			 * command line, where any local user could read them out of the
+			 * process list for as long as the import runs */
+			$defaults_file = audit_database_defaults_file($database_username, $database_password, $database_hostname, $database_port);
+
+			if ($defaults_file === false) {
+				print 'FATAL: Unable to create a private credentials file' . PHP_EOL;
+				exit(1);
+			}
+
 			exec($db_shell .
-				' -u' . cacti_escapeshellarg($database_username) .
-				' -p' . cacti_escapeshellarg($database_password) .
-				' -h' . cacti_escapeshellarg($database_hostname) .
-				' -P' . cacti_escapeshellarg($database_port) .
-				' ' . $database_default .
-				' < ' . $config['base_path'] . '/docs/audit_schema.sql', $output, $error);
+				' --defaults-extra-file=' . cacti_escapeshellarg($defaults_file) .
+				' ' . cacti_escapeshellarg($database_default) .
+				' < ' . cacti_escapeshellarg($config['base_path'] . '/docs/audit_schema.sql'), $output, $error);
+
+			unlink($defaults_file);
 
 			if ($error == 0) {
 				print ($altersopt ? '-- ' : '') . 'SUCCESS: Loaded the Audit Schema' . PHP_EOL;

--- a/cli/float_rrdfiles.php
+++ b/cli/float_rrdfiles.php
@@ -342,7 +342,7 @@ function float_rrdfile($rrd_path, $local_data_id, $step, $start_time, $end_time)
 			$fp = fopen($tmp_file, 'w');
 
 			if ($seebug) {
-				$lf = fopen('/tmp/clearer.log', 'a');
+				$lf = fopen(sys_get_temp_dir() . '/cacti_float_rrdfiles.log', 'a');
 			}
 
 			if (is_resource($fp)) {

--- a/cli/splice_rrd.php
+++ b/cli/splice_rrd.php
@@ -234,7 +234,7 @@ if (!file_exists($rrdtool)) {
 	}
 }
 
-$response = shell_exec($rrdtool);
+$response = shell_exec(cacti_escapeshellcmd($rrdtool));
 
 if (strlen($response)) {
 	$response_array = explode(' ', $response);
@@ -245,20 +245,20 @@ if (strlen($response)) {
 	exit(-1);
 }
 
-/* determine the temporary file name */
-$seed = mt_rand();
+/* The dump files and the backups were previously named from the RRD basename
+ * and mt_rand() directly in a world writable directory, and were created by
+ * shell redirection and copy(), both of which follow symlinks. Everything now
+ * goes in one private directory created for this run, so the names cannot be
+ * claimed in advance. */
+$tempdir = tempnam(sys_get_temp_dir(), 'cacti_splice_');
 
-if (substr_count(PHP_OS, 'WIN')) {
-	$tempdir    = getenv('TEMP');
-	$oldxmlfile = $tempdir . '/' . str_replace('.rrd', '', basename($oldrrd)) . '.dump.' . $seed;
-	$seed++;
-	$newxmlfile = $tempdir . '/' . str_replace('.rrd', '', basename($newrrd)) . '.dump.' . $seed;
-} else {
-	$tempdir    = '/tmp';
-	$oldxmlfile = '/tmp/' . str_replace('.rrd', '', basename($oldrrd)) . '.dump.' . $seed;
-	$seed++;
-	$newxmlfile = '/tmp/' . str_replace('.rrd', '', basename($newrrd)) . '.dump.' . $seed;
+if ($tempdir === false || !unlink($tempdir) || !mkdir($tempdir, 0700)) {
+	print 'FATAL: Unable to create a private working directory' . PHP_EOL;
+	exit(-1);
 }
+
+$oldxmlfile = $tempdir . '/' . str_replace('.rrd', '', basename($oldrrd)) . '.dump';
+$newxmlfile = $tempdir . '/' . str_replace('.rrd', '', basename($newrrd)) . '.dump';
 
 if ($finrrd == '') {
 	$finrrd = dirname($newrrd) . '/' . basename($newrrd) . '.new';
@@ -873,14 +873,16 @@ function writeXMLFile($output, $xmlfile) {
 }
 
 function backupRRDFile($rrdfile) {
-	global $tempdir, $seed, $html;
+	global $tempdir, $html;
 
 	$backupdir = $tempdir;
 
-	if (file_exists($backupdir . '/' . basename($rrdfile))) {
-		$newfile = basename($rrdfile) . '.' . $seed;
-	} else {
-		$newfile = basename($rrdfile);
+	/* the working directory is private to this run, so a name only has to be
+	 * unique within it rather than unguessable */
+	$newfile = basename($rrdfile);
+
+	for ($i = 1; file_exists($backupdir . '/' . $newfile); $i++) {
+		$newfile = basename($rrdfile) . '.' . $i;
 	}
 
 	print 'NOTE: Backing Up \'' . $rrdfile . '\' to \'' . $backupdir . '/' .  $newfile . '\'' . PHP_EOL;


### PR DESCRIPTION
Found while reviewing the scripts under `cli/`. All three need local access to the Cacti host; none is remotely reachable, so this is a public pull request rather than an advisory.

**Database password on the command line — `cli/audit_database.php`**

The password was passed as an argument to the mysql client. Escaping does not help: an argument is readable from `/proc/*/cmdline` by every local user for as long as the import runs. With `--debug` the same string was also printed to stdout.

The credentials now go in a defaults file created with `tempnam()`, narrowed to mode `0600` *before* the secret is written, passed as `--defaults-extra-file=`, and removed afterwards.

**Guessable temporary files — `cli/splice_rrd.php`**

The dump files were named from the RRD basename plus `mt_rand()` in a world-writable directory and created by shell redirection; `backupRRDFile()` copied into the same place. Both now use one private directory created for the run with mode `0700`, so the names cannot be claimed in advance.

Worth stating plainly: **this is hardening, not a fix for an exploitable path on a current system.** `fs.protected_symlinks` is enabled by default on every supported kernel and blocks the symlink case in sticky world-writable directories. I confirmed that while testing, and could not defeat it. The names should still not be guessable, and the `copy()` in `backupRRDFile()` does not benefit from the sticky-directory protection in the same way.

**Fixed log path — `cli/float_rrdfiles.php`**

The debug log appended to a fixed `/tmp/clearer.log`, which any local user could pre-create or read. It now uses the system temporary directory under its own name.

**Verification**

`php -l` clean on all three files. The credentials change was checked by confirming the defaults file is created `0600` before the password is written and unlinked after the command returns.

**Two further items that only apply to 1.2.x**

develop already fixed both of these; the maintenance branch did not get them.

- `splice_rrd.php` ran the configured RRDtool path through a shell unescaped at the version check, while two later calls in the same file escaped the same variable. The path comes from a database setting, so this is admin-controlled rather than attacker-controlled, but one file should not hold two conventions.
- In the `audit_database.php` command, the database name and the schema path were the only values not escaped while every other parameter was.

The companion pull request for develop is #7909.
