### PR TITLE
chore: file new issues with the namespaced labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug,unverified'
+labels: 'type:bug,status:needs-verification'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'enhancement'
+labels: 'type:enhancement'
 assignees: ''
 
 ---


### PR DESCRIPTION
The issue templates apply the flat labels, so every report filed through them arrives as `bug, unverified` or `enhancement` and the namespaced equivalents get added by hand afterwards.

```
bug_report.md       labels: 'bug,unverified'  ->  'type:bug,status:needs-verification'
feature_request.md  labels: 'enhancement'     ->  'type:enhancement'
```

All three targets already exist and are described as "Namespaced Cacti workflow label".

This is the source of the split. Checking who applies what: issues filed through the templates carry flat labels only, while namespaced ones are applied afterwards by hand. Until the templates change, every new report re-creates the gap.

Only `develop` matters here, since GitHub reads templates from the default branch. The copies on `1.2.x` are inert.

The open issues have already been brought onto the namespaced scheme separately, so after this merges both new and existing issues carry it.

Part of #7950.
