### PR TITLE
fix: detect a failed SNMP walk by exit code, not by device data

### DIFF
--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -817,11 +817,22 @@ function cacti_snmp_walk(string $hostname, mixed $community, string $oid, mixed 
 			$snmp_auth = cacti_get_snmpv3_auth($auth_proto, $auth_user, $auth_pass, $priv_proto, $priv_pass, $context, $engineid);
 		}
 
+		// cacti_get_snmpv3_auth() returns '' for an unknown protocol. Without this
+		// the walk builds a credential-less snmpwalk -v 3 and fails with no log
+		// line, unlike cacti_snmp_get/get_raw/getnext which all bail out here.
+		if (empty($snmp_auth)) {
+			cacti_log("WARNING: SNMP Error:'Missing credentials', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
+
+			return [];
+		}
+
 		if (read_config_option('oid_increasing_check_disable') == 'on') {
 			$oidCheck = '-Cc';
 		} else {
 			$oidCheck = '';
 		}
+
+		$return_code = 0;
 
 		if (file_exists($path_snmpbulkwalk) && ($version > 1) && ($bulk_walk_size > 1)) {
 			$command = cacti_escapeshellcmd($path_snmpbulkwalk) .
@@ -838,7 +849,7 @@ function cacti_snmp_walk(string $hostname, mixed $community, string $oid, mixed 
 				debug_log_insert('data_query', __esc('SNMP Command is: %s', $command));
 			}
 
-			$temp_array = exec_into_array($command);
+			$temp_array = exec_into_array($command, $return_code);
 		} else {
 			$command = cacti_escapeshellcmd(read_config_option('path_snmpwalk')) .
 				' -O QnU' . ($value_output_format == SNMP_STRING_OUTPUT_HEX ? 'x ' : ' ') . $snmp_auth .
@@ -853,17 +864,16 @@ function cacti_snmp_walk(string $hostname, mixed $community, string $oid, mixed 
 				debug_log_insert('data_query', __esc('SNMP Command is: %s', $command));
 			}
 
-			$temp_array = exec_into_array($command);
+			$temp_array = exec_into_array($command, $return_code);
 		}
 
-		if (str_contains(implode(' ', $temp_array), 'Timeout')) {
-			cacti_log("WARNING: SNMP Error:'Timeout', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
-
-			return [];
-		}
-
-		if (str_contains(implode(' ', $temp_array), '(tooBig)')) {
-			cacti_log("WARNING: SNMP Error:'Error in packet.  Response message would have been too large.', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
+		// net-snmp reports a timeout or an oversized response on stderr, which
+		// exec() does not capture, so the walk output can never contain either.
+		// Matching them against stdout only ever matched device data such as an
+		// ifAlias of 'Timeout Monitor', and discarded the whole walk. The exit
+		// code is the signal that actually distinguishes a failed walk.
+		if ($return_code != 0) {
+			cacti_log("WARNING: SNMP Error:'Exit Code $return_code', Device:'$hostname', OID:'$oid'", false, 'SNMP', POLLER_VERBOSITY_HIGH);
 
 			return [];
 		}

--- a/tests/Unit/DataCollection/Snmp/SnmpCoverageTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpCoverageTest.php
@@ -73,9 +73,9 @@ function __esc(string $message, mixed ...$args) : string {
 	return $args === [] ? $message : vsprintf($message, $args);
 }
 
-function exec_into_array(string $command) : array {
+function exec_into_array(string $command, int &$return_code = 0) : array {
 	$output = [];
-	exec($command, $output);
+	exec($command, $output, $return_code);
 
 	return $output;
 }

--- a/tests/Unit/DataCollection/Snmp/SnmpCoverageTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpCoverageTest.php
@@ -434,5 +434,9 @@ test('native and binary walks cover parsing, filtering, and diagnostics', functi
 		->and($no_credentials)->toBe([])
 		->and($invalid)->toBe([])
 		->and(implode(' ', array_column($GLOBALS['snmp_coverage_logs'], 0)))->toContain('exploit attempted')
-		->toContain('Timeout');
+		// A failed walk is now reported by its exit code. The previous wording
+		// came from matching 'Timeout' against the walk output, which only ever
+		// matched device data.
+		->toContain('Exit Code')
+		->toContain('Missing credentials');
 });

--- a/tests/Unit/DataCollection/Snmp/SnmpCoverageTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpCoverageTest.php
@@ -422,11 +422,16 @@ test('native and binary walks cover parsing, filtering, and diagnostics', functi
 	$GLOBALS['snmp_coverage_config']['oid_increasing_check_disable'] = 'off';
 	$without_oid_check                                               = cacti_snmp_walk($host, 'public', $oid, 3, 'user', '', '[None]', '', '[None]', port: $port);
 
+	// An auth protocol outside $snmp_auth_protocols makes cacti_get_snmpv3_auth()
+	// return '', which used to build a credential-less snmpwalk -v 3.
+	$no_credentials = cacti_snmp_walk($host, 'public', $oid, 3, 'user', 'secret', 'BOGUS', '', '[None]', port: $port);
+
 	expect($bulk[0]['value'])->toContain('coverage agent')
 		->and($regular[0]['value'])->toContain('coverage agent')
 		->and($timeout)->toBe([])
 		->and($too_big)->toBe([])
 		->and($without_oid_check)->not->toBe([])
+		->and($no_credentials)->toBe([])
 		->and($invalid)->toBe([])
 		->and(implode(' ', array_column($GLOBALS['snmp_coverage_logs'], 0)))->toContain('exploit attempted')
 		->toContain('Timeout');

--- a/tests/Unit/Snmp/SnmpWalkFailureDetectionTest.php
+++ b/tests/Unit/Snmp/SnmpWalkFailureDetectionTest.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$snmpSource = file_get_contents(dirname(__DIR__, 3) . '/lib/snmp.php');
+
+function cacti_snmp_walk_body(string $source) : string {
+	$start = strpos($source, 'function cacti_snmp_walk(');
+	$end   = strpos($source, "\nfunction ", $start + 1);
+
+	return substr($source, $start, $end - $start);
+}
+
+test('a failed walk is detected by the exit code, not by scanning device data', function () use ($snmpSource) {
+	$body = cacti_snmp_walk_body($snmpSource);
+
+	// net-snmp writes a timeout to stderr, which exec() does not capture, so
+	// matching 'Timeout' against walk output only ever matched device values
+	// such as an ifAlias of 'Timeout Monitor' and discarded the whole walk.
+	expect($body)->not->toContain("str_contains(implode(' ', \$temp_array), 'Timeout')")
+		->and($body)->toContain('$return_code != 0')
+		->and($body)->toContain('exec_into_array($command, $return_code)');
+});
+
+test('the walk refuses to run without credentials, as its siblings do', function () use ($snmpSource) {
+	expect(cacti_snmp_walk_body($snmpSource))->toContain('empty($snmp_auth)');
+});
+
+test('device values containing Timeout survive a healthy walk', function () {
+	// The guard the fix removes, applied to a healthy walk.
+	$rows = [
+		'.1.3.6.1.2.1.31.1.1.1.18.1 = STRING: Uplink to core',
+		'.1.3.6.1.2.1.31.1.1.1.18.2 = STRING: Timeout Monitor probe',
+	];
+
+	$discardedByOldGuard = str_contains(implode(' ', $rows), 'Timeout');
+	$discardedByExitCode = (0 != 0);
+
+	expect($discardedByOldGuard)->toBeTrue()
+		->and($discardedByExitCode)->toBeFalse();
+});

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -75,6 +75,7 @@ cmd_exec	./lib/poller.php	 * @param array  $pipes               The array of r/w
 cmd_exec	./lib/poller.php	 * @param mixed  $proc_fd             The file descriptor returned from proc_open()
 cmd_exec	./lib/rrd.php			$process = proc_open([$path, '-'], $descriptors, $pipes, null, null, ['bypass_shell' => true]);
 cmd_exec	./lib/rrdcheck.php		$process = proc_open($command, $fds, $pipes);
+cmd_exec	./lib/snmp.php			// exec() does not capture, so the walk output can never contain either.
 cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
 cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
 cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -75,6 +75,7 @@ cmd_exec	./lib/poller.php	 * @param array  $pipes               The array of r/w
 cmd_exec	./lib/poller.php	 * @param mixed  $proc_fd             The file descriptor returned from proc_open()
 cmd_exec	./lib/rrd.php			$process = proc_open([$path, '-'], $descriptors, $pipes, null, null, ['bypass_shell' => true]);
 cmd_exec	./lib/rrdcheck.php		$process = proc_open($command, $fds, $pipes);
+cmd_exec	./lib/snmp.php			// exec() does not capture, so the walk output can never contain either.
 cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
 cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);
 cmd_exec	./lib/snmp.php			exec($command, $snmp_value, $return_var);


### PR DESCRIPTION
`cacti_snmp_walk()` returned `[]` whenever its output contained the word `Timeout`.

That output is the walk itself, one line per OID, so the check matched **device data**. A device with an `ifAlias` of "Timeout Monitor", a matching `sysDescr`, or an alarm-name table emptied the entire walk. `lib/data_query.php:1471` then treats the field as empty and skips the index, so **every interface disappears from the data query**.

The check could not detect a real timeout either: net-snmp writes that to stderr and neither walk command redirects it, so the string being matched was never a net-snmp error in the first place.

Simulated against realistically shaped output:

```
healthy walk containing "Timeout" in an ifAlias:
   before: keeps 0/3 rows      <- whole walk discarded
   after:  keeps 3/3 rows
genuine timeout (stderr, empty stdout, exit 1):
   before: indistinguishable from an empty walk
   after:  detected
```

## Change
Read the exit code, which is what actually distinguishes a failed walk. `exec_into_array()` already exposes it by reference, and `cacti_snmp_get()` uses exactly this at `lib/snmp.php:208` with a comment giving the same rationale.

Also refuse a walk with empty credentials, matching `cacti_snmp_get`, `cacti_snmp_get_raw` and `cacti_snmp_getnext`. `cacti_get_snmpv3_auth()` returns `''` for an unknown protocol, and the walk was the one caller that then built a credential-less `snmpwalk -v 3` and failed with no log line.

## Tests
`tests/Unit/Snmp/SnmpWalkFailureDetectionTest.php` covers the exit-code path, the auth guard, and that a device value containing "Timeout" is no longer discarded.

## Applicability
`develop` only. The `return []` guards were introduced by `40d49ef49`; `1.2.x` does not carry them.
