### PR TITLE
chore: replace removed jQuery $.isFunction() with typeof checks

### DIFF
--- a/include/js/navigationBox.js
+++ b/include/js/navigationBox.js
@@ -688,7 +688,7 @@ class cactiButton extends cactiNavigation {
 
         // re-initialize resizable if box just became visible
         const $box = this._getBox(helper);
-        if ($box.hasClass('visible') && $box.attr('data-style') === 'overlay' && $.isFunction($.fn.resizable)) {
+        if ($box.hasClass('visible') && $box.attr('data-style') === 'overlay' && typeof $.fn.resizable === 'function') {
             $box.resizable({ handles: 'e' });
         }
     }
@@ -1229,7 +1229,7 @@ class cactiBox extends cactiNavigation {
 
     searchToHighlight(data) {
         // critical check: ensure external library mark.js is loaded
-        if (!$.isFunction($.fn.markRegExp)) {
+        if (!typeof $.fn.markRegExp === 'function') {
             console.error("NavigationBox Error: 'mark.js' is not loaded! The search function requires this library.");
             return;
         }

--- a/include/js/navigationBox.js
+++ b/include/js/navigationBox.js
@@ -1229,7 +1229,7 @@ class cactiBox extends cactiNavigation {
 
     searchToHighlight(data) {
         // critical check: ensure external library mark.js is loaded
-        if (!typeof $.fn.markRegExp === 'function') {
+        if (typeof $.fn.markRegExp !== 'function') {
             console.error("NavigationBox Error: 'mark.js' is not loaded! The search function requires this library.");
             return;
         }

--- a/include/js/navigationBox.tree.js
+++ b/include/js/navigationBox.tree.js
@@ -273,7 +273,7 @@ midwinter.navigationBox.tree = {
 
         const $tree = $box.find('.mdw-jstree-wrapper');
 
-        if ($tree.length && $.isFunction($tree.jstree)) {
+        if ($tree.length && typeof $tree.jstree === 'function') {
 
             if (command.includes('Selected')) {
                 const actualCommand = command.startsWith('expand') ? 'open_all' : 'close_all';


### PR DESCRIPTION
jQuery 4.0 removes `$.isFunction()`. This swaps the three call sites in Cacti's own code for behaviour-identical `typeof x === 'function'` checks:

- `include/js/navigationBox.js` — `$.fn.resizable`, `$.fn.markRegExp`
- `include/js/navigationBox.tree.js` — `$tree.jstree`

`jQuery.isFunction` was a thin wrapper over `typeof === 'function'`, so the semantics are unchanged.

This is the only jQuery-4-removed API in Cacti's own front-end code. It does not make Cacti jQuery-4-ready on its own — the remaining work is in the bundled plugins (tracked in #7914), several of which use removed APIs internally and have no maintained jQuery-4 upstream. This is just the small, safe first step.

`node --check` passes on both files.
