### PR TITLE
fix: commit transactions on MySQL as well as MariaDB

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.x
+-issue: Commit transactions on MySQL as well as MariaDB
 -security: Update bundled DOMPurify to 3.4.14
 -security: Revoke anonymous access when the guest account is disabled
 -security: Cast graph and device ids to int in get_allowed_* permission filters

--- a/lib/database.php
+++ b/lib/database.php
@@ -2075,9 +2075,15 @@ function db_commit_transaction($db_conn = false) {
 		}
 	}
 
-	if (db_fetch_cell('SELECT @@in_transaction', '', true, $db_conn) > 0) {
-		return $db_conn->commit();
+	/* @@in_transaction is a MariaDB variable. On MySQL the query raises
+	 * "Unknown system variable 'in_transaction'", the comparison is false, and
+	 * the transaction was left open without ever being committed. PDO tracks
+	 * this itself and answers the same question on both engines. */
+	if (!$db_conn->inTransaction()) {
+		return false;
 	}
+
+	return $db_conn->commit();
 }
 
 /**

--- a/tests/Unit/DatabaseTransactionPortabilityTest.php
+++ b/tests/Unit/DatabaseTransactionPortabilityTest.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$databaseSource = file_get_contents(dirname(__DIR__, 2) . '/lib/database.php');
+
+test('the commit path does not depend on the MariaDB in_transaction variable', function () use ($databaseSource) {
+	$start = strpos($databaseSource, 'function db_commit_transaction(');
+	$end   = strpos($databaseSource, "\nfunction ", $start + 1);
+	$body  = substr($databaseSource, $start, $end - $start);
+
+	// MySQL answers "Unknown system variable 'in_transaction'", so the guard was
+	// always false there and the commit never ran.
+	expect($body)->not->toContain("SELECT @@in_transaction")
+		->and($body)->toContain('inTransaction()');
+});
+
+test('PDO reports transaction state identically regardless of engine', function () {
+	$pdo = new PDO('sqlite::memory:', null, null, array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION));
+
+	expect($pdo->inTransaction())->toBeFalse();
+
+	$pdo->beginTransaction();
+	expect($pdo->inTransaction())->toBeTrue();
+
+	expect($pdo->commit())->toBeTrue()
+		->and($pdo->inTransaction())->toBeFalse();
+});


### PR DESCRIPTION
1.2.x port of #7928. Same defect, same fix.

`db_commit_transaction()` gated the commit on `SELECT @@in_transaction`, which exists only in MariaDB:

```
MariaDB 11:  SELECT @@in_transaction  ->  0
MySQL 8.4:   ERROR 1193 (HY000): Unknown system variable 'in_transaction'
```

On MySQL the query fails, the comparison is false, and the function returns without calling `commit()`. The transaction is left open and the caller is told the commit failed.

Use `PDO::inTransaction()`, which tracks the state itself and answers the same question on both engines. The 1.2.x copy also fell off the end returning `null` when the guard failed; it now returns `false` explicitly, matching the documented `bool` contract.

## Tests
`tests/Unit/DatabaseTransactionPortabilityTest.php` asserts the MariaDB-only query is gone from the commit path and that `PDO::inTransaction()` reports state correctly across begin and commit.
