### PR TITLE
docs: record how to refresh the security baselines and verify a branch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,6 +74,13 @@
 - Install/upgrade DB: `php -q cli/install_cacti.php --accept-eula --install --force` and `php -q cli/upgrade_database.php --forcever=$(cat include/cacti_version)`.
 - Run poller: `php poller.php --poller=1 --force --debug` (daemon debug: `./cactid.php --foreground --debug`).
 - Repo checks: `composer lint`, `composer phpstan`, `composer phpcsfixer` (dry-run).
+- Refresh security baselines when the sink or hotspot guard reports drift:
+  `tests/security/build_sink_inventory.sh | tr -d '\r' | LC_ALL=C sort > tests/security/baselines/sink_inventory.baseline.tsv`
+  and the matching `build_architectural_helper_report.sh --hotspots` for
+  `architectural_hotspots.baseline.tsv`. Use the command the verifier prints
+  rather than editing the file. The verifiers strip `:LINE` before comparing, so
+  most of the resulting diff is renumbering they ignore; say in the pull request
+  how many entries are substantive.
 
 ## Dependency management: never vendor packages
 - Do not add, copy, or update third-party package source under `include/vendor/` or elsewhere in the repository. Existing vendored dependencies may be removed by an in-scope change, but must not be expanded or refreshed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,39 @@ changes with `composer validate` and a clean `composer install`.
 If a third-party asset cannot be managed through Composer, stop and document
 the concrete packaging requirement before adding files. Do not silently create
 a vendored exception.
+
+## Confirm the defect before writing the fix
+
+A finding from a review, a scan or another agent is a claim about a branch, not
+a fact about this one. `develop` and `1.2.x` diverge, and a defect reported
+against one is often already fixed on the other, sometimes by a pull request
+that has since merged.
+
+Before writing a fix, check that the target still exists where you intend to
+land it:
+
+    git show upstream/develop:path/to/file.php | rg 'the pattern'
+    git log -S 'the pattern' --oneline upstream/develop | head
+
+Then choose the branch deliberately, and say in the pull request which branches
+the defect affects. Porting a fix to a branch that never had the bug adds review
+work and risk for no benefit.
+
+## A pull request with no checks has not been verified
+
+Branches pushed from a fork hold their workflow runs in `action_required` until
+someone approves them. Until that happens the pull request reports **no checks
+at all**, which is easy to read as passing in both the merge box and
+`gh pr checks`. Nothing has run.
+
+    # runs waiting for approval
+    gh run list --repo Cacti/cacti --limit 200 --json conclusion \
+      --jq '[.[]|select(.conclusion=="action_required")]|length'
+
+    # a pull request with zero checks is unverified, not green
+    gh pr checks <pr> --repo Cacti/cacti | wc -l
+
+`gh run list` pages by recency, so one sweep can miss older branches; re-check
+with `--branch <name>`. Report a pull request as green only once its checks
+exist and have completed.
+


### PR DESCRIPTION
Three things that cost real time recently and are written down nowhere. Documentation only, 43 lines across two files, no restructuring.

## `.github/copilot-instructions.md` — refreshing the security baselines
The sink and architectural hotspot guards compare against checked-in baselines and gate every pull request, but the refresh command is only printed by the verifier when it fails.

This is not hypothetical. `1.2.x` head was red on its own guards until #7924, so every pull request opened against that branch inherited a failure it did not cause.

Added to *Workflows you'll actually use*, alongside the other repo commands. Also records that the verifiers strip `:LINE` before comparing, so most of a regenerated diff is renumbering they ignore, and a pull request should say how many entries are substantive rather than leaving a reviewer to read several hundred lines of churn.

Verified: the documented command reproduces the committed baseline byte for byte, 655 rows.

## `AGENTS.md` — confirm the defect before writing the fix
`develop` and `1.2.x` diverge, and a defect reported against one is often already fixed on the other. During a recent review round several findings turned out to be already fixed, one of them by a pull request from this account that had since merged. Two commands make that a ten second check.

## `AGENTS.md` — a pull request with no checks has not been verified
Branches pushed from a fork hold their workflow runs in `action_required` until someone approves them. Until then the pull request reports **no checks at all**, which reads as passing in the merge box and in `gh pr checks`. Nothing has run.

Two hundred runs were sitting in that state across this repository earlier today; several pull requests looked green while nothing had executed. The section gives the command to find them and states plainly that zero checks means unverified rather than passing.

`CLAUDE.md` is gitignored here on purpose, so this goes in the two shared files.
