### PR TITLE
fix(deps): return phpseclib to the 3.x line

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "lipis/flag-icons": "^7.5.0",
         "mikepultz/netdns2": "^2.0",
         "php-mqtt/client": "^2.2",
-        "phpseclib/phpseclib": "^4.0",
+        "phpseclib/phpseclib": "^3.0",
         "psr/log": "^3.0",
         "slim/slim": "^4.14",
         "stevenmaguire/oauth2-keycloak": "^6.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e454a7a18480c59f0d3db3dfcaafc893",
+    "content-hash": "f7b48b26d1d49eea38648394c7fe5ae4",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -1057,6 +1057,56 @@
             "time": "2025-09-24T15:06:41+00:00"
         },
         {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
             "name": "php-mqtt/client",
             "version": "v2.3.2",
             "source": {
@@ -1115,35 +1165,31 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "4.0.0",
+            "version": "3.0.57",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "86669f07ca2ed75357329c910064a72c8ad1f507"
+                "reference": "d17e0ddaeaf6f22f7e007cbb437d78792fe2a0e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/86669f07ca2ed75357329c910064a72c8ad1f507",
-                "reference": "86669f07ca2ed75357329c910064a72c8ad1f507",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d17e0ddaeaf6f22f7e007cbb437d78792fe2a0e4",
+                "reference": "d17e0ddaeaf6f22f7e007cbb437d78792fe2a0e4",
                 "shasum": ""
             },
             "require": {
-                "paragonie/constant_time_encoding": "^2|^3",
-                "php": ">=8.1",
-                "symfony/polyfill-php82": "^1.26"
+                "paragonie/constant_time_encoding": "^1|^2|^3",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
             },
             "require-dev": {
-                "brianium/paratest": "^7.22",
-                "ext-xml": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3",
-                "phpunit/phpunit": "^13",
-                "squizlabs/php_codesniffer": "^3.7",
-                "vimeo/psalm": "*"
+                "phpunit/phpunit": "*"
             },
             "suggest": {
                 "ext-dom": "Install the DOM extension to load XML formatted public keys.",
                 "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
                 "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
                 "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
             },
             "type": "library",
@@ -1152,7 +1198,7 @@
                     "phpseclib/bootstrap.php"
                 ],
                 "psr-4": {
-                    "phpseclib4\\": "phpseclib/"
+                    "phpseclib3\\": "phpseclib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1184,16 +1230,10 @@
                     "name": "Graham Campbell",
                     "email": "graham@alt-three.com",
                     "role": "Developer"
-                },
-                {
-                    "name": "Jack Worman",
-                    "email": "jack.worman@gmail.com",
-                    "homepage": "https://jackworman.com",
-                    "role": "Developer"
                 }
             ],
             "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
-            "homepage": "https://phpseclib.com/",
+            "homepage": "http://phpseclib.sourceforge.net",
             "keywords": [
                 "BigInteger",
                 "aes",
@@ -1215,7 +1255,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/4.0.0"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.57"
             },
             "funding": [
                 {
@@ -1231,7 +1271,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-23T03:21:49+00:00"
+            "time": "2026-08-26T12:13:21+00:00"
         },
         {
             "name": "psr/container",
@@ -3071,86 +3111,6 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php82",
-            "version": "v1.38.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php82.git",
-                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
-                "reference": "002dc0cfe5fd4ed6033d48f27d4f19a486c4b04b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php82\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.2+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php82/tree/v1.38.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php83",

--- a/tests/Unit/Dependencies/PhpseclibNamespaceTest.php
+++ b/tests/Unit/Dependencies/PhpseclibNamespaceTest.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * phpseclib puts its major version in its namespace, so a major bump renames
+ * every class Cacti references. Composer accepts the upgrade, nothing fails at
+ * install time, and the first fatal arrives when someone creates an RSA
+ * keypair or talks to an RRDtool proxy.
+ *
+ * These tests fail at the point the constraint changes rather than in
+ * production.
+ */
+
+test('the classes the source references actually exist', function () {
+	require_once dirname(__DIR__, 3) . '/include/vendor/autoload.php';
+
+	expect(class_exists('phpseclib3\Crypt\RSA'))->toBeTrue()
+		->and(class_exists('phpseclib3\Crypt\Rijndael'))->toBeTrue()
+		->and(class_exists('phpseclib3\Crypt\Random'))->toBeTrue();
+});
+
+test('the composer constraint matches the namespace in the source', function () {
+	$root       = dirname(__DIR__, 3);
+	$composer   = json_decode(file_get_contents($root . '/composer.json'), true);
+	$constraint = $composer['require']['phpseclib/phpseclib'] ?? '';
+
+	/* the sources use phpseclib3\, which only the 3.x line provides */
+	expect($constraint)->toStartWith('^3.')
+		->and(file_get_contents($root . '/lib/auth.php'))->toContain('use phpseclib3\Crypt\RSA;');
+});


### PR DESCRIPTION
**develop is broken and the required CI job has been failing since #7867 merged.**

That pull request bumped `phpseclib/phpseclib` from 3.0.56 to **4.0.0**. phpseclib carries its major version in its namespace, so 4.0 ships `phpseclib4\` while `lib/auth.php` and `lib/rrd.php` reference `phpseclib3\`. Composer accepts the upgrade and nothing fails at install time.

```
$ php -r "require 'include/vendor/autoload.php';
          var_dump(class_exists('phpseclib3\\Crypt\\RSA'));"
bool(false)
```

**What is broken**

- `rsa_check_keypair()` in `lib/auth.php:4521`, which runs whenever no RSA key is stored, so on a fresh install
- the RRDtool proxy encryption path in `lib/rrd.php`, used by remote data collectors

Both fatal on a missing class.

**Evidence**

| | develop | with this change |
|---|---|---|
| PHPStan level 6 | 17 errors, all `class.notFound` | **no errors** |
| Pest | 12 failed, 2172 passed | **8 failed, 2176 passed** |

The eight remaining failures are pre-existing and environmental: the OrbStack integration tests and the ratchet baselines, which are unrelated to this change and fail identically on unmodified develop.

The required check on develop is currently red across `PHP 8.2` through `8.5`, the locked integration job, and the coverage gate.

**Why revert rather than migrate**

phpseclib 4 is a deliberate migration: the namespace moves and the API changes with it. That is worth doing on its own, with the call sites and the tests updated together and reviewed as a unit. It is not something a dependency bump should perform silently, and develop should not stay broken while it is written.

**Preventing a repeat**

`tests/Unit/Dependencies/PhpseclibNamespaceTest.php` asserts that the classes the sources reference actually resolve, and that the Composer constraint still matches the namespace in use. Re-applying the `^4.0` bump with the test in place:

```
✓ the classes the source references actually exist
⨯ the composer constraint matches the namespace in the source
Tests: 1 failed, 1 passed
```

So the next major bump fails in CI rather than in production.
