### PR TITLE
build: declare the PHP 8.1 floor 1.2.31 already shipped

### DIFF
--- a/.github/workflows/dependency-compatibility.yml
+++ b/.github/workflows/dependency-compatibility.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup PHP 8.0 release toolchain
         uses: ./.github/actions/setup-php-composer
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
           coverage: none
           dependency-mode: 1.2-locked-release

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "type": "composer-plugin",
     "license": "GPL-2.0-only",
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-PDO": "*",
         "ext-Phar": "*",
         "ext-dom": "*",
@@ -67,7 +67,7 @@
     "prefer-stable": true,
     "config": {
         "platform": {
-            "php": "8.0.0"
+            "php": "8.1.0"
         },
         "platform-check": "php-only",
         "sort-packages": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdc28112a2c2683a523983e4204b1c29",
+    "content-hash": "769aa7d5232a18b400ffe4e9a6249743",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",
@@ -304,7 +304,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-pdo": "*",
         "ext-phar": "*",
         "ext-dom": "*",
@@ -325,7 +325,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.0.0"
+        "php": "8.1.0"
     },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
`Requirements.md` has said "As of Cacti 1.2.31, PHP 8.1 is required" since that release, but `composer.json` on 1.2.x still declared `>=8.0` with `config.platform.php` at `8.0.0`. The lock, the locked-runtime matrix, and the release build all followed the manifest rather than the documentation.

This is not a floor move. It is the manifest catching up to what 1.2.31 shipped. PHP 8.0 has been unpatched since November 2023, so nothing here should still advertise it.

Four files:

- `composer.json` — sets `require.php` to `>=8.1` and `config.platform.php` to `8.1.0`
- `composer.lock` — regenerated with `composer update --lock`; content hash and platform only, with no package version changes
- `.github/workflows/dependency-compatibility.yml` — drops PHP 8.0 from `locked-runtime`, matching `native-dependencies`, which already starts at 8.1
- `.github/workflows/release-artifact.yml` — builds the release tarball on PHP 8.1

Composer-generated files under `include/vendor` are intentionally not committed. Clean installs and release builds regenerate the PHP platform check from the manifest and lock.

Validation:

- `composer validate`
- clean Composer install on PHP 8.1 through CI
- locked and native dependency matrices on PHP 8.1–8.4
- self-contained release artifact build and extraction smoke test

The floor should not move again inside the 1.2 line. If a fix needs a dependency that wants PHP 8.2, pin that dependency rather than moving the runtime under users mid-LTS.
