### PR TITLE
test: refresh the 1.2.x security baselines

### DIFF
--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -1,15 +1,15 @@
 class	location	match
 cmd_exec	./cactid.php:102		exec('pgrep -a php | grep cactid.php', $output);
-cmd_exec	./cli/audit_database.php:1037				$db_shell = shell_exec('which mysql');
-cmd_exec	./cli/audit_database.php:1046				exec($db_shell .
-cmd_exec	./cli/audit_database.php:151		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
-cmd_exec	./cli/audit_database.php:242								exec('php ' . $config['base_path'] . '/plugins/' . $pname . '/database_upgrade.php --type=large --force-ver=' . $old, $output, $return_var);
+cmd_exec	./cli/audit_database.php:1085				$db_shell = shell_exec('which mysql');
+cmd_exec	./cli/audit_database.php:1104				exec($db_shell .
+cmd_exec	./cli/audit_database.php:199		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
+cmd_exec	./cli/audit_database.php:290								exec('php ' . $config['base_path'] . '/plugins/' . $pname . '/database_upgrade.php --type=large --force-ver=' . $old, $output, $return_var);
 cmd_exec	./cli/batchgapfix.php:388			exec($command, $output, $return_var);
 cmd_exec	./cli/float_rrdfiles.php:335				$response = exec($command, $output, $return);
 cmd_exec	./cli/float_rrdfiles.php:443					$response = exec($command, $output, $return);
 cmd_exec	./cli/push_out_hosts.php:67		passthru($command, $exit_code);
 cmd_exec	./cli/remove_broken_graphs.php:47		$stty = shell_exec('stty size');
-cmd_exec	./cli/splice_rrd.php:237	$response = shell_exec($rrdtool);
+cmd_exec	./cli/splice_rrd.php:237	$response = shell_exec(cacti_escapeshellcmd($rrdtool));
 cmd_exec	./cli/splice_rrd.php:269	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($oldrrd) . ' > ' . cacti_escapeshellarg($oldxmlfile));
 cmd_exec	./cli/splice_rrd.php:272	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($newrrd) . ' > ' . cacti_escapeshellarg($newxmlfile));
 cmd_exec	./cli/splice_rrd.php:854		$result      = exec($command, $output, $return_var);
