### PR TITLE
ci: share one body across the per-script coverage workflows

### DIFF
--- a/.github/workflows/api-automation-tools-coverage.yml
+++ b/.github/workflows/api-automation-tools-coverage.yml
@@ -5,6 +5,7 @@ on:
     branches: [develop]
     paths:
       - '.github/workflows/api-automation-tools-coverage.yml'
+      - '.github/workflows/script-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'
       - 'composer.lock'
@@ -17,6 +18,7 @@ on:
     branches: [develop]
     paths:
       - '.github/workflows/api-automation-tools-coverage.yml'
+      - '.github/workflows/script-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'
       - 'composer.lock'

--- a/.github/workflows/api-automation-tools-coverage.yml
+++ b/.github/workflows/api-automation-tools-coverage.yml
@@ -34,37 +34,9 @@ concurrency:
   group: api-automation-tools-coverage-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  COMPOSER_ALLOW_SUPERUSER: 1
-
 jobs:
   coverage:
-    name: API automation tools 100% coverage
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-
-      - name: Setup locked PHP 8.2 dependencies
-        uses: ./.github/actions/setup-php-composer
-        with:
-          php-version: '8.2'
-          coverage: xdebug
-          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
-          dependency-mode: locked-api-coverage
-          install-args: --prefer-dist --no-progress --no-interaction
-
-      - name: Enforce line coverage
-        env:
-          XDEBUG_MODE: coverage
-        run: |
-          set -euo pipefail
-          include/vendor/bin/pest \
-            --configuration=phpunit-api-automation-tools.xml \
-            --coverage \
-            --coverage-text \
-            --min=100
+    uses: ./.github/workflows/script-coverage.yml
+    with:
+      job-name: API automation tools 100% coverage
+      phpunit-config: phpunit-api-automation-tools.xml

--- a/.github/workflows/client-address-coverage.yml
+++ b/.github/workflows/client-address-coverage.yml
@@ -32,37 +32,10 @@ concurrency:
   group: client-address-coverage-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  COMPOSER_ALLOW_SUPERUSER: 1
-
 jobs:
   coverage:
-    name: Client address 100% coverage
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-
-      - name: Set up PHP and Cacti test dependencies
-        uses: ./.github/actions/setup-php-composer
-        with:
-          php-version: '8.4'
-          coverage: xdebug
-          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
-          dependency-mode: locked-tests
-          install-args: --prefer-dist --no-progress --no-interaction
-
-      - name: Enforce line coverage
-        env:
-          XDEBUG_MODE: coverage
-        run: |
-          set -euo pipefail
-          composer test -- \
-            --configuration=phpunit-client-address.xml \
-            --coverage \
-            --coverage-text \
-            --min=100
+    uses: ./.github/workflows/script-coverage.yml
+    with:
+      job-name: Client address 100% coverage
+      phpunit-config: phpunit-client-address.xml
+      php-version: '8.4'

--- a/.github/workflows/client-address-coverage.yml
+++ b/.github/workflows/client-address-coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/client-address-coverage.yml'
       - 'composer.json'
       - 'composer.lock'
@@ -15,6 +16,7 @@ on:
   pull_request:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/client-address-coverage.yml'
       - 'composer.json'
       - 'composer.lock'

--- a/.github/workflows/entity-sensor-coverage.yml
+++ b/.github/workflows/entity-sensor-coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/entity-sensor-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/entity-sensor-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'

--- a/.github/workflows/entity-sensor-coverage.yml
+++ b/.github/workflows/entity-sensor-coverage.yml
@@ -30,37 +30,10 @@ concurrency:
   group: entity-sensor-coverage-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  COMPOSER_ALLOW_SUPERUSER: 1
-
 jobs:
   coverage:
-    name: scripts/ss_entity_sensor.php 100% coverage
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-
-      - name: Setup locked PHP 8.2 dependencies
-        uses: ./.github/actions/setup-php-composer
-        with:
-          php-version: '8.2'
-          coverage: xdebug
-          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring, snmp
-          dependency-mode: locked
-          install-args: --prefer-dist --no-progress --no-interaction
-
-      - name: Enforce line coverage
-        env:
-          XDEBUG_MODE: coverage
-        run: |
-          set -euo pipefail
-          include/vendor/bin/pest --colors=never \
-            --configuration=phpunit-entity-sensor.xml \
-            --coverage \
-            --coverage-text \
-            --min=100
+    uses: ./.github/workflows/script-coverage.yml
+    with:
+      job-name: scripts/ss_entity_sensor.php 100% coverage
+      phpunit-config: phpunit-entity-sensor.xml
+      extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring, snmp

--- a/.github/workflows/f5-cpu-coverage.yml
+++ b/.github/workflows/f5-cpu-coverage.yml
@@ -30,37 +30,10 @@ concurrency:
   group: f5-cpu-coverage-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  COMPOSER_ALLOW_SUPERUSER: 1
-
 jobs:
   coverage:
-    name: scripts/ss_f5_cpu.php 100% coverage
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-
-      - name: Setup locked PHP 8.2 dependencies
-        uses: ./.github/actions/setup-php-composer
-        with:
-          php-version: '8.2'
-          coverage: xdebug
-          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring, snmp
-          dependency-mode: locked
-          install-args: --prefer-dist --no-progress --no-interaction
-
-      - name: Enforce line coverage
-        env:
-          XDEBUG_MODE: coverage
-        run: |
-          set -euo pipefail
-          include/vendor/bin/pest --colors=never \
-            --configuration=phpunit-f5-cpu.xml \
-            --coverage \
-            --coverage-text \
-            --min=100
+    uses: ./.github/workflows/script-coverage.yml
+    with:
+      job-name: scripts/ss_f5_cpu.php 100% coverage
+      phpunit-config: phpunit-f5-cpu.xml
+      extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring, snmp

--- a/.github/workflows/f5-cpu-coverage.yml
+++ b/.github/workflows/f5-cpu-coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/f5-cpu-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/f5-cpu-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'

--- a/.github/workflows/form-coverage.yml
+++ b/.github/workflows/form-coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/form-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'lib/CactiForm.php'
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/form-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'lib/CactiForm.php'

--- a/.github/workflows/form-coverage.yml
+++ b/.github/workflows/form-coverage.yml
@@ -30,37 +30,9 @@ concurrency:
   group: form-coverage-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  COMPOSER_ALLOW_SUPERUSER: 1
-
 jobs:
   coverage:
-    name: Form API 100% coverage
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-
-      - name: Setup locked PHP 8.2 dependencies
-        uses: ./.github/actions/setup-php-composer
-        with:
-          php-version: '8.2'
-          coverage: xdebug
-          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
-          dependency-mode: locked-form-coverage
-          install-args: --prefer-dist --no-progress --no-interaction
-
-      - name: Enforce line coverage
-        env:
-          XDEBUG_MODE: coverage
-        run: |
-          set -euo pipefail
-          include/vendor/bin/pest \
-            --configuration=phpunit-form-coverage.xml \
-            --coverage \
-            --coverage-text \
-            --min=100
+    uses: ./.github/workflows/script-coverage.yml
+    with:
+      job-name: Form API 100% coverage
+      phpunit-config: phpunit-form-coverage.xml

--- a/.github/workflows/juniper-operating-coverage.yml
+++ b/.github/workflows/juniper-operating-coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/juniper-operating-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/juniper-operating-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'

--- a/.github/workflows/juniper-operating-coverage.yml
+++ b/.github/workflows/juniper-operating-coverage.yml
@@ -30,37 +30,10 @@ concurrency:
   group: juniper-operating-coverage-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  COMPOSER_ALLOW_SUPERUSER: 1
-
 jobs:
   coverage:
-    name: scripts/ss_juniper_operating.php 100% coverage
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-
-      - name: Setup locked PHP 8.2 dependencies
-        uses: ./.github/actions/setup-php-composer
-        with:
-          php-version: '8.2'
-          coverage: xdebug
-          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring, snmp
-          dependency-mode: locked
-          install-args: --prefer-dist --no-progress --no-interaction
-
-      - name: Enforce line coverage
-        env:
-          XDEBUG_MODE: coverage
-        run: |
-          set -euo pipefail
-          include/vendor/bin/pest --colors=never \
-            --configuration=phpunit-juniper-operating.xml \
-            --coverage \
-            --coverage-text \
-            --min=100
+    uses: ./.github/workflows/script-coverage.yml
+    with:
+      job-name: scripts/ss_juniper_operating.php 100% coverage
+      phpunit-config: phpunit-juniper-operating.xml
+      extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring, snmp

--- a/.github/workflows/md5-finder-coverage.yml
+++ b/.github/workflows/md5-finder-coverage.yml
@@ -30,37 +30,9 @@ concurrency:
   group: md5-finder-coverage-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  COMPOSER_ALLOW_SUPERUSER: 1
-
 jobs:
   coverage:
-    name: MD5 finder 100% coverage
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-
-      - name: Setup locked PHP 8.2 dependencies
-        uses: ./.github/actions/setup-php-composer
-        with:
-          php-version: '8.2'
-          coverage: xdebug
-          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
-          dependency-mode: locked-md5-finder-coverage
-          install-args: --prefer-dist --no-progress --no-interaction
-
-      - name: Enforce line coverage
-        env:
-          XDEBUG_MODE: coverage
-        run: |
-          set -euo pipefail
-          include/vendor/bin/pest \
-            --configuration=phpunit-md5-finder-coverage.xml \
-            --coverage \
-            --coverage-text \
-            --min=100
+    uses: ./.github/workflows/script-coverage.yml
+    with:
+      job-name: MD5 finder 100% coverage
+      phpunit-config: phpunit-md5-finder-coverage.xml

--- a/.github/workflows/md5-finder-coverage.yml
+++ b/.github/workflows/md5-finder-coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/md5-finder-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/md5-finder-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'

--- a/.github/workflows/notification-api-coverage.yml
+++ b/.github/workflows/notification-api-coverage.yml
@@ -36,37 +36,9 @@ concurrency:
   group: notification-api-coverage-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  COMPOSER_ALLOW_SUPERUSER: 1
