### PR TITLE
fix: relaunch RRDtool after a crash instead of failing the rest of the run

### DIFF
--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -37,6 +37,9 @@ define('RRD_PROXY_MAX_RESPONSE_SIZE', 67108864);
 define('RRDTOOL_MAX_COMMAND_BYTES', 16 * 1024 * 1024);
 define('RRDTOOL_MAX_RESPONSE_BYTES', 128 * 1024 * 1024);
 
+// Bound on in-run RRDtool process relaunches after a crash.
+define('RRDTOOL_MAX_RESTARTS', 5);
+
 if (read_config_option('storage_location')) {
 	global $encryption;
 	$encryption = true;
@@ -158,6 +161,7 @@ function __rrd_init(bool $output_to_term = true, mixed $lang = false) : mixed {
 		'stdout'         => $pipes[1],
 		'stderr'         => $pipes[2],
 		'alive'          => true,
+		'restarts'       => 0,
 		'output_to_term' => $output_to_term
 	];
 }
@@ -879,10 +883,73 @@ function rrdtool_command_language(string $command_line) : string|false {
  *
  * @return array{success: bool, output: string, error: string}
  */
+/**
+ * Relaunch a died RRDtool process in place.
+ *
+ * The poller opens one process per run and reuses it for every update, so a
+ * process that dies partway through would otherwise take the rest of the run
+ * with it. The replacement is written back into the same object so every holder
+ * of the handle recovers.
+ *
+ * @param object $process RRDtool process handle to revive
+ *
+ * @return bool Whether a working process is available afterwards
+ */
+function rrdtool_process_restart(object $process) : bool {
+	if (!rrdtool_is_process($process)) {
+		return false;
+	}
+
+	$attempts = isset($process->restarts) ? (int) $process->restarts : 0;
+
+	if ($attempts >= RRDTOOL_MAX_RESTARTS) {
+		return false;
+	}
+
+	foreach (['stdin', 'stdout', 'stderr'] as $pipe) {
+		if (isset($process->$pipe) && is_resource($process->$pipe)) {
+			fclose($process->$pipe);
+		}
+	}
+
+	if (isset($process->process) && is_resource($process->process)) {
+		proc_close($process->process);
+	}
+
+	$replacement = __rrd_init((bool) ($process->output_to_term ?? false));
+
+	if (!rrdtool_is_process($replacement)) {
+		$process->alive = false;
+
+		return false;
+	}
+
+	$process->process  = $replacement->process;
+	$process->stdin    = $replacement->stdin;
+	$process->stdout   = $replacement->stdout;
+	$process->stderr   = $replacement->stderr;
+	$process->alive    = true;
+	$process->restarts = $attempts + 1;
+
+	cacti_log(sprintf('WARNING: Detected RRDtool Crash, restarted the process (attempt %d of %d).', $attempts + 1, RRDTOOL_MAX_RESTARTS), false, 'RRDTOOL');
+
+	if (function_exists('debounce_run_notification')) {
+		debounce_run_notification('rrdtool_command_crash');
+	}
+
+	return true;
+}
+
 function rrdtool_process_command(object $process, string $command_line, float $timeout = 60.0) : array {
 	$result = ['success' => false, 'output' => '', 'error' => 'RRDtool process is unavailable.'];
 
-	if (!rrdtool_is_process($process) || !$process->alive) {
+	if (!rrdtool_is_process($process)) {
+		return $result;
+	}
+
+	// A died process used to be reopened and the command retried; without that
+	// every remaining update in the run fails.
+	if (!$process->alive && !rrdtool_process_restart($process)) {
 		return $result;
 	}
 

--- a/tests/Unit/RrdProcessSafetyTest.php
+++ b/tests/Unit/RrdProcessSafetyTest.php
@@ -165,3 +165,47 @@ test('process handle and complete write helpers reject invalid streams', functio
 		->and($result['success'])->toBeFalse()
 		->and($result['error'])->toContain('unavailable');
 });
+
+test('a died process is relaunched so the rest of the run still writes', function () {
+	$binary = trim((string) shell_exec('command -v rrdtool'));
+
+	if ($binary === '') {
+		test()->markTestSkipped('rrdtool is not installed');
+	}
+
+	set_config_option('path_rrdtool', $binary);
+
+	$process = __rrd_init(false);
+
+	expect(rrdtool_is_process($process))->toBeTrue();
+
+	// Kill it the way a crash would, then confirm a command still succeeds.
+	proc_terminate($process->process);
+	$process->alive = false;
+
+	$result = rrdtool_process_command($process, 'pwd');
+
+	expect($process->alive)->toBeTrue()
+		->and($process->restarts)->toBe(1)
+		->and($result['success'])->toBeTrue();
+
+	rrd_close($process);
+});
+
+test('process relaunches are bounded so a persistently failing binary cannot spin', function () {
+	$process = (object) [
+		'process'        => null,
+		'stdin'          => null,
+		'stdout'         => null,
+		'stderr'         => null,
+		'alive'          => false,
+		'restarts'       => RRDTOOL_MAX_RESTARTS,
+		'output_to_term' => false
+	];
+
+	expect(rrdtool_process_restart($process))->toBeFalse();
+});
+
+test('a handle that is not an RRDtool process is never relaunched', function () {
+	expect(rrdtool_process_restart((object) ['alive' => false]))->toBeFalse();
+});


### PR DESCRIPTION
#7615 replaced the RRDtool pipe protocol and, with it, the crash recovery.

The old path caught a failed write, logged `Detected RRDtool Crash`, called `rrd_close()` + `rrd_init()` and retried up to five times. `rrdtool_process_command()` instead sets `$process->alive = false` and terminates the process on a write failure, a response-size overrun or a status timeout — and nothing anywhere sets it back or reopens.

`poller.php:816` opens one process per run and `lib/poller.php:950` reuses it for every `rrdtool_function_update()`. So if RRDtool dies partway through a run, every later command returns `RRDtool process is unavailable` and **every remaining RRD write for that run is silently lost**. `git grep` on develop finds neither `Detected RRDtool Crash` nor `rrdtool_command_crash`; both are present in `964c1fb1f^`.

## Change
`rrdtool_process_restart()` relaunches and writes the replacement back into the same object, so the poller's long-lived handle recovers rather than each caller needing a new one. Bounded by `RRDTOOL_MAX_RESTARTS` (5, the count the old path used) with the counter carried on the handle. The crash log line and notification are restored.

## Verification
Exercised against a real rrdtool: opened a process, killed it with `proc_terminate()`, marked it dead, then confirmed the restart revives it and the revived process answers a command.

```
initial process alive:   yes
after simulated crash:   alive=no
restart returned:        true
after restart:           alive=yes restarts=1
revived process replies: YES (pwd returned the cwd)
bound respected:         yes
```

Regression tests added to `tests/Unit/RrdProcessSafetyTest.php`: a died process is relaunched and the next command succeeds, the restart bound is enforced, and a non-process handle is refused.