@@ -19,26 +19,26 @@ cmd_exec	./cmd_realtime.php:115				$cactiphp = proc_open(cacti_escapeshellcmd(re
 cmd_exec	./data_input.php:84			$output = shell_exec($php . ' -q ' . $script . ' --update --push ' . $id_arg);
 cmd_exec	./graph_realtime.php:219		shell_exec($php_binary . ' -q ' . $script_path . ' ' . $args);
 cmd_exec	./host.php:195		shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/poller_reindex_hosts.php') . ' --qid=all --id=' . cacti_escapeshellarg((string) $host_id));
-cmd_exec	./install/functions.php:538				$myinfo = @json_decode(shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/import_package.php') . ' --filename=' . cacti_escapeshellarg("/$path/$xmlfile") . ' --info'), true);
+cmd_exec	./install/functions.php:525				$myinfo = @json_decode(shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/import_package.php') . ' --filename=' . cacti_escapeshellarg("/$path/$xmlfile") . ' --info'), true);
 cmd_exec	./install/install.php:125			print '<li>' . __('The shell_exec() and/or exec() functions are currently blocked.') . '<br>' . __('See the PHP Manual: <a href="http://php.net/manual/en/ini.core.php#ini.disable-functions">Disable Functions</a>.') .'</li>';
-cmd_exec	./lib/database.php:2621		$process = proc_open(trim($cmd_string), $descriptors, $pipes, null, $env);
+cmd_exec	./lib/database.php:2658		$process = proc_open(trim($cmd_string), $descriptors, $pipes, null, $env);
 cmd_exec	./lib/dsstats.php:1083		$process = proc_open($command, $fds, $pipes);
-cmd_exec	./lib/functions.php:2234					$output = shell_exec($script_path);
-cmd_exec	./lib/functions.php:2249						$output = shell_exec($php . ' -q ' . $script);
-cmd_exec	./lib/functions.php:2533							$output = shell_exec($script_path);
-cmd_exec	./lib/functions.php:3133			return exec('whoami');
-cmd_exec	./lib/functions.php:3796		exec($command_line,$out,$err);
-cmd_exec	./lib/functions.php:7061				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v');
-cmd_exec	./lib/functions.php:7063				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v 2>&1');
-cmd_exec	./lib/functions.php:7262				exec('id -nu', $o, $r);
-cmd_exec	./lib/functions.php:7272				exec(sprintf('grep :%s: /etc/passwd | cut -d: -f1', (int) $uid), $o, $r);
-cmd_exec	./lib/functions.php:7564	 * shell_exec() callers that already assemble the command string.
-cmd_exec	./lib/functions.php:7604		$process = proc_open($argv, $descriptors, $pipes);
-cmd_exec	./lib/functions.php:7682	 * shell_exec() and expect a string return value.
-cmd_exec	./lib/installer.php:3393				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3425						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:3481						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
-cmd_exec	./lib/installer.php:824							$output = shell_exec(
+cmd_exec	./lib/functions.php:2224					$output = shell_exec($script_path);
+cmd_exec	./lib/functions.php:2239						$output = shell_exec($php . ' -q ' . $script);
+cmd_exec	./lib/functions.php:2523							$output = shell_exec($script_path);
+cmd_exec	./lib/functions.php:3124			return exec('whoami');
+cmd_exec	./lib/functions.php:3787		exec($command_line,$out,$err);
+cmd_exec	./lib/functions.php:7052				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v');
+cmd_exec	./lib/functions.php:7054				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v 2>&1');
+cmd_exec	./lib/functions.php:7253				exec('id -nu', $o, $r);
+cmd_exec	./lib/functions.php:7263				exec(sprintf('grep :%s: /etc/passwd | cut -d: -f1', (int) $uid), $o, $r);
+cmd_exec	./lib/functions.php:7555	 * shell_exec() callers that already assemble the command string.
+cmd_exec	./lib/functions.php:7595		$process = proc_open($argv, $descriptors, $pipes);
+cmd_exec	./lib/functions.php:7673	 * shell_exec() and expect a string return value.
+cmd_exec	./lib/installer.php:3405				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3437						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:3493						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
+cmd_exec	./lib/installer.php:837							$output = shell_exec(
 cmd_exec	./lib/ping.php:167					$result = shell_exec('ping ' . cacti_escapeshellarg($this->host['hostname']));
 cmd_exec	./lib/ping.php:169					$result = shell_exec('ping -m ' . ceil($this->timeout/1000) . ' -n ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
 cmd_exec	./lib/ping.php:171					$result = shell_exec('ping -t ' . ceil($this->timeout/1000) . ' -c ' . $this->retries . ' ' . cacti_escapeshellarg($this->host['hostname']));
@@ -69,9 +69,9 @@ cmd_exec	./lib/poller.php:52			$output = shell_exec($command);
 cmd_exec	./lib/poller.php:63	 *                    of the proc_open() and proc_close() functions (php 4.3+)
 cmd_exec	./lib/poller.php:64	 * @param  (array)    $pipes - the array of r/w pipes returned from proc_open()
 cmd_exec	./lib/poller.php:65	 * @param  (resource) $proc_fd - the file descriptor returned from proc_open()
-cmd_exec	./lib/rrd.php:319				$process = proc_open(cacti_escapeshellarg(read_config_option('path_rrdtool')) . ' - ' . $debug, $descriptorspec, $pipes);
+cmd_exec	./lib/rrd.php:1043					$fp = popen($rrdtool_cmd, 'r');
+cmd_exec	./lib/rrd.php:360				$process = proc_open(cacti_escapeshellarg(read_config_option('path_rrdtool')) . ' - ' . $debug, $descriptorspec, $pipes);
 cmd_exec	./lib/rrd.php:93		return popen($command, 'w');
-cmd_exec	./lib/rrd.php:991					$fp = popen($rrdtool_cmd, 'r');
 cmd_exec	./lib/rrdcheck.php:798		$process = proc_open($command, $fds, $pipes);
 cmd_exec	./lib/snmp.php:214			exec($command, $snmp_value);
 cmd_exec	./lib/snmp.php:314			exec($command, $snmp_value);
@@ -102,7 +102,7 @@ cmd_exec	./utilities.php:219					exec(cacti_escapeshellcmd(read_config_option('p
 cmd_exec	./utilities.php:237				$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
 cmd_exec	./utilities.php:257				exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
 dynamic_include	./automation_snmp.php:414		#include_once($config['base_path'].'/plugins/mactrack/lib/automation_functions.php');
-dynamic_include	./automation_tree_rules.php:538		include_once($config['base_path'].'/lib/html_tree.php');
+dynamic_include	./automation_tree_rules.php:545		include_once($config['base_path'].'/lib/html_tree.php');
 dynamic_include	./cli/add_data_query.php:27	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./cli/add_data_query.php:28	require_once($config['base_path'] . '/lib/api_automation.php');
 dynamic_include	./cli/add_data_query.php:29	require_once($config['base_path'] . '/lib/api_data_source.php');
@@ -156,8 +156,8 @@ dynamic_include	./cli/apply_automation_rules.php:35	require_once($config['base_p
 dynamic_include	./cli/apply_automation_rules.php:36	require_once($config['base_path'] . '/lib/reports.php');
 dynamic_include	./cli/apply_automation_rules.php:37	require_once($config['base_path'] . '/lib/template.php');
 dynamic_include	./cli/apply_automation_rules.php:38	require_once($config['base_path'] . '/lib/utility.php');
-dynamic_include	./cli/audit_database.php:215							include_once($plugin . '/setup.php');
-dynamic_include	./cli/audit_database.php:217								include_once($plugin . '/includes/database.php');
+dynamic_include	./cli/audit_database.php:263							include_once($plugin . '/setup.php');
+dynamic_include	./cli/audit_database.php:265								include_once($plugin . '/includes/database.php');
 dynamic_include	./cli/batchgapfix.php:35	require_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./cli/change_device.php:27	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./cli/change_device.php:28	require_once($config['base_path'] . '/lib/api_device.php');
@@ -277,8 +277,8 @@ dynamic_include	./color_templates.php:485		include_once($config['base_path'] . '
 dynamic_include	./graph_realtime.php:382	    <?php include($config['base_path'] . '/include/global_session.php'); ?>
 dynamic_include	./include/auth.php:121					require_once($config['base_path'] . '/auth_login.php');
 dynamic_include	./include/auth.php:176				require_once($config['base_path'] . '/auth_login.php');
+dynamic_include	./include/csrf.php:200	include_once($config['include_path'] . '/vendor/csrf/csrf-magic.php');
 dynamic_include	./include/csrf.php:25	require_once($config['include_path'] .'/vendor/csrf/csrf-conf.php');
-dynamic_include	./include/csrf.php:56	include_once($config['include_path'] . '/vendor/csrf/csrf-magic.php');
 dynamic_include	./include/global.php:277	include_once($config['library_path'] . '/database.php');
 dynamic_include	./include/global.php:278	include_once($config['library_path'] . '/functions.php');
 dynamic_include	./include/global.php:279	include_once($config['library_path'] . '/graph_template_input.php');
@@ -287,23 +287,23 @@ dynamic_include	./include/global.php:281	include_once($config['include_path'] . 
 dynamic_include	./include/global.php:282	include_once($config['library_path'] . '/html.php');
 dynamic_include	./include/global.php:283	include_once($config['library_path'] . '/html_utility.php');
 dynamic_include	./include/global.php:284	include_once($config['library_path'] . '/html_validate.php');
-dynamic_include	./include/global.php:540	include_once($config['include_path'] . '/global_languages.php');
-dynamic_include	./include/global.php:541	include_once($config['library_path'] . '/auth.php');
-dynamic_include	./include/global.php:542	include_once($config['library_path'] . '/plugins.php');
-dynamic_include	./include/global.php:543	include_once($config['include_path'] . '/plugins.php');
-dynamic_include	./include/global.php:544	include_once($config['include_path'] . '/global_arrays.php');
-dynamic_include	./include/global.php:545	include_once($config['include_path'] . '/global_settings.php');
-dynamic_include	./include/global.php:546	include_once($config['include_path'] . '/global_form.php');
-dynamic_include	./include/global.php:547	include_once($config['library_path'] . '/html_form.php');
-dynamic_include	./include/global.php:548	include_once($config['library_path'] . '/html_filter.php');
-dynamic_include	./include/global.php:549	include_once($config['library_path'] . '/variables.php');
-dynamic_include	./include/global.php:550	include_once($config['library_path'] . '/mib_cache.php');
-dynamic_include	./include/global.php:551	include_once($config['library_path'] . '/poller.php');
-dynamic_include	./include/global.php:552	include_once($config['library_path'] . '/snmpagent.php');
-dynamic_include	./include/global.php:553	include_once($config['library_path'] . '/aggregate.php');
-dynamic_include	./include/global.php:554	include_once($config['library_path'] . '/api_automation.php');
-dynamic_include	./include/global.php:555	include_once($config['include_path'] . '/csrf.php');
-dynamic_include	./include/global.php:556	include_once($config['include_path'] . '/vendor/autoload.php');
+dynamic_include	./include/global.php:528	include_once($config['include_path'] . '/global_languages.php');
+dynamic_include	./include/global.php:529	include_once($config['library_path'] . '/auth.php');
+dynamic_include	./include/global.php:530	include_once($config['library_path'] . '/plugins.php');
+dynamic_include	./include/global.php:531	include_once($config['include_path'] . '/plugins.php');
+dynamic_include	./include/global.php:532	include_once($config['include_path'] . '/global_arrays.php');
+dynamic_include	./include/global.php:533	include_once($config['include_path'] . '/global_settings.php');
+dynamic_include	./include/global.php:534	include_once($config['include_path'] . '/global_form.php');
+dynamic_include	./include/global.php:535	include_once($config['library_path'] . '/html_form.php');
+dynamic_include	./include/global.php:536	include_once($config['library_path'] . '/html_filter.php');
+dynamic_include	./include/global.php:537	include_once($config['library_path'] . '/variables.php');
+dynamic_include	./include/global.php:538	include_once($config['library_path'] . '/mib_cache.php');
+dynamic_include	./include/global.php:539	include_once($config['library_path'] . '/poller.php');
+dynamic_include	./include/global.php:540	include_once($config['library_path'] . '/snmpagent.php');
+dynamic_include	./include/global.php:541	include_once($config['library_path'] . '/aggregate.php');
+dynamic_include	./include/global.php:542	include_once($config['library_path'] . '/api_automation.php');
+dynamic_include	./include/global.php:543	include_once($config['include_path'] . '/csrf.php');
+dynamic_include	./include/global.php:544	include_once($config['include_path'] . '/vendor/autoload.php');
 dynamic_include	./include/global_languages.php:173				require_once($providerFull);
 dynamic_include	./install/background.php:29	include_once($config['base_path'] . '/install/functions.php');
 dynamic_include	./install/background.php:30	include_once($config['base_path'] . '/lib/api_data_source.php');
@@ -316,7 +316,7 @@ dynamic_include	./install/background.php:36	include_once($config['base_path'] . 
 dynamic_include	./install/background.php:37	include_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./install/background.php:38	include_once($config['base_path'] . '/lib/snmp.php');
 dynamic_include	./install/background.php:39	include_once($config['base_path'] . '/lib/utility.php');
-dynamic_include	./install/functions.php:1136		include_once($config['base_path'] . '/lib/poller.php');
+dynamic_include	./install/functions.php:1123		include_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./install/install.php:29	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./install/install.php:30	require_once($config['base_path'] . '/lib/api_automation.php');
 dynamic_include	./install/install.php:31	require_once($config['base_path'] . '/lib/api_data_source.php');
@@ -351,11 +351,11 @@ dynamic_include	./lib/api_automation.php:3083					include_once($config['base_pat
 dynamic_include	./lib/api_device.php:946		include_once($config['base_path'] . '/lib/utility.php');
 dynamic_include	./lib/api_device.php:947		include_once($config['base_path'] . '/lib/variables.php');
 dynamic_include	./lib/api_device.php:948		include_once($config['base_path'] . '/lib/data_query.php');
-dynamic_include	./lib/boost.php:1265		include($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/boost.php:1576			include_once($config['library_path'] . '/poller.php');
-dynamic_include	./lib/boost.php:277			include_once($config['library_path'] . '/poller.php');
-dynamic_include	./lib/boost.php:339		include_once($config['library_path'] . '/poller.php');
-dynamic_include	./lib/boost.php:701		include_once($config['library_path'] . '/rrd.php');
+dynamic_include	./lib/boost.php:1418		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/boost.php:1733			include_once($config['library_path'] . '/poller.php');
+dynamic_include	./lib/boost.php:329			include_once($config['library_path'] . '/poller.php');
+dynamic_include	./lib/boost.php:469		include_once($config['library_path'] . '/poller.php');
+dynamic_include	./lib/boost.php:819		include_once($config['library_path'] . '/rrd.php');
 dynamic_include	./lib/data_query.php:1963		include_once($config['library_path'] . '/sort.php');
 dynamic_include	./lib/data_query.php:2372		include_once($config['library_path'] . '/variables.php');
 dynamic_include	./lib/data_query.php:602		include_once($config['library_path'] . '/xml.php');
@@ -368,17 +368,17 @@ dynamic_include	./lib/dsstats.php:1032			include_once($config['library_path'] . 
 dynamic_include	./lib/dsstats.php:990			include_once($config['base_path'] . '/lib/rrd.php');
 dynamic_include	./lib/export.php:465		include_once($config['library_path'] . '/vdef.php');
 dynamic_include	./lib/functions.php:421		include_once($config['base_path'] . '/lib/poller.php');
-dynamic_include	./lib/functions.php:4932		include_once($config['base_path'] . '/include/global_session.php');
-dynamic_include	./lib/functions.php:4935			include_once($config['base_path'] . '/include/bottom_footer.php');
-dynamic_include	./lib/functions.php:4960			include_once($config['base_path'] . '/include/top_header.php');
-dynamic_include	./lib/functions.php:4967			include_once($config['base_path'] . '/include/top_graph_header.php');
-dynamic_include	./lib/functions.php:4974			include_once($config['base_path'] . '/include/top_general_header.php');
-dynamic_include	./lib/functions.php:5136		require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
-dynamic_include	./lib/functions.php:5137		require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
-dynamic_include	./lib/functions.php:5138		require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
-dynamic_include	./lib/functions.php:5625	    require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
-dynamic_include	./lib/functions.php:5626	    require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
-dynamic_include	./lib/functions.php:5627	    require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
+dynamic_include	./lib/functions.php:4923		include_once($config['base_path'] . '/include/global_session.php');
+dynamic_include	./lib/functions.php:4926			include_once($config['base_path'] . '/include/bottom_footer.php');
+dynamic_include	./lib/functions.php:4951			include_once($config['base_path'] . '/include/top_header.php');
+dynamic_include	./lib/functions.php:4958			include_once($config['base_path'] . '/include/top_graph_header.php');
+dynamic_include	./lib/functions.php:4965			include_once($config['base_path'] . '/include/top_general_header.php');
+dynamic_include	./lib/functions.php:5127		require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
+dynamic_include	./lib/functions.php:5128		require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
+dynamic_include	./lib/functions.php:5129		require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
+dynamic_include	./lib/functions.php:5616	    require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
+dynamic_include	./lib/functions.php:5617	    require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
+dynamic_include	./lib/functions.php:5618	    require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
 dynamic_include	./lib/graph_variables.php:65		include_once($config['library_path'] . '/rrd.php');
 dynamic_include	./lib/html.php:1268		include($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/html_tree.php:479		include_once($config['base_path'] . '/lib/data_query.php');
@@ -386,9 +386,9 @@ dynamic_include	./lib/html_tree.php:829		include($config['include_path'] . '/glo
 dynamic_include	./lib/html_tree.php:830		include_once($config['library_path'] . '/data_query.php');
 dynamic_include	./lib/html_tree.php:831		include_once($config['library_path'] . '/html_utility.php');
 dynamic_include	./lib/html_tree.php:93		include_once($config['library_path'] . '/data_query.php');
-dynamic_include	./lib/import.php:2071		include_once($config['library_path'] . '/vdef.php');
+dynamic_include	./lib/import.php:2112		include_once($config['library_path'] . '/vdef.php');
 dynamic_include	./lib/import.php:29		include_once($config['library_path'] . '/xml.php');
-dynamic_include	./lib/installer.php:3534					include_once($upgrade_file);
+dynamic_include	./lib/installer.php:3546					include_once($upgrade_file);
 dynamic_include	./lib/mib_cache.php:57			include_once($config['include_path'] . '/vendor/phpsnmp/mib_parser.php');
 dynamic_include	./lib/plugins.php:154							include_once($plugin_include);
 dynamic_include	./lib/plugins.php:464		include_once($config['library_path'] . '/database.php');
@@ -415,19 +415,19 @@ dynamic_include	./lib/reports.php:395		include_once($config['base_path'] . '/lib
 dynamic_include	./lib/reports.php:396		include_once($config['base_path'] . '/lib/html_reports.php');
 dynamic_include	./lib/reports.php:678		include_once($config['library_path'] . '/html_tree.php');
 dynamic_include	./lib/reports.php:755		include_once($config['base_path'] . '/lib/time.php');
-dynamic_include	./lib/rrd.php:1034		include_once($config['library_path'] . '/boost.php');
-dynamic_include	./lib/rrd.php:1122		include($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/rrd.php:1416		include_once($config['library_path'] . '/cdef.php');
-dynamic_include	./lib/rrd.php:1417		include_once($config['library_path'] . '/vdef.php');
-dynamic_include	./lib/rrd.php:1418		include_once($config['library_path'] . '/graph_variables.php');
-dynamic_include	./lib/rrd.php:1419		include_once($config['library_path'] . '/boost.php');
-dynamic_include	./lib/rrd.php:1420		include_once($config['library_path'] . '/xml.php');
-dynamic_include	./lib/rrd.php:1421		include($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/rrd.php:2730			include($rrdtheme);
-dynamic_include	./lib/rrd.php:3400		include_once($config['library_path'] . '/time.php');
-dynamic_include	./lib/rrd.php:4212			include($themefile);
-dynamic_include	./lib/rrd.php:601		include ($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/rrd.php:960		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/rrd.php:1012		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/rrd.php:1086		include_once($config['library_path'] . '/boost.php');
+dynamic_include	./lib/rrd.php:1174		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/rrd.php:1469		include_once($config['library_path'] . '/cdef.php');
+dynamic_include	./lib/rrd.php:1470		include_once($config['library_path'] . '/vdef.php');
+dynamic_include	./lib/rrd.php:1471		include_once($config['library_path'] . '/graph_variables.php');
+dynamic_include	./lib/rrd.php:1472		include_once($config['library_path'] . '/boost.php');
+dynamic_include	./lib/rrd.php:1473		include_once($config['library_path'] . '/xml.php');
+dynamic_include	./lib/rrd.php:1474		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/rrd.php:2783			include($rrdtheme);
+dynamic_include	./lib/rrd.php:3453		include_once($config['library_path'] . '/time.php');
+dynamic_include	./lib/rrd.php:4265			include($themefile);
+dynamic_include	./lib/rrd.php:653		include ($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/rrdcheck.php:716			include_once($config['base_path'] . '/lib/rrd.php');
 dynamic_include	./lib/rrdcheck.php:746			include_once($config['library_path'] . '/poller.php');
 dynamic_include	./lib/snmp.php:49		include_once($config['include_path'] . '/vendor/phpsnmp/extension.php');
@@ -442,8 +442,8 @@ dynamic_include	./lib/utility.php:182		include_once($config['library_path'] . '/
 dynamic_include	./lib/utility.php:46		include_once($config['library_path'] . '/api_data_source.php');
 dynamic_include	./lib/utility.php:837		include_once($config['library_path'] . '/api_data_source.php');
 dynamic_include	./link.php:73					include_once($file);
-dynamic_include	./poller.php:1047	    include_once($config['base_path'] . '/lib/poller.php');
-dynamic_include	./poller.php:1198	    include_once($config['base_path'] . '/lib/poller.php');
+dynamic_include	./poller.php:1057	    include_once($config['base_path'] . '/lib/poller.php');
+dynamic_include	./poller.php:1208	    include_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./poller.php:35	require_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./poller.php:36	require_once($config['base_path'] . '/lib/data_query.php');
 dynamic_include	./poller.php:37	require_once($config['base_path'] . '/lib/rrd.php');
@@ -469,7 +469,7 @@ dynamic_include	./poller_boost.php:36	require_once($config['base_path'] . '/lib/
 dynamic_include	./poller_boost.php:37	require_once($config['base_path'] . '/lib/dsstats.php');
 dynamic_include	./poller_boost.php:38	require_once($config['base_path'] . '/lib/rrdcheck.php');
 dynamic_include	./poller_boost.php:39	require_once($config['base_path'] . '/lib/rrd.php');
-dynamic_include	./poller_boost.php:717		include_once($config['library_path'] . '/rrd.php');
+dynamic_include	./poller_boost.php:780		include_once($config['library_path'] . '/rrd.php');
 dynamic_include	./poller_commands.php:40	require_once($config['base_path'] . '/lib/api_device.php');
 dynamic_include	./poller_commands.php:41	require_once($config['base_path'] . '/lib/api_data_source.php');
 dynamic_include	./poller_commands.php:42	require_once($config['base_path'] . '/lib/api_graph.php');
@@ -533,12 +533,8 @@ dynamic_include	./script_server.php:306				include_once($include_file);
 dynamic_include	./scripts/ss_netsnmp_lmsensors.php:24		include($config['base_path'] . '/lib/snmp.php');
 dynamic_include	./snmpagent_persist.php:165				include( $path_mibcache );
 dynamic_include	./spikekill.php:26	include_once($config['base_path'] . '/lib/spikekill.php');
-host_header	./include/global.php:422			if (!$is_https && isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI'])) {
-host_header	./include/global.php:423				header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
-host_header	./lib/html_utility.php:1077		} elseif (isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST'] != '') {
-host_header	./lib/html_utility.php:1078			$srv_host = preg_replace('/:\d+$/', '', $_SERVER['HTTP_HOST']);
 sort_order_input	./automation_snmp.php:533				ORDER BY sequence', array(get_request_var('id')));
-sort_order_input	./data_queries.php:872						ORDER BY field_name, sequence', array(get_request_var('id'), $data_template['id']));
+sort_order_input	./data_queries.php:883						ORDER BY field_name, sequence', array(get_request_var('id'), $data_template['id']));
 sort_order_input	./graph_templates.php:504			ORDER BY name', array(get_request_var('id')));
 sort_order_input	./graph_templates_inputs.php:236			ORDER BY gti.sequence", array(get_request_var('id'), get_request_var('graph_template_id')));
 sort_order_input	./graphs.php:1420				ORDER BY gti.sequence", array(get_request_var('id')));

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -1,14 +1,14 @@
 category	location	match
 cmd_exec	./cactid.php:102		exec('pgrep -a php | grep cactid.php', $output);
-cmd_exec	./cli/audit_database.php:1037				$db_shell = shell_exec('which mysql');
-cmd_exec	./cli/audit_database.php:1046				exec($db_shell .
-cmd_exec	./cli/audit_database.php:151		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
+cmd_exec	./cli/audit_database.php:1085				$db_shell = shell_exec('which mysql');
+cmd_exec	./cli/audit_database.php:1104				exec($db_shell .
+cmd_exec	./cli/audit_database.php:199		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
 cmd_exec	./cli/batchgapfix.php:388			exec($command, $output, $return_var);
 cmd_exec	./cli/float_rrdfiles.php:335				$response = exec($command, $output, $return);
 cmd_exec	./cli/float_rrdfiles.php:443					$response = exec($command, $output, $return);
 cmd_exec	./cli/push_out_hosts.php:67		passthru($command, $exit_code);
 cmd_exec	./cli/remove_broken_graphs.php:47		$stty = shell_exec('stty size');
-cmd_exec	./cli/splice_rrd.php:237	$response = shell_exec($rrdtool);
+cmd_exec	./cli/splice_rrd.php:237	$response = shell_exec(cacti_escapeshellcmd($rrdtool));
 cmd_exec	./cli/splice_rrd.php:269	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($oldrrd) . ' > ' . cacti_escapeshellarg($oldxmlfile));
 cmd_exec	./cli/splice_rrd.php:272	shell_exec(cacti_escapeshellcmd($rrdtool) . ' dump ' . cacti_escapeshellarg($newrrd) . ' > ' . cacti_escapeshellarg($newxmlfile));
 cmd_exec	./cli/splice_rrd.php:854		$result      = exec($command, $output, $return_var);
@@ -20,20 +20,20 @@ cmd_exec	./graph_realtime.php:219		shell_exec($php_binary . ' -q ' . $script_pat
 cmd_exec	./host.php:195		shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/poller_reindex_hosts.php') . ' --qid=all --id=' . cacti_escapeshellarg((string) $host_id));
 cmd_exec	./install/functions.php:525				$myinfo = @json_decode(shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' . cacti_escapeshellarg($config['base_path'] . '/cli/import_package.php') . ' --filename=' . cacti_escapeshellarg("/$path/$xmlfile") . ' --info'), true);
 cmd_exec	./install/install.php:125			print '<li>' . __('The shell_exec() and/or exec() functions are currently blocked.') . '<br>' . __('See the PHP Manual: <a href="http://php.net/manual/en/ini.core.php#ini.disable-functions">Disable Functions</a>.') .'</li>';
-cmd_exec	./lib/database.php:2621		$process = proc_open(trim($cmd_string), $descriptors, $pipes, null, $env);
+cmd_exec	./lib/database.php:2658		$process = proc_open(trim($cmd_string), $descriptors, $pipes, null, $env);
 cmd_exec	./lib/dsstats.php:1083		$process = proc_open($command, $fds, $pipes);
-cmd_exec	./lib/functions.php:2234					$output = shell_exec($script_path);
-cmd_exec	./lib/functions.php:2249						$output = shell_exec($php . ' -q ' . $script);
-cmd_exec	./lib/functions.php:2533							$output = shell_exec($script_path);
-cmd_exec	./lib/functions.php:3133			return exec('whoami');
-cmd_exec	./lib/functions.php:3796		exec($command_line,$out,$err);
-cmd_exec	./lib/functions.php:7061				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v');
-cmd_exec	./lib/functions.php:7063				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v 2>&1');
-cmd_exec	./lib/functions.php:7262				exec('id -nu', $o, $r);
-cmd_exec	./lib/functions.php:7272				exec(sprintf('grep :%s: /etc/passwd | cut -d: -f1', (int) $uid), $o, $r);
-cmd_exec	./lib/functions.php:7564	 * shell_exec() callers that already assemble the command string.
-cmd_exec	./lib/functions.php:7604		$process = proc_open($argv, $descriptors, $pipes);
-cmd_exec	./lib/functions.php:7682	 * shell_exec() and expect a string return value.
+cmd_exec	./lib/functions.php:2224					$output = shell_exec($script_path);
+cmd_exec	./lib/functions.php:2239						$output = shell_exec($php . ' -q ' . $script);
+cmd_exec	./lib/functions.php:2523							$output = shell_exec($script_path);
+cmd_exec	./lib/functions.php:3124			return exec('whoami');
+cmd_exec	./lib/functions.php:3787		exec($command_line,$out,$err);
+cmd_exec	./lib/functions.php:7052				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v');
+cmd_exec	./lib/functions.php:7054				$shell = shell_exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')) . ' -v 2>&1');
+cmd_exec	./lib/functions.php:7253				exec('id -nu', $o, $r);
+cmd_exec	./lib/functions.php:7263				exec(sprintf('grep :%s: /etc/passwd | cut -d: -f1', (int) $uid), $o, $r);
+cmd_exec	./lib/functions.php:7555	 * shell_exec() callers that already assemble the command string.
+cmd_exec	./lib/functions.php:7595		$process = proc_open($argv, $descriptors, $pipes);
+cmd_exec	./lib/functions.php:7673	 * shell_exec() and expect a string return value.
 cmd_exec	./lib/installer.php:3405				$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
 cmd_exec	./lib/installer.php:3437						shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
 cmd_exec	./lib/installer.php:3493						$results = shell_exec(cacti_escapeshellcmd(read_config_option('path_php_binary')) . ' -q ' .
@@ -68,9 +68,9 @@ cmd_exec	./lib/poller.php:52			$output = shell_exec($command);
 cmd_exec	./lib/poller.php:63	 *                    of the proc_open() and proc_close() functions (php 4.3+)
 cmd_exec	./lib/poller.php:64	 * @param  (array)    $pipes - the array of r/w pipes returned from proc_open()
 cmd_exec	./lib/poller.php:65	 * @param  (resource) $proc_fd - the file descriptor returned from proc_open()
-cmd_exec	./lib/rrd.php:319				$process = proc_open(cacti_escapeshellarg(read_config_option('path_rrdtool')) . ' - ' . $debug, $descriptorspec, $pipes);
+cmd_exec	./lib/rrd.php:1043					$fp = popen($rrdtool_cmd, 'r');
+cmd_exec	./lib/rrd.php:360				$process = proc_open(cacti_escapeshellarg(read_config_option('path_rrdtool')) . ' - ' . $debug, $descriptorspec, $pipes);
 cmd_exec	./lib/rrd.php:93		return popen($command, 'w');
-cmd_exec	./lib/rrd.php:991					$fp = popen($rrdtool_cmd, 'r');
 cmd_exec	./lib/rrdcheck.php:798		$process = proc_open($command, $fds, $pipes);
 cmd_exec	./lib/snmp.php:214			exec($command, $snmp_value);
 cmd_exec	./lib/snmp.php:314			exec($command, $snmp_value);
@@ -100,8 +100,8 @@ cmd_exec	./snmpagent_persist.php:86			exec($php . ' ' . $extra_args . ' > /dev/n
 cmd_exec	./utilities.php:219					exec(cacti_escapeshellcmd(read_config_option('path_rrdtool')), $out_array);
 cmd_exec	./utilities.php:237				$snmp_version = shell_exec(cacti_escapeshellcmd(read_config_option('path_snmpget')) . ' -V 2>&1');
 cmd_exec	./utilities.php:257				exec(cacti_escapeshellcmd(read_config_option('path_spine')) . ' --version', $out_array);
-deserialize	./lib/functions.php:4804				$items = unserialize($unstripped, array('allowed_classes' => false));
-deserialize	./lib/functions.php:8143		return @unserialize($strobj, array('allowed_classes' => false));
+deserialize	./lib/functions.php:4795				$items = unserialize($unstripped, array('allowed_classes' => false));
+deserialize	./lib/functions.php:8132		return @unserialize($strobj, array('allowed_classes' => false));
 dynamic_include	./automation_tree_rules.php:545		include_once($config['base_path'].'/lib/html_tree.php');
 dynamic_include	./cli/add_data_query.php:27	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./cli/add_data_query.php:28	require_once($config['base_path'] . '/lib/api_automation.php');
@@ -156,8 +156,8 @@ dynamic_include	./cli/apply_automation_rules.php:35	require_once($config['base_p
 dynamic_include	./cli/apply_automation_rules.php:36	require_once($config['base_path'] . '/lib/reports.php');
 dynamic_include	./cli/apply_automation_rules.php:37	require_once($config['base_path'] . '/lib/template.php');
 dynamic_include	./cli/apply_automation_rules.php:38	require_once($config['base_path'] . '/lib/utility.php');
-dynamic_include	./cli/audit_database.php:215							include_once($plugin . '/setup.php');
-dynamic_include	./cli/audit_database.php:217								include_once($plugin . '/includes/database.php');
+dynamic_include	./cli/audit_database.php:263							include_once($plugin . '/setup.php');
+dynamic_include	./cli/audit_database.php:265								include_once($plugin . '/includes/database.php');
 dynamic_include	./cli/batchgapfix.php:35	require_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./cli/change_device.php:27	require_once($config['base_path'] . '/lib/api_automation_tools.php');
 dynamic_include	./cli/change_device.php:28	require_once($config['base_path'] . '/lib/api_device.php');
@@ -287,23 +287,23 @@ dynamic_include	./include/global.php:281	include_once($config['include_path'] . 
 dynamic_include	./include/global.php:282	include_once($config['library_path'] . '/html.php');
 dynamic_include	./include/global.php:283	include_once($config['library_path'] . '/html_utility.php');
 dynamic_include	./include/global.php:284	include_once($config['library_path'] . '/html_validate.php');
-dynamic_include	./include/global.php:540	include_once($config['include_path'] . '/global_languages.php');
-dynamic_include	./include/global.php:541	include_once($config['library_path'] . '/auth.php');
-dynamic_include	./include/global.php:542	include_once($config['library_path'] . '/plugins.php');
-dynamic_include	./include/global.php:543	include_once($config['include_path'] . '/plugins.php');
-dynamic_include	./include/global.php:544	include_once($config['include_path'] . '/global_arrays.php');
-dynamic_include	./include/global.php:545	include_once($config['include_path'] . '/global_settings.php');
-dynamic_include	./include/global.php:546	include_once($config['include_path'] . '/global_form.php');
-dynamic_include	./include/global.php:547	include_once($config['library_path'] . '/html_form.php');
-dynamic_include	./include/global.php:548	include_once($config['library_path'] . '/html_filter.php');
-dynamic_include	./include/global.php:549	include_once($config['library_path'] . '/variables.php');
-dynamic_include	./include/global.php:550	include_once($config['library_path'] . '/mib_cache.php');
-dynamic_include	./include/global.php:551	include_once($config['library_path'] . '/poller.php');
-dynamic_include	./include/global.php:552	include_once($config['library_path'] . '/snmpagent.php');
-dynamic_include	./include/global.php:553	include_once($config['library_path'] . '/aggregate.php');
-dynamic_include	./include/global.php:554	include_once($config['library_path'] . '/api_automation.php');
-dynamic_include	./include/global.php:555	include_once($config['include_path'] . '/csrf.php');
-dynamic_include	./include/global.php:556	include_once($config['include_path'] . '/vendor/autoload.php');
+dynamic_include	./include/global.php:528	include_once($config['include_path'] . '/global_languages.php');
+dynamic_include	./include/global.php:529	include_once($config['library_path'] . '/auth.php');
+dynamic_include	./include/global.php:530	include_once($config['library_path'] . '/plugins.php');
+dynamic_include	./include/global.php:531	include_once($config['include_path'] . '/plugins.php');
+dynamic_include	./include/global.php:532	include_once($config['include_path'] . '/global_arrays.php');
+dynamic_include	./include/global.php:533	include_once($config['include_path'] . '/global_settings.php');
+dynamic_include	./include/global.php:534	include_once($config['include_path'] . '/global_form.php');
+dynamic_include	./include/global.php:535	include_once($config['library_path'] . '/html_form.php');
+dynamic_include	./include/global.php:536	include_once($config['library_path'] . '/html_filter.php');
+dynamic_include	./include/global.php:537	include_once($config['library_path'] . '/variables.php');
+dynamic_include	./include/global.php:538	include_once($config['library_path'] . '/mib_cache.php');
+dynamic_include	./include/global.php:539	include_once($config['library_path'] . '/poller.php');
+dynamic_include	./include/global.php:540	include_once($config['library_path'] . '/snmpagent.php');
+dynamic_include	./include/global.php:541	include_once($config['library_path'] . '/aggregate.php');
+dynamic_include	./include/global.php:542	include_once($config['library_path'] . '/api_automation.php');
+dynamic_include	./include/global.php:543	include_once($config['include_path'] . '/csrf.php');
+dynamic_include	./include/global.php:544	include_once($config['include_path'] . '/vendor/autoload.php');
 dynamic_include	./include/global_languages.php:173				require_once($providerFull);
 dynamic_include	./install/background.php:29	include_once($config['base_path'] . '/install/functions.php');
 dynamic_include	./install/background.php:30	include_once($config['base_path'] . '/lib/api_data_source.php');
@@ -366,17 +366,17 @@ dynamic_include	./lib/dsstats.php:1032			include_once($config['library_path'] . 
 dynamic_include	./lib/dsstats.php:990			include_once($config['base_path'] . '/lib/rrd.php');
 dynamic_include	./lib/export.php:465		include_once($config['library_path'] . '/vdef.php');
 dynamic_include	./lib/functions.php:421		include_once($config['base_path'] . '/lib/poller.php');
-dynamic_include	./lib/functions.php:4932		include_once($config['base_path'] . '/include/global_session.php');
-dynamic_include	./lib/functions.php:4935			include_once($config['base_path'] . '/include/bottom_footer.php');
-dynamic_include	./lib/functions.php:4960			include_once($config['base_path'] . '/include/top_header.php');
-dynamic_include	./lib/functions.php:4967			include_once($config['base_path'] . '/include/top_graph_header.php');
-dynamic_include	./lib/functions.php:4974			include_once($config['base_path'] . '/include/top_general_header.php');
-dynamic_include	./lib/functions.php:5136		require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
-dynamic_include	./lib/functions.php:5137		require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
-dynamic_include	./lib/functions.php:5138		require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
-dynamic_include	./lib/functions.php:5625	    require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
-dynamic_include	./lib/functions.php:5626	    require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
-dynamic_include	./lib/functions.php:5627	    require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
+dynamic_include	./lib/functions.php:4923		include_once($config['base_path'] . '/include/global_session.php');
+dynamic_include	./lib/functions.php:4926			include_once($config['base_path'] . '/include/bottom_footer.php');
+dynamic_include	./lib/functions.php:4951			include_once($config['base_path'] . '/include/top_header.php');
+dynamic_include	./lib/functions.php:4958			include_once($config['base_path'] . '/include/top_graph_header.php');
+dynamic_include	./lib/functions.php:4965			include_once($config['base_path'] . '/include/top_general_header.php');
+dynamic_include	./lib/functions.php:5127		require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
+dynamic_include	./lib/functions.php:5128		require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
+dynamic_include	./lib/functions.php:5129		require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
+dynamic_include	./lib/functions.php:5616	    require_once($config['include_path'] . '/vendor/phpmailer/src/Exception.php');
+dynamic_include	./lib/functions.php:5617	    require_once($config['include_path'] . '/vendor/phpmailer/src/PHPMailer.php');
+dynamic_include	./lib/functions.php:5618	    require_once($config['include_path'] . '/vendor/phpmailer/src/SMTP.php');
 dynamic_include	./lib/graph_variables.php:65		include_once($config['library_path'] . '/rrd.php');
 dynamic_include	./lib/html.php:1268		include($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/html_tree.php:479		include_once($config['base_path'] . '/lib/data_query.php');
@@ -413,19 +413,19 @@ dynamic_include	./lib/reports.php:395		include_once($config['base_path'] . '/lib
 dynamic_include	./lib/reports.php:396		include_once($config['base_path'] . '/lib/html_reports.php');
 dynamic_include	./lib/reports.php:678		include_once($config['library_path'] . '/html_tree.php');
 dynamic_include	./lib/reports.php:755		include_once($config['base_path'] . '/lib/time.php');
-dynamic_include	./lib/rrd.php:1034		include_once($config['library_path'] . '/boost.php');
-dynamic_include	./lib/rrd.php:1122		include($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/rrd.php:1416		include_once($config['library_path'] . '/cdef.php');
-dynamic_include	./lib/rrd.php:1417		include_once($config['library_path'] . '/vdef.php');
-dynamic_include	./lib/rrd.php:1418		include_once($config['library_path'] . '/graph_variables.php');
-dynamic_include	./lib/rrd.php:1419		include_once($config['library_path'] . '/boost.php');
-dynamic_include	./lib/rrd.php:1420		include_once($config['library_path'] . '/xml.php');
-dynamic_include	./lib/rrd.php:1421		include($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/rrd.php:2730			include($rrdtheme);
-dynamic_include	./lib/rrd.php:3400		include_once($config['library_path'] . '/time.php');
-dynamic_include	./lib/rrd.php:4212			include($themefile);
-dynamic_include	./lib/rrd.php:601		include ($config['include_path'] . '/global_arrays.php');
-dynamic_include	./lib/rrd.php:960		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/rrd.php:1012		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/rrd.php:1086		include_once($config['library_path'] . '/boost.php');
+dynamic_include	./lib/rrd.php:1174		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/rrd.php:1469		include_once($config['library_path'] . '/cdef.php');
+dynamic_include	./lib/rrd.php:1470		include_once($config['library_path'] . '/vdef.php');
+dynamic_include	./lib/rrd.php:1471		include_once($config['library_path'] . '/graph_variables.php');
+dynamic_include	./lib/rrd.php:1472		include_once($config['library_path'] . '/boost.php');
+dynamic_include	./lib/rrd.php:1473		include_once($config['library_path'] . '/xml.php');
+dynamic_include	./lib/rrd.php:1474		include($config['include_path'] . '/global_arrays.php');
+dynamic_include	./lib/rrd.php:2783			include($rrdtheme);
+dynamic_include	./lib/rrd.php:3453		include_once($config['library_path'] . '/time.php');
+dynamic_include	./lib/rrd.php:4265			include($themefile);
+dynamic_include	./lib/rrd.php:653		include ($config['include_path'] . '/global_arrays.php');
 dynamic_include	./lib/rrdcheck.php:716			include_once($config['base_path'] . '/lib/rrd.php');
 dynamic_include	./lib/rrdcheck.php:746			include_once($config['library_path'] . '/poller.php');
 dynamic_include	./lib/snmp.php:49		include_once($config['include_path'] . '/vendor/phpsnmp/extension.php');
@@ -439,8 +439,8 @@ dynamic_include	./lib/utility.php:182		include_once($config['library_path'] . '/
 dynamic_include	./lib/utility.php:46		include_once($config['library_path'] . '/api_data_source.php');
 dynamic_include	./lib/utility.php:837		include_once($config['library_path'] . '/api_data_source.php');
 dynamic_include	./link.php:73					include_once($file);
-dynamic_include	./poller.php:1050	    include_once($config['base_path'] . '/lib/poller.php');
-dynamic_include	./poller.php:1201	    include_once($config['base_path'] . '/lib/poller.php');
+dynamic_include	./poller.php:1057	    include_once($config['base_path'] . '/lib/poller.php');
+dynamic_include	./poller.php:1208	    include_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./poller.php:35	require_once($config['base_path'] . '/lib/poller.php');
 dynamic_include	./poller.php:36	require_once($config['base_path'] . '/lib/data_query.php');
 dynamic_include	./poller.php:37	require_once($config['base_path'] . '/lib/rrd.php');
@@ -532,9 +532,10 @@ dynamic_include	./snmpagent_persist.php:165				include( $path_mibcache );
 dynamic_include	./spikekill.php:26	include_once($config['base_path'] . '/lib/spikekill.php');
 fs_write	./cactid.php:110		$STDERR = fopen('null', 'wb');
 fs_write	./cactid.php:99		$STDERR = fopen('/dev/null', 'wb');
+fs_write	./cli/audit_database.php:180		if (file_put_contents($path, $contents) === false) {
 fs_write	./cli/change_device.php:987		$fh = fopen($file, 'r');
 fs_write	./cli/float_rrdfiles.php:342				$fp = fopen($tmp_file, 'w');
-fs_write	./cli/float_rrdfiles.php:345					$lf = fopen('/tmp/clearer.log', 'a');
+fs_write	./cli/float_rrdfiles.php:345					$lf = fopen(sys_get_temp_dir() . '/cacti_float_rrdfiles.log', 'a');
 fs_write	./cli/import_package.php:159				$fp   = fopen($filename, 'r');
 fs_write	./cli/import_template.php:121				$fp = fopen($filename,'r');
 fs_write	./cli/input_whitelist.php:188			file_put_contents($config['input_whitelist'], json_encode($input));
@@ -554,22 +555,22 @@ fs_write	./install/functions.php:843						$fp = fopen($config_file, 'w');
 fs_write	./lib/api_device.php:2637							file_put_contents($new_xmlfile, $data);
 fs_write	./lib/boost.php:424		$fileptr = fopen($temp_file, 'wb');
 fs_write	./lib/boost.php:576								if ($fileptr = fopen($cache_file, 'rb')) {
-fs_write	./lib/clog_webapi.php:119					$log_fh = fopen($logfile, 'w');
+fs_write	./lib/clog_webapi.php:127					$log_fh = fopen($logfile, 'w');
 fs_write	./lib/csp_report_endpoint.php:164	$input   = @fopen('php://input', 'rb');
 fs_write	./lib/csp_report_endpoint.php:199		   leaving a symlink there gave fopen() somewhere else to write. */
 fs_write	./lib/csp_report_endpoint.php:229		$fh = @fopen($bucket, 'c+');
 fs_write	./lib/database.php:206					file_put_contents(sys_get_temp_dir() . '/cacti-option.log',
-fs_write	./lib/database.php:2466		file_put_contents(sys_get_temp_dir() . '/cacti-sql.log', get_debug_prefix() . $line, FILE_APPEND);
+fs_write	./lib/database.php:2503		file_put_contents(sys_get_temp_dir() . '/cacti-sql.log', get_debug_prefix() . $line, FILE_APPEND);
 fs_write	./lib/database.php:74					file_put_contents(sys_get_temp_dir() . '/cacti-option.log',
-fs_write	./lib/functions.php:1353			$fp = @fopen($logfile, 'a');
-fs_write	./lib/functions.php:1428		$fp = fopen($file_name, 'r');
+fs_write	./lib/functions.php:1343			$fp = @fopen($logfile, 'a');
+fs_write	./lib/functions.php:1418		$fp = fopen($file_name, 'r');
 fs_write	./lib/functions.php:483			file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() . cacti_debug_backtrace($config_name, false, false, 0, 1) . "\n", FILE_APPEND);
 fs_write	./lib/functions.php:698			file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() . cacti_debug_backtrace($config_name, false, false, 0, 1) . "\n", FILE_APPEND);
 fs_write	./lib/functions.php:710				file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() .
-fs_write	./lib/functions.php:7156			if (($f = @fopen($path, 'a'))) {
-fs_write	./lib/functions.php:7165		if (($f = @fopen($path, 'w'))) {
+fs_write	./lib/functions.php:7147			if (($f = @fopen($path, 'a'))) {
+fs_write	./lib/functions.php:7156		if (($f = @fopen($path, 'w'))) {
 fs_write	./lib/functions.php:719					file_put_contents(sys_get_temp_dir() . '/cacti-option.log', get_debug_prefix() .
-fs_write	./lib/functions.php:7239				file_put_contents($tmp_file, 'cacti');
+fs_write	./lib/functions.php:7230				file_put_contents($tmp_file, 'cacti');
 fs_write	./lib/import.php:466		$f   = fopen($filename, 'r');
 fs_write	./lib/import.php:671							$file = fopen($filename, 'wb');
 fs_write	./lib/installer.php:2969				$file = fopen($cacheFile, "r");
@@ -578,9 +579,9 @@ fs_write	./lib/poller.php:1423												file_put_contents($mypath, $contents);
 fs_write	./lib/poller.php:1452								file_put_contents($mypath, $contents);
 fs_write	./lib/reports.php:1704			$f = fopen($fn, 'wb');
 fs_write	./lib/reports.php:1745			$f = fopen($fn, 'wb');
-fs_write	./lib/rrd.php:2592					if ($fp = fopen($graph_data_array['export_realtime'], 'w')) {
+fs_write	./lib/rrd.php:2645					if ($fp = fopen($graph_data_array['export_realtime'], 'w')) {
 fs_write	./lib/spikekill.php:780			return file_put_contents($xmlfile, $output);
-fs_write	./package_import.php:383					file_put_contents($xmlfile, $data);
+fs_write	./package_import.php:387					file_put_contents($xmlfile, $data);
 fs_write	./package_import.php:96		if (file_put_contents($xmlfile, $_SESSION['sess_import_package']) === false) {
 fs_write	./script_server.php:49		define('STDIN', fopen('php://stdin', 'r'));
 fs_write	./script_server.php:50		define('STDOUT', fopen('php://stdout', 'w'));
@@ -870,9 +871,9 @@ header_redirect	./lib/auth.php:4793					header('Location: ' . $config['url_path'
 header_redirect	./lib/auth.php:4795					header('Location: ' . $config['url_path'] . 'index.php' . ($newtheme ? '?newtheme=1':''));
 header_redirect	./lib/auth.php:4800				header('Location: ' . $config['url_path'] . 'graph_view.php' . ($newtheme ? '?newtheme=1':''));
 header_redirect	./lib/auth.php:4995			header ('Location: ' . $config['url_path'] . 'auth_changepassword.php?action=force&ref=' . urlencode(validate_redirect_url(isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : 'index.php')));
-header_redirect	./lib/clog_webapi.php:99			header('Location: ' . get_current_page());
-header_redirect	./lib/functions.php:8248		header('Location: ' . $save_url);
-header_redirect	./lib/functions.php:8271		header('Location: ' . $safe_url, true, $status);
+header_redirect	./lib/clog_webapi.php:107			header('Location: ' . get_current_page());
+header_redirect	./lib/functions.php:8237		header('Location: ' . $save_url);
+header_redirect	./lib/functions.php:8260		header('Location: ' . $safe_url, true, $status);
 header_redirect	./lib/html_graph.php:498			header('Location: ' . $page . '?host_id=' . $host_id . '&header=false');
 header_redirect	./lib/html_reports.php:1507				header('Location: reports.php');
 header_redirect	./lib/html_reports.php:274					header('Location: reports.php');


### PR DESCRIPTION
`1.2.x` head is currently red on its own security gates, independent of any pull request:

```
$ tests/security/verify_sink_inventory.sh          -> ERROR: sink inventory drift detected
$ tests/security/verify_architectural_hotspots.sh  -> ERROR: new architectural hotspots detected
```

The baselines were never refreshed after the hardening that landed in #7910, #7072 and related changes, so every pull request targeting `1.2.x` inherits a failing gate.

Regenerated with the commands the verifiers themselves print.

## What actually changed
Eleven entries are substantive, all matching already-merged work:

- `cli/splice_rrd.php` — `shell_exec($rrdtool)` is now `shell_exec(cacti_escapeshellcmd($rrdtool))`
- `cli/float_rrdfiles.php` — moved off the fixed `/tmp/clearer.log` path
- `cli/audit_database.php` — gained a `file_put_contents` (from #7910)
- plus six corresponding architectural-hotspot entries

The remaining diff is line numbers. The verifiers strip `:LINE` from the location field before comparing (`verify_sink_inventory.sh:20`), so that portion is inert; it is included only because the refresh command regenerates the file wholesale.

## Verification
Both gates pass on this branch:

```
OK: sink inventory matches baseline
OK: no new architectural hotspots.
```

## Note for reviewers
#7871 and #7907 each carry their own copy of this same baseline refresh, which is most of their diff. If this lands first, both can drop it and shrink substantially.

Follow-up worth considering separately: `develop` stores these baselines with line numbers already stripped, `1.2.x` still stores them. Normalising `1.2.x` to match would stop this file churning on every pull request that shifts a line.
