### PR TITLE
build: make the containerised test image run the whole suite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .git
 .github
+# check-changelog.py is a composer 'check' step
+!.github/scripts
 *.md
 !README.md
 LICENSE
@@ -9,6 +11,10 @@ LICENSE
 docker-compose.override.yml
 data/
 cache/
+# the tracked redirect guards are part of the sink inventory
+!cache/index.php
+!cache/**/index.php
 log/
+!log/index.php
 rra/*.rrd
 *.log

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -3,7 +3,7 @@ FROM cacti-web
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends git unzip \
+	&& apt-get install -y --no-install-recommends git unzip nodejs npm python3 ripgrep \
 	&& pecl install xdebug \
 	&& docker-php-ext-enable xdebug \
 	&& apt-get clean \
@@ -13,11 +13,15 @@ WORKDIR /work
 
 COPY . ./
 
-RUN composer install --prefer-dist --no-progress --no-interaction \
+# include/js/htmx.js is generated from package.json rather than committed,
+# and the htmx suites fail without it.
+RUN npm_config_cache=/tmp/.npm npm ci \
+	&& composer install --prefer-dist --no-progress --no-interaction \
 	&& mkdir -p cache log rra \
 	&& touch log/cacti.log \
 	&& chmod -R a+rwX cache log rra \
 	&& cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini \
+	&& sed -i 's/^memory_limit = .*/memory_limit = 2G/' /usr/local/etc/php/php.ini \
 	&& git init \
 	&& git add --force . \
 	&& chown -R www-data:www-data /work


### PR DESCRIPTION
Makes the whole of `composer check` runnable inside the test image. Four of the nine steps could not run in it; the details are in #7952.

`docker/Dockerfile.test`:

- installs `nodejs npm python3 ripgrep`, which `test-js`, `changelog`, `hotspot-guard` and `sink-guard` need
- runs `npm ci` before `composer install`, because `include/js/htmx.js` is generated from `package.json` rather than committed and 16 htmx tests fail without it
- raises `memory_limit` to 2G, since PHPStan crashes at the `php.ini-development` default of 128M

`.dockerignore` re-includes only the tracked files the guards read:

```
!.github/scripts        check-changelog.py
!cache/index.php
!cache/**/index.php     five redirect guards in the sink inventory
!log/index.php          the sixth
```

Docker's re-include inside an excluded directory is easy to get wrong, so I checked it on a throwaway image first: the guards and `check-changelog.py` come through, while `.github/workflows` and generated cache content stay out. I also compared every path in the sink baseline against the full exclusion list rather than fixing them one at a time, which found exactly two directories mattered.

Verified on x86_64 Ubuntu 24.04 by building this image and running each step inside it, `COPY`-based rather than bind-mounted:

```
lint PASS   php-cs-fixer PASS   phpstan PASS   hardening PASS   changelog PASS
sink-guard PASS   hotspot-guard PASS   test-js PASS   pest PASS
```

Nine of nine, against four before.

Closes #7952.