-
 jobs:
   coverage:
-    name: Notification API 100% coverage
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-
-      - name: Setup locked PHP 8.2 dependencies
-        uses: ./.github/actions/setup-php-composer
-        with:
-          php-version: '8.2'
-          coverage: xdebug
-          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
-          dependency-mode: locked-notification-api-coverage
-          install-args: --prefer-dist --no-progress --no-interaction
-
-      - name: Enforce line coverage
-        env:
-          XDEBUG_MODE: coverage
-        run: |
-          set -euo pipefail
-          include/vendor/bin/pest \
-            --configuration=phpunit-notification-coverage.xml \
-            --coverage \
-            --coverage-text \
-            --min=100
+    uses: ./.github/workflows/script-coverage.yml
+    with:
+      job-name: Notification API 100% coverage
+      phpunit-config: phpunit-notification-coverage.xml

--- a/.github/workflows/notification-api-coverage.yml
+++ b/.github/workflows/notification-api-coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/notification-api-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'
@@ -17,6 +18,7 @@ on:
   pull_request:
     branches: [develop]
     paths:
+      - '.github/workflows/script-coverage.yml'
       - '.github/workflows/notification-api-coverage.yml'
       - '.github/actions/setup-php-composer/**'
       - 'composer.json'

--- a/.github/workflows/script-coverage.yml
+++ b/.github/workflows/script-coverage.yml
@@ -1,0 +1,70 @@
+name: Script Coverage
+
+# Reusable body for the per-script coverage workflows. Each caller supplies the
+# PHPUnit configuration and the job name; everything else was identical across
+# them and is kept here so it can only drift in one place.
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        description: Name shown for the job, usually the script and its target.
+        required: true
+        type: string
+      phpunit-config:
+        description: PHPUnit configuration file for this script.
+        required: true
+        type: string
+      php-version:
+        description: PHP version to run the suite against.
+        required: false
+        type: string
+        default: '8.2'
+      extensions:
+        description: PHP extensions the suite needs.
+        required: false
+        type: string
+        default: 'intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring'
+      min-coverage:
+        description: Minimum line coverage percentage.
+        required: false
+        type: number
+        default: 100
+
+permissions:
+  contents: read
+
+env:
+  COMPOSER_ALLOW_SUPERUSER: 1
+
+jobs:
+  coverage:
+    name: ${{ inputs.job-name }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Setup locked PHP ${{ inputs.php-version }} dependencies
+        uses: ./.github/actions/setup-php-composer
+        with:
+          php-version: ${{ inputs.php-version }}
+          coverage: xdebug
+          extensions: ${{ inputs.extensions }}
+          dependency-mode: locked
+          install-args: --prefer-dist --no-progress --no-interaction
+
+      - name: Enforce line coverage
+        env:
+          XDEBUG_MODE: coverage
+        run: |
+          set -euo pipefail
+          include/vendor/bin/pest --colors=never \
+            --configuration=${{ inputs.phpunit-config }} \
+            --coverage \
+            --coverage-text \
+            --min=${{ inputs.min-coverage }}


### PR DESCRIPTION
Eight of the eleven `*-coverage.yml` workflows were the same file with four things changed. Everything else, the triggers, `permissions`, `concurrency`, checkout, `setup-php-composer` and the Pest invocation, was copied between them, so changing any of it meant eight edits and eight chances to miss one.

They now call a reusable workflow and pass only what differs:

```yaml
jobs:
  coverage:
    uses: ./.github/workflows/script-coverage.yml
    with:
      job-name: scripts/ss_f5_cpu.php 100% coverage
      phpunit-config: phpunit-f5-cpu.xml
      extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring, snmp
```

**What actually varied**

| Input | Values across the eight |
|---|---|
| `phpunit-config` | one per script |
| `job-name` | one per script |
| `php-version` | `8.2`, except client-address on `8.4` |
| `extensions` | base, or base plus `snmp` for three |

`php-version` and `extensions` default in the reusable workflow, so a caller only names them when it differs.

**Behaviour is unchanged**

Each caller keeps its own path filters and concurrency group, which are genuinely per-script. Verified for all eight that the PHP version, extensions, PHPUnit configuration, concurrency group and path list resolve to the same values as before, with one deliberate addition: `.github/workflows/script-coverage.yml` is added to every caller's paths, so editing the shared body reruns the suites it drives. That was missing in my first pass and would have meant a change to the shared file ran nothing.

540 lines of callers become 320, plus a 70 line reusable workflow.

**Left alone**

`installer-coverage.yml`, `snmp-coverage.yml` and `rrd-graph-item-coverage.yml` run more than one suite or produce clover output. Folding them in would mean parameterising the shared body until it stopped being shared, so they stay as they are.

**Not included**

While reviewing I also thought four workflows pinned `actions/checkout` by tag rather than SHA, and three used `ubuntu-latest` instead of the pinned `ubuntu-24.04`. All eight occurrences turned out to be inside commented-out blocks, so there is nothing to fix. Every live usage already pins `3d3c42e5` and `ubuntu-24.04`.


Fixes #7923.