### PR TITLE
chore: exclude development-only files from the release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,24 @@
 # entry format and issue/feature grouping rather than numeric order, so keeping
 # both sides is a valid resolution.
 CHANGELOG merge=union
+
+# Development-only paths are excluded from `git archive`, which is how the
+# release tarball is built. Keep build/ and patches/ exportable: the release
+# runs `npm ci` inside the archived tree and its postinstall needs them.
+/.dockerignore      export-ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.github/           export-ignore
+/.gitignore         export-ignore
+/.php-cs-fixer.php  export-ignore
+/.phpstan-bootstrap.php export-ignore
+/.phpstan.neon      export-ignore
+/build/psalm/       export-ignore
+/docker-compose.yml export-ignore
+/phpstan-baseline.neon export-ignore
+/phpunit.xml        export-ignore
+/phpunit-*.xml      export-ignore
+/psalm-baseline.xml export-ignore
+/psalm.xml          export-ignore
+/rector.php         export-ignore
+/tests/             export-ignore


### PR DESCRIPTION
The release tarball is built with `git archive HEAD` (`release-artifact.yml`), but `.gitattributes` carried no `export-ignore` rules. Every development file therefore shipped to production.

Measured on `develop` by building the archive both ways: **547 files excluded** after this change.

| Shipped today | Files |
|---|---|
| `tests/` (incl. fixtures) | 402 |
| `.github/` (workflows, actions) | 45 |
| `phpunit.xml` + `phpunit-*.xml` | 13 |
| `psalm.xml`, `psalm-baseline.xml`, `.phpstan.neon`, `phpstan-baseline.neon`, `.phpstan-bootstrap.php`, `rector.php`, `.php-cs-fixer.php`, `docker-compose.yml`, `.dockerignore`, `.editorconfig` | ~10 |

These land in a web-served directory on every Cacti install. It is unnecessary weight and needless attack surface (test fixtures and CI configuration disclosed in production).

## What is deliberately still exported
`build/` and `patches/` remain exportable: the release runs `npm ci` **inside** the archived tree and its `postinstall` (`patch-package && node build/sync-js.mjs`) needs them. Only `build/psalm/` (a dev-only stub) is excluded.

## Verification
- Built the archive before and after: 6392 → 5845 entries.
- Diffed the two file lists: the only removals are the intended dev paths; **no file under `include/`, `lib/`, `plugins/`, `resource/` or any runtime path is affected**.
- Release-critical files confirmed still present: `package.json`, `package-lock.json`, `build/sync-js.mjs`, `composer.json`, `composer.lock`.
