### PR TITLE
ci: skip the page crawl when nothing it exercises changed

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -441,7 +441,42 @@ jobs:
         sudo -u www-data -- php poller.php --poller=1 --force --debug
         grep -q "SYSTEM STATS" log/cacti.log
 
+    # The recursive crawl walks the whole authenticated UI one request at a
+    # time and is the single most expensive step in CI. Nothing it exercises can
+    # change unless server-rendered code, assets or the schema changed, so skip
+    # it when a pull request touches only tests, workflows or documentation.
+    - name: Decide whether the page crawl can affect this change
+      id: crawl_scope
+      run: |
+        set -euo pipefail
+
+        if [[ "${{ github.event_name }}" != 'pull_request' ]]; then
+          echo 'required=true' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        base='${{ github.event.pull_request.base.sha }}'
+
+        # Fail open: if the diff cannot be read, run the crawl.
+        if ! changed=$(git diff --name-only "$base" HEAD 2>/dev/null); then
+          echo 'required=true' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ -z "$changed" ]]; then
+          echo 'required=true' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if printf '%s\n' "$changed" | grep -qvE '^(tests/|\.github/|docs/|locales/|CHANGELOG|changelog\.d/|.*\.md$)'; then
+          echo 'required=true' >> "$GITHUB_OUTPUT"
+        else
+          echo 'required=false' >> "$GITHUB_OUTPUT"
+          echo "Only tests, workflows or documentation changed; skipping the page crawl."
+        fi
+
     - name: Check All Pages Using Recursive wget
+      if: steps.crawl_scope.outputs.required == 'true'
       run: |
         set -euo pipefail
         install -m 0600 /dev/null .my.cnf


### PR DESCRIPTION
Measured across the last 120 workflow runs (189.6 CI-minutes total):

```
Cacti Commit Audit (syntax.yml)        95.5 min    50% of all CI minutes
  └─ PHP 8.2 locked integration        11.8 min    72% of that workflow
       └─ Check All Pages via wget      7.0 min    60% of that job
```

One step is roughly a third of the project's entire CI spend. Every other job in that workflow finishes in under a minute.

`tests/tools/check_all_pages.sh:621` runs `wget --recursive --level=0`, which is unlimited depth, single threaded, against the authenticated UI. Nothing it exercises can change unless server-rendered code, assets or the schema changed, yet it runs on every pull request — including ones that touch only tests, a changelog fragment or a workflow file, which is most of them.

## Change
Skip the step when the diff contains nothing outside `tests/`, `.github/`, `docs/`, `locales/`, `CHANGELOG`, `changelog.d/` and `*.md`.

The **step** is gated rather than the job, deliberately: `CI / required` asserts `result = success` for each of its `needs`, so skipping the job would turn a skip into a failed merge gate. Gating the step leaves the job, and the aggregator, untouched.

The decision fails open. A push rather than a pull request, an unreadable diff, or an empty diff all run the crawl.

## Verification
The classifier was exercised against realistic change sets with GNU grep, both on the host and in a container, since a local `ugrep` alias silently disagrees with GNU grep on `-qv`:

```
lib/html.php                  -> run
graph_view.php                -> run
cacti.sql                     -> run
install/upgrades/1_3_0.php    -> run
tests/x.php + lib/html.php    -> run     (mixed diffs still run)
tests only                    -> skip
workflow only                 -> skip
changelog.d fragment          -> skip
docs + *.md                   -> skip
locales                       -> skip
```

## Expected effect
The median pull request in this repository touches tests, workflows or a changelog fragment, so it should drop from roughly 8.7 minutes to about 2, with no loss of coverage on the pull requests that actually change what the crawl inspects.

Two further optimisations are worth considering separately: bounding `--level`, and parallelising with `wget2 --max-threads`. Both change what the crawl does, so they deserve their own review.
