### PR TITLE
[1.2.x] Preserve layout after plugin dependency errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,7 @@ Cacti CHANGELOG
 -security: Harden advisory command execution and database DDL sink validation
 -security: Restrict graph input fields across the template, graph and import handoffs
 -security: Treat a non-boolean signature result as a failure in import_package
+-issue#7961: Preserve the full Plugin Management layout after dependency errors
 -issue#7809: Undefined array key "source" warning reindexing SNMP data queries with output-only fields
 -issue#7819: Remove obsolete pre-PHP 8 compatibility branches
 -issue#7617: Allow the graph tree sidebar to shrink with collapsed content

--- a/lib/plugins.php
+++ b/lib/plugins.php
@@ -594,7 +594,7 @@ function api_plugin_install($plugin) {
 
 		raise_message('dependency_check', $message, MESSAGE_LEVEL_ERROR);
 
-		header('Location: plugins.php?header=false');
+		header('Location: plugins.php');
 
 		exit;
 	}

--- a/tests/e2e/docker/tests/07-session-cookie-failure.sh
+++ b/tests/e2e/docker/tests/07-session-cookie-failure.sh
@@ -8,6 +8,20 @@ cd "$(dirname "$0")/.."
 
 DC=(docker compose -f docker-compose.yml)
 
+cleanup() {
+	"${DC[@]}" exec -T cacti-master cp \
+		/tmp/c07-config.php /var/www/html/include/config.php >/dev/null 2>&1 || true
+	"${DC[@]}" exec -T cacti-master rm -f \
+		/tmp/c07-config.php /tmp/c07.jar /tmp/c07_form \
+		/tmp/c07_headers /tmp/c07_response >/dev/null 2>&1 || true
+	# php.ini-production caches file timestamps for two seconds.
+	sleep 3
+}
+
+"${DC[@]}" exec -T cacti-master cp \
+	/var/www/html/include/config.php /tmp/c07-config.php
+trap cleanup EXIT
+
 "${DC[@]}" exec -T cacti-master sh -c \
 	'printf '\''%s\n'\'' "\$cacti_cookie_domain = '\''example.com'\'';" >> /var/www/html/include/config.php'
 # php.ini-production caches file timestamps for two seconds.

