### PR TITLE
ci: stop the nightly lock job failing on discussions

### DIFF
--- a/.github/workflows/oldissues.yml
+++ b/.github/workflows/oldissues.yml
@@ -42,7 +42,7 @@ jobs:
         days-before-close: 30
         remove-stale-when-updated: true
 
-        exempt-issue-labels: 'pinned, security, enhancement, future release'
+        exempt-issue-labels: 'pinned, security, type:security, enhancement, type:enhancement, future release'
 
         stale-issue-label: 'outdated'
         stale-issue-message: >
@@ -50,7 +50,7 @@ jobs:
           not had recent activity. It will be closed if no further activity
           occurs. Thank you for your contributions.
 
-        exempt-pr-labels: 'pinned, security, enhancement, future release'
+        exempt-pr-labels: 'pinned, security, type:security, enhancement, type:enhancement, future release'
 
         stale-pr-label: 'outdated'
         stale-pr-message: >
@@ -86,5 +86,7 @@ jobs:
         #   has not been any recent activity after it was closed. Please
         #   open a new issue for related bugs.
         pr-lock-reason: ''
-        process-only: ''
+        # Empty means every thread type, including discussions, which the
+        # job has no permission for and which failed the run every night.
+        process-only: 'issues, prs'
         debug-run: true


### PR DESCRIPTION
The nightly "Maintain old issues" run has failed every night. Splitting it by job:

```
stale: success
lock:  failure
```

The `lock` job dies here:

```
##[debug]Locking (discussion: 6284)
##[error]Request failed due to following response errors:
 - Resource not accessible by integration
```

`process-only` was empty, which means lock-threads walks every thread type including discussions, and the workflow grants only `issues: write` and `pull-requests: write`. Setting it to `issues, prs` matches the permissions the job actually has. Nothing has been locking as a result, so this restores the intended behaviour rather than changing it.

The exempt lists are the second change. They match on the flat label names, and the namespaced scheme is being adopted alongside them:

```
exempt-issue-labels: 'pinned, security, enhancement, future release'
```

The stale job is live and working, with `days-before-stale: 365`. 99 of the 100 oldest open issues are protected by the `enhancement` entry alone. Once the flat labels are retired those issues lose the exemption and become eligible for automatic closure, so the lists now carry both spellings while the two schemes coexist.

Worth stating plainly for whoever retires the flat labels later: that is what currently holds the old backlog open, and removing it is a policy decision about closing unchampioned enhancements, not a cleanup.

Closes #7949.
