### PR TITLE
build: report when include/vendor and composer.lock disagree

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -216,6 +216,14 @@ jobs:
       run: composer run-script hardening-patterns -- --base="${{ github.event.pull_request.base.sha }}" --head=HEAD
       working-directory: .
 
+    # Reported, not gated.  The tree and the lock disagree today (see #7940),
+    # so this surfaces the drift on every run without blocking unrelated work.
+    # Flip continue-on-error off once the tree is refreshed.
+    - name: Check include/vendor against composer.lock
+      run: composer run-script vendor-sync
+      working-directory: .
+      continue-on-error: true
+
     - name: Checking coding standards on base code
       run: composer run-script phpcsfixer
       working-directory: .

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
         "php-cs-fixer": "php-cs-fixer fix --allow-unsupported-php-version=yes --dry-run --diff --config=./.php-cs-fixer.php ",
         "phpcsfixer": "@php-cs-fixer",
         "hardening-patterns": "php tests/tools/check_hardening_patterns.php",
+        "vendor-sync": "php tests/tools/check_vendor_sync.php",
         "php-cs-fixit": "php-cs-fixer fix ",
         "install-hooks": "bash -c 'install -m 755 tests/tools/pre-commit \"$(git rev-parse --git-path hooks/pre-commit)\"'",
         "test": "include/vendor/bin/pest --display-warnings",

--- a/tests/tools/check_vendor_sync.php
+++ b/tests/tools/check_vendor_sync.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Compares the committed include/vendor tree against composer.lock.
+ *
+ * Cacti commits both, so a checkout has working dependencies without running
+ * Composer.  That only holds while the two agree; when they drift, a source
+ * checkout runs code against package versions the lock never selected.
+ */
+
+$root = dirname(__DIR__, 2);
+
+$lock_file      = $root . '/composer.lock';
+$installed_file = $root . '/include/vendor/composer/installed.json';
+
+foreach ([$lock_file, $installed_file] as $file) {
+	if (!is_readable($file)) {
+		fwrite(STDERR, sprintf("Cannot read %s\n", $file));
+
+		exit(1);
+	}
+}
+
+$lock = json_decode(file_get_contents($lock_file), true);
+
+if (!is_array($lock) || !isset($lock['packages'])) {
+	fwrite(STDERR, "composer.lock is not valid JSON or has no packages\n");
+
+	exit(1);
+}
+
+$installed = json_decode(file_get_contents($installed_file), true);
+
+if (!is_array($installed)) {
+	fwrite(STDERR, "installed.json is not valid JSON\n");
+
+	exit(1);
+}
+
+// Composer 2 nests the list under 'packages'; Composer 1 wrote a bare array.
+$installed_packages = isset($installed['packages']) ? $installed['packages'] : $installed;
+
+$locked = [];
+
+foreach ($lock['packages'] as $package) {
+	$locked[$package['name']] = $package['version'];
+}
+
+$present = [];
+
+foreach ($installed_packages as $package) {
+	$present[$package['name']] = $package['version'];
+}
+
+$missing    = array_diff_key($locked, $present);
+$unexpected = array_diff_key($present, $locked);
+$mismatched = [];
+
+foreach (array_intersect_key($locked, $present) as $name => $version) {
+	if ($present[$name] !== $version) {
+		$mismatched[$name] = [$present[$name], $version];
+	}
+}
+
+if (empty($missing) && empty($unexpected) && empty($mismatched)) {
+	print 'include/vendor matches composer.lock (' . count($locked) . ' packages)' . PHP_EOL;
+
+	exit(0);
+}
+
+fwrite(STDERR, "The committed include/vendor tree does not match composer.lock.\n\n");
+
+foreach ($mismatched as $name => $versions) {
+	fwrite(STDERR, sprintf("  %-40s vendor %-14s lock %s\n", $name, $versions[0], $versions[1]));
+}
+
+foreach ($missing as $name => $version) {
+	fwrite(STDERR, sprintf("  %-40s absent from vendor, lock %s\n", $name, $version));
+}
+
+foreach ($unexpected as $name => $version) {
+	fwrite(STDERR, sprintf("  %-40s in vendor as %s, absent from lock\n", $name, $version));
+}
+
+fwrite(STDERR, "\nRun 'composer install' and commit the resulting include/vendor tree.\n");
+
+exit(1);


### PR DESCRIPTION
Adds a check that compares the committed `include/vendor` tree against `composer.lock`, reported rather than gated for now.

Cacti commits both so a checkout has working dependencies without running Composer. That only holds while the two agree, and #7940 records that they no longer do: ten packages differ, eight of them across a major version. The sharpest case is `phpseclib`, where the namespace moved with the major, so `lib/rrd.php` and `lib/auth.php` call `phpseclib4\` against a tree that ships `phpseclib3`.

Keeping the two in sync was the aim of #7274 and #7745. What was missing is anything that notices when they come apart, which is what this adds.

`tests/tools/check_vendor_sync.php` follows the existing `check_hardening_patterns.php` shape and is wired as a `vendor-sync` Composer script. Against develop today:

```
$ composer run-script vendor-sync
The committed include/vendor tree does not match composer.lock.

  phpseclib/phpseclib      vendor 3.0.56    lock 4.0.0
  symfony/event-dispatcher vendor v6.4.43   lock v7.4.17
  ... 8 more version mismatches ...
  symfony/finder           absent from vendor, lock v6.4.44
  symfony/polyfill-php82   absent from vendor, lock v1.38.1
  paragonie/random_compat  in vendor as v9.99.100, absent from lock
```

and against a tree that matches its lock:

```
include/vendor matches composer.lock (48 packages)
```

**The CI step is `continue-on-error: true` on purpose.** Gating it would fail develop immediately, since the drift is present now and refreshing the tree is a separate change. The step carries a comment saying to drop that line once the tree is refreshed.

One limit worth stating: this compares `installed.json` against the lock, so it catches version and membership drift but not a hand-edited file inside a package at the right version. Checksums would catch that and seemed like more machinery than the problem warrants.