--- a/tests/e2e/docker/tests/08-plugin-dependency-redirect.sh
+++ b/tests/e2e/docker/tests/08-plugin-dependency-redirect.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Verify a rejected plugin dependency check returns native POST navigation to
+# the full Plugin Management page instead of an unskinned header=false fragment.
+set -euo pipefail
+IFS=$'\n\t'
+
+: "${CACTI_E2E_PORT:=8088}"
+
+cd "$(dirname "$0")/.."
+
+DC=(docker compose -f docker-compose.yml)
+FIXTURE='dependency_fixture'
+COOKIE_JAR='/tmp/c08.jar'
+
+run_curl() {
+	"${DC[@]}" exec -T cacti-master curl -sS -b "$COOKIE_JAR" -c "$COOKIE_JAR" "$@"
+}
+
+cleanup() {
+	"${DC[@]}" exec -T cacti-master rm -rf \
+		"/var/www/html/plugins/$FIXTURE" >/dev/null 2>&1 || true
+	"${DC[@]}" exec -T cacti-master rm -f \
+		"$COOKIE_JAR" /tmp/c08_login_form /tmp/c08_login_result \
+		/tmp/c08_plugins /tmp/c08_result >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+"${DC[@]}" exec -T cacti-master mkdir -p "/var/www/html/plugins/$FIXTURE"
+docker cp "../../fixtures/plugins/$FIXTURE/." "cacti-e2e-master:/var/www/html/plugins/$FIXTURE"
+"${DC[@]}" exec -T cacti-master chown -R www-data:www-data "/var/www/html/plugins/$FIXTURE"
+"${DC[@]}" exec -T cacti-master rm -f "$COOKIE_JAR"
+
+run_curl -L -o /tmp/c08_login_form 'http://127.0.0.1/index.php'
+CSRF=$("${DC[@]}" exec -T cacti-master php \
+	/var/www/html/tests/e2e/docker/probes/extract_csrf.php /tmp/c08_login_form || true)
+if [ -z "$CSRF" ]; then
+	echo 'FAIL: could not extract the login CSRF token' >&2
+	exit 1
+fi
+
+run_curl -L -o /tmp/c08_login_result \
+	--data-urlencode 'action=login' \
+	--data-urlencode 'login_username=admin' \
+	--data-urlencode 'login_password=cacti-e2e-admin' \
+	--data-urlencode "__csrf_magic=$CSRF" \
+	--data-urlencode 'realm=local' \
+	'http://127.0.0.1/index.php'
+
+LOGIN_BODY=$("${DC[@]}" exec -T cacti-master cat /tmp/c08_login_result)
+if echo "$LOGIN_BODY" | grep -q '<title>Login to Cacti</title>'; then
+	echo 'FAIL: authentication returned the login page' >&2
+	exit 1
+fi
+if ! echo "$LOGIN_BODY" | grep -qE "class=['\"]cactiPageHead['\"]"; then
+	echo 'FAIL: authenticated response is missing the Cacti page layout' >&2
+	exit 1
+fi
+
+run_curl -o /tmp/c08_plugins 'http://127.0.0.1/plugins.php'
+if ! "${DC[@]}" exec -T cacti-master grep -q \
+	'Dependency Redirect Fixture' /tmp/c08_plugins; then
+	echo 'FAIL: dependency fixture is absent from Plugin Management' >&2
+	exit 1
+fi
+if ! "${DC[@]}" exec -T cacti-master grep -qi \
+	'missing_fixture_dependency' /tmp/c08_plugins; then
+	echo 'FAIL: Plugin Management does not show the fixture dependency' >&2
+	exit 1
+fi
+
+CSRF=$("${DC[@]}" exec -T cacti-master php \
+	/var/www/html/tests/e2e/docker/probes/extract_csrf.php /tmp/c08_plugins || true)
+if [ -z "$CSRF" ]; then
+	echo 'FAIL: could not extract the Plugin Management CSRF token' >&2
+	exit 1
+fi
+
+FINAL_URL=$(run_curl -L -o /tmp/c08_result -w '%{url_effective}' \
+	--data-urlencode 'mode=install' \
+	--data-urlencode "id=$FIXTURE" \
+	--data-urlencode "__csrf_magic=$CSRF" \
+	'http://127.0.0.1/plugins.php')
+
+if [ "$FINAL_URL" != 'http://127.0.0.1/plugins.php' ]; then
+	echo "FAIL: dependency error ended at $FINAL_URL instead of the full plugins.php page" >&2
+	exit 1
+fi
+
+BODY=$("${DC[@]}" exec -T cacti-master cat /tmp/c08_result)
+if ! echo "$BODY" | grep -qE "class=['\"]cactiPageHead['\"]"; then
+	echo 'FAIL: dependency error response is missing the full Cacti page layout' >&2
+	exit 1
+fi
+if ! echo "$BODY" | grep -q 'Plugin cannot be installed'; then
+	echo 'FAIL: dependency error response is missing the installation error' >&2
+	exit 1
+fi
+if ! echo "$BODY" | grep -qi 'missing_fixture_dependency'; then
+	echo 'FAIL: dependency error response does not name the missing dependency' >&2
+	exit 1
+fi
+
+PLUGIN_ROWS=$("${DC[@]}" exec -T cacti-db mariadb -N -B \
+	-ucactiuser -pcactiuser cacti \
+	-e "SELECT COUNT(*) FROM plugin_config WHERE directory='$FIXTURE'")
+if [ "$PLUGIN_ROWS" != '0' ]; then
+	echo 'FAIL: rejected plugin was unexpectedly installed' >&2
+	exit 1
+fi
+
+echo 'PASS: plugin dependency errors retain the full Plugin Management layout'

--- a/tests/e2e/docker/tests/08-plugin-dependency-redirect.sh
+++ b/tests/e2e/docker/tests/08-plugin-dependency-redirect.sh
@@ -27,7 +27,12 @@ cleanup() {
 trap cleanup EXIT
 
 "${DC[@]}" exec -T cacti-master mkdir -p "/var/www/html/plugins/$FIXTURE"
-docker cp "../../fixtures/plugins/$FIXTURE/." "cacti-e2e-master:/var/www/html/plugins/$FIXTURE"
+MASTER_CONTAINER=$("${DC[@]}" ps -q cacti-master)
+if [ -z "$MASTER_CONTAINER" ]; then
+	echo 'FAIL: cacti-master container is not running' >&2
+	exit 1
+fi
+docker cp "../../fixtures/plugins/$FIXTURE/." "$MASTER_CONTAINER:/var/www/html/plugins/$FIXTURE"
 "${DC[@]}" exec -T cacti-master chown -R www-data:www-data "/var/www/html/plugins/$FIXTURE"
 "${DC[@]}" exec -T cacti-master rm -f "$COOKIE_JAR"
 

--- a/tests/fixtures/plugins/dependency_fixture/INFO
+++ b/tests/fixtures/plugins/dependency_fixture/INFO
@@ -1,0 +1,8 @@
+[info]
+name = dependency_fixture
+version = 1.0
+longname = Dependency Redirect Fixture
+author = The Cacti Group
+homepage = https://www.cacti.net
+compat = 1.2.0
+requires = missing_fixture_dependency:1.0

--- a/tests/fixtures/plugins/dependency_fixture/setup.php
+++ b/tests/fixtures/plugins/dependency_fixture/setup.php
@@ -1,0 +1,14 @@
+<?php
+
+function plugin_dependency_fixture_install() {
+}
+
+function plugin_dependency_fixture_version() {
+	return array(
+		'name'     => 'dependency_fixture',
+		'version'  => '1.0',
+		'longname' => 'Dependency Redirect Fixture',
+		'author'   => 'The Cacti Group',
+		'homepage' => 'https://www.cacti.net',
+	);
+}

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -883,7 +883,7 @@ header_redirect	./lib/html_reports.php:409			header('Location: ' . get_reports_p
 header_redirect	./lib/html_reports.php:494			header('Location: ' . get_reports_page() . '?header=false');
 header_redirect	./lib/html_reports.php:523			header('Location: ' . get_reports_page() . '?header=false');
 header_redirect	./lib/index.php:25	header("Location:../index.php");
-header_redirect	./lib/plugins.php:597			header('Location: plugins.php?header=false');
+header_redirect	./lib/plugins.php:597			header('Location: plugins.php');
 header_redirect	./link.php:35		header('Location: index.php');
 header_redirect	./link.php:84			header('Location: index.php');
 header_redirect	./links.php:109			header('Location: links.php?header=false');


### PR DESCRIPTION
## Summary

- redirect rejected plugin dependency checks to the full Plugin Management page after native POST navigation
- add an authenticated Docker regression test with a purpose-built missing-dependency fixture
- restore the configuration mutated by the preceding session-cookie E2E test so ordered test runs remain isolated
- update the changelog and security sink inventory baseline

This backports the dependency-error redirect behavior already present on `develop` to `1.2.x`.

## Verification

- complete ordered Docker E2E suite: 8/8 passed
- dependency redirect test: final URL is `/plugins.php`, full layout and dependency error are present, rejected plugin remains absent from `plugin_config`
- CSRF hardening Pest suite: 9/9 passed with PHP 8.1 via `mise`
- PHP syntax checks passed with PHP 8.1 via `mise`
- `tests/security/verify_sink_inventory.sh`
- `tests/security/verify_architectural_hotspots.sh`
- mandatory pre-push multi-review gate: PASS, no findings or missing tests

## Pre-existing test failures

The broader `tests/Unit/Plugin` run has two existing failures in `PluginMoveorderBugTest` concerning its `sql_mode` source assertions. They reproduce on the unmodified `1.2.x` base and are unrelated to this redirect change.

Fixes #7961
Related to #7946
