### PR TITLE
fix: commit transactions on MySQL as well as MariaDB

### DIFF
--- a/lib/database.php
+++ b/lib/database.php
@@ -2114,11 +2114,15 @@ function db_commit_transaction(mixed $db_conn = false) : bool {
 		}
 	}
 
-	if (db_fetch_cell('SELECT @@in_transaction', '', true, $db_conn) > 0) {
-		return $db_conn->commit();
-	} else {
+	// @@in_transaction is a MariaDB variable. On MySQL the query raises
+	// "Unknown system variable 'in_transaction'", the comparison is false, and
+	// the transaction was left open without ever being committed. PDO tracks
+	// this itself and answers the same question on both engines.
+	if (!$db_conn->inTransaction()) {
 		return false;
 	}
+
+	return $db_conn->commit();
 }
 
 /**

--- a/tests/Unit/ConsolidatedFunctionalFixesTest.php
+++ b/tests/Unit/ConsolidatedFunctionalFixesTest.php
@@ -31,7 +31,7 @@ test('database recovery and identifier handling retain the corrected connection'
 
 	expect($source)->toContain('function db_check_reconnect(mixed &$db_conn = false')
 		->and($source)->toContain('$db_conn = $cnn_id;')
-		->and($source)->toContain("db_fetch_cell('SELECT @@in_transaction', '', true, \$db_conn)")
+		->and($source)->toContain('if (!$db_conn->inTransaction())')
 		->and($source)->toContain("str_replace('`', '``', \$k)")
 		->and($source)->toContain("VALUES(' . \$ek . ')'");
 });

--- a/tests/Unit/Database/DatabaseTransactionPortabilityTest.php
+++ b/tests/Unit/Database/DatabaseTransactionPortabilityTest.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$databaseSource = file_get_contents(dirname(__DIR__, 3) . '/lib/database.php');
+
+test('the commit path does not depend on the MariaDB in_transaction variable', function () use ($databaseSource) {
+	$start = strpos($databaseSource, 'function db_commit_transaction(');
+	$end   = strpos($databaseSource, 'function ', $start + 1);
+	$body  = substr($databaseSource, $start, $end - $start);
+
+	// MySQL answers "Unknown system variable 'in_transaction'", so the guard
+	// was always false there and the commit never ran.
+	expect($body)->not->toContain("SELECT @@in_transaction")
+		->and($body)->toContain('inTransaction()');
+});
+
+test('PDO reports transaction state identically regardless of engine', function () {
+	$pdo = new PDO('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+	expect($pdo->inTransaction())->toBeFalse();
+
+	$pdo->beginTransaction();
+	expect($pdo->inTransaction())->toBeTrue();
+
+	expect($pdo->commit())->toBeTrue()
+		->and($pdo->inTransaction())->toBeFalse();
+});
+
+test('committing without an open transaction is refused rather than fatal', function () {
+	$pdo = new PDO('sqlite::memory:', null, null, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+
+	// The guard exists because PDO::commit() throws when nothing is open.
+	expect($pdo->inTransaction())->toBeFalse();
+});


### PR DESCRIPTION
`db_commit_transaction()` gated the commit on `SELECT @@in_transaction`. That variable exists only in MariaDB.

Verified against both engines:

```
MariaDB 11:  SELECT @@in_transaction  ->  0
MySQL 8.4:   ERROR 1193 (HY000): Unknown system variable 'in_transaction'
```

On MySQL the query fails, the `> 0` comparison is false, and the function returns without ever calling `commit()` — so the transaction is left open and the caller is told the commit failed.

Every caller is affected. Device removal is the most visible: `api_device_remove()` reports *"Unable to remove Device N because its database transaction could not be committed"* and the device stays. The same path covers `api_device_remove_multi()` from `host.php` and `cli/remove_device.php`, plus template import, graph duplication and the password reset.

## Change
Use `PDO::inTransaction()`. PDO tracks the state itself, so it answers the same question on both engines and needs no server variable. The guard is still required because `PDO::commit()` throws when no transaction is open.

## Tests
`tests/Unit/Database/DatabaseTransactionPortabilityTest.php`:
- the commit path no longer issues the MariaDB-only query and does use `inTransaction()`
- `PDO::inTransaction()` reports state correctly across begin and commit
- committing with nothing open is refused rather than fatal

## Note
`1.2.x` carries the same defect in the same function. A matching pull request follows once this shape is agreed.
