### PR TITLE
build: analyse at PHPStan level 8 and unpin the analyser

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -2,6 +2,8 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
+    level: 8
+
     parallel:
         maximumNumberOfProcesses: 8
     scanDirectories:

--- a/composer.json
+++ b/composer.json
@@ -69,12 +69,12 @@
         "overtrue/phplint": "^9.6",
         "pestphp/pest": "^2 || ^3",
         "pestphp/pest-plugin-drift": "^2.0 || ^3.0",
-        "phpstan/phpstan": "2.2.9",
+        "phpstan/phpstan": "^2.2.12",
         "rector/rector": "^2.1.2"
     },
     "scripts": {
         "lint": "phplint --no-cache --exclude=include/vendor --exclude=plugins ",
-        "phpstan": "phpstan analyse --level 6 ",
+        "phpstan": "phpstan analyse ",
         "php-cs-fixer": "php-cs-fixer fix --allow-unsupported-php-version=yes --dry-run --diff --config=./.php-cs-fixer.php ",
         "phpcsfixer": "@php-cs-fixer",
         "hardening-patterns": "php tests/tools/check_hardening_patterns.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e454a7a18480c59f0d3db3dfcaafc893",
+    "content-hash": "31db7cf9f6ccd957f9f3bfb6e8824256",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -5394,11 +5394,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.9",
+            "version": "2.2.12",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/13d6b4f347bad222da436580c8304fa6f83e6bd0",
-                "reference": "13d6b4f347bad222da436580c8304fa6f83e6bd0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/174b0d88710f00a42598886504dd7a146f91ace5",
+                "reference": "174b0d88710f00a42598886504dd7a146f91ace5",
                 "shasum": ""
             },
             "require": {
@@ -5454,7 +5454,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-22T07:38:16+00:00"
+            "time": "2026-08-31T19:09:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2389,24 +2389,6 @@ parameters:
 			path: include/themes/midwinter/update_hash.php
 
 		-
-			message: '#^Variable \$argc might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: install/cli_check.php
-
-		-
-			message: '#^Variable \$argv might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: install/cli_check.php
-
-		-
-			message: '#^Variable \$argv might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: install/cli_test.php
-
-		-
 			message: '#^Parameter \#2 \$subject of function preg_match expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2389,6 +2389,24 @@ parameters:
 			path: include/themes/midwinter/update_hash.php
 
 		-
+			message: '#^Variable \$argc might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: install/cli_check.php
+
+		-
+			message: '#^Variable \$argv might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: install/cli_check.php
+
+		-
+			message: '#^Variable \$argv might not be defined\.$#'
+			identifier: variable.undefined
+			count: 1
+			path: install/cli_test.php
+
+		-
 			message: '#^Parameter \#2 \$subject of function preg_match expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -5457,31 +5475,37 @@ parameters:
 		-
 			message: '#^Access to an undefined property object\:\:\$alive\.$#'
 			identifier: property.notFound
-			count: 1
+			count: 6
 			path: lib/rrd.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$process\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 3
+			path: lib/rrd.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$restarts\.$#'
+			identifier: property.notFound
+			count: 1
 			path: lib/rrd.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$stderr\.$#'
 			identifier: property.notFound
-			count: 1
+			count: 2
 			path: lib/rrd.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$stdin\.$#'
 			identifier: property.notFound
-			count: 1
+			count: 2
 			path: lib/rrd.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$stdout\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 3
 			path: lib/rrd.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3655,6 +3655,12 @@ parameters:
 			path: lib/database.php
 
 		-
+			message: '#^Call to an undefined method object\:\:inTransaction\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/database.php
+
+		-
 			message: '#^Call to an undefined method object\:\:lastInsertId\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,2394 @@
 parameters:
 	ignoreErrors:
 		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''aggregate_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''gprint_format'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''gprint_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''graph_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''graph_type_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''local_graph_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''local_graph_template_graph_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''local_graph_template_item_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''order_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''sequence'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''template_propogation'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''title_format'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''total'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''total_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset ''total_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset mixed on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Cannot access offset non\-falsy\-string on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_keys expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 2
+			path: aggregate_graphs.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Argument of an invalid type array\|true supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''gprint_format'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''gprint_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''graph_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''order_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''total'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''total_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Cannot access offset ''total_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Parameter \#3 \$_object of function draw_aggregate_graph_items_list expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: aggregate_templates.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: api/include/db_functions.php
+
+		-
+			message: '#^Parameter \#1 \$string of method Psr\\Http\\Message\\StreamInterface\:\:write\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 18
+			path: api/public/index.php
+
+		-
+			message: '#^Cannot access offset ''login_opts'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_2fa.php
+
+		-
+			message: '#^Cannot access offset ''tfa_secret'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_2fa.php
+
+		-
+			message: '#^Cannot access offset ''username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: auth_2fa.php
+
+		-
+			message: '#^Argument of an invalid type list\<array\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: auth_changepassword.php
+
+		-
+			message: '#^Cannot access offset ''password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_changepassword.php
+
+		-
+			message: '#^Cannot access offset ''password_history'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_changepassword.php
+
+		-
+			message: '#^Cannot access offset ''realm'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_changepassword.php
+
+		-
+			message: '#^Offset ''host'' might not exist on array\{scheme\?\: string, host\?\: string, port\?\: int\<0, 65535\>, user\?\: string, pass\?\: string, path\?\: string, query\?\: string, fragment\?\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 2
+			path: auth_changepassword.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: auth_login.php
+
+		-
+			message: '#^Cannot access offset ''login_opts'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: auth_login.php
+
+		-
+			message: '#^Cannot access offset ''must_change_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_login.php
+
+		-
+			message: '#^Cannot access offset ''username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: auth_login.php
+
+		-
+			message: '#^Cannot access offset ''username'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: auth_login.php
+
+		-
+			message: '#^Parameter \#1 \$user of function auth_user_has_access expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: auth_login.php
+
+		-
+			message: '#^Parameter \#1 \$user of function set_auth_cookie expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: auth_login.php
+
+		-
+			message: '#^Cannot access offset ''tfa_enabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_profile.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_profile.php
+
+		-
+			message: '#^Cannot access offset ''email_address'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_resetpassword.php
+
+		-
+			message: '#^Cannot access offset ''hash'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: auth_resetpassword.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 12
+			path: auth_resetpassword.php
+
+		-
+			message: '#^Cannot access offset ''password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: auth_resetpassword.php
+
+		-
+			message: '#^Cannot access offset ''password_history'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_resetpassword.php
+
+		-
+			message: '#^Cannot access offset ''username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: auth_resetpassword.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: automation_devices.php
+
+		-
+			message: '#^Cannot access offset ''ping_method'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_devices.php
+
+		-
+			message: '#^Cannot access offset ''ping_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_devices.php
+
+		-
+			message: '#^Cannot access offset ''ping_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_devices.php
+
+		-
+			message: '#^Cannot access offset ''ping_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_devices.php
+
+		-
+			message: '#^Cannot access offset ''poller_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_devices.php
+
+		-
+			message: '#^Cannot access offset ''graph_type_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_graph_rules.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: automation_graph_rules.php
+
+		-
+			message: '#^Parameter \#1 \$rule of function display_matching_hosts expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: automation_graph_rules.php
+
+		-
+			message: '#^Parameter \#1 \$rule of function display_new_graphs expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: automation_graph_rules.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_networks.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: automation_networks.php
+
+		-
+			message: '#^Cannot access offset ''up'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_networks.php
+
+		-
+			message: '#^Parameter \#1 \$network of function network_get_field_array expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: automation_networks.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: automation_snmp.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: automation_snmp.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_snmp.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: automation_snmp.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: automation_templates.php
+
+		-
+			message: '#^Cannot access offset ''host_template'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: automation_templates.php
+
+		-
+			message: '#^Cannot access offset ''rule_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: automation_templates.php
+
+		-
+			message: '#^Cannot access offset ''enabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: automation_tree_rules.php
+
+		-
+			message: '#^Cannot access offset ''field'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: automation_tree_rules.php
+
+		-
+			message: '#^Cannot access offset ''leaf_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: automation_tree_rules.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: automation_tree_rules.php
+
+		-
+			message: '#^Cannot access offset ''tree_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_tree_rules.php
+
+		-
+			message: '#^Cannot access offset ''tree_item_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: automation_tree_rules.php
+
+		-
+			message: '#^Parameter \#3 \$item of function display_matching_trees expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: automation_tree_rules.php
+
+		-
+			message: '#^Function get_options\(\) should return array but returns array\<string, list\<mixed\>\|string\|false\>\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: cactid.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cdef.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: cdef.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: cdef.php
+
+		-
+			message: '#^Cannot access offset ''type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: cdef.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cdef.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_shift expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: changelog.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#10 \$snmp_timeout of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#12 \$availability_method of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#14 \$ping_port of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#15 \$ping_timeout of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#16 \$ping_retries of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#2 \$device_template_id of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#23 \$max_oids of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#24 \$device_threads of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#25 \$poller_id of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#26 \$site_id of function api_device_save expects int, int\<0, max\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#29 \$bulk_walk_size of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#31 \$snmp_retries of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#6 \$snmp_version of function api_device_save expects int, int\<0, 3\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Parameter \#9 \$snmp_port of function api_device_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_device.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/add_graphs.php
+
+		-
+			message: '#^Parameter \#1 \$string of function cacti_strtolower expects string, list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_graphs.php
+
+		-
+			message: '#^Parameter \#2 \$snmp_query_id of function getSNMPFields expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_graphs.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, list\<mixed\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_graphs.php
+
+		-
+			message: '#^Parameter \#3 \$snmp_query_id of function getSNMPValues expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_graphs.php
+
+		-
+			message: '#^Part \$snmpValue \(0\|0\.0\|''''\|''0''\|array\{\}\|false\|null\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: cli/add_graphs.php
+
+		-
+			message: '#^Function fetchCurl\(\) should return string\|false but returns string\|true\.$#'
+			identifier: return.type
+			count: 1
+			path: cli/add_site.php
+
+		-
+			message: '#^Parameter \#2 \$doMap of function mapDevices expects bool, string\|true given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_site.php
+
+		-
+			message: '#^Parameter \#3 \$value of function curl_setopt expects non\-empty\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_site.php
+
+		-
+			message: '#^Offset ''graph''\|''header''\|''host''\|''site'' might not exist on array\{header\: 1, graph\: 2, host\: 3\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: cli/add_tree.php
+
+		-
+			message: '#^Parameter \#9 \$host_grouping_type of function api_tree_item_save expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/add_tree.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/analyze_database.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 9
+			path: cli/audit_database.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/audit_database.php
+
+		-
+			message: '#^Binary operation "\." between non\-falsy\-string and non\-empty\-array\<string\>\|non\-falsy\-string\|true results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: cli/audit_database.php
+
+		-
+			message: '#^Cannot access offset ''Collation'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: cli/audit_database.php
+
+		-
+			message: '#^Cannot access offset ''ENGINE'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/audit_database.php
+
+		-
+			message: '#^Cannot access offset ''idx_column_name''\|''idx_comment''\|''idx_key_name''\|''idx_non_unique''\|''idx_packed''\|''idx_seq_in_index'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: cli/audit_database.php
+
+		-
+			message: '#^Cannot access offset ''info'' on array\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/audit_database.php
+
+		-
+			message: '#^Cannot access offset ''table_default''\|''table_extra''\|''table_key''\|''table_null''\|''table_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: cli/audit_database.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, array\<string\>\|string\|true given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/audit_database.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: cli/audit_database.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, array\<string\>\|string\|true given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/audit_database.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, array\<string\>\|string\|true given\.$#'
+			identifier: argument.type
+			count: 3
+			path: cli/audit_database.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/audit_graph_template_inputs.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/batchgapfix.php
+
+		-
+			message: '#^Parameter \#1 \.\.\.\$arrays of function array_merge expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/change_device.php
+
+		-
+			message: '#^Parameter \#25 \$poller_id of function api_device_save expects int, float\|int\<0, max\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/change_device.php
+
+		-
+			message: '#^Parameter \#26 \$site_id of function api_device_save expects int, float\|int\<0, max\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/change_device.php
+
+		-
+			message: '#^Parameter \#6 \$snmp_version of function api_device_save expects int, float\|int\<0, 3\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/change_device.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Cannot access offset ''class'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fgets expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#2 \$device_template_name of function api_clone_device_template_check_for_errors expects string, list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#2 \$template_name of function api_clone_device_template expects string, list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#3 \$include_gt of function api_clone_device_template expects string, list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#3 \$include_gt of function api_clone_device_template_check_for_errors expects string, list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#4 \$clone_gt of function api_clone_device_template expects string, list\<mixed\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#4 \$clone_gt of function api_clone_device_template_check_for_errors expects string, list\<mixed\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#5 \$include_dq of function api_clone_device_template expects string, list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#5 \$include_dq of function api_clone_device_template_check_for_errors expects string, list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#6 \$clone_dq of function api_clone_device_template expects string, list\<mixed\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#6 \$clone_dq of function api_clone_device_template_check_for_errors expects string, list\<mixed\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#7 \$include_dt of function api_clone_device_template expects string, list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#7 \$include_dt of function api_clone_device_template_check_for_errors expects string, list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#8 \$clone_dt of function api_clone_device_template expects string, list\<mixed\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Parameter \#8 \$clone_dt of function api_clone_device_template_check_for_errors expects string, list\<mixed\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/clone_device_template.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/convert_tables.php
+
+		-
+			message: '#^Cannot access offset ''Value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/convert_tables.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/fix_mediumint.php
+
+		-
+			message: '#^Cannot access offset 2 on list\<string\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Cannot access offset 5 on list\<string\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Cannot access offset 7 on list\<string\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fwrite expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 6
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#10 \$end_time of function float_master_handler expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#2 \$timestamp of function date expects int\|null, int\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#3 \$host_id of function float_master_handler expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function register_process_start expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function unregister_process expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#4 \$host_template_id of function float_master_handler expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#4 \$pid of function unregister_process expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#4 \$start_time of function float_rrdfile expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#5 \$end_time of function float_rrdfile expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#5 \$graph_template_id of function float_master_handler expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#7 \$threads of function float_master_handler expects int, int\<min, \-1\>\|int\<1, max\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#9 \$start_time of function float_master_handler expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/float_rrdfiles.php
+
+		-
+			message: '#^Parameter \#1 \$csr of function openssl_csr_sign expects OpenSSLCertificateSigningRequest\|string, OpenSSLCertificateSigningRequest\|true given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/genkey.php
+
+		-
+			message: '#^Parameter \#4 \$days of function openssl_csr_sign expects int, int\|list\<mixed\>\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/genkey.php
+
+		-
+			message: '#^Part \$author \(list\<mixed\>\|string\|false\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: cli/genkey.php
+
+		-
+			message: '#^Part \$email \(list\<mixed\>\|string\|false\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: cli/genkey.php
+
+		-
+			message: '#^Part \$homepage \(list\<mixed\>\|string\|false\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: cli/genkey.php
+
+		-
+			message: '#^Argument of an invalid type list\<mixed\>\|string supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/genmanifest.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/genmanifest.php
+
+		-
+			message: '#^Parameter \#2 \$content of method CactiFilesystem\:\:writeFile\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/genmanifest.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_package.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fread expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_package.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_package.php
+
+		-
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_package.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_template.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fread expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_template.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_template.php
+
+		-
+			message: '#^Parameter \#1 \$xml_data of function import_xml_data expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_template.php
+
+		-
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_template.php
+
+		-
+			message: '#^Parameter \#3 \$web of function import_display_results expects bool, int\|true given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/import_template.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/input_whitelist.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: cli/input_whitelist.php
+
+		-
+			message: '#^Parameter \#2 \$content of method CactiFilesystem\:\:writeFile\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/input_whitelist.php
+
+		-
+			message: '#^Parameter \#2 \$contents of function debug_install_array expects array, array\<mixed, mixed\>\|object given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/install_cacti.php
+
+		-
+			message: '#^Parameter \#1 \$basePath of method CactiMd5FileFinder\:\:findHashes\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/md5sum.php
+
+		-
+			message: '#^Cannot access offset ''description'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: cli/migrate_poller.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/migrate_poller.php
+
+		-
+			message: '#^Cannot access offset ''id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: cli/migrate_poller.php
+
+		-
+			message: '#^Cannot access offset ''poller_id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: cli/migrate_poller.php
+
+		-
+			message: '#^Parameter \#1 \$device of function migrate_device expects array, array\|true given\.$#'
+			identifier: argument.type
+			count: 2
+			path: cli/migrate_poller.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: cli/migrate_poller.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/poller_data_sources_reapply_names.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/poller_graphs_reapply_names.php
+
+		-
+			message: '#^Binary operation "\-" between 0\|string and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: cli/poller_reindex_hosts.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function register_process_start expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/poller_reindex_hosts.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function unregister_process expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/poller_reindex_hosts.php
+
+		-
+			message: '#^Parameter \#4 \$pid of function unregister_process expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/poller_reindex_hosts.php
+
+		-
+			message: '#^Parameter \#5 \$threads of function reindex_master_handler expects int, int\<min, \-1\>\|int\<1, max\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/poller_reindex_hosts.php
+
+		-
+			message: '#^Binary operation "\-" between 0\|string and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: cli/rebuild_poller_cache.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function register_process_start expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rebuild_poller_cache.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function unregister_process expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rebuild_poller_cache.php
+
+		-
+			message: '#^Parameter \#4 \$pid of function unregister_process expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rebuild_poller_cache.php
+
+		-
+			message: '#^Parameter \#5 \$threads of function pushout_master_handler expects int, int\<min, \-1\>\|int\<1, max\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rebuild_poller_cache.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/remove_broken_graphs.php
+
+		-
+			message: '#^Binary operation "\-" between 80\|non\-falsy\-string and 5 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: cli/remove_broken_graphs.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/remove_broken_graphs.php
+
+		-
+			message: '#^Argument of an invalid type array\|true supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/remove_graphs.php
+
+		-
+			message: '#^Parameter \#5 \$out_start of class spikekill constructor expects string, int\<min, \-1\>\|int\<1, max\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/removespikes.php
+
+		-
+			message: '#^Parameter \#6 \$out_end of class spikekill constructor expects string, int\<min, \-1\>\|int\<1, max\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/removespikes.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/reorder_data_query.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 8
+			path: cli/repair_database.php
+
+		-
+			message: '#^Cannot access offset ''description'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/repair_database.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 9
+			path: cli/repair_database.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/repair_database.php
+
+		-
+			message: '#^Cannot access offset ''local_data_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: cli/repair_database.php
+
+		-
+			message: '#^Cannot access offset ''snmp_index'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/repair_database.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_graph_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/repair_database.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/repair_database.php
+
+		-
+			message: '#^Cannot access offset ''type_code'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/repair_database.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/repair_graphs.php
+
+		-
+			message: '#^Cannot access offset 0 on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: cli/repair_graphs.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 4
+			path: cli/repair_templates.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Cannot access offset ''data_template_id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_flip expects array\<int\|string\>, list\<float\|int\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Parameter \#1 \$directory of function mkdir expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function substr_count expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Parameter \#1 \$value of function count expects array\|Countable, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Parameter \#1 \$value of function sizeof expects array\|Countable, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Variable \$calculated_index in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: cli/rrdresize.php
+
+		-
+			message: '#^Parameter \#1 \$string of function cacti_strtolower expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/show_perms.php
+
+		-
+			message: '#^Call to an undefined method object\:\:exec\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: cli/splice_rrd.php
+
+		-
+			message: '#^Parameter \#1 \$output of function preProcessXML expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: cli/splice_rrd.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/splice_rrd.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/splice_rrd.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/splice_rrd.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: cli/sqltable_to_php.php
+
+		-
+			message: '#^Cannot access offset ''CHARACTER_SET_NAME'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/sqltable_to_php.php
+
+		-
+			message: '#^Cannot access offset ''ENGINE'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/sqltable_to_php.php
+
+		-
+			message: '#^Cannot access offset ''ROW_FORMAT'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cli/sqltable_to_php.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: cli/update_heartbeat.php
+
+		-
+			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cli/update_heartbeat.php
+
+		-
+			message: '#^Cannot access offset ''Type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cmd.php
+
+		-
+			message: '#^Cannot access offset ''availability_method'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: cmd.php
+
+		-
+			message: '#^Cannot access offset ''ping_method'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cmd.php
+
+		-
+			message: '#^Cannot access offset ''ping_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cmd.php
+
+		-
+			message: '#^Cannot access offset ''ping_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cmd.php
+
+		-
+			message: '#^Cannot access offset ''ping_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cmd.php
+
+		-
+			message: '#^Function collect_device_data\(\) should return string but returns float\|int\|string\.$#'
+			identifier: return.type
+			count: 1
+			path: cmd.php
+
+		-
+			message: '#^Function get_max_column_width\(\) should return int but returns int\|string\.$#'
+			identifier: return.type
+			count: 1
+			path: cmd.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function substr_count expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cmd.php
+
+		-
+			message: '#^Parameter \#2 \$item of function open_snmp_session expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: cmd.php
+
+		-
+			message: '#^Cannot access offset ''max_oids'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: cmd_realtime.php
+
+		-
+			message: '#^Cannot access offset ''ping_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: cmd_realtime.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: color.php
+
+		-
+			message: '#^Cannot access offset ''hex'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: color.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: color.php
+
+		-
+			message: '#^Parameter \#1 \$colors of function color_import_processor expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: color.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: color_templates.php
+
+		-
+			message: '#^Cannot access offset ''color_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: color_templates.php
+
+		-
+			message: '#^Cannot access offset ''color_template_item_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: color_templates.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: color_templates.php
+
+		-
+			message: '#^Cannot access offset ''sequence'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 10
+			path: color_templates.php
+
+		-
+			message: '#^Parameter \#1 \$id of function get_next_sequence expects int, array\|float\|int\|string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: color_templates.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: color_templates.php
+
+		-
+			message: '#^Cannot access offset ''data_source_path'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_debug.php
+
+		-
+			message: '#^Cannot access offset ''datasource'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_debug.php
+
+		-
+			message: '#^Cannot access offset ''done'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_debug.php
+
+		-
+			message: '#^Cannot access offset ''info'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: data_debug.php
+
+		-
+			message: '#^Cannot access offset ''issue'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_debug.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: data_input.php
+
+		-
+			message: '#^Cannot access offset ''data_input_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_input.php
+
+		-
+			message: '#^Cannot access offset ''data_name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_input.php
+
+		-
+			message: '#^Cannot access offset ''data_sources'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_input.php
+
+		-
+			message: '#^Cannot access offset ''input_output'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_input.php
+
+		-
+			message: '#^Cannot access offset ''input_string'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_input.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: data_input.php
+
+		-
+			message: '#^Cannot access offset ''templates'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_input.php
+
+		-
+			message: '#^Cannot access offset ''type_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: data_input.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: data_queries.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: data_queries.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: data_source_profiles.php
+
+		-
+			message: '#^Cannot access offset ''data_source_profile_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_source_profiles.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_source_profiles.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_source_profiles.php
+
+		-
+			message: '#^Cannot access offset ''step'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_source_profiles.php
+
+		-
+			message: '#^Cannot access offset ''steps'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_source_profiles.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: data_source_profiles.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''active'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''data_input_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''data_source_name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''data_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''heartbeat'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''poller_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''step'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''total'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset non\-falsy\-string on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_sources.php
+
+		-
+			message: '#^Cannot access offset ''data_input_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: data_templates.php
+
+		-
+			message: '#^Cannot access offset ''data_source_name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_templates.php
+
+		-
+			message: '#^Cannot access offset ''data_sources'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_templates.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_templates.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: data_templates.php
+
+		-
+			message: '#^Cannot access offset mixed on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: data_templates.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: gprint_presets.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: gprint_presets.php
+
+		-
+			message: '#^Parameter \#1 \$string of function rrdtool_create_error_image expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: graph_image.php
+
+		-
+			message: '#^Offset ''graph_height'' might not exist on array\{graph_start\?\: mixed, graph_end\?\: mixed, graph_height\?\: mixed, graph_width\: mixed, graph_nolegend\: mixed, print_source\?\: mixed, disable_cache\?\: true, graph_theme\?\: string, \.\.\.\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: graph_json.php
+
+		-
+			message: '#^Offset ''graph_height'' might not exist on array\{graph_start\?\: mixed, graph_end\?\: mixed, graph_height\?\: mixed, graph_width\: mixed, graph_nolegend\?\: mixed, print_source\?\: mixed, disable_cache\?\: true, graph_theme\?\: string, \.\.\.\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: graph_json.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: graph_json.php
+
+		-
+			message: '#^Parameter \#1 \$string of function rrdtool_create_error_image expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: graph_json.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: graph_json.php
+
+		-
+			message: '#^Parameter \#3 \$offset of function strpos expects int, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: graph_json.php
+
+		-
+			message: '#^Cannot access offset ''height'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graph_realtime.php
+
+		-
+			message: '#^Cannot access offset ''width'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graph_realtime.php
+
+		-
+			message: '#^Offset ''graph_start'' might not exist on array\{ds_step\: mixed, graph_height\: mixed, graph_width\: mixed, graph_nolegend\?\: ''true'', graph_start\?\: mixed, graph_end\: mixed, print_source\?\: mixed, image_format\: ''png''\|''svg\+xml'', \.\.\.\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: graph_realtime.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: graph_realtime.php
+
+		-
+			message: '#^Parameter \#2 \$data of function hash expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: graph_realtime.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: graph_templates.php
+
+		-
+			message: '#^Cannot access offset ''graph_type_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graph_templates.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: graph_templates.php
+
+		-
+			message: '#^Cannot access offset ''legend'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graph_templates.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graph_templates.php
+
+		-
+			message: '#^Cannot access offset ''task_item_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: graph_templates.php
+
+		-
+			message: '#^Cannot access offset \(int\|string\) on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graph_templates.php
+
+		-
+			message: '#^Cannot access offset ''base_value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graph_xport.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''data_input_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''gprint_format'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''gprint_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''graph_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''graph_type_id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''local_graph_template_item_id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''order_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''src'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''task_item_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''total'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''total_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Cannot access offset ''total_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Function parse_validate_graph_template_id\(\) should return string but returns int\|string\.$#'
+			identifier: return.type
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Parameter \#1 \$graph of function get_common_graph_templates expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Parameter \#2 \$host of function draw_item_filter expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: graphs.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: graphs_new.php
+
+		-
+			message: '#^Cannot access offset ''allow_nulls'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs_new.php
+
+		-
+			message: '#^Cannot access offset ''description'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs_new.php
+
+		-
+			message: '#^Cannot access offset ''host_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: graphs_new.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs_new.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 11
+			path: graphs_new.php
+
+		-
+			message: '#^Cannot access offset non\-falsy\-string on non\-empty\-array\<non\-falsy\-string, true\>\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: graphs_new.php
+
+		-
+			message: '#^Parameter \#3 \$host of function draw_graphs_new_filter expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: graphs_new.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: host.php
+
+		-
+			message: '#^Cannot access offset ''description'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: host.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: host.php
+
+		-
+			message: '#^Function get_maint_hosts\(\) should return array but returns array\|bool\.$#'
+			identifier: return.type
+			count: 1
+			path: host.php
+
+		-
+			message: '#^Parameter \#1 \$host of function create_host_edit_filter expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 2
+			path: host.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: host.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fputcsv expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: host.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: host_templates.php
+
+		-
+			message: '#^Cannot access offset ''enabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: include/auth.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: include/global_arrays.php
+
+		-
+			message: '#^Binary operation "\-" between string\|false and 20 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: include/global_arrays.php
+
+		-
+			message: '#^Argument of an invalid type array\|true supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: include/global_languages.php
+
+		-
+			message: '#^Function number_format_i18n\(\) should return string but returns string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: include/global_languages.php
+
+		-
+			message: '#^Parameter \#1 \$constant_name of function defined expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: include/global_languages.php
+
+		-
+			message: '#^Parameter \#1 \$name of function constant expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: include/global_languages.php
+
+		-
+			message: '#^Parameter \#1 \$num of function number_format expects float, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: include/global_languages.php
+
+		-
+			message: '#^Parameter \#2 \$num of function numfmt_format expects float\|int, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: include/global_languages.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: include/global_languages.php
+
+		-
+			message: '#^Cannot call method close\(\) on Directory\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: include/global_settings.php
+
+		-
+			message: '#^Cannot call method read\(\) on Directory\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: include/global_settings.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_replace_callback_array expects array\|string, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: include/themes/midwinter/update_hash.php
+
+		-
 			message: '#^Variable \$argc might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -19,97 +2407,6493 @@ parameters:
 			path: install/cli_test.php
 
 		-
-			message: '#^Parameter \#2 \$filter of function filter_var expects int, string given\.$#'
+			message: '#^Parameter \#2 \$subject of function preg_match expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: install/functions.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function stripos expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: install/install.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: install/step_json.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: install/step_json.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: install/upgrades/1_2_17.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: install/upgrades/1_2_20.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: install/upgrades/1_2_20.php
+
+		-
+			message: '#^Cannot access offset ''local_data_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: install/upgrades/1_2_20.php
+
+		-
+			message: '#^Cannot access offset ''snmp_index'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: install/upgrades/1_2_20.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_graph_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: install/upgrades/1_2_20.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: install/upgrades/1_2_20.php
+
+		-
+			message: '#^Cannot access offset ''type_code'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: install/upgrades/1_2_20.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 4
+			path: install/upgrades/1_3_0.php
+
+		-
+			message: '#^Cannot access offset ''Value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: install/upgrades/1_3_0.php
+
+		-
+			message: '#^Cannot access offset ''domain_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: install/upgrades/1_3_0.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''gprint_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''graph_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''order_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''seq'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''total'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''total_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset ''total_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Cannot access offset string on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Function auto_title\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Offset ''cdef_text'' might not exist on array\{id\: mixed, name\?\: mixed, cdef_text\?\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 3
+			path: lib/aggregate.php
+
+		-
+			message: '#^Offset ''name'' might not exist on array\{id\: mixed, name\?\: mixed, cdef_text\?\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Offset int\<min, \-1\>\|int\<1, max\> might not exist on array\{1\: ''Error'', 2\: ''Warning'', 4\: ''Parsing Error'', 8\: ''Notice'', 16\: ''Core Error'', 32\: ''Core Warning'', 64\: ''Compile Error'', 128\: ''Compile Warning'', \.\.\.\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/aggregate.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 6
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''auto_padding'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''gprint_format'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''gprint_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''graph_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''order_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''title'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''title_cache'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''total'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''total_prefix'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset ''total_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset 0 on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset mixed on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset non\-falsy\-string on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset string on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Cannot access offset string on non\-empty\-array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Parameter \#1 \$form_data of function html_create_list expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Parameter \#1 \.\.\.\$arrays of function array_merge expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_aggregate.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 12
+			path: lib/api_automation.php
+
+		-
+			message: '#^Cannot access offset ''cidr'' on array\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_automation.php
+
+		-
+			message: '#^Cannot access offset ''field'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_automation.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_automation.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/api_automation.php
+
+		-
+			message: '#^Cannot access offset ''parent'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_automation.php
+
+		-
+			message: '#^Cannot access offset \(int\|string\) on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_automation.php
+
+		-
+			message: '#^Function automation_find_os\(\) should return array\|false but returns array\|bool\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/api_automation.php
+
+		-
+			message: '#^Function create_header_node\(\) should return bool\|int but returns int\|false\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/api_automation.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 4
+			path: lib/api_automation_tools.php
+
+		-
+			message: '#^Argument of an invalid type array\|true supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 6
+			path: lib/api_automation_tools.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''data_source_path'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''data_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''input_string'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''name_cache'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''snmp_index'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''type_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset mixed on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset non\-falsy\-string on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_data_source.php
+
+		-
+			message: '#^Cannot access offset ''archive'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''author'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''availability_method'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''class'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''copyright'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''disabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''disabled''\|''hostname''\|''poller_id''\|''snmp_auth_protocol''\|''snmp_community''\|''snmp_context''\|''snmp_engine_id''\|''snmp_password''\|''snmp_port''\|''snmp_priv_passphrase''\|''snmp_priv_protocol''\|''snmp_timeout''\|''snmp_username''\|''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''email'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''homepage'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''host_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''installation'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 10
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''ping_method'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''ping_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''ping_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''ping_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''poller_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''script'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''server'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''site_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''snmp'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''tags'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Offset ''dirname'' might not exist on array\{dirname\?\: string, basename\: string, extension\?\: string, filename\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Offset ''extension'' might not exist on array\{dirname\?\: string, basename\: string, extension\?\: string, filename\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_filter expects array, array\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Parameter \#1 \$xml_data of function find_dependent_files expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Parameter \#2 \$data_query_name of function data_query_duplicate expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Parameter \#2 \$group of function chgrp expects int\|string, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Parameter \#2 \$user of function chown expects int\|string, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Parameter \#3 \$data_source_title of function api_data_source_duplicate expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Parameter \#3 \$graph_title of function api_duplicate_graph expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/api_device.php
+
+		-
+			message: '#^Property Net_Ping\:\:\$host \(array\) does not accept array\|bool\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: lib/api_device.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_graph.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_graph.php
+
+		-
+			message: '#^Cannot access offset ''multiple'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_graph.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_graph.php
+
+		-
+			message: '#^Cannot access offset ''snmp_index'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_graph.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_graph.php
+
+		-
+			message: '#^Cannot access offset ''title'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/api_graph.php
+
+		-
+			message: '#^Cannot access offset ''title_cache'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_graph.php
+
+		-
+			message: '#^Cannot access offset mixed on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_graph.php
+
+		-
+			message: '#^Cannot access offset non\-falsy\-string on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_graph.php
+
+		-
+			message: '#^Parameter \#2 \$timestamp of function date expects int\|null, float\|int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/api_scheduler.php
+
+		-
+			message: '#^Cannot access offset ''graph_tree_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_tree.php
+
+		-
+			message: '#^Cannot access offset ''local_graph_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_tree.php
+
+		-
+			message: '#^Cannot access offset ''parent'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_tree.php
+
+		-
+			message: '#^Cannot access offset ''sort_children_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/api_tree.php
+
+		-
+			message: '#^Parameter \#1 \$variable of function api_tree_parse_node_data expects string, int\<min, \-1\>\|int\<1, max\>\|string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: lib/api_tree.php
+
+		-
+			message: '#^Parameter \#1 \$variable of function api_tree_parse_node_data expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/api_tree.php
+
+		-
+			message: '#^Anonymous function should return array\|false but returns array\|bool\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 4
+			path: lib/auth.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''email_address'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''enabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''full_name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 12
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''lastfail'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''locked'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''must_change_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''password_history'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''realm'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''tfa_enabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''tfa_secret'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''time'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''total_rows'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Cannot access offset ''username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: lib/auth.php
+
+		-
+			message: '#^Parameter \#1 \$user of function set_auth_cookie expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Parameter \#1 \$user_info of function auth_cookie_user_currently_allowed expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Parameter \#2 \$parent of function is_tree_branch_empty expects int, float\|int\|string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/auth.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: lib/boost.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/boost.php
+
+		-
+			message: '#^Call to an undefined method object\:\:count\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: lib/boost.php
+
+		-
+			message: '#^Call to an undefined method object\:\:set\(\)\.$#'
+			identifier: method.notFound
+			count: 14
+			path: lib/boost.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/boost.php
+
+		-
+			message: '#^Cannot access offset ''snmp_index'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/boost.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/boost.php
+
+		-
+			message: '#^Parameter \#1 \$data_local of function rrdtool_function_interface_speed expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/boost.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/boost.php
+
+		-
+			message: '#^Parameter \#2 \$data of function fwrite expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/boost.php
+
+		-
+			message: '#^Parameter \#2 \$group of function chgrp expects int\|string, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/boost.php
+
+		-
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/boost.php
+
+		-
+			message: '#^Parameter \#2 \$user of function chown expects int\|string, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/boost.php
+
+		-
+			message: '#^Cannot access offset ''type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/cdef.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/cdef.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/clog_webapi.php
+
+		-
+			message: '#^Parameter \#1 \$logfile of function create_clog_filter expects string, bool\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/clog_webapi.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/clog_webapi.php
+
+		-
+			message: '#^Function csp_report_sanitize_field\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/csp_report_endpoint.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/csp_report_endpoint.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/csp_report_endpoint.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Binary operation "\." between ''SECURITY\: data…'' and array\<string\>\|string\|null results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''data_input_field_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''data_template_data_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''disabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''index_type'' on non\-empty\-array\|int\<min, \-1\>\|int\<1, max\>\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''index_value'' on non\-empty\-array\|int\<min, \-1\>\|int\<1, max\>\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''output_type'' on non\-empty\-array\|int\<min, \-1\>\|int\<1, max\>\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''poller_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''site_disabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''status'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''title_format'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/data_query.php
+
+		-
+			message: '#^Cannot access offset 0 on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#1 \$ip of function inet_ntop expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#1 \$string of function bin2hex expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#1 \$string of function mb_detect_encoding expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#2 \$array of function implode expects array, array\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#2 \$array of function implode expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_match expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#3 \$oid of function cacti_snmp_get expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#5 \$value of function data_query_format_record expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#5 \$value of function data_query_format_record expects string, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Parameter \#7 \$oid of function data_query_format_record expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/data_query.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 5
+			path: lib/database.php
+
+		-
+			message: '#^Argument of an invalid type array\|true supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: lib/database.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Call to an undefined method object\:\:beginTransaction\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Call to an undefined method object\:\:commit\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Call to an undefined method object\:\:lastInsertId\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Call to an undefined method object\:\:prepare\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Call to an undefined method object\:\:quote\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Call to an undefined method object\:\:rollBack\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Cannot access offset ''Value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/database.php
+
+		-
+			message: '#^Function db_get_grants\(\) should return array but returns array\|bool\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Function db_sql_apply_timeout\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Parameter \#1 \$callback of function set_error_handler expects \(callable\(int, string, string, int\)\: bool\)\|null, ''db_warning_handler'' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_map expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/database.php
+
+		-
+			message: '#^Cannot access offset ''Create Table'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/dbparallel.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/dsdebug.php
+
+		-
+			message: '#^Argument of an invalid type array\|true supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/dsdebug.php
+
+		-
+			message: '#^Cannot access an offset on float\|int\|string\|false\|null\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/dsdebug.php
+
+		-
+			message: '#^Cannot access offset ''info'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/dsdebug.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\{name\: string, passwd\: string, gid\: int, members\: list\<string\>\}\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/dsdebug.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\{name\: string, passwd\: string, uid\: int, gid\: int, gecos\: string, dir\: string, shell\: string\}\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/dsdebug.php
+
+		-
+			message: '#^Parameter \#1 \$group_id of function posix_getgrgid expects int, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/dsdebug.php
+
+		-
+			message: '#^Parameter \#1 \$user_id of function posix_getpwuid expects int, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/dsdebug.php
+
+		-
+			message: '#^Binary operation "\+" between \(float\|int\) and ''NULL''\|float\|int\|numeric\-string results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: lib/dsstats.php
+
+		-
+			message: '#^Binary operation "\+" between float and ''NULL''\|float\|int\|numeric\-string results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: lib/dsstats.php
+
+		-
+			message: '#^Function get_rrdfile_names\(\) should return array but returns array\|bool\.$#'
+			identifier: return.type
+			count: 2
+			path: lib/dsstats.php
+
+		-
+			message: '#^Parameter \#1 \$num of function abs expects float\|int, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/dsstats.php
+
+		-
+			message: '#^Parameter \#1 \$num of function round expects float\|int, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/dsstats.php
+
+		-
+			message: '#^Parameter \#1 \$value of function dsstats_is_unknown_data expects string, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/dsstats.php
+
+		-
+			message: '#^Cannot access offset ''data_input_id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/export.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/export.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/export.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_to_sql_or expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/export.php
+
+		-
+			message: '#^Parameter \#1 \.\.\.\$arrays of function array_merge_recursive expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/export.php
+
+		-
+			message: '#^Argument of an invalid type array\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/functions.php
+
+		-
+			message: '#^Argument of an invalid type array\|string\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/functions.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/functions.php
+
+		-
+			message: '#^Cannot access offset ''active'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/functions.php
+
+		-
+			message: '#^Cannot access offset ''data_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/functions.php
+
+		-
+			message: '#^Cannot access offset ''description'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/functions.php
+
+		-
+			message: '#^Cannot access offset ''email_address'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/functions.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/functions.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/functions.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/functions.php
+
+		-
+			message: '#^Cannot access offset ''title'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/functions.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/functions.php
+
+		-
+			message: '#^Function get_supported_rrdtool_version\(\) should return string\|false but returns int\|string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/functions.php
+
+		-
+			message: '#^Parameter \#1 \$transport of class Symfony\\Component\\Mailer\\Mailer constructor expects Symfony\\Component\\Mailer\\Transport\\TransportInterface, Symfony\\Component\\Mailer\\Transport\\TransportInterface\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: lib/functions.php
 
 		-
-			message: '#^Cannot use \+\+ on string\.$#'
-			identifier: postInc.type
+			message: '#^Function rrdtool_function_stats\(\) should return string but returns string\|false\.$#'
+			identifier: return.type
+			count: 3
+			path: lib/graph_variables.php
+
+		-
+			message: '#^Parameter \#1 \.\.\.\$arg1 of function max expects non\-empty\-array, list given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/graph_variables.php
+
+		-
+			message: '#^Parameter \#2 \$precision of function round expects int, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/graph_variables.php
+
+		-
+			message: '#^Parameter \#2 \$start_time of function bandwidth_summation expects int, float\|int given\.$#'
+			identifier: argument.type
+			count: 3
+			path: lib/graph_variables.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/graphs.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Cannot access offset ''disabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Cannot access offset ''path'' on array\<mixed\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Cannot use array destructuring on array\|bool\.$#'
+			identifier: offsetAccess.nonArray
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Offset ''id'' might not exist on array\{selected\: bool\}\|array\{title\: string, image\: string, id\: ''list'', url\: ''graph_view\.php…'', selected\?\: bool\}\|array\{title\: string, image\: string, id\: ''preview'', url\: ''graph_view\.php…'', selected\?\: bool\}\|array\{title\: string, image\: string, id\: ''tree'', url\: ''graph_view\.php…'', selected\: bool\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Offset ''selected'' might not exist on array\{title\: string, image\: '''', id\: ''list'', url\: ''graph_view\.php…'', selected\?\: bool\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Offset ''selected'' might not exist on array\{title\: string, image\: '''', id\: ''preview'', url\: ''graph_view\.php…'', selected\?\: bool\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Offset ''selected'' might not exist on array\{title\: string, image\: non\-empty\-string, id\: ''list'', url\: ''graph_view\.php…'', selected\?\: bool\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Offset ''selected'' might not exist on array\{title\: string, image\: non\-empty\-string, id\: ''preview'', url\: ''graph_view\.php…'', selected\?\: bool\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Parameter \#1 \$realm of function is_realm_allowed expects int, float\|int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 4
+			path: lib/html.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html.php
+
+		-
+			message: '#^Method CactiTableFilter\:\:create_filter\(\) should return string but returns string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/html_filter.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/html_form.php
+
+		-
+			message: '#^Cannot access an offset on float\|int\|list\<array\<string, string\>\>\|string\|false\|null\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_form.php
+
+		-
+			message: '#^Cannot access offset ''path'' on array\{scheme\?\: string, host\?\: string, port\?\: int\<0, 65535\>, user\?\: string, pass\?\: string, path\?\: string, query\?\: string, fragment\?\: string\}\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_form.php
+
+		-
+			message: '#^Cannot access offset int\<0, max\> on 0\|0\.0\|''''\|array\<mixed\>\|false\|null\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_form.php
+
+		-
+			message: '#^Parameter \#1 \$form_data of function html_create_list expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html_form.php
+
+		-
+			message: '#^Parameter \#2 \$form_data of function form_dropdown expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html_form.php
+
+		-
+			message: '#^Cannot access offset ''data_input_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_form_template.php
+
+		-
+			message: '#^Cannot access offset ''data_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_form_template.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_form_template.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/html_form_template.php
+
+		-
+			message: '#^Cannot access offset ''local_data_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_form_template.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_form_template.php
+
+		-
+			message: '#^Cannot access offset ''type_code'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_form_template.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_form_template.php
+
+		-
+			message: '#^Cannot access offset mixed on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_form_template.php
+
+		-
+			message: '#^Cannot access offset ''disabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''height'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''local_graph_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 7
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''rows'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''step'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''steps'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''timespan'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''title_cache'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_graph.php
+
+		-
+			message: '#^Cannot access offset ''width'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_graph.php
+
+		-
+			message: '#^Parameter \#2 \$values_array of function draw_nontemplated_fields_graph expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html_graph.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''alignment'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''cformat'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''font_size'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id''\|''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''graph_width'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''local_graph_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/html_reports.php
+
+		-
+			message: '#^Cannot access offset ''user_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Function reports_item_validate\(\) should return string but returns string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Parameter \#1 \$string of function htmle expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html_reports.php
+
+		-
+			message: '#^Argument of an invalid type array\|string supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Cannot access offset ''graph_tree_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Cannot access offset ''host_grouping_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/html_tree.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Cannot access offset ''parent'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/html_tree.php
+
+		-
+			message: '#^Cannot access offset ''policy_trees'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Cannot access offset ''site_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Cannot access offset ''title'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_push expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Parameter \#2 \$leaf_id of function grow_right_pane_tree expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Parameter \#2 \$parent of function api_tree_get_main expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Parameter \#3 \$data_query_id of function get_host_graph_list expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/html_tree.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: lib/html_utility.php
+
+		-
+			message: '#^Offset ''message'' might not exist on array\{type\: int, message\: string, file\: string, line\: int\}\|null\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/html_utility.php
+
+		-
+			message: '#^Offset int\<min, \-1\>\|int\<1, max\> might not exist on array\{1\: string, 2\: string, 3\: string, 4\: string, 5\: string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/html_utility.php
+
+		-
+			message: '#^Parameter \#1 \$string of function htmle expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: lib/html_utility.php
+
+		-
+			message: '#^Parameter \#1 \$string of function mb_convert_encoding expects array\|string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/html_utility.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Cannot access offset ''author'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Cannot access offset ''class'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Cannot access offset ''copyright'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Cannot access offset ''email'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Cannot access offset ''homepage'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Cannot access offset ''installation'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Cannot access offset ''tags'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Cannot access offset ''version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#1 \$data of function openssl_verify expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#1 \$data of function simplexml_load_string expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#1 \$data of function xml2array expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#1 \$string of function md5 expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#1 \$xml_data of function import_xml_data expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#2 \$data of function fwrite expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#2 \$previous_data of function compare_data expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 19
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#2 \$signature of function openssl_verify expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 4
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/import.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 6
+			path: lib/installer.php
+
+		-
+			message: '#^Argument of an invalid type array\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: lib/installer.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/installer.php
+
+		-
+			message: '#^Cannot access offset ''cacti'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/installer.php
+
+		-
+			message: '#^Cannot access offset ''enabled'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/installer.php
+
+		-
+			message: '#^Cannot access offset ''id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/installer.php
+
+		-
+			message: '#^Cannot access offset ''path'' on array\{scheme\?\: string, host\?\: string, port\?\: int\<0, 65535\>, user\?\: string, pass\?\: string, path\?\: string, query\?\: string, fragment\?\: string\}\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/installer.php
+
+		-
+			message: '#^Cannot access offset ''subnet_range'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/installer.php
+
+		-
+			message: '#^Method Installer\:\:isDatabaseTooOld\(\) should return bool but returns int\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/installer.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_column expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/installer.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/installer.php
+
+		-
+			message: '#^Parameter \#1 \$text of static method Installer\:\:sectionNormal\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 10
+			path: lib/installer.php
+
+		-
+			message: '#^Parameter \#2 \$subject of function preg_match expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/installer.php
+
+		-
+			message: '#^Parameter \#2 \$text of function log_install_debug expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/installer.php
+
+		-
+			message: '#^Property Installer\:\:\$eula \(int\) does not accept int\|string\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: lib/installer.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''bind_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''cn_email'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''cn_full_name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''count'' on non\-empty\-array\<int\|string, array\|int\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''debug'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''dn'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''dn'' on array\|int\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''encryption'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''group_attrib'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''group_dn'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''group_member_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''group_require'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''mode'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''network_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''port_ssl'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''proto_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''referrals'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''search_base'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''search_filter'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''server'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''specific_dn'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''specific_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Cannot access offset ''tls_certificate'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Parameter \#1 \$ldap of function ldap_get_entries expects LDAP\\Connection, object given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Parameter \#1 \$ldap of function ldap_search expects array\|LDAP\\Connection, object given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, array\|int given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/ldap.php
+
+		-
+			message: '#^Parameter \#2 \$result of function ldap_first_entry expects LDAP\\Result, array\|LDAP\\Result\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Parameter \#2 \$result of function ldap_get_entries expects LDAP\\Result, array\|LDAP\\Result given\.$#'
+			identifier: argument.type
+			count: 3
+			path: lib/ldap.php
+
+		-
+			message: '#^Parameter \#4 \$value of function ldap_compare expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/ldap.php
+
+		-
+			message: '#^Method MibCache\:\:exists\(\) should return bool but returns string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/mib_cache.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/package.php
+
+		-
+			message: '#^Call to an undefined method object\:\:prepare\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/package.php
+
+		-
+			message: '#^Cannot access offset ''info'' on array\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/package.php
+
+		-
+			message: '#^Cannot access offset ''key'' on array\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/package.php
+
+		-
+			message: '#^Parameter \#1 \$data of function openssl_sign expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/package.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/package.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fwrite expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/package.php
+
+		-
+			message: '#^Parameter \#1 \$text of function xml_character_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/package.php
+
+		-
+			message: '#^Parameter \#1 \$xml_data of function find_dependent_files expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/package.php
+
+		-
+			message: '#^Method Net_Ping\:\:seteuid\(\) should return int but returns int\|string\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/ping.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_sum expects array, array\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/ping.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function strpos expects string, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 3
+			path: lib/ping.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 3
+			path: lib/ping.php
+
+		-
+			message: '#^Property Net_Ping\:\:\$socket \(Socket\) does not accept Socket\|false\.$#'
+			identifier: assign.propertyType
+			count: 4
+			path: lib/ping.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: lib/plugins.php
+
+		-
+			message: '#^Binary operation "\." between '','' and array\<string\>\|string results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot access offset ''author'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot access offset ''file'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot access offset ''info'' on array\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot access offset ''status'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot access offset ''version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot access offset ''webpage'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot access offset 0 on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot assign offset ''body'' to array\<string, mixed\>\|string\.$#'
+			identifier: offsetAssign.dimType
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Cannot cast array\<string\>\|string to string\.$#'
+			identifier: cast.string
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, bool\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 7
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#1 \$string of function strlen expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_key_exists expects array, array\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#2 \$needle of function str_starts_with expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#2 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, callable given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#3 \$function of function api_plugin_run_plugin_hook expects string, callable given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#3 \$function of function api_plugin_run_plugin_hook_function expects string, callable given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#3 \$value of function curl_setopt expects non\-empty\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Parameter \#3 \$value of function curl_setopt expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/plugins.php
+
+		-
+			message: '#^Trying to invoke string but it might not be a callable\.$#'
+			identifier: callable.nonCallable
+			count: 10
+			path: lib/plugins.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 8
+			path: lib/poller.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''Create Table'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''Value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbdefault'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbhost'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbpass'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbport'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbretries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbssl'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbsslca'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbsslcapath'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbsslcert'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbsslkey'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbsslverifyservercert'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''dbuser'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''reindex_method'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''script'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''server'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''snmp'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot access offset ''timeout_exceeded'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot call method close\(\) on Directory\|false\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: lib/poller.php
+
+		-
+			message: '#^Cannot call method read\(\) on Directory\|false\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: lib/poller.php
+
+		-
+			message: '#^Function exec_poll_php\(\) should return string but returns string\|false\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_column expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#1 \$command of function proc_open expects list\<string\>\|string, non\-empty\-array\<string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#1 \$handle of function pclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function substr_count expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#1 \$num1 of function bcadd expects numeric\-string, 0\|numeric\-string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#1 \$results of function boost_poller_on_demand expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#2 \$column of function db_column_exists expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#2 \$data of function replicate_out_table expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 28
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#2 \$data of function replicate_table_to_poller expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/poller.php
+
+		-
+			message: '#^Parameter \#4 \$pid of function register_process expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: lib/poller.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''alignment'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''cformat'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''font_size'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''format_file'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''graph_columns'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''local_graph_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''notification'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''report_attachments'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''report_html_output'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''run_command'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''run_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''source'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''source_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset ''user_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: lib/reports.php
+
+		-
+			message: '#^Cannot access offset mixed on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Function utime_add\(\) should return int but returns int\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#1 \$report of function expand_branch expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#1 \$report of function reports_expand_device expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#1 \$report of function reports_expand_tree expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#1 \$report of function reports_graph_image expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#2 \$baseTimestamp of function strtotime expects int\|null, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#2 \$timestamp of function date expects int\|null, int\|false given\.$#'
+			identifier: argument.type
+			count: 11
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#6 \$color of function imagefilledrectangle expects int, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/reports.php
+
+		-
+			message: '#^Parameter \#6 \$color of function imagestring expects int, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/reports.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$alive\.$#'
+			identifier: property.notFound
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$process\.$#'
+			identifier: property.notFound
+			count: 2
+			path: lib/rrd.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$stderr\.$#'
+			identifier: property.notFound
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$stdin\.$#'
+			identifier: property.notFound
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$stdout\.$#'
+			identifier: property.notFound
+			count: 2
+			path: lib/rrd.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getElementsByTagName\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: lib/rrd.php
+
+		-
+			message: '#^Call to an undefined method object\:\:importNode\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot access offset ''auto_padding'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot access offset ''data_source_profile_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot access offset ''end_time'' on array\<''start_time''\|int\<0, max\>, non\-empty\-array\<string, ''U''\|numeric\-string\>\|string\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot access offset ''local_graph_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot access offset ''rrd_step'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot access property \$nodeValue on DOMElement\|null\.$#'
+			identifier: property.nonObject
+			count: 7
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot access property \$parentNode on DOMElement\|null\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot assign offset string to array\<string, string\>\|string\.$#'
+			identifier: offsetAssign.dimType
+			count: 3
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot call method appendChild\(\) on DOMNode\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot call method cloneNode\(\) on DOMElement\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot call method getElementsByTagName\(\) on DOMElement\|null\.$#'
+			identifier: method.nonObject
+			count: 8
+			path: lib/rrd.php
+
+		-
+			message: '#^Cannot call method removeChild\(\) on DOMNode\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Offset ''cdef_cache'' might not exist on array\{\}\|array\{text_format\: non\-empty\-array\<mixed\>, value\?\: non\-empty\-array\<mixed\>\}\|array\{text_format\?\: non\-empty\-array\<mixed\>, value\: non\-empty\-array\<mixed\>, cdef_cache\: non\-empty\-array\<mixed\>, vdef_cache\: non\-empty\-array\<mixed\>\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Offset ''text_format'' might not exist on array\{\}\|array\{text_format\?\: non\-empty\-array\<mixed\>, value\: non\-empty\-array\<mixed\>, cdef_cache\: non\-empty\-array\<mixed\>, vdef_cache\: non\-empty\-array\<mixed\>\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Offset ''value'' might not exist on array\{text_format\: non\-empty\-array\<mixed\>, value\: non\-empty\-array\<mixed\>, cdef_cache\: non\-empty\-array\<mixed\>, vdef_cache\: non\-empty\-array\<mixed\>\}\|array\{text_format\: non\-empty\-array\<mixed\>, value\?\: non\-empty\-array\<mixed\>\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Offset ''vdef_cache'' might not exist on array\{\}\|array\{text_format\: non\-empty\-array\<mixed\>, value\?\: non\-empty\-array\<mixed\>\}\|array\{text_format\?\: non\-empty\-array\<mixed\>, value\: non\-empty\-array\<mixed\>, cdef_cache\: non\-empty\-array\<mixed\>, vdef_cache\: non\-empty\-array\<mixed\>\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Parameter \#2 \$graph of function rrdtool_resolve_graph_text expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 5
+			path: lib/rrd.php
+
+		-
+			message: '#^Parameter \#2 \$graph of function variable_bandwidth_summation expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Parameter \#2 \$graph of function variable_nth_percentile expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Parameter \#2 \$offset of function substr expects int, float\|int\<4, max\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Parameter \#3 \$graph of function rrd_function_process_graph_options expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Parameter \#3 \$length of function substr expects int\|null, float\|int\<1, max\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/rrd.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: lib/rrdcheck.php
+
+		-
+			message: '#^Cannot access offset int\<0, max\> on list\<string\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: lib/rrdcheck.php
+
+		-
+			message: '#^Parameter \#2 \$length of function array_chunk expects int\<1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/rrdcheck.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$bulk_walk_size\.$#'
+			identifier: property.notFound
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$info\.$#'
+			identifier: property.notFound
+			count: 3
+			path: lib/snmp.php
+
+		-
+			message: '#^Access to an undefined property object\:\:\$value_output_format\.$#'
+			identifier: property.notFound
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getErrno\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getError\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#1 \$callback of function call_user_func_array expects callable\(\)\: mixed, array\{object, string\} given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#1 \$codepoint of function chr expects int, float\|int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_starts_with expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#1 \$string of function format_snmp_string expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 3
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#3 \$object_id of function snmp2_get expects non\-empty\-string, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#3 \$object_id of function snmp2_real_walk expects array\|non\-empty\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#3 \$object_id of function snmpget expects non\-empty\-string, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#3 \$object_id of function snmprealwalk expects array\|non\-empty\-string, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#4 \$timeout of class phpsnmp\\SNMP constructor expects int\<\-1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#4 \$timeout of function snmp2_get expects int\<\-1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#4 \$timeout of function snmp2_getnext expects int\<\-1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#4 \$timeout of function snmp2_real_walk expects int\<\-1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#4 \$timeout of function snmpget expects int\<\-1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#4 \$timeout of function snmpgetnext expects int\<\-1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Parameter \#4 \$timeout of function snmprealwalk expects int\<\-1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/snmp.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Argument of an invalid type array\|true supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Call to an undefined method object\:\:row\(\)\.$#'
+			identifier: method.notFound
+			count: 18
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Call to an undefined method object\:\:select\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Call to an undefined method object\:\:set\(\)\.$#'
+			identifier: method.notFound
+			count: 58
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Call to an undefined method object\:\:truncate\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''availability'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''avg_time'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''cur_time'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''description'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''disabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''failed_polls'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''max_time'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''min_time'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''status'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''status_event_count'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''status_fail_date'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''status_last_error'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''status_rec_date'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Cannot access offset ''total_polls'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Offset mixed might not exist on array\{0\?\: 0, 1\?\: 1, 2\?\: 2, 3\?\: 3, 4\?\: 4\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/snmpagent.php
+
+		-
+			message: '#^Parameter \#1 \$output of method spikekill\:\:removeComments\(\) expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/spikekill.php
+
+		-
+			message: '#^Property spikekill\:\:\$user_info \(array\) does not accept array\|bool\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: lib/spikekill.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: lib/template.php
+
+		-
+			message: '#^Cannot access offset ''column_name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/template.php
+
+		-
+			message: '#^Cannot access offset ''data_input_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/template.php
+
+		-
+			message: '#^Cannot access offset ''graph_template_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: lib/template.php
+
+		-
+			message: '#^Cannot access offset ''hash'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/template.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/template.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: lib/template.php
+
+		-
+			message: '#^Cannot access offset ''input_string'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/template.php
+
+		-
+			message: '#^Cannot access offset ''status'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/template.php
+
+		-
+			message: '#^Cannot access offset mixed on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/template.php
+
+		-
+			message: '#^Offset ''snmp_query_graph_id'' might not exist on array\{\}\|array\{snmp_query_id\: int, snmp_index_on\: mixed, snmp_query_graph_id\: \(int\|string\)\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/template.php
+
+		-
+			message: '#^Offset ''snmp_query_id'' might not exist on array\{snmp_index\: mixed\}\|array\{snmp_query_id\: int, snmp_index_on\: mixed, snmp_query_graph_id\: \(int\|string\), snmp_index\: mixed\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 3
+			path: lib/template.php
+
+		-
+			message: '#^Offset ''snmp_query_id'' might not exist on array\{\}\|array\{snmp_index\: mixed\}\|array\{snmp_query_id\: int, snmp_index_on\: mixed, snmp_query_graph_id\: \(int\|string\), snmp_index\?\: mixed\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: lib/template.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/template.php
+
+		-
+			message: '#^Parameter \#3 \$profile of function change_data_template expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/template.php
+
+		-
+			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/timespan_settings.php
+
+		-
+			message: '#^Parameter \#2 \$timestamp of function date expects int\|null, float\|int\|string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/timespan_settings.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 17
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''active'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''data_input_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''host_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 19
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''output_type'' on array\|int\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''poller_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''snmp_index'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''snmp_query_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''type_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset 0 on list\<string\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Function utilities_php_modules\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Parameter \#2 \$string2 of function strcasecmp expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: lib/utility.php
+
+		-
+			message: '#^Parameter \#2 \$version2 of function version_compare expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/utility.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 5
+			path: lib/utility.php
+
+		-
+			message: '#^Cannot access offset ''availability'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''avg_time'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''cur_time'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''description'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''external_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''location'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''max_oids'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''notes'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''ping_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''poller_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''polling_time'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''site_name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_sysContact'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_sysDescr'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_sysLocation'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_sysName'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_sysObjectID'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_sysUpTimeInstance'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset mixed on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: lib/variables.php
+
+		-
+			message: '#^Function null_out_substitutions\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_keys expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 4
+			path: lib/variables.php
+
+		-
+			message: '#^Parameter \#1 \$host of function get_uptime expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: lib/variables.php
+
+		-
+			message: '#^Cannot access offset ''type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/vdef.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: lib/vdef.php
+
+		-
+			message: '#^Cannot access offset ''contentfile'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: link.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: link.php
+
+		-
+			message: '#^Cannot access offset ''style'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: link.php
+
+		-
+			message: '#^Cannot access offset ''title'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: link.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: links.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: managers.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: managers.php
+
+		-
+			message: '#^Cannot access offset ''description'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: managers.php
+
+		-
+			message: '#^Parameter \#1 \$string of function htmle expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: oauth2.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: package.php
+
+		-
+			message: '#^Parameter \#1 \$xml_data of function find_dependent_files expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: package.php
+
+		-
+			message: '#^Cannot access offset ''repo_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: package_import.php
+
+		-
+			message: '#^Parameter \#1 \$a of class Diff constructor expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: package_import.php
+
+		-
+			message: '#^Parameter \#1 \$data of function openssl_verify expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 4
+			path: package_import.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 4
+			path: package_import.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: package_import.php
+
+		-
+			message: '#^Parameter \#2 \$b of class Diff constructor expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: package_import.php
+
+		-
+			message: '#^Parameter \#2 \$signature of function openssl_verify expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 4
+			path: package_import.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: package_repos.php
+
+		-
+			message: '#^Cannot access offset ''repo_type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: package_repos.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: plugins.php
+
+		-
+			message: '#^Parameter \#1 \$string of function htmle expects string, float\|int\|string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 2
+			path: plugins.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: poller.php
+
+		-
+			message: '#^Cannot access offset ''processes'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller.php
+
+		-
+			message: '#^Cannot access offset ''totalErrors'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_unique expects array, list\<string\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller.php
+
+		-
+			message: '#^Cannot access offset ''deleted'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''dns_servers'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''enable_netbios'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''last_runtime'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''last_started'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''notification_enabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''ping_method'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''ping_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''ping_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''ping_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''poller_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''same_sysname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''site_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''snmp'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''snmp_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''status'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''subnet_range'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: poller_automation.php
+
+		-
+			message: '#^Cannot access offset ''up'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function str_contains expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function strpos expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#1 \$pid of function killProcess expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#1 \$pid of function removeMyProcess expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#1 \$string of function cacti_strtolower expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#1 \$string of function substr expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#2 \$network of function rerunDataQueries expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 2
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#2 \$pid of function addSNMPDevice expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#2 \$pid of function addUpDevice expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#2 \$pid of function clearTask expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#2 \$pid of function endTask expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_automation.php
+
+		-
+			message: '#^Parameter \#2 \$pid of function registerTask expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: poller_automation.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: poller_boost.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: poller_boost.php
+
+		-
+			message: '#^Cannot access offset ''Value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_boost.php
+
+		-
+			message: '#^Cannot access offset ''timestamp'' on 0\|array\<float\|int\|string\>\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_boost.php
+
+		-
+			message: '#^Cannot access offset mixed on 0\|array\<float\|int\|string\>\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 9
+			path: poller_boost.php
+
+		-
+			message: '#^Parameter \#1 \$array of function array_column expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 2
+			path: poller_boost.php
+
+		-
+			message: '#^Parameter \#3 \$last_run_time of function boost_time_to_run expects int, float\|int\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_boost.php
+
+		-
+			message: '#^Parameter \#4 \$next_run_time of function boost_time_to_run expects int, float\|int\|string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_boost.php
+
+		-
+			message: '#^Parameter \#4 \$pid of function unregister_process expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: poller_boost.php
+
+		-
+			message: '#^Parameter \#4 \$pid of function unregister_process expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: poller_commands.php
+
+		-
+			message: '#^Parameter \#2 \$thread_id of function dsstats_log_child_stats expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: poller_dsstats.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function register_process_start expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_dsstats.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function unregister_process expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_dsstats.php
+
+		-
+			message: '#^Parameter \#3 \$thread_id of function dsstats_get_and_store_ds_avgpeak_values expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 4
+			path: poller_dsstats.php
+
+		-
+			message: '#^Parameter \#4 \$pid of function unregister_process expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_dsstats.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: poller_maintenance.php
+
+		-
+			message: '#^Binary operation "\." between non\-falsy\-string and array\<string\>\|string results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Call to an undefined method object\:\:format\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: poller_maintenance.php
+
+		-
+			message: '#^Call to an undefined method object\:\:modify\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Cannot access offset ''processes'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: poller_maintenance.php
+
+		-
+			message: '#^Cannot access offset ''threads'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Parameter \#1 \$file_array of function remove_files expects array, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Parameter \#1 \$filename of function file_exists expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: poller_maintenance.php
+
+		-
+			message: '#^Parameter \#1 \$filename of function unlink expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Parameter \#1 \$from of function rename expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Parameter \#1 \$num of function decoct expects int, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Parameter \#1 \$path of function pathinfo expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Parameter \#2 \$group of function chgrp expects int\|string, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: poller_maintenance.php
+
+		-
+			message: '#^Parameter \#2 \$permissions of function chmod expects int, float\|int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Parameter \#2 \$user of function chown expects int\|string, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_maintenance.php
+
+		-
+			message: '#^Part \$real_file \(array\<string\>\|string\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 3
+			path: poller_maintenance.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: poller_realtime.php
+
+		-
+			message: '#^Parameter \#1 \$command of function shell_exec expects string, array\<string\>\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_realtime.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, array\<string\>\|string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_realtime.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: poller_reports.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_reports.php
+
+		-
+			message: '#^Cannot access offset ''user_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: poller_reports.php
+
+		-
+			message: '#^Parameter \#1 \$schedule_id of function generate_report expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_reports.php
+
+		-
+			message: '#^Parameter \#1 \$thread_id of function do_rrdcheck expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_rrdcheck.php
+
+		-
+			message: '#^Parameter \#2 \$thread_id of function rrdcheck_log_child_stats expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_rrdcheck.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function register_process_start expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_rrdcheck.php
+
+		-
+			message: '#^Parameter \#3 \$taskid of function unregister_process expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_rrdcheck.php
+
+		-
+			message: '#^Parameter \#4 \$pid of function unregister_process expects int, int\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_rrdcheck.php
+
+		-
+			message: '#^Argument of an invalid type float\|int\|list\<string\>\|string\|false\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: poller_spikekill.php
+
+		-
+			message: '#^Parameter \#1 \$haystack of function substr_count expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_spikekill.php
+
+		-
+			message: '#^Parameter \#1 \$templates of function kill_spikes expects array, float\|int\|list\<string\>\|string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_spikekill.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: poller_spikekill.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: pollers.php
+
+		-
+			message: '#^Argument of an invalid type list\<array\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: pollers.php
+
+		-
+			message: '#^Cannot access offset ''dbhost'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: pollers.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: pollers.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: pollers.php
+
+		-
+			message: '#^Cannot access offset ''timezone'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: pollers.php
+
+		-
+			message: '#^Offset ''dbhost'' might not exist on array\{id\: mixed, name\: mixed, hostname\: mixed, log_level\: mixed, timezone\: mixed, notes\: mixed, processes\: mixed, threads\: mixed, \.\.\.\}\|array\{id\: mixed, name\: mixed, hostname\: mixed, log_level\: mixed, timezone\: mixed, notes\: mixed, processes\: mixed, threads\: mixed\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: pollers.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''max_oids'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''ping_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: remote_agent.php
+
+		-
+			message: '#^Cannot access offset ''Update_time'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: rrdcleaner.php
 
 		-
-			message: '#^Variable \$calculated_index in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.variable
+			message: '#^Cannot access offset ''local_data_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: cli/rrdresize.php
+			path: rrdcleaner.php
 
 		-
-			message: '#^Offset 1 on array\{non\-falsy\-string, string\} in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.offset
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: lib/functions.php
+			path: rrdcleaner.php
 
 		-
-			message: '#^Undefined variable\: \$graph_template_item_id$#'
-			identifier: variable.undefined
+			message: '#^Binary operation "\." between ''DEBUG\: SERVER\: '' and list\<mixed\>\|string\|false results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
-			path: aggregate_graphs.php
+			path: script_server.php
 
 		-
-			message: '#^Variable \$graph_template_item_id in empty\(\) is never defined\.$#'
-			identifier: empty.variable
-			count: 1
-			path: aggregate_graphs.php
+			message: '#^Binary operation "\." between ''PHP Script Server…'' and list\<mixed\>\|string\|false results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: script_server.php
 
 		-
-			message: '#^Undefined variable\: \$color_template_item_id$#'
-			identifier: variable.undefined
-			count: 1
-			path: color_templates.php
+			message: '#^Parameter \#1 \$str of function strtr expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: script_server.php
 
 		-
-			message: '#^Variable \$color_template_item_id in empty\(\) is never defined\.$#'
-			identifier: empty.variable
-			count: 1
-			path: color_templates.php
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 2
+			path: script_server.php
 
 		-
-			message: '#^Undefined variable\: \$graph_template_item_id$#'
-			identifier: variable.undefined
-			count: 1
-			path: graph_templates.php
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
 
 		-
-			message: '#^Variable \$graph_template_item_id in empty\(\) is never defined\.$#'
-			identifier: empty.variable
-			count: 1
-			path: graph_templates.php
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
 
 		-
-			message: '#^Undefined variable\: \$graph_template_item_id$#'
-			identifier: variable.undefined
-			count: 1
-			path: graphs.php
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
 
 		-
-			message: '#^Variable \$graph_template_item_id in empty\(\) is never defined\.$#'
-			identifier: empty.variable
-			count: 1
-			path: graphs.php
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
 
 		-
-			message: '#^Offset ''image'' on array\{title\: string, image\: string, id\: ''tree'', url\: ''graph_view\.php…'', selected\?\: true\} in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.offset
-			count: 1
-			path: lib/html.php
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
 
 		-
-			message: '#^Offset ''image'' on array\{title\: string, image\: string, id\: ''list'', url\: ''graph_view\.php…'', selected\?\: true\} in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.offset
-			count: 1
-			path: lib/html.php
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
 
 		-
-			message: '#^Offset ''image'' on array\{title\: string, image\: string, id\: ''preview'', url\: ''graph_view\.php…'', selected\?\: true\} in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.offset
-			count: 1
-			path: lib/html.php
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
 
 		-
-			message: '#^Call to function is_numeric\(\) with float\|int\|numeric\-string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/aruba_instant_wlan_client.php
+
+		-
+			message: '#^Binary operation "\-" between int\<\-599, \-1\>\|int\<1, max\> and string\|false results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 2
+			path: scripts/cacti_user_stats.php
+
+		-
+			message: '#^Binary operation "\|" between string\|false and string\|false results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
-			path: lib/data_query.php
+			path: scripts/cacti_user_stats.php
+
+		-
+			message: '#^Parameter \#1 \$path of function realpath expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: scripts/cacti_user_stats.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: scripts/sql.php
+
+		-
+			message: '#^Parameter \#2 \$string of function explode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: scripts/ss_apache_stats.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_ap.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_aruba_instant_client.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Offset ''vsf'' might not exist on array\{fan\: array\{index\: ''\.1\.3\.6\.1\.4\.1\.47196…'', name\: ''\.1\.3\.6\.1\.4\.1\.47196…'', state\: ''\.1\.3\.6\.1\.4\.1\.47196…'', rpm\: ''\.1\.3\.6\.1\.4\.1\.47196…''\}, temp\: array\{index\: ''\.1\.3\.6\.1\.4\.1\.47196…'', name\: ''\.1\.3\.6\.1\.4\.1\.47196…'', state\: ''\.1\.3\.6\.1\.4\.1\.47196…'', actual\: ''\.1\.3\.6\.1\.4\.1\.47196…''\}, power\: array\{index\: ''\.1\.3\.6\.1\.4\.1\.47196…'', name\: ''\.1\.3\.6\.1\.4\.1\.47196…'', state\: ''\.1\.3\.6\.1\.4\.1\.47196…'', actual\: ''\.1\.3\.6\.1\.4\.1\.47196…''\}, vsf_standalone\: array\{index\: ''\.1\.3\.6\.1\.4\.1\.47196…'', name\: ''\.1\.3\.6\.1\.2\.1\.1\.5'', cpu\: ''\.1\.3\.6\.1\.4\.1\.47196…'', memory\: ''\.1\.3\.6\.1\.4\.1\.47196…'', uptime\: ''\.1\.3\.6\.1\.2\.1\.1\.3''\}, vsf_member\: array\{index\: ''\.1\.3\.6\.1\.4\.1\.47196…'', name\: ''\.1\.3\.6\.1\.4\.1\.47196…'', state\: ''\.1\.3\.6\.1\.4\.1\.47196…'', cpu\: ''\.1\.3\.6\.1\.4\.1\.47196…'', memory\: ''\.1\.3\.6\.1\.4\.1\.47196…'', uptime\: ''\.1\.3\.6\.1\.4\.1\.47196…''\}, vsf\?\: array\{index\: ''\.1\.3\.6\.1\.4\.1\.47196…'', name\: ''\.1\.3\.6\.1\.2\.1\.1\.5'', cpu\: ''\.1\.3\.6\.1\.4\.1\.47196…'', memory\: ''\.1\.3\.6\.1\.4\.1\.47196…'', uptime\: ''\.1\.3\.6\.1\.2\.1\.1\.3''\}\|array\{index\: ''\.1\.3\.6\.1\.4\.1\.47196…'', name\: ''\.1\.3\.6\.1\.4\.1\.47196…'', state\: ''\.1\.3\.6\.1\.4\.1\.47196…'', cpu\: ''\.1\.3\.6\.1\.4\.1\.47196…'', memory\: ''\.1\.3\.6\.1\.4\.1\.47196…'', uptime\: ''\.1\.3\.6\.1\.4\.1\.47196…''\}\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: scripts/ss_aruba_oscx_6x00.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''max_oids'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_count_oids.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: scripts/ss_cpoller.php
+
+		-
+			message: '#^Function ss_entity_sensor_field\(\) should return array\<string, string\> but returns array\<int\|string, int\|string\>\.$#'
+			identifier: return.type
+			count: 1
+			path: scripts/ss_entity_sensor.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_esxi_vhosts.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_esxi_vhosts.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_esxi_vhosts.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_esxi_vhosts.php
+
+		-
+			message: '#^Function ss_f5_cpu_field\(\) should return array\<string, string\> but returns array\<int\|string, int\|string\>\.$#'
+			identifier: return.type
+			count: 1
+			path: scripts/ss_f5_cpu.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ips.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_fortigate_ipsec.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_fortigate_virus.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: scripts/ss_gexport.php
+
+		-
+			message: '#^Function ss_juniper_operating_field\(\) should return array\<string, string\> but returns array\<int\|string, int\|string\>\.$#'
+			identifier: return.type
+			count: 1
+			path: scripts/ss_juniper_operating.php
+
+		-
+			message: '#^Cannot access offset ''avgCPU'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_cpu.php
+
+		-
+			message: '#^Cannot access offset ''maxCPU'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_cpu.php
+
+		-
+			message: '#^Cannot access offset ''diskSize'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_disk.php
+
+		-
+			message: '#^Cannot access offset ''diskUsed'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_disk.php
+
+		-
+			message: '#^Cannot access offset ''memSize'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_mem.php
+
+		-
+			message: '#^Cannot access offset ''memUsed'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_mem.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_mikrotik_snmpget.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_multicpu_avg.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''max_oids'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: scripts/ss_net_snmp_disk_bytes.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''max_oids'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: scripts/ss_net_snmp_disk_io.php
+
+		-
+			message: '#^Binary operation "\-" between ''''\|numeric\-string and 4294967294 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''max_oids'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Offset ''index'' might not exist on non\-empty\-array\{index\?\: numeric\-string, reading\?\: mixed, name\?\: non\-empty\-string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 6
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Offset ''name'' might not exist on non\-empty\-array\{index\?\: numeric\-string, reading\?\: mixed, name\?\: non\-empty\-string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Offset ''reading'' might not exist on non\-empty\-array\{index\?\: numeric\-string, reading\?\: mixed, name\?\: non\-empty\-string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Offset 1 might not exist on array\{\}\|array\{non\-empty\-string, numeric\-string\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: scripts/ss_netsnmp_lmsensors.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_nimble_alletra_total.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_auth_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_community'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_context'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_engine_id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_password'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_port'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_passphrase'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_priv_protocol'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_retries'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_timeout'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Cannot access offset ''snmp_version'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 8
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Offset ''high'' might not exist on ''\.1\.3\.6\.1\.4\.1\.37447…''\|array\{low\: ''\.1\.3\.6\.1\.4\.1\.37447…'', high\: ''\.1\.3\.6\.1\.4\.1\.37447…''\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 2
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Offset ''low'' might not exist on ''\.1\.3\.6\.1\.4\.1\.37447…''\|array\{low\: ''\.1\.3\.6\.1\.4\.1\.37447…'', high\: ''\.1\.3\.6\.1\.4\.1\.37447…''\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 2
+			path: scripts/ss_nimble_alletra_volumes.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: scripts/ss_poller.php
+
+		-
+			message: '#^Cannot access offset ''disabled'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_poller.php
+
+		-
+			message: '#^Cannot access offset ''successful'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_poller.php
+
+		-
+			message: '#^Cannot access offset ''triggered'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: scripts/ss_poller.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: scripts/ss_sql.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: scripts/ss_sql.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 5
+			path: scripts/ss_sql.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: scripts/ss_webseer.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 2
+			path: sites.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: sites.php
+
+		-
+			message: '#^Parameter \#1 \$values of method CactiForm\:\:withValues\(\) expects array\<string, mixed\>, array\|bool given\.$#'
+			identifier: argument.type
+			count: 1
+			path: sites.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: snmpagent_mibcachechild.php
+
+		-
+			message: '#^Cannot access offset int\<0, max\> on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: snmpagent_mibcachechild.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: snmpagent_mibcachechild.php
+
+		-
+			message: '#^Function get_options\(\) should return array but returns array\<string, list\<mixed\>\|string\|false\>\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: snmpagent_persist.php
+
+		-
+			message: '#^Parameter \#1 \$handle of function pclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: snmpagent_persist.php
+
+		-
+			message: '#^Parameter \#1 \$string of function trim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 3
+			path: snmpagent_persist.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 7
+			path: support.php
+
+		-
+			message: '#^Argument of an invalid type list\<string\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: support.php
+
+		-
+			message: '#^Function support_redact\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: support.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: support.php
+
+		-
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: support.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 3
+			path: support.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function str_ireplace expects array\<string\>\|string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: support.php
+
+		-
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: templates_import.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: templates_import.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fread expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: templates_import.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: templates_import.php
+
+		-
+			message: '#^Parameter \#1 \$xml_data of function import_xml_data expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: templates_import.php
+
+		-
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: templates_import.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: tree.php
+
+		-
+			message: '#^Cannot access offset ''graph_tree_id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tree.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tree.php
+
+		-
+			message: '#^Cannot access offset ''id'' on non\-empty\-array\|true\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tree.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tree.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 5
+			path: user_admin.php
+
+		-
+			message: '#^Cannot access offset ''policy_graph_templates'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: user_admin.php
+
+		-
+			message: '#^Cannot access offset ''policy_graphs'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: user_admin.php
+
+		-
+			message: '#^Cannot access offset ''policy_hosts'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: user_admin.php
+
+		-
+			message: '#^Cannot access offset ''policy_trees'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: user_admin.php
+
+		-
+			message: '#^Cannot access offset ''realm'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: user_admin.php
+
+		-
+			message: '#^Cannot access offset ''username'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: user_admin.php
+
+		-
+			message: '#^Cannot access offset ''domain_name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: user_domains.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 4
+			path: user_group_admin.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: user_group_admin.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: user_group_admin.php
+
+		-
+			message: '#^Cannot access offset ''policy_graph_templates'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: user_group_admin.php
+
+		-
+			message: '#^Cannot access offset ''policy_graphs'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: user_group_admin.php
+
+		-
+			message: '#^Cannot access offset ''policy_hosts'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: user_group_admin.php
+
+		-
+			message: '#^Cannot access offset ''policy_trees'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: user_group_admin.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: user_log.php
+
+		-
+			message: '#^Argument of an invalid type array\|bool supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
+			path: utilities.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: utilities.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fwrite expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: utilities.php
+
+		-
+			message: '#^Cannot access offset ''id'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: vdef.php
+
+		-
+			message: '#^Cannot access offset ''name'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: vdef.php
+
+		-
+			message: '#^Cannot access offset ''type'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: vdef.php
+
+		-
+			message: '#^Cannot access offset ''value'' on array\|bool\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: vdef.php


### PR DESCRIPTION
# Summary

Moves the authoritative PHPStan level into `.phpstan.neon`, raises analysis to level 8, regenerates the baseline, and changes the Composer script to call `phpstan analyse` without overriding repository configuration.

This branch is rebased on current `develop` after #7888. It keeps phpseclib 4 (`^4.0`) and no longer depends on or carries the obsolete phpseclib 3 rollback from #7916.

## Why

`composer run-script phpstan` previously supplied `--level 6`, while direct PHPStan and editor integrations had no configured level and therefore produced a different result. Keeping the level in the shared configuration makes CI, local runs, and editor integrations agree.

PHPStan was also pinned exactly at `2.2.9`; it is now allowed to receive compatible updates through `^2.2.12`.

## Baseline

The clean-install level-8 run currently contains 2,805 known findings. Those are recorded in the regenerated baseline so the gate passes for existing debt and fails for newly introduced findings.

The dominant category remains unchecked database-result offsets: 1,561 findings are `Cannot access offset ... on array|bool`. Addressing the database helper return contracts should be a separate focused change.

## Verification

- `composer validate --no-check-publish`
- Clean `composer install` from the rebased lock file, installing phpseclib 4.0.0 and PHPStan 2.2.12
- `phpstan analyse --debug --no-progress --memory-limit=2G`: no errors with the regenerated level-8 baseline
- Confirmed the branch contains no phpseclib 3 rollback commit and no merge commits
