### PR TITLE
fix: harden Boost lifecycle, PHP 8.5 graph CF, and UI initialization

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -35,6 +35,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  boost-mariadb:
+    name: Boost MariaDB contracts
+    runs-on: ubuntu-22.04
+    services:
+      mysql:
+        image: mariadb:10.6
+        env:
+          MYSQL_DATABASE: cacti_boost_contract
+          MYSQL_USER: cactiuser
+          MYSQL_PASSWORD: cactiuser
+          MYSQL_ROOT_PASSWORD: cactiroot
+        ports:
+        - 3306:3306
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=5s --health-retries=10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Install PHP 8.1
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.1'
+        extensions: pdo_mysql
+        coverage: none
+
+    - name: Install test dependencies
+      working-directory: tests
+      run: composer install --no-interaction --no-progress --prefer-dist
+
+    - name: Run Boost MariaDB contracts
+      working-directory: tests
+      env:
+        BOOST_DB_HOST: 127.0.0.1
+        BOOST_DB_NAME: cacti_boost_contract
+        BOOST_DB_USER: cactiuser
+        BOOST_DB_PASSWORD: cactiuser
+      run: php vendor/bin/pest --configuration=phpunit-boost-mariadb.xml --colors=never
+
   boost-contracts:
     name: Boost contracts
     runs-on: ubuntu-22.04

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -35,6 +35,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  boost-contracts:
+    name: Boost contracts
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+
+    - name: Install PHP 8.1
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.1'
+        coverage: none
+
+    - name: Install test dependencies
+      working-directory: tests
+      run: composer install --no-interaction --no-progress --prefer-dist
+
+    - name: Run Boost contracts
+      working-directory: tests
+      run: php vendor/bin/pest --configuration=phpunit-boost.xml --colors=never
+
   javascript-contracts:
     name: JavaScript contracts
     runs-on: ubuntu-22.04

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ Cacti CHANGELOG
 -security: Treat a non-boolean signature result as a failure in import_package
 -issue#7809: Undefined array key "source" warning reindexing SNMP data queries with output-only fields
 -issue#7819: Remove obsolete pre-PHP 8 compatibility branches
+-issue#7868: Apply Boost process-table columns on the 1.2.32 upgrade path
 -issue#7617: Allow the graph tree sidebar to shrink with collapsed content
 -issue#5679: Attempt SNMP in Ping-OR-SNMP availability checks when ping fails
 -issue#6609: Return a controlled empty export when RRDtool XPORT omits metadata

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ Cacti CHANGELOG
 -security: Restrict graph input fields across the template, graph and import handoffs
 -security: Treat a non-boolean signature result as a failure in import_package
 -issue#7809: Undefined array key "source" warning reindexing SNMP data queries with output-only fields
+-issue#7810: Stop using null as a graph CF cache offset on PHP 8.5
 -issue#7819: Remove obsolete pre-PHP 8 compatibility branches
 -issue#7868: Apply Boost process-table columns on the 1.2.32 upgrade path
 -issue#7617: Allow the graph tree sidebar to shrink with collapsed content

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,7 @@ Cacti CHANGELOG
 -issue#7810: Stop using null as a graph CF cache offset on PHP 8.5
 -issue#7819: Remove obsolete pre-PHP 8 compatibility branches
 -issue#7868: Apply Boost process-table columns on the 1.2.32 upgrade path
+-issue#7954: Guard applySkin when cactiNonce is not defined
 -issue#7617: Allow the graph tree sidebar to shrink with collapsed content
 -issue#5679: Attempt SNMP in Ping-OR-SNMP availability checks when ping fails
 -issue#6609: Return a controlled empty export when RRDtool XPORT omits metadata

--- a/cacti.sql
+++ b/cacti.sql
@@ -2239,8 +2239,7 @@ CREATE TABLE `poller_output_boost` (
   `rrd_name` varchar(19) NOT NULL default '',
   `time` timestamp NOT NULL default '0000-00-00 00:00:00',
   `output` varchar(512) NOT NULL,
-  PRIMARY KEY USING BTREE (`local_data_id`, `time`, `rrd_name`),
-  KEY `time` (`time`)
+  PRIMARY KEY USING BTREE (`local_data_id`, `time`, `rrd_name`)
 ) ENGINE=InnoDB ROW_FORMAT=Dynamic;
 
 --

--- a/cacti.sql
+++ b/cacti.sql
@@ -2247,10 +2247,13 @@ CREATE TABLE `poller_output_boost` (
 --
 
 CREATE TABLE `poller_output_boost_local_data_ids` (
+	`run_id` char(32) NOT NULL DEFAULT '',
   `local_data_id` int(10) unsigned NOT NULL DEFAULT 0,
-  `process_handler` int(10) unsigned DEFAULT 0,
-  PRIMARY KEY (`local_data_id`),
-  KEY `process_handler` (`process_handler`)
+	`process_handler` int(10) unsigned NOT NULL DEFAULT 0,
+	`cursor_time` timestamp NULL DEFAULT NULL,
+	`cursor_rrd_name` varchar(19) NOT NULL DEFAULT '',
+	PRIMARY KEY (`run_id`,`local_data_id`),
+	KEY `process_handler` (`run_id`,`process_handler`)
 ) ENGINE=MEMORY;
 
 --

--- a/cacti.sql
+++ b/cacti.sql
@@ -2239,7 +2239,8 @@ CREATE TABLE `poller_output_boost` (
   `rrd_name` varchar(19) NOT NULL default '',
   `time` timestamp NOT NULL default '0000-00-00 00:00:00',
   `output` varchar(512) NOT NULL,
-  PRIMARY KEY USING BTREE (`local_data_id`, `time`, `rrd_name`)
+  PRIMARY KEY USING BTREE (`local_data_id`, `time`, `rrd_name`),
+  KEY `time` (`time`)
 ) ENGINE=InnoDB ROW_FORMAT=Dynamic;
 
 --

--- a/include/layout.js
+++ b/include/layout.js
@@ -807,9 +807,11 @@ function setupSelectmenuScrollClose() {
  *  that can't be set using a live attribute 'on()' */
 function applySkin() {
 	// Support callback nonces
-	$.ajaxSetup({
-		nonce: cactiNonce
-	});
+	if (typeof cactiNonce !== 'undefined') {
+		$.ajaxSetup({
+			nonce: cactiNonce
+		});
+	}
 
 	pageName = basename($(location).attr('pathname'));
 

--- a/install/upgrades/1_2_32.php
+++ b/install/upgrades/1_2_32.php
@@ -40,4 +40,5 @@ function upgrade_to_1_2_32() {
 	db_install_add_column('poller_output_boost_processes', array('name' => 'run_id', 'type' => 'char(32)', 'NULL' => false, 'default' => '', 'after' => 'sock_int_value'));
 	db_install_add_column('poller_output_boost_processes', array('name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'run_id'));
 	db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', array('run_id', 'child_id'));
+	db_install_add_key('poller_output_boost', 'KEY', 'time', array('time'));
 }

--- a/install/upgrades/1_2_32.php
+++ b/install/upgrades/1_2_32.php
@@ -27,7 +27,13 @@ function upgrade_to_1_2_32() {
 	 * 1.2.31 had already shipped. Installs sitting on 1.2.31 never re-run that
 	 * file. db_install_add_column() is a no-op when the column exists, so
 	 * 1.2.30 -> 1.2.32 is safe. */
-	if (db_table_exists('poller_output_boost_processes')) {
+	if (!db_table_exists('poller_output_boost_processes')) {
+		db_install_execute("CREATE TABLE IF NOT EXISTS `poller_output_boost_processes` (
+			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
+			`status` varchar(255) default NULL,
+			PRIMARY KEY (`sock_int_value`))
+			ENGINE=MEMORY");
+	} else {
 		db_install_execute('TRUNCATE TABLE poller_output_boost_processes');
 	}
 

--- a/install/upgrades/1_2_32.php
+++ b/install/upgrades/1_2_32.php
@@ -40,5 +40,4 @@ function upgrade_to_1_2_32() {
 	db_install_add_column('poller_output_boost_processes', array('name' => 'run_id', 'type' => 'char(32)', 'NULL' => false, 'default' => '', 'after' => 'sock_int_value'));
 	db_install_add_column('poller_output_boost_processes', array('name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'run_id'));
 	db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', array('run_id', 'child_id'));
-	db_install_add_key('poller_output_boost', 'KEY', 'time', array('time'));
 }

--- a/install/upgrades/1_2_32.php
+++ b/install/upgrades/1_2_32.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | This program is distributed in the hope that it will be useful,         |
+ | but WITHOUT ANY WARRANTY; without even the implied warranty of          |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           |
+ | GNU General Public License for more details.                            |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDTool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+ | This code is designed, written, and maintained by the Cacti Group. See  |
+ | about.php and/or the AUTHORS file for specific developer information.   |
+ +-------------------------------------------------------------------------+
+ | http://www.cacti.net/                                                   |
+ +-------------------------------------------------------------------------+
+*/
+
+function upgrade_to_1_2_32() {
+	global $config;
+
+	/* #7728 landed these columns in cacti.sql and in upgrade_to_1_2_31() after
+	 * 1.2.31 had already shipped. Installs sitting on 1.2.31 never re-run that
+	 * file. db_install_add_column() is a no-op when the column exists, so
+	 * 1.2.30 -> 1.2.32 is safe. */
+	db_install_execute('TRUNCATE TABLE poller_output_boost_processes');
+	db_install_add_column('poller_output_boost_processes', array('name' => 'run_id', 'type' => 'char(32)', 'NULL' => false, 'default' => '', 'after' => 'sock_int_value'));
+	db_install_add_column('poller_output_boost_processes', array('name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'run_id'));
+	db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', array('run_id', 'child_id'));
+}

--- a/install/upgrades/1_2_32.php
+++ b/install/upgrades/1_2_32.php
@@ -23,8 +23,6 @@
 */
 
 function upgrade_to_1_2_32() {
-	global $config;
-
 	/* #7728 landed these columns in cacti.sql and in upgrade_to_1_2_31() after
 	 * 1.2.31 had already shipped. Installs sitting on 1.2.31 never re-run that
 	 * file. db_install_add_column() is a no-op when the column exists, so

--- a/install/upgrades/1_2_32.php
+++ b/install/upgrades/1_2_32.php
@@ -29,7 +29,10 @@ function upgrade_to_1_2_32() {
 	 * 1.2.31 had already shipped. Installs sitting on 1.2.31 never re-run that
 	 * file. db_install_add_column() is a no-op when the column exists, so
 	 * 1.2.30 -> 1.2.32 is safe. */
-	db_install_execute('TRUNCATE TABLE poller_output_boost_processes');
+	if (db_table_exists('poller_output_boost_processes')) {
+		db_install_execute('TRUNCATE TABLE poller_output_boost_processes');
+	}
+
 	db_install_add_column('poller_output_boost_processes', array('name' => 'run_id', 'type' => 'char(32)', 'NULL' => false, 'default' => '', 'after' => 'sock_int_value'));
 	db_install_add_column('poller_output_boost_processes', array('name' => 'child_id', 'type' => 'int(10)', 'unsigned' => true, 'NULL' => false, 'default' => '0', 'after' => 'run_id'));
 	db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', array('run_id', 'child_id'));

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -23,41 +23,53 @@
 */
 
 /**
- * boost_array_orderby - performs a multicolumn sort of an
- *   array
- */
-/**
  * Ensure poller_output_boost_processes has the run_id/child_id shape.
  * Git-following 1.2.x installs can already be stamped 1.2.32 without
  * ever running an upgrade file that adds those columns.
  */
 function boost_ensure_process_table() {
 	if (!db_table_exists('poller_output_boost_processes')) {
-		db_execute('CREATE TABLE `poller_output_boost_processes` (
+		db_execute("CREATE TABLE `poller_output_boost_processes` (
 			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
-			`run_id` char(32) NOT NULL default "",
-			`child_id` int(10) unsigned NOT NULL default "0",
+			`run_id` char(32) NOT NULL default '',
+			`child_id` int(10) unsigned NOT NULL default '0',
 			`status` varchar(255) default NULL,
 			PRIMARY KEY (`sock_int_value`),
 			UNIQUE KEY `run_child` (`run_id`, `child_id`))
-			ENGINE=MEMORY');
+			ENGINE=MEMORY");
 
 		return;
 	}
 
-	if (db_column_exists('poller_output_boost_processes', 'run_id')) {
+	$needs_run_id   = !db_column_exists('poller_output_boost_processes', 'run_id');
+	$needs_child_id = !db_column_exists('poller_output_boost_processes', 'child_id');
+	$needs_key      = !db_index_exists('poller_output_boost_processes', 'run_child');
+
+	if (!$needs_run_id && !$needs_child_id && !$needs_key) {
 		return;
 	}
 
-	db_execute('TRUNCATE TABLE poller_output_boost_processes');
-	db_execute('ALTER TABLE poller_output_boost_processes ADD `run_id` char(32) NOT NULL default "" AFTER `sock_int_value`');
-	db_execute('ALTER TABLE poller_output_boost_processes ADD `child_id` int(10) unsigned NOT NULL default "0" AFTER `run_id`');
+	if ($needs_run_id || $needs_child_id) {
+		db_execute('TRUNCATE TABLE poller_output_boost_processes');
+	}
 
-	if (!db_index_exists('poller_output_boost_processes', 'run_child')) {
+	if ($needs_run_id) {
+		db_execute("ALTER TABLE poller_output_boost_processes ADD `run_id` char(32) NOT NULL default '' AFTER `sock_int_value`");
+	}
+
+	if ($needs_child_id) {
+		db_execute("ALTER TABLE poller_output_boost_processes ADD `child_id` int(10) unsigned NOT NULL default '0' AFTER `run_id`");
+	}
+
+	if ($needs_key) {
 		db_execute('ALTER TABLE poller_output_boost_processes ADD UNIQUE KEY `run_child` (`run_id`, `child_id`)');
 	}
 }
 
+/**
+ * boost_array_orderby - performs a multicolumn sort of an
+ *   array
+ */
 function boost_array_orderby() {
 	$args = func_get_args();
 	$data = array_shift($args);

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -156,12 +156,79 @@ function boost_file_size_display($file_size, $digits = 2) {
 	}
 }
 
-function boost_get_total_rows() {
-	return db_fetch_cell("SELECT SUM(TABLE_ROWS)
+/**
+ * Return a bounded page without splitting the fields belonging to one RRD
+ * timestamp.  The caller must fetch max_rows + 1 ordered rows so this function
+ * can prove whether the final timestamp is complete.
+ *
+ * @return array|false A safe page, or false when one timestamp alone exceeds
+ *                     the configured bound.
+ */
+function boost_limit_complete_timestamp_page($rows, $max_rows) {
+	$max_rows = max(1, (int) $max_rows);
+
+	if (!is_array($rows) || count($rows) <= $max_rows) {
+		return $rows;
+	}
+
+	$overflow = $rows[$max_rows];
+	$rows     = array_slice($rows, 0, $max_rows);
+	$last     = end($rows);
+
+	if ($last['local_data_id'] == $overflow['local_data_id'] && $last['timestamp'] == $overflow['timestamp']) {
+		$split_id   = $last['local_data_id'];
+		$split_time = $last['timestamp'];
+
+		while (count($rows)) {
+			$last = end($rows);
+
+			if ($last['local_data_id'] != $split_id || $last['timestamp'] != $split_time) {
+				break;
+			}
+
+			array_pop($rows);
+		}
+
+		if (!count($rows)) {
+			return false;
+		}
+	}
+
+	return $rows;
+}
+
+function boost_get_total_rows($stop_after = 0) {
+	$tables = db_fetch_assoc("SELECT TABLE_NAME
 		FROM information_schema.tables
 		WHERE table_schema = SCHEMA()
 		AND (table_name LIKE 'poller_output_boost_arch_%'
-		OR table_name LIKE 'poller_output_boost')");
+		OR table_name = 'poller_output_boost')");
+	$rows = 0;
+	$stop_after = max(0, (int) $stop_after);
+
+	if (!is_array($tables)) {
+		return 0;
+	}
+
+	foreach($tables as $table) {
+		$table_name = $table['TABLE_NAME'];
+
+		if ($table_name === 'poller_output_boost' || boost_is_valid_archive_table($table_name)) {
+			if ($stop_after > 0) {
+				$remaining = max(1, $stop_after - $rows + 1);
+				$rows += (int) db_fetch_cell("SELECT COUNT(*)
+					FROM (SELECT 1 FROM `$table_name` LIMIT $remaining) AS boost_rows");
+			} else {
+				$rows += (int) db_fetch_cell("SELECT COUNT(*) FROM `$table_name`");
+			}
+
+			if ($stop_after > 0 && $rows > $stop_after) {
+				break;
+			}
+		}
+	}
+
+	return $rows;
 }
 
 function boost_error_handler($errno, $errmsg, $filename, $linenum, $vars = []) {
@@ -925,6 +992,64 @@ function boost_get_arch_table_names($latest_table = '') {
 	}
 }
 
+/** Cache metadata reused when a hot data source spans multiple bounded pages. */
+function boost_get_unused_data_source_names($local_data_id) {
+	static $cache = array();
+
+	$local_data_id = (int) $local_data_id;
+
+	if ($local_data_id <= 0) {
+		return array();
+	}
+
+	if (!isset($cache[$local_data_id])) {
+		$cache[$local_data_id] = array_rekey(
+			db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
+				FROM data_template_rrd AS dtr
+				LEFT JOIN graph_templates_item AS gti
+				ON dtr.id = gti.task_item_id
+				WHERE dtr.local_data_id = ?
+				AND gti.task_item_id IS NULL', array($local_data_id)),
+			'data_source_name', 'data_source_name'
+		);
+	}
+
+	return $cache[$local_data_id];
+}
+
+function boost_get_input_field_names($local_data_id, $templated) {
+	static $cache = array();
+
+	$local_data_id = (int) $local_data_id;
+	$key           = $local_data_id . ':' . ($templated ? '1' : '0');
+
+	if ($local_data_id <= 0) {
+		return array();
+	}
+
+	if (!isset($cache[$key])) {
+		if ($templated) {
+			$rows = db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
+				FROM graph_templates_item AS gti
+				INNER JOIN data_template_rrd AS dtr
+				ON gti.task_item_id = dtr.id
+				INNER JOIN data_input_fields AS dif
+				ON dtr.data_input_field_id = dif.id
+				WHERE dtr.local_data_id = ?', array($local_data_id));
+		} else {
+			$rows = db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
+				FROM data_template_rrd AS dtr
+				INNER JOIN data_input_fields AS dif
+				ON dtr.data_input_field_id = dif.id
+				WHERE dtr.local_data_id = ?', array($local_data_id));
+		}
+
+		$cache[$key] = array_rekey($rows, 'data_name', 'data_source_name');
+	}
+
+	return $cache[$key];
+}
+
 /**
  * boost_process_poller_output - grabs data from the 'poller_output' and 'poller_output_boost*'
  *   table and feeds to RRDtool for processing.  This function has been repurposed for a
@@ -972,7 +1097,11 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 	set_error_handler('boost_error_handler');
 
 
-	$data_ids_to_get = read_config_option('boost_rrd_update_max_records_per_select');
+	$max_rows = (int) read_config_option('boost_rrd_update_max_records_per_select');
+
+	if ($max_rows < 1) {
+		$max_rows = 50000;
+	}
 
 	$archive_tables = boost_get_arch_table_names($archive_table);
 
@@ -1021,7 +1150,8 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 			ON po.local_data_id = dl.id
 			WHERE po.local_data_id = ?
 			AND po.time < FROM_UNIXTIME(?)
-			ORDER BY time ASC, rrd_name ASC";
+			ORDER BY time ASC, rrd_name ASC
+			LIMIT " . ($max_rows + 1);
 	} else {
 		$query_string = 'SELECT po.local_data_id, dl.data_template_id,
 			UNIX_TIMESTAMP(po.time) AS timestamp, po.rrd_name, po.output
@@ -1030,7 +1160,8 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 			ON po.local_data_id = dl.id
 			WHERE po.local_data_id = ?
 			AND po.time < FROM_UNIXTIME(?)
-			ORDER BY time ASC, rrd_name ASC';
+			ORDER BY time ASC, rrd_name ASC
+			LIMIT ' . ($max_rows + 1);
 	}
 
 	$sql_params[] = $local_data_id;
@@ -1044,6 +1175,14 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 
 	if ($temp_table !== false) {
 		db_execute("DROP TEMPORARY TABLE $temp_table");
+	}
+
+	if (cacti_sizeof($results) > $max_rows) {
+		cacti_log("WARNING: On-demand Boost processing for Local Data ID '$local_data_id' exceeded the $max_rows row request limit; rows were retained for scheduled processing.", false, 'BOOST');
+		restore_error_handler();
+		error_reporting($previous_error_reporting);
+
+		return -1;
 	}
 
 	cacti_log('Local Data ID: ' . $local_data_id . ', Boost Results: ' . $boost_results, false, 'BOOST', POLLER_VERBOSITY_MEDIUM);
@@ -1103,16 +1242,7 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 		cacti_log('The RRDpath is ' . $rrd_path, false, 'BOOST', POLLER_VERBOSITY_MEDIUM);
 		cacti_log('The RRDpath template is ' . $rrd_tmpl, false, 'BOOST', POLLER_VERBOSITY_MEDIUM);
 
-		$unused_data_source_names = array_rekey(
-			db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
-				FROM data_template_rrd AS dtr
-				LEFT JOIN graph_templates_item AS gti
-				ON dtr.id = gti.task_item_id
-				WHERE dtr.local_data_id = ?
-				AND gti.task_item_id IS NULL',
-				array($local_data_id)),
-			'data_source_name', 'data_source_name'
-		);
+		$unused_data_source_names = boost_get_unused_data_source_names($local_data_id);
 
 		boost_timer('results_cycle', BOOST_TIMER_START);
 
@@ -1184,39 +1314,10 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 
 				if (!$multi_vals_set) {
 					if ($item['data_template_id'] > 0) {
-						$rrd_field_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
-								FROM graph_templates_item AS gti
-								INNER JOIN data_template_rrd AS dtr
-								ON gti.task_item_id = dtr.id
-								INNER JOIN data_input_fields AS dif
-								ON dtr.data_input_field_id = dif.id
-								WHERE dtr.local_data_id = ?',
-								array($item['local_data_id'])),
-							'data_name', 'data_source_name'
-						);
-
-						$unused_data_source_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
-								FROM data_template_rrd AS dtr
-								LEFT JOIN graph_templates_item AS gti
-								ON dtr.id = gti.task_item_id
-								WHERE dtr.local_data_id = ?
-								AND gti.task_item_id IS NULL',
-								array($item['local_data_id'])),
-							'data_source_name', 'data_source_name'
-						);
+						$rrd_field_names          = boost_get_input_field_names($item['local_data_id'], true);
+						$unused_data_source_names = boost_get_unused_data_source_names($item['local_data_id']);
 					} else {
-						$rrd_field_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
-								FROM data_template_rrd AS dtr
-								INNER JOIN data_input_fields AS dif
-								ON dtr.data_input_field_id = dif.id
-								WHERE dtr.local_data_id = ?',
-								array($item['local_data_id'])),
-							'data_name', 'data_source_name'
-						);
-
+						$rrd_field_names = boost_get_input_field_names($item['local_data_id'], false);
 						$unused_data_source_names = array();
 					}
 
@@ -1276,39 +1377,10 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 			} else {
 				if (!$multi_vals_set) {
 					if ($item['data_template_id'] > 0) {
-						$rrd_field_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
-								FROM graph_templates_item AS gti
-								INNER JOIN data_template_rrd AS dtr
-								ON gti.task_item_id = dtr.id
-								INNER JOIN data_input_fields AS dif
-								ON dtr.data_input_field_id = dif.id
-								WHERE dtr.local_data_id = ?',
-								array($item['local_data_id'])),
-							'data_name', 'data_source_name'
-						);
-
-						$unused_data_source_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
-								FROM data_template_rrd AS dtr
-								LEFT JOIN graph_templates_item AS gti
-								ON dtr.id = gti.task_item_id
-								WHERE dtr.local_data_id = ?
-								AND gti.task_item_id IS NULL',
-								array($item['local_data_id'])),
-							'data_source_name', 'data_source_name'
-						);
+						$rrd_field_names          = boost_get_input_field_names($item['local_data_id'], true);
+						$unused_data_source_names = boost_get_unused_data_source_names($item['local_data_id']);
 					} else {
-						$rrd_field_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
-								FROM data_template_rrd AS dtr
-								INNER JOIN data_input_fields AS dif
-								ON dtr.data_input_field_id = dif.id
-								WHERE dtr.local_data_id = ?',
-								array($item['local_data_id'])),
-							'data_name', 'data_source_name'
-						);
-
+						$rrd_field_names = boost_get_input_field_names($item['local_data_id'], false);
 						$unused_data_source_names = array();
 					}
 
@@ -1317,8 +1389,8 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 
 				$expected = '';
 
-				if (cacti_sizeof($nt_rrd_field_names)) {
-					foreach($nt_rrd_field_names as $field) {
+				if (cacti_sizeof($rrd_field_names)) {
+					foreach($rrd_field_names as $field) {
 						if (cacti_sizeof($unused_data_source_names) && isset($unused_data_source_names[$field])) {
 							continue;
 						}

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -26,6 +26,38 @@
  * boost_array_orderby - performs a multicolumn sort of an
  *   array
  */
+/**
+ * Ensure poller_output_boost_processes has the run_id/child_id shape.
+ * Git-following 1.2.x installs can already be stamped 1.2.32 without
+ * ever running an upgrade file that adds those columns.
+ */
+function boost_ensure_process_table() {
+	if (!db_table_exists('poller_output_boost_processes')) {
+		db_execute('CREATE TABLE `poller_output_boost_processes` (
+			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
+			`run_id` char(32) NOT NULL default "",
+			`child_id` int(10) unsigned NOT NULL default "0",
+			`status` varchar(255) default NULL,
+			PRIMARY KEY (`sock_int_value`),
+			UNIQUE KEY `run_child` (`run_id`, `child_id`))
+			ENGINE=MEMORY');
+
+		return;
+	}
+
+	if (db_column_exists('poller_output_boost_processes', 'run_id')) {
+		return;
+	}
+
+	db_execute('TRUNCATE TABLE poller_output_boost_processes');
+	db_execute('ALTER TABLE poller_output_boost_processes ADD `run_id` char(32) NOT NULL default "" AFTER `sock_int_value`');
+	db_execute('ALTER TABLE poller_output_boost_processes ADD `child_id` int(10) unsigned NOT NULL default "0" AFTER `run_id`');
+
+	if (!db_index_exists('poller_output_boost_processes', 'run_child')) {
+		db_execute('ALTER TABLE poller_output_boost_processes ADD UNIQUE KEY `run_child` (`run_id`, `child_id`)');
+	}
+}
+
 function boost_array_orderby() {
 	$args = func_get_args();
 	$data = array_shift($args);

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -29,16 +29,20 @@
  */
 function boost_ensure_process_table() {
 	if (!db_table_exists('poller_output_boost_processes')) {
-		db_execute("CREATE TABLE `poller_output_boost_processes` (
+		if (db_execute("CREATE TABLE `poller_output_boost_processes` (
 			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
 			`run_id` char(32) NOT NULL default '',
 			`child_id` int(10) unsigned NOT NULL default '0',
 			`status` varchar(255) default NULL,
 			PRIMARY KEY (`sock_int_value`),
 			UNIQUE KEY `run_child` (`run_id`, `child_id`))
-			ENGINE=MEMORY");
+			ENGINE=MEMORY") === false) {
+			cacti_log('ERROR: Unable to create poller_output_boost_processes', true, 'BOOST');
 
-		return;
+			return false;
+		}
+
+		return true;
 	}
 
 	$needs_run_id   = !db_column_exists('poller_output_boost_processes', 'run_id');
@@ -46,22 +50,40 @@ function boost_ensure_process_table() {
 	$needs_key      = !db_index_exists('poller_output_boost_processes', 'run_child');
 
 	if (!$needs_run_id && !$needs_child_id && !$needs_key) {
-		return;
+		return true;
 	}
 
-	db_execute('TRUNCATE TABLE poller_output_boost_processes');
-
 	if ($needs_run_id) {
-		db_execute("ALTER TABLE poller_output_boost_processes ADD `run_id` char(32) NOT NULL default '' AFTER `sock_int_value`");
+		if (db_execute("ALTER TABLE poller_output_boost_processes ADD `run_id` char(32) NOT NULL default '' AFTER `sock_int_value`") === false) {
+			cacti_log('ERROR: Unable to add run_id to poller_output_boost_processes', true, 'BOOST');
+
+			return false;
+		}
 	}
 
 	if ($needs_child_id) {
-		db_execute("ALTER TABLE poller_output_boost_processes ADD `child_id` int(10) unsigned NOT NULL default '0' AFTER `run_id`");
+		if (db_execute("ALTER TABLE poller_output_boost_processes ADD `child_id` int(10) unsigned NOT NULL default '0' AFTER `run_id`") === false) {
+			cacti_log('ERROR: Unable to add child_id to poller_output_boost_processes', true, 'BOOST');
+
+			return false;
+		}
 	}
 
 	if ($needs_key) {
-		db_execute('ALTER TABLE poller_output_boost_processes ADD UNIQUE KEY `run_child` (`run_id`, `child_id`)');
+		if (db_execute('TRUNCATE TABLE poller_output_boost_processes') === false) {
+			cacti_log('ERROR: Unable to truncate poller_output_boost_processes before adding run_child', true, 'BOOST');
+
+			return false;
+		}
+
+		if (db_execute('ALTER TABLE poller_output_boost_processes ADD UNIQUE KEY `run_child` (`run_id`, `child_id`)') === false) {
+			cacti_log('ERROR: Unable to add run_child key to poller_output_boost_processes', true, 'BOOST');
+
+			return false;
+		}
 	}
+
+	return true;
 }
 
 /**

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -49,9 +49,7 @@ function boost_ensure_process_table() {
 		return;
 	}
 
-	if ($needs_run_id || $needs_child_id) {
-		db_execute('TRUNCATE TABLE poller_output_boost_processes');
-	}
+	db_execute('TRUNCATE TABLE poller_output_boost_processes');
 
 	if ($needs_run_id) {
 		db_execute("ALTER TABLE poller_output_boost_processes ADD `run_id` char(32) NOT NULL default '' AFTER `sock_int_value`");

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -27,6 +27,25 @@
  * Git-following 1.2.x installs can already be stamped 1.2.32 without
  * ever running an upgrade file that adds those columns.
  */
+function boost_process_table_exists_uncached() {
+	return (bool) db_fetch_cell_prepared('SELECT COUNT(*)
+		FROM information_schema.TABLES
+		WHERE TABLE_SCHEMA = SCHEMA()
+		AND TABLE_NAME = ?', array('poller_output_boost_processes'));
+}
+
+function boost_process_column_exists_uncached($column) {
+	if (!in_array($column, array('run_id', 'child_id'), true)) {
+		return false;
+	}
+
+	return (bool) db_fetch_cell_prepared('SELECT COUNT(*)
+		FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = SCHEMA()
+		AND TABLE_NAME = ?
+		AND COLUMN_NAME = ?', array('poller_output_boost_processes', $column));
+}
+
 function boost_ensure_process_table($repair_key = false) {
 	if (!db_table_exists('poller_output_boost_processes')) {
 		if (db_execute("CREATE TABLE IF NOT EXISTS `poller_output_boost_processes` (
@@ -36,7 +55,7 @@ function boost_ensure_process_table($repair_key = false) {
 			`status` varchar(255) default NULL,
 			PRIMARY KEY (`sock_int_value`),
 			UNIQUE KEY `run_child` (`run_id`, `child_id`))
-			ENGINE=MEMORY") === false && !db_table_exists('poller_output_boost_processes')) {
+			ENGINE=MEMORY") === false && !boost_process_table_exists_uncached()) {
 			cacti_log('ERROR: Unable to create poller_output_boost_processes', true, 'BOOST');
 
 			return false;
@@ -55,7 +74,7 @@ function boost_ensure_process_table($repair_key = false) {
 
 	if ($needs_run_id) {
 		if (db_execute("ALTER TABLE poller_output_boost_processes ADD `run_id` char(32) NOT NULL default '' AFTER `sock_int_value`") === false &&
-			!db_column_exists('poller_output_boost_processes', 'run_id')) {
+			!boost_process_column_exists_uncached('run_id')) {
 			cacti_log('ERROR: Unable to add run_id to poller_output_boost_processes', true, 'BOOST');
 
 			return false;
@@ -64,7 +83,7 @@ function boost_ensure_process_table($repair_key = false) {
 
 	if ($needs_child_id) {
 		if (db_execute("ALTER TABLE poller_output_boost_processes ADD `child_id` int(10) unsigned NOT NULL default '0' AFTER `run_id`") === false &&
-			!db_column_exists('poller_output_boost_processes', 'child_id')) {
+			!boost_process_column_exists_uncached('child_id')) {
 			cacti_log('ERROR: Unable to add child_id to poller_output_boost_processes', true, 'BOOST');
 
 			return false;
@@ -521,7 +540,7 @@ function boost_atomic_write_cache($cache_file, $output) {
 
 	$flushed = fflush($fileptr);
 	fclose($fileptr);
-	if (!$flushed || !chmod($temp_file, 0644)) {
+	if (!$flushed || !chmod($temp_file, 0640)) {
 		@unlink($temp_file);
 
 		return false;

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -503,6 +503,8 @@ function boost_atomic_write_cache($cache_file, $output) {
 	$temp_file = tempnam(dirname($cache_file), '.boost-');
 
 	if ($temp_file === false) {
+		cacti_log('ERROR: Boost could not create a temporary graph cache file.', false, 'BOOST');
+
 		return false;
 	}
 
@@ -510,6 +512,7 @@ function boost_atomic_write_cache($cache_file, $output) {
 
 	if ($fileptr === false) {
 		@unlink($temp_file);
+		cacti_log('ERROR: Boost could not open its temporary graph cache file.', false, 'BOOST');
 
 		return false;
 	}
@@ -529,6 +532,7 @@ function boost_atomic_write_cache($cache_file, $output) {
 			if ($result === false || $result === 0) {
 				fclose($fileptr);
 				@unlink($temp_file);
+				cacti_log('ERROR: Boost could not finish writing its graph cache file.', false, 'BOOST');
 
 				return false;
 			}
@@ -540,10 +544,16 @@ function boost_atomic_write_cache($cache_file, $output) {
 
 	$flushed = fflush($fileptr);
 	fclose($fileptr);
-	if (!$flushed || !chmod($temp_file, 0640)) {
+	if (!$flushed) {
 		@unlink($temp_file);
+		cacti_log('ERROR: Boost could not flush its graph cache file.', false, 'BOOST');
 
 		return false;
+	}
+
+	if (!chmod($temp_file, 0640)) {
+		/* tempnam() creates a stricter 0600 file, so publication remains safe. */
+		cacti_log('WARNING: Boost could not set shared graph cache permissions; publishing with the existing stricter mode.', false, 'BOOST');
 	}
 
 	$published = @rename($temp_file, $cache_file);
@@ -554,6 +564,7 @@ function boost_atomic_write_cache($cache_file, $output) {
 
 	if (!$published) {
 		@unlink($temp_file);
+		cacti_log('ERROR: Boost could not publish its graph cache file.', false, 'BOOST');
 
 		return false;
 	}

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -172,7 +172,7 @@ function boost_error_handler($errno, $errmsg, $filename, $linenum, $vars = []) {
 		}
 
 		/* create an error string for the log */
-		$err = "ERRNO:'"  . $errno   . "' TYPE:'"    . $errortype[$errno] .
+		$err = "ERRNO:'"  . $errno   . "' TYPE:'"    . ($errortype[$errno] ?? 'Unknown Error') .
 			"' MESSAGE:'" . $errmsg  . "' IN FILE:'" . $filename .
 			"' LINE NO:'" . $linenum . "'";
 
@@ -224,7 +224,6 @@ function boost_flush_output_batch($value_tuples, $conn = false) {
 	$overhead   = strlen($sql_prefix) + 1;
 	$out_buffer = '';
 	$out_length = 0;
-	$success    = true;
 	$rows       = 0;
 
 	foreach ($value_tuples as $tuple) {
@@ -238,7 +237,7 @@ function boost_flush_output_batch($value_tuples, $conn = false) {
 			}
 
 			if (!$acknowledged) {
-				$success = false;
+				return false;
 			} elseif (db_affected_rows($conn) < $rows) {
 				cacti_log('WARNING: Boost staging ignored one or more duplicate sample keys.', false, 'BOOST');
 			}
@@ -261,13 +260,13 @@ function boost_flush_output_batch($value_tuples, $conn = false) {
 		}
 
 		if (!$acknowledged) {
-			$success = false;
+			return false;
 		} elseif (db_affected_rows($conn) < $rows) {
 			cacti_log('WARNING: Boost staging ignored one or more duplicate sample keys.', false, 'BOOST');
 		}
 	}
 
-	return $success;
+	return true;
 }
 
 function boost_validate_poller_ownership($results, $poller_id, $conn = false) {
@@ -459,7 +458,7 @@ function boost_graph_cache_filename($cache_directory, $local_graph_id, $rra_id, 
 		if (!is_string($secret) || !preg_match('/^[a-f0-9]{64}$/D', $secret)) {
 			$candidate = bin2hex(random_bytes(32));
 			db_execute_prepared('INSERT IGNORE INTO settings (name, value) VALUES (?, ?)', array('boost_png_cache_secret', $candidate));
-			$secret = read_config_option('boost_png_cache_secret');
+			$secret = read_config_option('boost_png_cache_secret', true);
 
 			if (!is_string($secret) || !preg_match('/^[a-f0-9]{64}$/D', $secret)) {
 				$secret = $candidate;
@@ -478,7 +477,7 @@ function boost_graph_cache_filename($cache_directory, $local_graph_id, $rra_id, 
 		'nolegend'       => isset($graph_data_array['graph_nolegend'])
 	));
 
-	return rtrim($cache_directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . hash_hmac('sha256', $cache_key, $secret) . '.png';
+	return rtrim($cache_directory, '/\\') . DIRECTORY_SEPARATOR . hash_hmac('sha256', $cache_key, $secret) . '.png';
 }
 
 function boost_atomic_write_cache($cache_file, $output) {
@@ -496,33 +495,73 @@ function boost_atomic_write_cache($cache_file, $output) {
 		return false;
 	}
 
-	$length  = strlen($output);
-	$written = 0;
+	$length     = strlen($output);
+	$written    = 0;
+	$chunk_size = 1024 * 1024;
 
 	while ($written < $length) {
-		$result = fwrite($fileptr, substr($output, $written));
+		$chunk         = substr($output, $written, $chunk_size);
+		$chunk_length  = strlen($chunk);
+		$chunk_written = 0;
 
-		if ($result === false || $result === 0) {
-			fclose($fileptr);
-			@unlink($temp_file);
+		while ($chunk_written < $chunk_length) {
+			$result = fwrite($fileptr, substr($chunk, $chunk_written));
 
-			return false;
+			if ($result === false || $result === 0) {
+				fclose($fileptr);
+				@unlink($temp_file);
+
+				return false;
+			}
+
+			$chunk_written += $result;
+			$written       += $result;
 		}
-
-		$written += $result;
 	}
 
 	$flushed = fflush($fileptr);
 	fclose($fileptr);
-	chmod($temp_file, 0640);
+	if (!$flushed || !chmod($temp_file, 0644)) {
+		@unlink($temp_file);
 
-	if (!$flushed || !rename($temp_file, $cache_file)) {
+		return false;
+	}
+
+	$published = @rename($temp_file, $cache_file);
+
+	if (!$published && PHP_OS_FAMILY === 'Windows') {
+		$published = boost_replace_cache_file_on_windows($temp_file, $cache_file);
+	}
+
+	if (!$published) {
 		@unlink($temp_file);
 
 		return false;
 	}
 
 	return true;
+}
+
+function boost_replace_cache_file_on_windows($temp_file, $cache_file) {
+	if (!is_file($temp_file) || !is_file($cache_file)) {
+		return false;
+	}
+
+	$backup_file = tempnam(dirname($cache_file), '.boost-old-');
+
+	if ($backup_file === false || !@unlink($backup_file) || !@rename($cache_file, $backup_file)) {
+		return false;
+	}
+
+	if (@rename($temp_file, $cache_file)) {
+		@unlink($backup_file);
+
+		return true;
+	}
+
+	@rename($backup_file, $cache_file);
+
+	return false;
 }
 
 function boost_graph_cache_check($local_graph_id, $rra_id, $rrdtool_pipe, &$graph_data_array, $return = true) {
@@ -878,6 +917,12 @@ function boost_get_arch_table_names($latest_table = '') {
 function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 	global $config, $database_default, $boost_sock, $boost_timeout, $debug, $get_memory, $memory_used;
 
+	$local_data_id = (int) $local_data_id;
+
+	if ($local_data_id <= 0) {
+		return -1;
+	}
+
 	static $archive_table = false;
 	static $warning_issued;
 
@@ -906,7 +951,7 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 	/* avoid getting rows in the middle of poller run */
 	$timestamp = db_fetch_cell('SELECT MIN(UNIX_TIMESTAMP(start_time))
 		FROM poller_time
-		WHERE end_time="0000-00-00"');
+		WHERE end_time=\'0000-00-00\'');
 
 	if (empty($timestamp)) {
 		$timestamp = time() - 10;
@@ -1076,7 +1121,7 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 					$vals_in_buffer = 0;
 
 					/* check return status for delete operation */
-					if (strpos(trim($return_value), 'OK') === false && $return_value != '') {
+					if (trim((string) $return_value) !== 'OK') {
 						cacti_log("WARNING: RRD Update Warning '" . $return_value . "' for Local Data ID '$local_data_id'", false, 'BOOST');
 						$updates_ok = false;
 					}
@@ -1273,7 +1318,7 @@ function boost_process_poller_output($local_data_id, $rrdtool_pipe = '') {
 			boost_timer('rrdupdate', BOOST_TIMER_END);
 
 			/* check return status for delete operation */
-			if (strpos(trim($return_value), 'OK') === false && $return_value != '') {
+			if (trim((string) $return_value) !== 'OK') {
 				cacti_log("WARNING: RRD Update Warning '" . $return_value . "' for Local Data ID '$local_data_id'", false, 'BOOST');
 				$updates_ok = false;
 			}
@@ -1740,9 +1785,19 @@ function boost_rrdtool_function_update($local_data_id, $rrd_path, $rrd_update_te
 
 		// Check for a Data Source that has been removed
 		if ($ds_exists) {
-			$valid_entry = boost_rrdtool_function_create($local_data_id, false, $rrdtool_pipe);
+			boost_rrdtool_function_create($local_data_id, false, $rrdtool_pipe);
+
+			if (read_config_option('storage_location')) {
+				$valid_entry = rrdtool_execute_path_command('file_exists', $rrd_path, '', true, RRDTOOL_OUTPUT_BOOLEAN, $rrdtool_pipe, 'BOOST');
+			} else {
+				$valid_entry = file_exists($rrd_path);
+			}
 		} else {
 			return 'OK';
+		}
+
+		if (!$valid_entry) {
+			return 'ERROR: Unable to create RRD file';
 		}
 	}
 

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -27,7 +27,7 @@
  * Git-following 1.2.x installs can already be stamped 1.2.32 without
  * ever running an upgrade file that adds those columns.
  */
-function boost_ensure_process_table() {
+function boost_ensure_process_table($repair_key = false) {
 	if (!db_table_exists('poller_output_boost_processes')) {
 		if (db_execute("CREATE TABLE `poller_output_boost_processes` (
 			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
@@ -47,7 +47,7 @@ function boost_ensure_process_table() {
 
 	$needs_run_id   = !db_column_exists('poller_output_boost_processes', 'run_id');
 	$needs_child_id = !db_column_exists('poller_output_boost_processes', 'child_id');
-	$needs_key      = !db_index_exists('poller_output_boost_processes', 'run_child');
+	$needs_key      = $repair_key && !db_index_exists('poller_output_boost_processes', 'run_child');
 
 	if (!$needs_run_id && !$needs_child_id && !$needs_key) {
 		return true;

--- a/lib/boost.php
+++ b/lib/boost.php
@@ -29,14 +29,14 @@
  */
 function boost_ensure_process_table($repair_key = false) {
 	if (!db_table_exists('poller_output_boost_processes')) {
-		if (db_execute("CREATE TABLE `poller_output_boost_processes` (
+		if (db_execute("CREATE TABLE IF NOT EXISTS `poller_output_boost_processes` (
 			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
 			`run_id` char(32) NOT NULL default '',
 			`child_id` int(10) unsigned NOT NULL default '0',
 			`status` varchar(255) default NULL,
 			PRIMARY KEY (`sock_int_value`),
 			UNIQUE KEY `run_child` (`run_id`, `child_id`))
-			ENGINE=MEMORY") === false) {
+			ENGINE=MEMORY") === false && !db_table_exists('poller_output_boost_processes')) {
 			cacti_log('ERROR: Unable to create poller_output_boost_processes', true, 'BOOST');
 
 			return false;
@@ -54,7 +54,8 @@ function boost_ensure_process_table($repair_key = false) {
 	}
 
 	if ($needs_run_id) {
-		if (db_execute("ALTER TABLE poller_output_boost_processes ADD `run_id` char(32) NOT NULL default '' AFTER `sock_int_value`") === false) {
+		if (db_execute("ALTER TABLE poller_output_boost_processes ADD `run_id` char(32) NOT NULL default '' AFTER `sock_int_value`") === false &&
+			!db_column_exists('poller_output_boost_processes', 'run_id')) {
 			cacti_log('ERROR: Unable to add run_id to poller_output_boost_processes', true, 'BOOST');
 
 			return false;
@@ -62,7 +63,8 @@ function boost_ensure_process_table($repair_key = false) {
 	}
 
 	if ($needs_child_id) {
-		if (db_execute("ALTER TABLE poller_output_boost_processes ADD `child_id` int(10) unsigned NOT NULL default '0' AFTER `run_id`") === false) {
+		if (db_execute("ALTER TABLE poller_output_boost_processes ADD `child_id` int(10) unsigned NOT NULL default '0' AFTER `run_id`") === false &&
+			!db_column_exists('poller_output_boost_processes', 'child_id')) {
 			cacti_log('ERROR: Unable to add child_id to poller_output_boost_processes', true, 'BOOST');
 
 			return false;
@@ -76,7 +78,8 @@ function boost_ensure_process_table($repair_key = false) {
 			return false;
 		}
 
-		if (db_execute('ALTER TABLE poller_output_boost_processes ADD UNIQUE KEY `run_child` (`run_id`, `child_id`)') === false) {
+		if (db_execute('ALTER TABLE poller_output_boost_processes ADD UNIQUE KEY `run_child` (`run_id`, `child_id`)') === false &&
+			!db_index_exists('poller_output_boost_processes', 'run_child')) {
 			cacti_log('ERROR: Unable to add run_child key to poller_output_boost_processes', true, 'BOOST');
 
 			return false;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3224,23 +3224,25 @@ function generate_data_source_path($local_data_id) {
 function generate_graph_best_cf($local_data_id, $requested_cf, $ds_step = 60) {
 	static $best_cf = 1;
 
-	if ($local_data_id > 0) {
-		$avail_cf_functions = get_rrd_cfs($local_data_id);
+	if ($local_data_id <= 0) {
+		return 1;
+	}
 
-		if (cacti_sizeof($avail_cf_functions)) {
-			/* workaround until we have RRA presets in 0.8.8 */
-			/* check through the cf's and get the best */
-			/* if none was found, take the first */
-			$best_cf = reset($avail_cf_functions);
+	$avail_cf_functions = get_rrd_cfs($local_data_id);
 
-			foreach($avail_cf_functions as $cf) {
-				if ($cf == $requested_cf) {
-					$best_cf = $requested_cf;
-				}
+	if (cacti_sizeof($avail_cf_functions)) {
+		/* workaround until we have RRA presets in 0.8.8 */
+		/* check through the cf's and get the best */
+		/* if none was found, take the first */
+		$best_cf = reset($avail_cf_functions);
+
+		foreach($avail_cf_functions as $cf) {
+			if ($cf == $requested_cf) {
+				$best_cf = $requested_cf;
 			}
-		} else {
-			$best_cf = '1';
 		}
+	} else {
+		$best_cf = '1';
 	}
 
 	/* if you can not figure it out return average */

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3222,7 +3222,7 @@ function generate_data_source_path($local_data_id) {
  *  @return - the best cf to use
  */
 function generate_graph_best_cf($local_data_id, $requested_cf, $ds_step = 60) {
-	static $best_cf;
+	static $best_cf = 1;
 
 	if ($local_data_id > 0) {
 		$avail_cf_functions = get_rrd_cfs($local_data_id);

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -3242,7 +3242,7 @@ function generate_graph_best_cf($local_data_id, $requested_cf, $ds_step = 60) {
 			}
 		}
 	} else {
-		$best_cf = '1';
+		$best_cf = 1;
 	}
 
 	/* if you can not figure it out return average */

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -1710,6 +1710,8 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 	if (cacti_sizeof($graph_items)) {
 		/* we need to add a new column 'cf_reference', so unless PHP 5 is used, this foreach syntax is required */
 		foreach ($graph_items as $key => $graph_item) {
+			$dtr_id = $graph_item['data_template_rrd_id'] ?? '';
+
 			/* mimic the old behavior: LINE[123], AREA and STACK items use the CF specified in the graph item */
 			switch ($graph_item['graph_type_id']) {
 				case GRAPH_ITEM_TYPE_LINE1:
@@ -1724,7 +1726,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					/* remember the last CF for this data source for use with GPRINT
 					 * if e.g. an AREA/AVERAGE and a LINE/MAX is used
 					 * we will have AVERAGE first and then MAX, depending on GPRINT sequence */
-					$last_graph_cf[$graph_item['data_source_name']][$graph_item['local_data_template_rrd_id']] = $graph_cf;
+					$last_graph_cf[$graph_item['data_source_name'] ?? ''][$graph_item['local_data_template_rrd_id'] ?? ''] = $graph_cf;
 
 					/* remember this for second foreach loop */
 					$graph_items[$key]['cf_reference'] = $graph_cf;
@@ -1737,8 +1739,8 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					 * see 'man rrdgraph_data' for the correct VDEF based notation
 					 * so our task now is to 'guess' the very graph_item, this GPRINT is related to
 					 * and to use that graph_item's CF */
-					if (isset($last_graph_cf[$graph_item['data_source_name']][$graph_item['local_data_template_rrd_id']])) {
-						$graph_cf = $last_graph_cf[$graph_item['data_source_name']][$graph_item['local_data_template_rrd_id']];
+					if (isset($last_graph_cf[$graph_item['data_source_name'] ?? ''][$graph_item['local_data_template_rrd_id'] ?? ''])) {
+						$graph_cf = $last_graph_cf[$graph_item['data_source_name'] ?? ''][$graph_item['local_data_template_rrd_id'] ?? ''];
 						/* remember this for second foreach loop */
 						$graph_items[$key]['cf_reference'] = $graph_cf;
 					} else {
@@ -1778,7 +1780,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					break;
 			}
 
-			if (!empty($graph_item['local_data_id']) && !isset($cf_ds_cache[$graph_item['data_template_rrd_id']][$graph_cf])) {
+			if (!empty($graph_item['local_data_id']) && !isset($cf_ds_cache[$dtr_id][$graph_cf])) {
 				/* use a user-specified ds path if one is entered */
 				if (isset($graph_data_array['export_realtime'])) {
 					if (!isset($_SESSION['sess_realtime_hash'])) {
@@ -1818,7 +1820,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					the same way, except a 'cdef' is put on the beginning of the hash */
 					$graph_defs .= 'DEF:' . generate_graph_def_name(strval($i)) . '=' . cacti_escapeshellarg($data_source_path) . ':' . cacti_escapeshellarg($graph_item['data_source_name'], true) . ':' . $consolidation_functions[$graph_cf] . RRD_NL;
 
-					$cf_ds_cache[$graph_item['data_template_rrd_id']][$graph_cf] = "$i";
+					$cf_ds_cache[$dtr_id][$graph_cf] = "$i";
 
 					$i++;
 				}
@@ -1971,6 +1973,8 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 
 	if (cacti_sizeof($graph_items)) {
 		foreach ($graph_items as $graph_item) {
+			$dtr_id = $graph_item['data_template_rrd_id'] ?? '';
+
 			// ToDO: The code blcok appears to not be required as at the end of the block
 			// we simply discard the $cf_id for the computed 'cf_reference' that was
 			// computed previously.
@@ -1991,18 +1995,18 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 
 			/* first we need to check if there is a DEF for the current data source/cf combination. if so,
 			we will use that */
-			if (isset($cf_ds_cache[$graph_item['data_template_rrd_id']][$graph_cf])) {
+			if (isset($cf_ds_cache[$dtr_id][$graph_cf])) {
 				$cf_id = $graph_item['consolidation_function_id'];
 			} else {
 				/* if there is not a DEF defined for the current data source/cf combination, then we will have to
 				improvise. choose the first available cf in the following order: AVERAGE, MAX, MIN, LAST */
-				if (isset($cf_ds_cache[$graph_item['data_template_rrd_id']][1])) {
+				if (isset($cf_ds_cache[$dtr_id][1])) {
 					$cf_id = 1; // CF: AVERAGE
-				} elseif (isset($cf_ds_cache[$graph_item['data_template_rrd_id']][3])) {
+				} elseif (isset($cf_ds_cache[$dtr_id][3])) {
 					$cf_id = 3; // CF: MAX
-				} elseif (isset($cf_ds_cache[$graph_item['data_template_rrd_id']][2])) {
+				} elseif (isset($cf_ds_cache[$dtr_id][2])) {
 					$cf_id = 2; // CF: MIN
-				} elseif (isset($cf_ds_cache[$graph_item['data_template_rrd_id']][4])) {
+				} elseif (isset($cf_ds_cache[$dtr_id][4])) {
 					$cf_id = 4; // CF: LAST
 				} else {
 					$cf_id = 1; // CF: AVERAGE
@@ -2010,7 +2014,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 			}
 
 			/* Compensate for RRDfiles that are missing CF's required for the Graph Template */
-			$cf_id = $graph_item['cf_reference'];
+			$cf_id = $graph_item['cf_reference'] ?? 1;
 
 			/* +++++++++++++++++++++++ GRAPH ITEMS: CDEF START +++++++++++++++++++++++ */
 
@@ -2018,7 +2022,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 			data source of global cdef, but is unique when those two variables combine. */
 			$cdef_graph_defs = '';
 
-			if ((!empty($graph_item['cdef_id'])) && (!isset($cdef_cache[$graph_item['cdef_id']][$graph_item['data_template_rrd_id']][$cf_id]))) {
+			if ((!empty($graph_item['cdef_id'])) && (!isset($cdef_cache[$graph_item['cdef_id']][$dtr_id][$cf_id]))) {
 				$cdef_string 	= $graph_variables['cdef_cache'][$graph_item['graph_templates_item_id']];
 				$magic_item 	= array();
 				$already_seen	= array();
@@ -2176,7 +2180,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 					$cdef_string = str_replace('CURRENT_DATA_SOURCE_PI', read_config_option('poller_interval'), $cdef_string);
 				}
 
-				$cdef_string = str_replace('CURRENT_DATA_SOURCE', generate_graph_def_name(strval((isset($cf_ds_cache[$graph_item['data_template_rrd_id']][$cf_id]) ? $cf_ds_cache[$graph_item['data_template_rrd_id']][$cf_id] : '0'))), $cdef_string);
+				$cdef_string = str_replace('CURRENT_DATA_SOURCE', generate_graph_def_name(strval((isset($cf_ds_cache[$dtr_id][$cf_id]) ? $cf_ds_cache[$dtr_id][$cf_id] : '0'))), $cdef_string);
 
 				/* allow automatic rate calculations on raw gauge data */
 				if (isset($graph_item['local_data_id'])) {
@@ -2276,7 +2280,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 				$cdef_graph_defs .= " \\\n";
 
 				/* the CDEF cache is so we do not create duplicate CDEF's on a graph */
-				$cdef_cache[$graph_item['cdef_id']][$graph_item['data_template_rrd_id']][$cf_id] = $i;
+				$cdef_cache[$graph_item['cdef_id']][$dtr_id][$cf_id] = $i;
 			}
 
 			/* add the cdef string to the end of the def string */
@@ -2289,15 +2293,15 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 			/* make vdef string here, copied from cdef stuff */
 			$vdef_graph_defs = '';
 
-			if ((!empty($graph_item['vdef_id'])) && (!isset($vdef_cache[$graph_item['vdef_id']][$graph_item['cdef_id']][$graph_item['data_template_rrd_id']][$cf_id]))) {
+			if ((!empty($graph_item['vdef_id'])) && (!isset($vdef_cache[$graph_item['vdef_id']][$graph_item['cdef_id']][$dtr_id][$cf_id]))) {
 				$vdef_string = $graph_variables['vdef_cache'][$graph_item['graph_templates_item_id']];
 				/* do we refer to a CDEF within this VDEF? */
 				if ($graph_item['cdef_id'] != '0') {
 					/* 'calculated' VDEF: use (cached) CDEF as base, only way to get calculations into VDEFs */
-					$vdef_string = 'cdef' . str_replace('CURRENT_DATA_SOURCE', generate_graph_def_name(strval(isset($cdef_cache[$graph_item['cdef_id']][$graph_item['data_template_rrd_id']][$cf_id]) ? $cdef_cache[$graph_item['cdef_id']][$graph_item['data_template_rrd_id']][$cf_id] : '0')), $vdef_string);
+					$vdef_string = 'cdef' . str_replace('CURRENT_DATA_SOURCE', generate_graph_def_name(strval(isset($cdef_cache[$graph_item['cdef_id']][$dtr_id][$cf_id]) ? $cdef_cache[$graph_item['cdef_id']][$dtr_id][$cf_id] : '0')), $vdef_string);
 				} else {
 					/* 'pure' VDEF: use DEF as base */
-					$vdef_string = str_replace('CURRENT_DATA_SOURCE', generate_graph_def_name(strval(isset($cf_ds_cache[$graph_item['data_template_rrd_id']][$cf_id]) ? $cf_ds_cache[$graph_item['data_template_rrd_id']][$cf_id] : '0')), $vdef_string);
+					$vdef_string = str_replace('CURRENT_DATA_SOURCE', generate_graph_def_name(strval(isset($cf_ds_cache[$dtr_id][$cf_id]) ? $cf_ds_cache[$dtr_id][$cf_id] : '0')), $vdef_string);
 				}
 
 				# TODO: It would be possible to refer to a CDEF, but that's all. So ALL_DATA_SOURCES_NODUPS and stuff can't be used directly!
@@ -2314,7 +2318,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 				/* the VDEF cache is so we do not create duplicate VDEFs on a graph,
 				* but take info account, that same VDEF may use different CDEFs
 				* so index over VDEF_ID, CDEF_ID per DATA_TEMPLATE_RRD_ID, lvm */
-				$vdef_cache[$graph_item['vdef_id']][$graph_item['cdef_id']][$graph_item['data_template_rrd_id']][$cf_id] = $i;
+				$vdef_cache[$graph_item['vdef_id']][$graph_item['cdef_id']][$dtr_id][$cf_id] = $i;
 			}
 
 			/* add the cdef string to the end of the def string */
@@ -2332,13 +2336,13 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 			/* IF this graph item has a data source... get a DEF name for it, or the cdef if that applies
 			to this graph item */
 			if ($graph_item['cdef_id'] == '0') {
-				if (isset($cf_ds_cache[$graph_item['data_template_rrd_id']][$cf_id])) {
-					$data_source_name = generate_graph_def_name(strval($cf_ds_cache[$graph_item['data_template_rrd_id']][$cf_id]));
+				if (isset($cf_ds_cache[$dtr_id][$cf_id])) {
+					$data_source_name = generate_graph_def_name(strval($cf_ds_cache[$dtr_id][$cf_id]));
 				} else {
 					$data_source_name = '';
 				}
 			} else {
-				$data_source_name = 'cdef' . generate_graph_def_name(strval($cdef_cache[$graph_item['cdef_id']][$graph_item['data_template_rrd_id']][$cf_id]));
+				$data_source_name = 'cdef' . generate_graph_def_name(strval($cdef_cache[$graph_item['cdef_id']][$dtr_id][$cf_id]));
 			}
 
 			/* IF this graph item has a data source... get a DEF name for it, or the vdef if that applies
@@ -2346,7 +2350,7 @@ function rrdtool_function_graph($local_graph_id, $rra_id, $graph_data_array, $rr
 			if ($graph_item['vdef_id'] == '0') {
 				/* do not overwrite $data_source_name that stems from cdef above */
 			} else {
-				$data_source_name = 'vdef' . generate_graph_def_name(strval($vdef_cache[$graph_item['vdef_id']][$graph_item['cdef_id']][$graph_item['data_template_rrd_id']][$cf_id]));
+				$data_source_name = 'vdef' . generate_graph_def_name(strval($vdef_cache[$graph_item['vdef_id']][$graph_item['cdef_id']][$dtr_id][$cf_id]));
 			}
 
 			/* to make things easier... if there is no text format set; set blank text */

--- a/poller.php
+++ b/poller.php
@@ -1024,17 +1024,7 @@ function poller_table_maintenance() {
 		db_execute('ALTER TABLE poller_output_boost ENGINE=InnoDB');
 	}
 
-	// catch the unlikely event that the poller_output_boost_processes is missing
-	if (!db_table_exists('poller_output_boost_processes')) {
-		db_execute('CREATE TABLE  `poller_output_boost_processes` (
-			`sock_int_value` bigint(20) unsigned NOT NULL auto_increment,
-			`run_id` char(32) NOT NULL default "",
-			`child_id` int(10) unsigned NOT NULL default "0",
-			`status` varchar(255) default NULL,
-			PRIMARY KEY (`sock_int_value`),
-			UNIQUE KEY `run_child` (`run_id`, `child_id`))
-			ENGINE=MEMORY');
-	}
+	boost_ensure_process_table();
 
 	// catch the unlikely event that the poller_output_realtime is missing
 	if (!db_table_exists('poller_output_realtime')) {

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -185,6 +185,8 @@ if ($child == false) {
 		/* Check if processes are running and kill them */
 		boost_kill_running_processes();
 
+		boost_ensure_process_table();
+
 		/* Truncate the rrd_update_counter table */
 		db_execute('TRUNCATE TABLE poller_output_boost_processes');
 

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -277,14 +277,14 @@ if ($child == false) {
 				dsstats_boost_bottom();
 				rrdcheck_boost_bottom();
 
-					api_plugin_hook('boost_poller_bottom');
-				}
-			} else {
-				$rrd_updates = 0;
-				set_config_option('boost_poller_status', 'failed - end time:' . date('Y-m-d H:i:s'));
-				set_config_option('boost_last_run_time', $last_run_time);
-				cacti_log('ERROR: Boost preparation failed; no child processes were launched.', true, 'BOOST');
+				api_plugin_hook('boost_poller_bottom');
 			}
+		} else {
+			$rrd_updates = 0;
+			set_config_option('boost_poller_status', 'failed - end time:' . date('Y-m-d H:i:s'));
+			set_config_option('boost_last_run_time', $last_run_time);
+			cacti_log('ERROR: Boost preparation failed; no child processes were launched.', true, 'BOOST');
+		}
 
 		cacti_log('INFO: Boost unregistering master process', true, 'BOOST');
 

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -185,7 +185,10 @@ if ($child == false) {
 		/* Check if processes are running and kill them */
 		boost_kill_running_processes();
 
-		boost_ensure_process_table();
+		if (boost_ensure_process_table() === false) {
+			cacti_log('ERROR: Boost process table is not ready', true, 'BOOST');
+			exit(1);
+		}
 
 		/* Truncate the rrd_update_counter table */
 		db_execute('TRUNCATE TABLE poller_output_boost_processes');

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -185,7 +185,7 @@ if ($child == false) {
 		/* Check if processes are running and kill them */
 		boost_kill_running_processes();
 
-		if (boost_ensure_process_table() === false) {
+		if (boost_ensure_process_table(true) === false) {
 			cacti_log('ERROR: Boost process table is not ready', true, 'BOOST');
 			unregister_process('boost', 'master', $config['poller_id'], getmypid());
 			exit(1);

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -121,6 +121,7 @@ if (function_exists('pcntl_signal')) {
 $start = microtime(true);
 $start_time = time();
 $rrd_updates = -1;
+$exit_code   = 0;
 
 /* let's give this script lot of time to run for ever */
 ini_set('max_execution_time', '0');
@@ -190,7 +191,11 @@ if ($child == false) {
 		boost_debug('Time to Run Boost, Force Run is ' . ($forcerun ? 'true!':'false.'));
 
 		/* Check if processes are running and kill them */
-		boost_kill_running_processes();
+		if (!boost_kill_running_processes()) {
+			cacti_log('ERROR: Boost could not confirm that the previous workers stopped; shared work tables were not modified.', true, 'BOOST');
+			unregister_process('boost', 'master', $config['poller_id'], getmypid());
+			exit(1);
+		}
 
 		if (boost_ensure_process_table(true) === false) {
 			cacti_log('ERROR: Boost process table is not ready', true, 'BOOST');
@@ -232,9 +237,6 @@ if ($child == false) {
 
 			cacti_log('INFO: Boost last child processes ended.', true, 'BOOST');
 
-			/* tell the main poller that we are done */
-			set_config_option('boost_poller_status', 'complete - end time:' . date('Y-m-d H:i:s'));
-
 			/* Finish processing post */
 			set_config_option('boost_last_run_time', $current_time);
 
@@ -248,6 +250,8 @@ if ($child == false) {
 				AND CAST(status AS SIGNED) >= 0', array($run_id));
 
 			if (!$run_complete) {
+				set_config_option('boost_poller_status', 'failed - end time:' . date('Y-m-d H:i:s'));
+				$exit_code = 1;
 				boost_log_statistics($rrd_updates);
 				set_config_option('boost_last_run_time', $last_run_time);
 				cacti_log('WARNING: Boost retained archive tables because the child run was incomplete or reported an RRD update failure.', true, 'BOOST');
@@ -260,6 +264,12 @@ if ($child == false) {
 			} else { /* rollback last run time */
 				set_config_option('boost_last_run_time', $last_run_time);
 			}
+
+			if ($run_complete) {
+				set_config_option('boost_poller_status', 'complete - end time:' . date('Y-m-d H:i:s'));
+			}
+
+			set_config_option('boost_poller_started', 0);
 
 			if ($rrd_updates > 0 && $run_complete) {
 				cacti_log('INFO: Boost removing archive tables ...', true, 'BOOST');
@@ -282,6 +292,8 @@ if ($child == false) {
 		} else {
 			$rrd_updates = 0;
 			set_config_option('boost_poller_status', 'failed - end time:' . date('Y-m-d H:i:s'));
+			set_config_option('boost_poller_started', 0);
+			$exit_code = 1;
 			set_config_option('boost_last_run_time', $last_run_time);
 			cacti_log('ERROR: Boost preparation failed; no child processes were launched.', true, 'BOOST');
 		}
@@ -294,6 +306,7 @@ if ($child == false) {
 		set_config_option('boost_last_end_time', time());
 	} else {
 		set_config_option('boost_poller_status', 'complete');
+		set_config_option('boost_poller_started', 0);
 	}
 
 	/* store the next run time so that people understand */
@@ -307,7 +320,7 @@ if ($child == false) {
 
 	boost_purge_cached_png_files($forcerun);
 
-	exit(0);
+	exit($exit_code);
 } else {
 	if (!preg_match('/^[a-f0-9]{32}$/D', $run_id)) {
 		cacti_log('ERROR: Boost child refused to run without a valid parent run identifier.', true, 'BOOST');
@@ -337,7 +350,7 @@ if ($child == false) {
 
 	unregister_process('boost', 'child', $child);
 
-	exit($completion_recorded === false ? 1 : 0);
+	exit($completion_recorded === false || $rrd_updates < 0 ? 1 : 0);
 }
 
 function sig_handler($signo) {
@@ -348,12 +361,12 @@ function sig_handler($signo) {
 		case SIGINT:
 			cacti_log('WARNING: Boost Poller terminated by user', true, 'BOOST');
 
-			/* tell the main poller that we are done */
-			set_config_option('boost_poller_status', 'terminated - end time:' . date('Y-m-d H:i:s'));
-
 			if ($child) {
 				unregister_process('boost', 'child', $child, getmypid());
 			} else {
+				/* only the master owns the global Boost lifecycle status */
+				set_config_option('boost_poller_status', 'terminated - end time:' . date('Y-m-d H:i:s'));
+				set_config_option('boost_poller_started', 0);
 				unregister_process('boost', 'master', $config['poller_id'], getmypid());
 			}
 
@@ -371,22 +384,66 @@ function sig_handler($signo) {
 	}
 }
 
-function boost_kill_running_processes() {
+function boost_kill_running_processes($wait_seconds = 10) {
 	$processes = db_fetch_assoc_prepared('SELECT *
 		FROM processes
 		WHERE tasktype = \'boost\'
 		AND pid != ?',
 		array(getmypid()));
 
-	if (cacti_sizeof($processes)) {
-		foreach($processes as $p) {
-			cacti_log(sprintf('WARNING: Killing Boost %s PID %d due to another boost process starting.', ucfirst($p['taskname']), $p['pid']), true, 'BOOST');
-
-			posix_kill($p['pid'], SIGTERM);
-
-			unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], $p['pid']);
-		}
+	if (!cacti_sizeof($processes)) {
+		return true;
 	}
+
+	$waiting = array();
+
+	foreach($processes as $p) {
+		$pid = (int) $p['pid'];
+
+		if (is_system_pid($pid)) {
+			cacti_log(sprintf('ERROR: Refusing to signal reserved Boost PID %d.', $pid), true, 'BOOST');
+
+			return false;
+		}
+
+		if (!cacti_process_still_running($pid)) {
+			unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], $pid);
+			continue;
+		}
+
+		cacti_log(sprintf('WARNING: Stopping Boost %s PID %d due to another boost process starting.', ucfirst($p['taskname']), $pid), true, 'BOOST');
+
+		if (!posix_kill($pid, SIGTERM)) {
+			cacti_log(sprintf('ERROR: Unable to signal Boost PID %d.', $pid), true, 'BOOST');
+
+			return false;
+		}
+
+		$waiting[] = $p;
+	}
+
+	$deadline = microtime(true) + max(1, (int) $wait_seconds);
+
+	do {
+		foreach($waiting as $index => $p) {
+			if (!cacti_process_still_running((int) $p['pid'])) {
+				unregister_process($p['tasktype'], $p['taskname'], $p['taskid'], (int) $p['pid']);
+				unset($waiting[$index]);
+			}
+		}
+
+		if (!cacti_sizeof($waiting)) {
+			return true;
+		}
+
+		usleep(100000);
+	} while (microtime(true) < $deadline);
+
+	foreach($waiting as $p) {
+		cacti_log(sprintf('ERROR: Boost PID %d did not terminate before the takeover deadline.', $p['pid']), true, 'BOOST');
+	}
+
+	return false;
 }
 
 function boost_processes_running() {
@@ -413,34 +470,36 @@ function boost_failed_children($run_id) {
 
 function boost_prepare_process_table() {
 	global $start_time, $archive_table, $max_run_duration, $config, $database_default, $debug, $get_memory, $memory_used;
-	global $boost_run_arch_tables;
+	global $boost_run_arch_tables, $run_id;
 
 	boost_debug('Parallel Process Setup Begins.');
 
-	$boost_poller_status = read_config_option('boost_poller_status');
+	$boost_poller_status  = read_config_option('boost_poller_status');
+	$previous_start_time = (int) read_config_option('boost_poller_started');
 	if (!$boost_poller_status) {
 		$boost_poller_status = 'not started';
 	}
 
 	/* detect a process that has overrun it's warning time */
-	if (substr_count($boost_poller_status, 'running')) {
+	if (!$previous_start_time && substr_count($boost_poller_status, 'running')) {
 		$status_array = explode(':', $boost_poller_status);
 
 		if (!empty($status_array[1])) {
 			$previous_start_time = strtotime($status_array[1]);
-
-			/* if the runtime was exceeded, allow the next process to run */
-			if ($previous_start_time + $max_run_duration < $start_time) {
-				cacti_log('WARNING: Detected Poller Boost Overrun, Possible Boost Poller Crash', true, 'BOOST SVR');
-
-				admin_email(__('Cacti System Warning'), __('WARNING: Detected Poller Boost Overrun, Possible Boost Poller Crash', 'BOOST SVR'));
-			}
 		}
+	}
+
+	/* if the runtime was exceeded, allow the next process to run */
+	if ($previous_start_time && $previous_start_time + $max_run_duration < $start_time) {
+		cacti_log('WARNING: Detected Poller Boost Overrun, Possible Boost Poller Crash', true, 'BOOST SVR');
+
+		admin_email(__('Cacti System Warning'), __('WARNING: Detected Poller Boost Overrun, Possible Boost Poller Crash', 'BOOST SVR'));
 	}
 
 	/* if the poller is not running, or has never run, start */
 	/* mark the boost server as running */
 	set_config_option('boost_poller_status', 'running - start time:' . date('Y-m-d H:i:s'));
+	set_config_option('boost_poller_started', $start_time);
 
 	$delayed_inserts = db_fetch_row("SHOW STATUS LIKE 'Not_flushed_delayed_rows'");
 
@@ -489,11 +548,7 @@ function boost_prepare_process_table() {
 
 	cacti_log('INFO: Boost counting entries in archive tables ...', true, 'BOOST');
 	foreach($arch_tables as $table) {
-		$table_rows = db_fetch_cell_prepared('SELECT TABLE_ROWS
-			FROM information_schema.TABLES
-			WHERE TABLE_SCHEMA = SCHEMA()
-			AND TABLE_NAME = ?',
-			array($table));
+		$table_rows = (int) db_fetch_cell("SELECT COUNT(*) FROM `$table`");
 
 		$total_rows += $table_rows;
 
@@ -510,37 +565,37 @@ function boost_prepare_process_table() {
 		cacti_log('INFO: Boost processing a total of ' . $total_rows . ' entries.', true, 'BOOST');
 	}
 
-	if (db_execute('CREATE TABLE IF NOT EXISTS poller_output_boost_local_data_ids (
-		local_data_id int unsigned default 0,
-		process_handler int unsigned default 0,
-		PRIMARY KEY (local_data_id),
-		INDEX process_handler(process_handler))
-		ENGINE=InnoDB') === false) {
+	if (db_execute('DROP TABLE IF EXISTS poller_output_boost_local_data_ids') === false ||
+		db_execute('CREATE TABLE poller_output_boost_local_data_ids (
+			run_id char(32) NOT NULL,
+			local_data_id int unsigned NOT NULL default 0,
+			process_handler int unsigned NOT NULL default 0,
+			cursor_time timestamp NULL default NULL,
+			cursor_rrd_name varchar(19) NOT NULL default \'\',
+			PRIMARY KEY (run_id, local_data_id),
+			INDEX process_handler(run_id, process_handler))
+			ENGINE=MEMORY') === false) {
 		cacti_log('ERROR: Boost failed to create its process-distribution table.', true, 'BOOST');
 
 		return false;
 	}
 
-	if (db_execute('TRUNCATE poller_output_boost_local_data_ids') === false) {
-		cacti_log('ERROR: Boost failed to reset its process-distribution table.', true, 'BOOST');
-
-		return false;
-	}
-
 	foreach($arch_tables as $table) {
-		if (db_execute("INSERT IGNORE INTO poller_output_boost_local_data_ids
-			(local_data_id)
-			SELECT DISTINCT local_data_id
-			FROM `$table`") === false) {
+		if (db_execute_prepared("INSERT IGNORE INTO poller_output_boost_local_data_ids
+			(run_id, local_data_id)
+			SELECT ?, local_data_id
+			FROM `$table`
+			GROUP BY local_data_id", array($run_id), false) === false) {
 			cacti_log('ERROR: Boost failed to stage archive data-source identifiers.', true, 'BOOST');
 
 			return false;
 		}
 	}
 
-	$data_ids = db_fetch_cell("SELECT
+	$data_ids = db_fetch_cell_prepared("SELECT
 		COUNT(local_data_id)
-		FROM poller_output_boost_local_data_ids");
+		FROM poller_output_boost_local_data_ids
+		WHERE run_id = ?", array($run_id));
 
 	$processes = read_config_option('boost_parallel');
 
@@ -557,9 +612,10 @@ function boost_prepare_process_table() {
 	while ($count <= $processes) {
 		if (db_execute_prepared('UPDATE poller_output_boost_local_data_ids
 			SET process_handler = ?
-			WHERE process_handler = 0
+			WHERE run_id = ?
+			AND process_handler = 0
 			LIMIT ' . $data_ids_per_process,
-			array($count)) === false) {
+			array($count, $run_id)) === false) {
 			cacti_log('ERROR: Boost failed to assign data sources to a child process.', true, 'BOOST');
 
 			return false;
@@ -660,8 +716,8 @@ function boost_time_to_run($forcerun, $current_time, $last_run_time, $next_run_t
 		}
 
 		/* determine if you must output boost table now */
-		$current_records = boost_get_total_rows();
 		$max_records     = read_config_option('boost_rrd_update_max_records');
+		$current_records = boost_get_total_rows((int) $max_records);
 
 		boost_debug('Records Found:' . $current_records . ', Max Threshold:' . $max_records . '.');
 
@@ -687,7 +743,7 @@ function boost_time_to_run($forcerun, $current_time, $last_run_time, $next_run_t
 		}
 
 		/* we are force to run until boost is finished */
-		$rows = boost_get_total_rows();
+		$rows = boost_get_total_rows(1);
 
 		if ($rows > 0) {
 			$run_now = true;
@@ -698,7 +754,7 @@ function boost_time_to_run($forcerun, $current_time, $last_run_time, $next_run_t
 }
 
 function boost_output_rrd_data($child) {
-	global $start, $archive_table, $max_run_duration, $config, $database_default, $debug, $get_memory, $memory_used;
+	global $start, $archive_table, $max_run_duration, $config, $database_default, $debug, $get_memory, $memory_used, $run_id;
 
 	$rrd_updates       = 0;
 	$processed_rows    = 0;
@@ -731,8 +787,9 @@ function boost_output_rrd_data($child) {
 			FROM $table AS at
 			INNER JOIN poller_output_boost_local_data_ids AS bpt
 			ON at.local_data_id = bpt.local_data_id
+			AND bpt.run_id = ?
 			AND bpt.process_handler = ?",
-			array($child));
+			array($run_id, $child));
 	}
 
 	if ($total_rows == 0) {
@@ -749,34 +806,13 @@ function boost_output_rrd_data($child) {
 		$max_per_select = 50000;
 	}
 
-	$data_ids = db_fetch_cell_prepared("SELECT
-		COUNT(local_data_id)
-		FROM poller_output_boost_local_data_ids
-		WHERE process_handler = ?",
-		array($child));
+	$passes  = ceil($total_rows / $max_per_select);
+	$curpass = 1;
 
-	$passes       = ceil($total_rows / $max_per_select);
-	$ids_per_pass = ceil($data_ids / $passes);
-	$curpass      = 1;
+	while (true) {
+		boost_debug("Processing page $curpass of approximately $passes for Boost Process $child");
 
-	while ($data_ids > 0) {
-		boost_debug("Processing $curpass of $passes for Boost Process $child");
-
-		$last_id = db_fetch_cell_prepared("SELECT MAX(local_data_id)
-			FROM (
-				SELECT local_data_id
-				FROM poller_output_boost_local_data_ids
-				WHERE process_handler = ?
-				ORDER BY local_data_id ASC
-				LIMIT $ids_per_pass
-			) AS result",
-			array($child));
-
-		if (empty($last_id)) {
-			break;
-		}
-
-		$pass_rows = boost_process_local_data_ids($last_id, $child, $rrdtool_pipe);
+		$pass_rows = boost_process_local_data_ids($child, $rrdtool_pipe, $max_per_select);
 
 		if ($pass_rows < 0) {
 			rrd_close($rrdtool_pipe);
@@ -784,14 +820,13 @@ function boost_output_rrd_data($child) {
 			return -1;
 		}
 
+		if ($pass_rows === 0) {
+			break;
+		}
+
 		$processed_rows += $pass_rows;
 
 		$curpass++;
-
-		$data_ids = db_fetch_cell_prepared('SELECT COUNT(*)
-			FROM poller_output_boost_local_data_ids
-			WHERE process_handler = ?',
-			array($child));
 
 		if (((time()-$start) > $max_run_duration) && (!$runtime_exceeded)) {
 			cacti_log('WARNING: RRD On Demand Updater Exceeded Runtime Limits. Continuing to Process!!!', true, 'BOOST');
@@ -816,11 +851,12 @@ function boost_output_rrd_data($child) {
 
 /* boost_process_local_data_ids - grabs data from the 'poller_output' table and feeds the *completed*
      results to RRDTool for processing
-   @arg $last_id - the last id to process
-   @arg $child - the current process
-   @arg $rrdtool_pipe - the socket that has been opened for the RRDtool operation */
-function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
+	 @arg $child - the current process
+	 @arg $rrdtool_pipe - the socket that has been opened for the RRDtool operation
+	 @arg $max_rows - maximum rows to materialize in one page */
+function boost_process_local_data_ids($child, $rrdtool_pipe, $max_rows) {
 	global $config, $archive_table, $boost_sock, $boost_timeout, $debug, $get_memory, $memory_used, $current_lock;
+	global $run_id, $max_run_duration;
 
 	/* cache this call as it takes time */
 	static $archive_tables  = false;
@@ -858,7 +894,7 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 	/* load system variables needed */
 	$upd_string_len		 = read_config_option('boost_rrd_update_string_length');
 	$rrd_update_interval = read_config_option('boost_rrd_update_interval');
-	$data_ids_to_get     = read_config_option('boost_rrd_update_max_records_per_select');
+	$max_rows = max(1, (int) $max_rows);
 
 	if ($archive_tables === false) {
 		$archive_tables = boost_get_arch_table_names($archive_table);
@@ -883,27 +919,61 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 	}
 
 	$query_string = 'SELECT * FROM (';
-	$query_string_suffix = 'ORDER BY local_data_id ASC, timestamp ASC, rrd_name ASC';
+	$query_string_suffix = 'ORDER BY local_data_id ASC, sample_time ASC, rrd_name ASC LIMIT ' . ($max_rows + 1);
 
 	$sub_query_string = '';
+	$sql_params       = array();
 
 	foreach ($archive_tables as $table) {
 		$sub_query_string .= ($sub_query_string != '' ? ' UNION ALL ':'') .
-			" SELECT $table.local_data_id, dl.data_template_id, UNIX_TIMESTAMP(time) AS timestamp, rrd_name, output
-			FROM $table
+			" SELECT `$table`.local_data_id, dl.data_template_id, UNIX_TIMESTAMP(`$table`.time) AS timestamp,
+				`$table`.time AS sample_time, `$table`.rrd_name, `$table`.output
+			FROM `$table`
 			INNER JOIN poller_output_boost_local_data_ids AS bpt
-			ON $table.local_data_id = bpt.local_data_id
+			ON `$table`.local_data_id = bpt.local_data_id
 			INNER JOIN data_local AS dl
-			ON $table.local_data_id = dl.id
-			WHERE bpt.local_data_id <= $last_id
-			AND bpt.process_handler = $child";
+			ON `$table`.local_data_id = dl.id
+			WHERE bpt.run_id = ?
+			AND bpt.process_handler = ?
+			AND (bpt.cursor_time IS NULL
+				OR `$table`.time > bpt.cursor_time
+				OR (`$table`.time = bpt.cursor_time AND `$table`.rrd_name > bpt.cursor_rrd_name))";
+		$sql_params[] = $run_id;
+		$sql_params[] = $child;
 	}
 
 	$query_string = $query_string . $sub_query_string . ') t ' . $query_string_suffix;
 
 	boost_timer('get_records', BOOST_TIMER_START);
-	$results = db_fetch_assoc($query_string);
+	$results = db_fetch_assoc_prepared($query_string, $sql_params);
 	boost_timer('get_records', BOOST_TIMER_END);
+
+	if ($results === false) {
+		restore_error_handler();
+		error_reporting($previous_error_reporting);
+
+		return -1;
+	}
+
+	if (!cacti_sizeof($results)) {
+		db_execute_prepared('DELETE FROM poller_output_boost_local_data_ids
+			WHERE run_id = ?
+			AND process_handler = ?', array($run_id, $child));
+		restore_error_handler();
+		error_reporting($previous_error_reporting);
+
+		return 0;
+	}
+
+	$results = boost_limit_complete_timestamp_page($results, $max_rows);
+
+	if ($results === false) {
+		cacti_log("ERROR: Boost row limit $max_rows is smaller than one complete timestamp group; queued rows were retained.", true, 'BOOST');
+		restore_error_handler();
+		error_reporting($previous_error_reporting);
+
+		return -1;
+	}
 
 	/* log memory */
 	if ($get_memory) {
@@ -933,6 +1003,8 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 
 		/* go through each poller_output_boost entries and process */
 		foreach ($results as $item) {
+			$skip_item = false;
+
 			if ($local_data_id == $item['local_data_id'] && cacti_sizeof($unused_data_source_names) && isset($unused_data_source_names[$item['rrd_name']])) {
 				continue;
 			}
@@ -944,55 +1016,56 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 			 * and discover the template for the next RRDfile.
 			 */
 			if ($local_data_id != $item['local_data_id']) {
-				$unused_data_source_names = array_rekey(
-					db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
-						FROM data_template_rrd AS dtr
-						LEFT JOIN graph_templates_item AS gti
-						ON dtr.id = gti.task_item_id
-						WHERE dtr.local_data_id = ?
-						AND gti.task_item_id IS NULL',
-						array($item['local_data_id'])),
-					'data_source_name', 'data_source_name'
-				);
-				if (cacti_sizeof($unused_data_source_names) && isset($unused_data_source_names[$item['rrd_name']])) {
-					continue;
-				}
+				/* Flush the previous RRD while its legacy named lock is still held. */
+				if ($vals_in_buffer) {
+					$outarray[] = $tv_tmpl;
+					$flush_ok   = boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe);
 
-				$reset_template = true;
+					$buflen         = 0;
+					$vals_in_buffer = 0;
+					$outarray       = array();
 
-				if (isset($nt_rrd_field_names)) {
-					unset($nt_rrd_field_names);
+					if (!$flush_ok) {
+						$updates_ok = false;
+						break;
+					}
 				}
 
 				/* release the previous lock */
-				if (cacti_version_compare($rrdtool_version, '1.5', '<')) {
-					db_execute("SELECT RELEASE_LOCK('boost.single_ds.$local_data_id')");
+				if (cacti_version_compare($rrdtool_version, '1.5', '<') && $current_lock !== false) {
+					db_execute("SELECT RELEASE_LOCK('boost.single_ds.$current_lock')");
 				}
 
 				$current_lock = false;
 
 				/* acquire lock in order to prevent race conditions, only a problem pre-rrdtool 1.5 */
 				if (cacti_version_compare($rrdtool_version, '1.5', '<')) {
+					$lock_deadline = microtime(true) + max(1, min(30, (int) $max_run_duration));
+
 					while (!db_fetch_cell("SELECT GET_LOCK('boost.single_ds." . $item['local_data_id'] . "', 1)")) {
+						if (microtime(true) >= $lock_deadline) {
+							cacti_log('ERROR: Boost timed out acquiring the RRD lock for Local Data ID ' . $item['local_data_id'] . '; queued rows were retained.', true, 'BOOST');
+							restore_error_handler();
+							error_reporting($previous_error_reporting);
+
+							return -1;
+						}
+
 						usleep(50000);
 					}
 				}
 
 				$current_lock = $item['local_data_id'];
 
-				/* update the rrd for the previous local_data_id */
-				if ($vals_in_buffer) {
-					/* place the latest update at the end of the output array */
-					$outarray[] = $tv_tmpl;
+				$unused_data_source_names = boost_get_unused_data_source_names($item['local_data_id']);
+				if (cacti_sizeof($unused_data_source_names) && isset($unused_data_source_names[$item['rrd_name']])) {
+					$skip_item = true;
+				}
 
-					/* new process output function */
-					if (!boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe)) {
-						$updates_ok = false;
-					}
+				$reset_template = true;
 
-					$buflen = 0;
-					$vals_in_buffer = 0;
-					$outarray = array();
+				if (isset($nt_rrd_field_names)) {
+					unset($nt_rrd_field_names);
 				}
 
 				/* reset the rrd file path and templates, assume non multi output */
@@ -1031,6 +1104,10 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 				}
 
 				$tv_tmpl = $rrd_tmplpts;
+
+				if ($skip_item) {
+					continue;
+				}
 			} else {
 				$reset_template = false;
 			}
@@ -1052,13 +1129,16 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 
 				if ($buflen > $upd_string_len) {
 					/* new process output function */
-					if (!boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe)) {
-						$updates_ok = false;
-					}
+					$flush_ok = boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, $rrdtool_pipe);
 
 					$buflen         = 0;
 					$vals_in_buffer = 0;
 					$outarray       = array();
+
+					if (!$flush_ok) {
+						$updates_ok = false;
+						break;
+					}
 				}
 
 				$time = $item['timestamp'];
@@ -1090,16 +1170,7 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 					$rrd_tmpl = '';
 				} else {
 					if ($item['data_template_id'] > 0) {
-						$unused_data_source_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
-								FROM data_template_rrd AS dtr
-								LEFT JOIN graph_templates_item AS gti
-								ON dtr.id = gti.task_item_id
-								WHERE dtr.local_data_id = ?
-								AND gti.task_item_id IS NULL',
-								array($item['local_data_id'])),
-							'data_source_name', 'data_source_name'
-						);
+						$unused_data_source_names = boost_get_unused_data_source_names($item['local_data_id']);
 					} else {
 						$unused_data_source_names = array();
 					}
@@ -1145,27 +1216,9 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 							 * a graph.  So, for that case, we need the RRDfile to include all data sources
 							 */
 							if ($item['data_template_id'] > 0) {
-								$nt_rrd_field_names = array_rekey(
-									db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
-										FROM graph_templates_item AS gti
-										INNER JOIN data_template_rrd AS dtr
-										ON gti.task_item_id = dtr.id
-										INNER JOIN data_input_fields AS dif
-										ON dtr.data_input_field_id=dif.id
-										WHERE dtr.local_data_id = ?',
-										array($item['local_data_id'])),
-									'data_name', 'data_source_name'
-								);
+								$nt_rrd_field_names = boost_get_input_field_names($item['local_data_id'], true);
 							} else {
-								$nt_rrd_field_names = array_rekey(
-									db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
-										FROM data_template_rrd AS dtr
-										INNER JOIN data_input_fields AS dif
-										ON dtr.data_input_field_id=dif.id
-										WHERE dtr.local_data_id = ?',
-										array($item['local_data_id'])),
-									'data_name', 'data_source_name'
-								);
+								$nt_rrd_field_names = boost_get_input_field_names($item['local_data_id'], false);
 							}
 
 							if (cacti_sizeof($nt_rrd_field_names)) {
@@ -1211,40 +1264,11 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 			} else {
 				if ($reset_template) {
 					if ($item['data_template_id'] > 0) {
-						$unused_data_source_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dtr.data_source_name
-								FROM data_template_rrd AS dtr
-								LEFT JOIN graph_templates_item AS gti
-								ON dtr.id = gti.task_item_id
-								WHERE dtr.local_data_id = ?
-								AND gti.task_item_id IS NULL',
-								array($item['local_data_id'])),
-							'data_source_name', 'data_source_name'
-						);
-
-						$nt_rrd_field_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
-								FROM graph_templates_item AS gti
-								INNER JOIN data_template_rrd AS dtr
-								ON gti.task_item_id = dtr.id
-								INNER JOIN data_input_fields AS dif
-								ON dtr.data_input_field_id=dif.id
-								WHERE dtr.local_data_id = ?',
-								array($item['local_data_id'])),
-							'data_name', 'data_source_name'
-						);
+						$unused_data_source_names = boost_get_unused_data_source_names($item['local_data_id']);
+						$nt_rrd_field_names       = boost_get_input_field_names($item['local_data_id'], true);
 					} else {
 						$unused_data_source_names = array();
-
-						$nt_rrd_field_names = array_rekey(
-							db_fetch_assoc_prepared('SELECT DISTINCT dtr.data_source_name, dif.data_name
-								FROM data_template_rrd AS dtr
-								INNER JOIN data_input_fields AS dif
-								ON dtr.data_input_field_id=dif.id
-								WHERE dtr.local_data_id = ?',
-								array($item['local_data_id'])),
-							'data_name', 'data_source_name'
-						);
+						$nt_rrd_field_names       = boost_get_input_field_names($item['local_data_id'], false);
 					}
 				}
 
@@ -1282,8 +1306,8 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 		}
 
 		/* release the last lock */
-		if (cacti_version_compare(get_rrdtool_version(), '1.5', '<')) {
-			db_execute("SELECT RELEASE_LOCK('boost.single_ds." . $item['local_data_id'] . "')");
+		if (cacti_version_compare(get_rrdtool_version(), '1.5', '<') && $current_lock !== false) {
+			db_execute("SELECT RELEASE_LOCK('boost.single_ds.$current_lock')");
 		}
 
 		$current_lock = false;
@@ -1291,7 +1315,7 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 		boost_timer('results_cycle', BOOST_TIMER_END);
 	}
 
-	/* remove the entries from the table */
+	/* Advance only the primary-key cursors whose RRD updates were acknowledged. */
 	boost_timer('delete', BOOST_TIMER_START);
 
 	if (!isset($updates_ok)) {
@@ -1299,12 +1323,25 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 	}
 
 	if ($updates_ok && $results !== false) {
-		db_execute_prepared("DELETE FROM poller_output_boost_local_data_ids
-			WHERE local_data_id <= ?
-			AND process_handler = ?",
-			array($last_id, $child));
+		$cursors = array();
+
+		foreach($results as $item) {
+			$cursors[$item['local_data_id']] = array($item['sample_time'], $item['rrd_name']);
+		}
+
+		foreach($cursors as $local_data_id => $cursor) {
+			if (db_execute_prepared('UPDATE poller_output_boost_local_data_ids
+				SET cursor_time = ?, cursor_rrd_name = ?
+				WHERE run_id = ?
+				AND local_data_id = ?
+				AND process_handler = ?',
+				array($cursor[0], $cursor[1], $run_id, $local_data_id, $child), false) === false) {
+				$updates_ok = false;
+				break;
+			}
+		}
 	} else {
-		cacti_log("WARNING: Boost retained shard $child through local data ID $last_id because one or more RRD updates failed.", true, 'BOOST');
+		cacti_log("WARNING: Boost retained the current page for shard $child because one or more RRD updates failed.", true, 'BOOST');
 	}
 
 	boost_timer('delete', BOOST_TIMER_END);

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -187,6 +187,7 @@ if ($child == false) {
 
 		if (boost_ensure_process_table() === false) {
 			cacti_log('ERROR: Boost process table is not ready', true, 'BOOST');
+			unregister_process('boost', 'master', $config['poller_id'], getmypid());
 			exit(1);
 		}
 

--- a/poller_boost.php
+++ b/poller_boost.php
@@ -68,7 +68,13 @@ if (cacti_sizeof($parms)) {
 
 		switch ($arg) {
 			case '--child':
-				$child = $value;
+				if (!preg_match('/^[1-9]\d*$/D', $value)) {
+					print "ERROR: Child identifier must be a positive integer.\n\n";
+					display_help();
+					exit(1);
+				}
+
+				$child = (int) $value;
 				break;
 			case '--run-id':
 				if (preg_match('/^[a-f0-9]{32}$/D', $value)) {
@@ -145,7 +151,8 @@ if ($child == false) {
 		$next_run_time = $boost_next_run_time;
 	}
 
-	$seconds_offset = read_config_option('boost_rrd_update_interval') * 60;
+	$interval_minutes = (int) read_config_option('boost_rrd_update_interval');
+	$seconds_offset   = ($interval_minutes > 0 ? $interval_minutes : 120) * 60;
 
 	$run_now = boost_time_to_run($forcerun, $current_time, $last_run_time, $next_run_time);
 
@@ -270,9 +277,14 @@ if ($child == false) {
 				dsstats_boost_bottom();
 				rrdcheck_boost_bottom();
 
-				api_plugin_hook('boost_poller_bottom');
+					api_plugin_hook('boost_poller_bottom');
+				}
+			} else {
+				$rrd_updates = 0;
+				set_config_option('boost_poller_status', 'failed - end time:' . date('Y-m-d H:i:s'));
+				set_config_option('boost_last_run_time', $last_run_time);
+				cacti_log('ERROR: Boost preparation failed; no child processes were launched.', true, 'BOOST');
 			}
-		}
 
 		cacti_log('INFO: Boost unregistering master process', true, 'BOOST');
 
@@ -312,16 +324,20 @@ if ($child == false) {
 	/* output all the rrd data to the rrd files */
 	$rrd_updates = boost_output_rrd_data($child);
 
-	db_execute_prepared('INSERT INTO poller_output_boost_processes
+	$completion_recorded = db_execute_prepared('INSERT INTO poller_output_boost_processes
 		(run_id, child_id, status) VALUES (?, ?, ?)
 		ON DUPLICATE KEY UPDATE status = VALUES(status)',
 		array($run_id, $child, $rrd_updates));
+
+	if ($completion_recorded === false) {
+		cacti_log('ERROR: Boost child could not record its completion status.', true, 'BOOST');
+	}
 
 	boost_log_child_statistics($rrd_updates, $child);
 
 	unregister_process('boost', 'child', $child);
 
-	exit(0);
+	exit($completion_recorded === false ? 1 : 0);
 }
 
 function sig_handler($signo) {
@@ -341,25 +357,24 @@ function sig_handler($signo) {
 				unregister_process('boost', 'master', $config['poller_id'], getmypid());
 			}
 
-			exit;
-			break;
+			if (cacti_version_compare(get_rrdtool_version(), '1.5', '<')) {
+				if ($current_lock !== false && $child) {
+					db_execute("SELECT RELEASE_LOCK('boost.single_ds.$current_lock')");
+				} elseif (!$child) {
+					db_execute('SELECT RELEASE_ALL_LOCKS()');
+				}
+			}
+
+			exit(1);
 		default:
 			/* ignore all other signals */
-	}
-
-	if (cacti_version_compare(get_rrdtool_version(), '1.5', '<')) {
-		if ($current_lock !== false && $child) {
-			db_execute("SELECT RELEASE_LOCK('boost.single_ds.$current_lock')");
-		} elseif (!$child) {
-			db_execute("SELECT RELEASE_ALL_LOCKS()");
-		}
 	}
 }
 
 function boost_kill_running_processes() {
 	$processes = db_fetch_assoc_prepared('SELECT *
 		FROM processes
-		WHERE tasktype = "boost"
+		WHERE tasktype = \'boost\'
 		AND pid != ?',
 		array(getmypid()));
 
@@ -377,8 +392,8 @@ function boost_kill_running_processes() {
 function boost_processes_running() {
 	$running = db_fetch_cell('SELECT COUNT(*)
 		FROM processes
-		WHERE tasktype = "boost"
-		AND taskname = "child"');
+		WHERE tasktype = \'boost\'
+		AND taskname = \'child\'');
 
 	return $running;
 }
@@ -442,9 +457,22 @@ function boost_prepare_process_table() {
 	$interim_table = 'poller_output_boost_' . $time;
 
 	cacti_log('INFO: Boost rotating poller_output_boost into archive table: ' . $archive_table, true, 'BOOST');
-	db_execute("CREATE TABLE $interim_table LIKE poller_output_boost");
-	db_execute("RENAME TABLE poller_output_boost TO $archive_table, $interim_table TO poller_output_boost");
-	db_execute("ANALYZE TABLE $archive_table");
+	if (db_execute("CREATE TABLE `$interim_table` LIKE poller_output_boost") === false) {
+		cacti_log('ERROR: Boost failed to create its interim output table.', true, 'BOOST');
+
+		return false;
+	}
+
+	if (db_execute("RENAME TABLE poller_output_boost TO `$archive_table`, `$interim_table` TO poller_output_boost") === false) {
+		db_execute("DROP TABLE IF EXISTS `$interim_table`");
+		cacti_log('ERROR: Boost failed to rotate its output table.', true, 'BOOST');
+
+		return false;
+	}
+
+	if (db_execute("ANALYZE TABLE `$archive_table`") === false) {
+		cacti_log('WARNING: Boost could not analyze its archive table; processing will continue.', true, 'BOOST');
+	}
 	cacti_log('INFO: Boost done rotating poller_output_boost', true, 'BOOST');
 
 	$arch_tables = boost_get_arch_table_names($archive_table);
@@ -482,20 +510,32 @@ function boost_prepare_process_table() {
 		cacti_log('INFO: Boost processing a total of ' . $total_rows . ' entries.', true, 'BOOST');
 	}
 
-	db_execute('CREATE TABLE IF NOT EXISTS poller_output_boost_local_data_ids (
-		local_data_id int unsigned default "0",
-		process_handler int unsigned default "0",
+	if (db_execute('CREATE TABLE IF NOT EXISTS poller_output_boost_local_data_ids (
+		local_data_id int unsigned default 0,
+		process_handler int unsigned default 0,
 		PRIMARY KEY (local_data_id),
 		INDEX process_handler(process_handler))
-		ENGINE=InnoDB');
+		ENGINE=InnoDB') === false) {
+		cacti_log('ERROR: Boost failed to create its process-distribution table.', true, 'BOOST');
 
-	db_execute('TRUNCATE poller_output_boost_local_data_ids');
+		return false;
+	}
+
+	if (db_execute('TRUNCATE poller_output_boost_local_data_ids') === false) {
+		cacti_log('ERROR: Boost failed to reset its process-distribution table.', true, 'BOOST');
+
+		return false;
+	}
 
 	foreach($arch_tables as $table) {
-		db_execute("INSERT IGNORE INTO poller_output_boost_local_data_ids
+		if (db_execute("INSERT IGNORE INTO poller_output_boost_local_data_ids
 			(local_data_id)
 			SELECT DISTINCT local_data_id
-			FROM $table");
+			FROM `$table`") === false) {
+			cacti_log('ERROR: Boost failed to stage archive data-source identifiers.', true, 'BOOST');
+
+			return false;
+		}
 	}
 
 	$data_ids = db_fetch_cell("SELECT
@@ -515,11 +555,15 @@ function boost_prepare_process_table() {
 	$count = 1;
 
 	while ($count <= $processes) {
-		db_execute_prepared('UPDATE poller_output_boost_local_data_ids
+		if (db_execute_prepared('UPDATE poller_output_boost_local_data_ids
 			SET process_handler = ?
 			WHERE process_handler = 0
 			LIMIT ' . $data_ids_per_process,
-			array($count));
+			array($count)) === false) {
+			cacti_log('ERROR: Boost failed to assign data sources to a child process.', true, 'BOOST');
+
+			return false;
+		}
 
 		$count++;
 	}
@@ -533,8 +577,8 @@ function boost_prune_memstats() {
 	$processes = read_config_option('boost_parallel');
 
 	db_execute_prepared('DELETE FROM settings
-		WHERE name LIKE "boost_peak_memory%"
-		AND REPLACE(name, "boost_peak_memory_", "") > ?',
+		WHERE name LIKE \'boost_peak_memory%\'
+		AND REPLACE(name, \'boost_peak_memory_\', \'\') > ?',
 		array($processes));
 }
 
@@ -587,11 +631,11 @@ function boost_time_to_run($forcerun, $current_time, $last_run_time, $next_run_t
 			set_config_option('boost_rrd_update_system_enable', 'on');
 		}
 
-		$seconds_offset = read_config_option('boost_rrd_update_interval') * 60;
+		$seconds_offset = (int) read_config_option('boost_rrd_update_interval') * 60;
 
 		/* Initialize seconds offset, if not set to 2 hours */
 		if (empty($seconds_offset)) {
-			$seconds_offset = 120;
+			$seconds_offset = 120 * 60;
 			set_config_option('boost_rrd_update_interval', 120);
 		}
 
@@ -631,7 +675,7 @@ function boost_time_to_run($forcerun, $current_time, $last_run_time, $next_run_t
 			set_config_option('boost_next_run_time', $next_run_time);
 		}
 	} else {
-		$pollers = db_fetch_cell('SELECT COUNT(*) FROM pollers WHERE disabled = ""');
+		$pollers = db_fetch_cell('SELECT COUNT(*) FROM pollers WHERE disabled = \'\'');
 
 		if ($pollers > 1) {
 			boost_debug('Someone attempted to disable boost through there are multiple Data Collectors Defined!');
@@ -833,7 +877,7 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 	if (!cacti_sizeof($rrd_field_names)) {
 		$rrd_field_names = array_rekey(
 			db_fetch_assoc_prepared('SELECT ' . SQL_NO_CACHE . '
-				CONCAT(data_template_id, "_", data_name) AS keyname, data_source_names AS data_source_name
+					CONCAT(data_template_id, \'_\', data_name) AS keyname, data_source_names AS data_source_name
 				FROM poller_data_template_field_mappings'),
 			'keyname', array('data_source_name'));
 	}
@@ -877,7 +921,6 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 		$time           = -1;
 		$buflen         = 0;
 		$outarray       = array();
-		$locked         = false;
 		$last_update    = -1;
 		$reset_template = true;
 
@@ -895,19 +938,6 @@ function boost_process_local_data_ids($last_id, $child, $rrdtool_pipe) {
 			}
 
 			$item['timestamp'] = trim($item['timestamp']);
-
-			if (!$locked) {
-				/* acquire lock in order to prevent race conditions, only a problem pre-rrdtool 1.5 */
-				if (cacti_version_compare($rrdtool_version, '1.5', '<')) {
-					while (!db_fetch_cell("SELECT GET_LOCK('boost.single_ds." . $item['local_data_id'] . "', 1)")) {
-						usleep(50000);
-					}
-				}
-
-				$current_lock = $item['local_data_id'];
-
-				$locked = true;
-			}
 
 			/**
 			 * if the local_data_id changes, we need to flush the buffer
@@ -1306,7 +1336,7 @@ function boost_process_output($local_data_id, $outarray, $rrd_path, $rrd_tmplp, 
 	boost_timer('rrdupdate', BOOST_TIMER_END);
 
 	/* check return status for delete operation */
-	if (trim($return_value) != 'OK' && $return_value != '') {
+	if (trim((string) $return_value) !== 'OK') {
 		cacti_log("WARNING: RRD Update Warning '" . $return_value . "' for Local Data ID '$local_data_id'", true, 'BOOST');
 
 		return false;
@@ -1352,11 +1382,17 @@ function boost_log_statistics($rrd_updates) {
 
 	$stats = db_fetch_assoc('SELECT value
 		FROM settings
-		WHERE name LIKE "stats_detail_boost_%"');
+		WHERE name LIKE \'stats_detail_boost_%\'');
 
 	if (cacti_sizeof($stats)) {
 		foreach($stats as $stat) {
-			$stat = json_decode($stat['value']);
+			$stat = json_decode($stat['value'], true);
+
+			if (!is_array($stat)) {
+				cacti_log('WARNING: Ignoring malformed Boost child statistics.', true, 'BOOST');
+
+				continue;
+			}
 
 			foreach($stat as $key => $value) {
 				if (isset($output[$key])) {
@@ -1392,7 +1428,7 @@ function boost_log_statistics($rrd_updates) {
 
 	/* prune old process statistics if the number has changed */
 	$processes = read_config_option('boost_parallel');
-	$stats     = db_fetch_assoc('SELECT * FROM settings WHERE name LIKE "stats_boost_%"');
+	$stats     = db_fetch_assoc('SELECT * FROM settings WHERE name LIKE \'stats_boost_%\'');
 	if (cacti_sizeof($stats)) {
 		foreach($stats as $stat) {
 			$process = str_replace('stats_boost_', '', $stat['name']);
@@ -1403,7 +1439,7 @@ function boost_log_statistics($rrd_updates) {
 	}
 
 	/* prune all detailed stats */
-	db_execute('DELETE FROM settings WHERE name LIKE "stats_detail_boost_%"');
+	db_execute('DELETE FROM settings WHERE name LIKE \'stats_detail_boost_%\'');
 }
 
 function boost_log_child_statistics($rrd_updates, $child) {

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -198,12 +198,12 @@ if ($run) {
 
 	db_execute_prepared('REPLACE INTO settings
 		(name, value)
-		VALUES ("recovery_pid", ?)',
+		VALUES (\'recovery_pid\', ?)',
 		array($my_pid), true, $local_db_cnn_id);
 
 	/* let the console know you are in recovery mode */
 	db_execute_prepared('UPDATE poller
-		SET status = "5"
+		SET status = 5
 		WHERE id = ?',
 		array($poller_id), true, $remote_db_cnn_id);
 
@@ -230,7 +230,8 @@ if ($run) {
 			$rows = db_fetch_assoc_prepared('SELECT *
 				FROM poller_output_boost
 				WHERE time <= ?
-				ORDER BY time ASC, local_data_id ASC',
+				ORDER BY time ASC, local_data_id ASC, rrd_name ASC
+				LIMIT ' . (int) $record_limit,
 				array($max_time), true, $local_db_cnn_id);
 
 			if (cacti_sizeof($rows)) {
@@ -273,12 +274,10 @@ if ($run) {
 
 	db_execute("DELETE FROM settings WHERE name='recovery_pid'", true, $local_db_cnn_id);
 
-	if (!$transfer_failed) {
-		/* let the console know you are in online mode */
-		db_execute_prepared('UPDATE poller
-			SET status="2"
-			WHERE id= ?', array($poller_id), false, $remote_db_cnn_id);
-	}
+	/* Recovery failures are reported by the log and exit status. */
+	db_execute_prepared('UPDATE poller
+		SET status = 2
+		WHERE id = ?', array($poller_id), false, $remote_db_cnn_id);
 } else {
 	debug('Recovery process still running, exiting');
 	cacti_log('RECOVERY: Recovery process still running for Poller ' . $poller_id . '.  PID is ' . $recovery_pid, false, 'POLLER');

--- a/poller_recovery.php
+++ b/poller_recovery.php
@@ -274,10 +274,12 @@ if ($run) {
 
 	db_execute("DELETE FROM settings WHERE name='recovery_pid'", true, $local_db_cnn_id);
 
-	/* Recovery failures are reported by the log and exit status. */
-	db_execute_prepared('UPDATE poller
-		SET status = 2
-		WHERE id = ?', array($poller_id), false, $remote_db_cnn_id);
+	if (!$transfer_failed) {
+		/* let the console know you are in online mode */
+		db_execute_prepared('UPDATE poller
+			SET status = 2
+			WHERE id = ?', array($poller_id), false, $remote_db_cnn_id);
+	}
 } else {
 	debug('Recovery process still running, exiting');
 	cacti_log('RECOVERY: Recovery process still running for Poller ' . $poller_id . '.  PID is ' . $recovery_pid, false, 'POLLER');

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -91,8 +91,8 @@ test('Graph cache names are opaque and writes are atomically published', functio
 
 	expect($boost)->toContain("hash_hmac('sha256', \$cache_key, \$secret) . '.png'");
 	expect($boost)->toContain("tempnam(dirname(\$cache_file), '.boost-')");
-	expect($boost)->toContain('if (!$flushed || !rename($temp_file, $cache_file))');
-	expect($boost)->toContain('chmod($temp_file, 0640)');
+	expect($boost)->toContain("if (!\$published && PHP_OS_FAMILY === 'Windows')");
+	expect($boost)->toContain('chmod($temp_file, 0644)');
 	expect($boost)->not->toContain("get_selected_theme() . '_lgi_'");
 
 	$directory = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));

--- a/tests/HandOff/BoostDataHandOffTest.php
+++ b/tests/HandOff/BoostDataHandOffTest.php
@@ -92,7 +92,7 @@ test('Graph cache names are opaque and writes are atomically published', functio
 	expect($boost)->toContain("hash_hmac('sha256', \$cache_key, \$secret) . '.png'");
 	expect($boost)->toContain("tempnam(dirname(\$cache_file), '.boost-')");
 	expect($boost)->toContain("if (!\$published && PHP_OS_FAMILY === 'Windows')");
-	expect($boost)->toContain('chmod($temp_file, 0644)');
+	expect($boost)->toContain('chmod($temp_file, 0640)');
 	expect($boost)->not->toContain("get_selected_theme() . '_lgi_'");
 
 	$directory = sys_get_temp_dir() . '/cacti-boost-cache-' . bin2hex(random_bytes(8));

--- a/tests/Unit/BoostProcessTableUpgradeTest.php
+++ b/tests/Unit/BoostProcessTableUpgradeTest.php
@@ -44,6 +44,8 @@ test('Boost recovers the process-table columns without waiting for an upgrade st
 
 	expect($boost)->toContain('function boost_ensure_process_table()')
 		->and($boost)->toContain("db_column_exists('poller_output_boost_processes', 'run_id')")
+		->and($boost)->toContain("db_column_exists('poller_output_boost_processes', 'child_id')")
+		->and($boost)->toContain("db_index_exists('poller_output_boost_processes', 'run_child')")
 		->and($poller)->toContain('boost_ensure_process_table()')
 		->and($child)->toContain('boost_ensure_process_table()');
 });

--- a/tests/Unit/BoostProcessTableUpgradeTest.php
+++ b/tests/Unit/BoostProcessTableUpgradeTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * #7728 added run_id/child_id to poller_output_boost_processes in cacti.sql
+ * and in upgrade_to_1_2_31(). 1.2.31 already shipped, so installs that
+ * upgraded to 1.2.31 never run that file again. The installer walks
+ * $cacti_version_codes and includes install/upgrades/<version>.php for each
+ * version after the database version. 1.2.32 is already in that map.
+ */
+
+$root = dirname(__DIR__, 2);
+
+test('the 1.2.32 upgrade file exists so already-upgraded 1.2.31 installs receive the Boost process columns', function () use ($root) {
+	expect(file_exists($root . '/install/upgrades/1_2_32.php'))->toBeTrue();
+});
+
+test('upgrade_to_1_2_32 adds the Boost process-table columns and unique key', function () use ($root) {
+	$src = file_get_contents($root . '/install/upgrades/1_2_32.php');
+
+	expect($src)->toContain('function upgrade_to_1_2_32()')
+		->and($src)->toContain("db_install_add_column('poller_output_boost_processes'")
+		->and($src)->toContain("'name' => 'run_id'")
+		->and($src)->toContain("'name' => 'child_id'")
+		->and($src)->toContain("db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child'");
+});
+
+test('1.2.32 is in the installer version chain', function () use ($root) {
+	$src = file_get_contents($root . '/include/global_arrays.php');
+
+	expect($src)->toContain("'1.2.32'");
+});

--- a/tests/Unit/BoostProcessTableUpgradeTest.php
+++ b/tests/Unit/BoostProcessTableUpgradeTest.php
@@ -36,3 +36,14 @@ test('1.2.32 is in the installer version chain', function () use ($root) {
 
 	expect($src)->toContain("'1.2.32'");
 });
+
+test('Boost recovers the process-table columns without waiting for an upgrade stamp', function () use ($root) {
+	$boost  = file_get_contents($root . '/lib/boost.php');
+	$poller = file_get_contents($root . '/poller.php');
+	$child  = file_get_contents($root . '/poller_boost.php');
+
+	expect($boost)->toContain('function boost_ensure_process_table()')
+		->and($boost)->toContain("db_column_exists('poller_output_boost_processes', 'run_id')")
+		->and($poller)->toContain('boost_ensure_process_table()')
+		->and($child)->toContain('boost_ensure_process_table()');
+});

--- a/tests/Unit/CactiNonceApplySkinTest.php
+++ b/tests/Unit/CactiNonceApplySkinTest.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * applySkin() used cactiNonce as a bare identifier. Plugin pages, and any
+ * request whose inline session script is blocked, never define that variable.
+ * The resulting ReferenceError aborts the rest of applySkin().
+ */
+
+$root = dirname(__DIR__, 2);
+
+test('applySkin does not read cactiNonce unless it is defined', function () use ($root) {
+	$src = file_get_contents($root . '/include/layout.js');
+	$fn  = strstr($src, 'function applySkin()');
+	$fn  = substr($fn, 0, strpos($fn, "\nfunction ", 1));
+
+	$guard = strpos($fn, "typeof cactiNonce !== 'undefined'");
+	$use   = strpos($fn, 'nonce: cactiNonce');
+
+	expect($guard)->not->toBeFalse()
+		->and($use)->not->toBeFalse()
+		->and($guard)->toBeLessThan($use);
+});

--- a/tests/Unit/Core/Boost/BoostAtomicWriteFailureTest.php
+++ b/tests/Unit/Core/Boost/BoostAtomicWriteFailureTest.php
@@ -17,8 +17,10 @@ function boostAtomicFailureReset(array $overrides = array()) {
 	$GLOBALS['boost_atomic_failure_state'] = array_merge(array(
 		'flush'   => true,
 		'chmod'   => true,
+		'rename'  => true,
 		'unlinks' => array(),
 		'renames' => array(),
+		'logs'    => array(),
 	), $overrides);
 }
 
@@ -49,13 +51,17 @@ function boostAtomicFailureChmod($path, $mode) {
 function boostAtomicFailureRename($source, $destination) {
 	$GLOBALS['boost_atomic_failure_state']['renames'][] = array($source, $destination);
 
-	return true;
+	return $GLOBALS['boost_atomic_failure_state']['rename'];
 }
 
 function boostAtomicFailureUnlink($path) {
 	$GLOBALS['boost_atomic_failure_state']['unlinks'][] = $path;
 
 	return true;
+}
+
+function boostAtomicFailureLog($message, $output = false, $facility = '') {
+	$GLOBALS['boost_atomic_failure_state']['logs'][] = array($message, $facility);
 }
 
 function boostAtomicFailureLoad($root) {
@@ -81,6 +87,7 @@ function boostAtomicFailureLoad($root) {
 		'chmod',
 		'rename',
 		'unlink',
+		'cacti_log',
 	), array(
 		'boostAtomicFailureWrite',
 		'boostAtomicFailureTempnam',
@@ -91,6 +98,7 @@ function boostAtomicFailureLoad($root) {
 		'boostAtomicFailureChmod',
 		'boostAtomicFailureRename',
 		'boostAtomicFailureUnlink',
+		'boostAtomicFailureLog',
 	), $function);
 
 	eval($function);
@@ -106,13 +114,23 @@ test('a cache flush failure removes the temporary file without publishing it', f
 
 	expect(boostAtomicFailureWrite('/cache/final.png', 'payload'))->toBeFalse()
 		->and($GLOBALS['boost_atomic_failure_state']['unlinks'])->toBe(array('/cache/.boost-test'))
-		->and($GLOBALS['boost_atomic_failure_state']['renames'])->toBe(array());
+		->and($GLOBALS['boost_atomic_failure_state']['renames'])->toBe(array())
+		->and($GLOBALS['boost_atomic_failure_state']['logs'][0][0])->toContain('could not flush');
 });
 
-test('a cache permission failure removes the temporary file without publishing it', function () {
+test('a cache permission failure logs a warning and publishes the stricter temporary mode', function () {
 	boostAtomicFailureReset(array('chmod' => false));
+
+	expect(boostAtomicFailureWrite('/cache/final.png', 'payload'))->toBeTrue()
+		->and($GLOBALS['boost_atomic_failure_state']['unlinks'])->toBe(array())
+		->and($GLOBALS['boost_atomic_failure_state']['renames'])->toBe(array(array('/cache/.boost-test', '/cache/final.png')))
+		->and($GLOBALS['boost_atomic_failure_state']['logs'][0][0])->toContain('existing stricter mode');
+});
+
+test('a cache publication failure removes the temporary file and logs the error', function () {
+	boostAtomicFailureReset(array('rename' => false));
 
 	expect(boostAtomicFailureWrite('/cache/final.png', 'payload'))->toBeFalse()
 		->and($GLOBALS['boost_atomic_failure_state']['unlinks'])->toBe(array('/cache/.boost-test'))
-		->and($GLOBALS['boost_atomic_failure_state']['renames'])->toBe(array());
+		->and($GLOBALS['boost_atomic_failure_state']['logs'][0][0])->toContain('could not publish');
 });

--- a/tests/Unit/Core/Boost/BoostAtomicWriteFailureTest.php
+++ b/tests/Unit/Core/Boost/BoostAtomicWriteFailureTest.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+
+function boostAtomicFailureReset(array $overrides = array()) {
+	$GLOBALS['boost_atomic_failure_state'] = array_merge(array(
+		'flush'   => true,
+		'chmod'   => true,
+		'unlinks' => array(),
+		'renames' => array(),
+	), $overrides);
+}
+
+function boostAtomicFailureTempnam($directory, $prefix) {
+	return $directory . '/' . $prefix . 'test';
+}
+
+function boostAtomicFailureFopen($path, $mode) {
+	return new stdClass();
+}
+
+function boostAtomicFailureFwrite($stream, $data) {
+	return strlen($data);
+}
+
+function boostAtomicFailureFflush($stream) {
+	return $GLOBALS['boost_atomic_failure_state']['flush'];
+}
+
+function boostAtomicFailureFclose($stream) {
+	return true;
+}
+
+function boostAtomicFailureChmod($path, $mode) {
+	return $GLOBALS['boost_atomic_failure_state']['chmod'];
+}
+
+function boostAtomicFailureRename($source, $destination) {
+	$GLOBALS['boost_atomic_failure_state']['renames'][] = array($source, $destination);
+
+	return true;
+}
+
+function boostAtomicFailureUnlink($path) {
+	$GLOBALS['boost_atomic_failure_state']['unlinks'][] = $path;
+
+	return true;
+}
+
+function boostAtomicFailureLoad($root) {
+	if (function_exists('boostAtomicFailureWrite')) {
+		return;
+	}
+
+	$source = file_get_contents($root . '/lib/boost.php');
+	$start  = strpos($source, 'function boost_atomic_write_cache(');
+	$end    = strpos($source, "\nfunction ", $start + 1);
+
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+	$function = str_replace(array(
+		'boost_atomic_write_cache',
+		'tempnam',
+		'fopen',
+		'fwrite',
+		'fflush',
+		'fclose',
+		'chmod',
+		'rename',
+		'unlink',
+	), array(
+		'boostAtomicFailureWrite',
+		'boostAtomicFailureTempnam',
+		'boostAtomicFailureFopen',
+		'boostAtomicFailureFwrite',
+		'boostAtomicFailureFflush',
+		'boostAtomicFailureFclose',
+		'boostAtomicFailureChmod',
+		'boostAtomicFailureRename',
+		'boostAtomicFailureUnlink',
+	), $function);
+
+	eval($function);
+}
+
+beforeEach(function () use ($root) {
+	boostAtomicFailureLoad($root);
+	boostAtomicFailureReset();
+});
+
+test('a cache flush failure removes the temporary file without publishing it', function () {
+	boostAtomicFailureReset(array('flush' => false));
+
+	expect(boostAtomicFailureWrite('/cache/final.png', 'payload'))->toBeFalse()
+		->and($GLOBALS['boost_atomic_failure_state']['unlinks'])->toBe(array('/cache/.boost-test'))
+		->and($GLOBALS['boost_atomic_failure_state']['renames'])->toBe(array());
+});
+
+test('a cache permission failure removes the temporary file without publishing it', function () {
+	boostAtomicFailureReset(array('chmod' => false));
+
+	expect(boostAtomicFailureWrite('/cache/final.png', 'payload'))->toBeFalse()
+		->and($GLOBALS['boost_atomic_failure_state']['unlinks'])->toBe(array('/cache/.boost-test'))
+		->and($GLOBALS['boost_atomic_failure_state']['renames'])->toBe(array());
+});

--- a/tests/Unit/Core/Boost/BoostBatchBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostBatchBehaviorTest.php
@@ -1,0 +1,154 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+
+function boostBatchTestReset(array $overrides = array()) {
+	$GLOBALS['boost_batch_test_state'] = array_merge(array(
+		'packet_limit'  => 1048576,
+		'queries'       => array(),
+		'affected_rows' => 1000,
+		'fail_at'       => 0,
+		'throw_at'      => 0,
+		'logs'          => array(),
+	), $overrides);
+}
+
+function boostBatchTestSizeof($value) {
+	return is_countable($value) ? count($value) : 0;
+}
+
+function boostBatchTestFetchRow($sql, $assoc, $conn) {
+	return array('Value' => $GLOBALS['boost_batch_test_state']['packet_limit']);
+}
+
+function boostBatchTestExecute($sql, $log, $conn) {
+	$state =& $GLOBALS['boost_batch_test_state'];
+	$state['queries'][] = $sql;
+	$call = count($state['queries']);
+
+	if ($state['throw_at'] === $call) {
+		throw new RuntimeException('injected database failure');
+	}
+
+	return $state['fail_at'] !== $call;
+}
+
+function boostBatchTestAffectedRows($conn) {
+	return $GLOBALS['boost_batch_test_state']['affected_rows'];
+}
+
+function boostBatchTestLog($message, $output = false, $facility = '') {
+	$GLOBALS['boost_batch_test_state']['logs'][] = array($message, $output, $facility);
+}
+
+function boostBatchTestLoadFunction($root) {
+	if (function_exists('boostBatchTestFlush')) {
+		return;
+	}
+
+	$source = file_get_contents($root . '/lib/boost.php');
+	expect($source)->not->toBeFalse();
+
+	$start = strpos($source, 'function boost_flush_output_batch(');
+	$end   = strpos($source, "\nfunction ", $start + 1);
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+	$function = str_replace(array(
+		'boost_flush_output_batch',
+		'cacti_sizeof',
+		'db_fetch_row',
+		'db_execute',
+		'db_affected_rows',
+		'cacti_log',
+	), array(
+		'boostBatchTestFlush',
+		'boostBatchTestSizeof',
+		'boostBatchTestFetchRow',
+		'boostBatchTestExecute',
+		'boostBatchTestAffectedRows',
+		'boostBatchTestLog',
+	), $function);
+
+	eval($function);
+}
+
+beforeEach(function () use ($root) {
+	boostBatchTestLoadFunction($root);
+	boostBatchTestReset();
+});
+
+test('an empty handoff succeeds without querying the packet limit or writing SQL', function () {
+	expect(boostBatchTestFlush(array(), new stdClass()))->toBeTrue()
+		->and($GLOBALS['boost_batch_test_state']['queries'])->toBe(array());
+});
+
+test('a handoff below the packet limit is emitted as one insert', function () {
+	$conn   = new stdClass();
+	$tuples = array("(1,'a','2026-01-01 00:00:00','1')", "(2,'b','2026-01-01 00:00:00','2')");
+
+	expect(boostBatchTestFlush($tuples, $conn))->toBeTrue()
+		->and($GLOBALS['boost_batch_test_state']['queries'])->toHaveCount(1)
+		->and($GLOBALS['boost_batch_test_state']['queries'][0])->toContain(implode(',', $tuples));
+});
+
+test('packet-aware handoffs preserve tuple order across multiple inserts', function () {
+	boostBatchTestReset(array('packet_limit' => 120));
+	$conn   = new stdClass();
+	$tuples = array(
+		"(1,'alpha','2026-01-01 00:00:00','1111111111')",
+		"(2,'beta','2026-01-01 00:00:01','2222222222')",
+		"(3,'gamma','2026-01-01 00:00:02','3333333333')",
+	);
+
+	expect(boostBatchTestFlush($tuples, $conn))->toBeTrue()
+		->and($GLOBALS['boost_batch_test_state']['queries'])->toHaveCount(3);
+
+	foreach ($tuples as $index => $tuple) {
+		expect($GLOBALS['boost_batch_test_state']['queries'][$index])->toEndWith($tuple);
+	}
+});
+
+test('a false database acknowledgement fails the handoff', function () {
+	boostBatchTestReset(array('fail_at' => 1));
+
+	expect(boostBatchTestFlush(array("(1,'a','2026-01-01 00:00:00','1')"), new stdClass()))->toBeFalse();
+});
+
+test('a failed chunk stops the handoff before later chunks can be partially staged', function () {
+	boostBatchTestReset(array('packet_limit' => 120, 'fail_at' => 2));
+	$tuples = array(
+		"(1,'alpha','2026-01-01 00:00:00','1111111111')",
+		"(2,'beta','2026-01-01 00:00:01','2222222222')",
+		"(3,'gamma','2026-01-01 00:00:02','3333333333')",
+	);
+
+	expect(boostBatchTestFlush($tuples, new stdClass()))->toBeFalse()
+		->and($GLOBALS['boost_batch_test_state']['queries'])->toHaveCount(2);
+});
+
+test('a thrown database exception fails the handoff instead of escaping', function () {
+	boostBatchTestReset(array('throw_at' => 1));
+
+	expect(boostBatchTestFlush(array("(1,'a','2026-01-01 00:00:00','1')"), new stdClass()))->toBeFalse();
+});
+
+test('ignored duplicate keys are acknowledged but logged', function () {
+	boostBatchTestReset(array('affected_rows' => 0));
+
+	expect(boostBatchTestFlush(array("(1,'a','2026-01-01 00:00:00','1')"), new stdClass()))->toBeTrue()
+		->and($GLOBALS['boost_batch_test_state']['logs'])->toHaveCount(1)
+		->and($GLOBALS['boost_batch_test_state']['logs'][0][0])->toContain('duplicate sample keys');
+});

--- a/tests/Unit/Core/Boost/BoostCoreBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostCoreBehaviorTest.php
@@ -54,6 +54,39 @@ test('multi-column ordering honors each requested direction', function () {
 	expect(array_column($sorted, 'id'))->toBe(array('first', 'second', 'third'));
 });
 
+test('bounded Boost pages never split one data-source timestamp', function () {
+	$rows = array(
+		array('local_data_id' => 1, 'timestamp' => 100, 'rrd_name' => 'a'),
+		array('local_data_id' => 1, 'timestamp' => 100, 'rrd_name' => 'b'),
+		array('local_data_id' => 1, 'timestamp' => 101, 'rrd_name' => 'a'),
+		array('local_data_id' => 1, 'timestamp' => 101, 'rrd_name' => 'b'),
+	);
+
+	$page = boost_limit_complete_timestamp_page($rows, 3);
+
+	expect($page)->toHaveCount(2)
+		->and(array_unique(array_column($page, 'timestamp')))->toBe(array(100));
+});
+
+test('a timestamp wider than the configured Boost page fails closed', function () {
+	$rows = array(
+		array('local_data_id' => 1, 'timestamp' => 100, 'rrd_name' => 'a'),
+		array('local_data_id' => 1, 'timestamp' => 100, 'rrd_name' => 'b'),
+		array('local_data_id' => 1, 'timestamp' => 100, 'rrd_name' => 'c'),
+	);
+
+	expect(boost_limit_complete_timestamp_page($rows, 2))->toBeFalse();
+});
+
+test('a complete page at the configured limit is retained intact', function () {
+	$rows = array(
+		array('local_data_id' => 1, 'timestamp' => 100, 'rrd_name' => 'a'),
+		array('local_data_id' => 1, 'timestamp' => 100, 'rrd_name' => 'b'),
+	);
+
+	expect(boost_limit_complete_timestamp_page($rows, 2))->toBe($rows);
+});
+
 test('atomic cache publication writes all bytes replaces an old file and leaves no temporary files', function () {
 	$directory  = sys_get_temp_dir() . '/cacti-boost-core-' . bin2hex(random_bytes(8));
 	$cache_file = $directory . '/cache.png';

--- a/tests/Unit/Core/Boost/BoostCoreBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostCoreBehaviorTest.php
@@ -1,0 +1,148 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 4) . '/lib/boost.php';
+
+test('archive table validation accepts only generated numeric identifiers', function () {
+	$valid = array(
+		'poller_output_boost_arch_0',
+		'poller_output_boost_arch_1234567890',
+		'poller_output_boost_arch_0001',
+	);
+
+	foreach ($valid as $table) {
+		expect(boost_is_valid_archive_table($table))->toBeTrue($table);
+	}
+
+	$invalid = array(
+		'',
+		null,
+		123,
+		'poller_output_boost_arch_',
+		'poller_output_boost_arch_-1',
+		'poller_output_boost_arch_1.0',
+		'poller_output_boost_arch_1_extra',
+		"poller_output_boost_arch_1\n",
+		'poller_output_boost_arch_1; DROP TABLE settings',
+		'../poller_output_boost_arch_1',
+	);
+
+	foreach ($invalid as $table) {
+		expect(boost_is_valid_archive_table($table))->toBeFalse(var_export($table, true));
+	}
+});
+
+test('multi-column ordering honors each requested direction', function () {
+	$rows = array(
+		array('group' => 'b', 'value' => 1, 'id' => 'third'),
+		array('group' => 'a', 'value' => 1, 'id' => 'second'),
+		array('group' => 'a', 'value' => 3, 'id' => 'first'),
+	);
+
+	$sorted = boost_array_orderby($rows, 'group', SORT_ASC, 'value', SORT_DESC);
+
+	expect(array_column($sorted, 'id'))->toBe(array('first', 'second', 'third'));
+});
+
+test('atomic cache publication writes all bytes replaces an old file and leaves no temporary files', function () {
+	$directory  = sys_get_temp_dir() . '/cacti-boost-core-' . bin2hex(random_bytes(8));
+	$cache_file = $directory . '/cache.png';
+	$first      = str_repeat('first-payload-', 4096);
+	$second     = str_repeat('second-payload-', 8192);
+
+	expect(mkdir($directory, 0700))->toBeTrue();
+
+	try {
+		expect(boost_atomic_write_cache($cache_file, $first))->toBeTrue()
+			->and(file_get_contents($cache_file))->toBe($first)
+			->and(boost_atomic_write_cache($cache_file, $second))->toBeTrue()
+			->and(file_get_contents($cache_file))->toBe($second)
+			->and(glob($directory . '/.boost-*'))->toBe(array());
+	} finally {
+		@unlink($cache_file);
+		@rmdir($directory);
+	}
+});
+
+test('atomic cache publication supports an empty payload without leaking a temporary file', function () {
+	$directory  = sys_get_temp_dir() . '/cacti-boost-empty-' . bin2hex(random_bytes(8));
+	$cache_file = $directory . '/cache.png';
+
+	expect(mkdir($directory, 0700))->toBeTrue();
+
+	try {
+		expect(boost_atomic_write_cache($cache_file, ''))->toBeTrue()
+			->and(file_get_contents($cache_file))->toBe('')
+			->and(glob($directory . '/.boost-*'))->toBe(array());
+	} finally {
+		@unlink($cache_file);
+		@rmdir($directory);
+	}
+});
+
+test('Windows cache replacement preserves the new payload and removes its backup', function () {
+	$directory  = sys_get_temp_dir() . '/cacti-boost-replace-' . bin2hex(random_bytes(8));
+	$cache_file = $directory . '/cache.png';
+	$temp_file  = $directory . '/pending.png';
+
+	expect(mkdir($directory, 0700))->toBeTrue();
+	file_put_contents($cache_file, 'old');
+	file_put_contents($temp_file, 'new');
+
+	try {
+		expect(boost_replace_cache_file_on_windows($temp_file, $cache_file))->toBeTrue()
+			->and(file_get_contents($cache_file))->toBe('new')
+			->and(file_exists($temp_file))->toBeFalse()
+			->and(glob($directory . '/.boost-old-*'))->toBe(array());
+	} finally {
+		@unlink($temp_file);
+		@unlink($cache_file);
+		foreach (glob($directory . '/.boost-old-*') ?: array() as $backup) {
+			@unlink($backup);
+		}
+		@rmdir($directory);
+	}
+});
+
+test('Boost timer records complete cycles and ignores an unmatched end', function () {
+	if (!defined('BOOST_TIMER_START')) {
+		define('BOOST_TIMER_START', 0);
+	}
+
+	if (!defined('BOOST_TIMER_END')) {
+		define('BOOST_TIMER_END', 1);
+	}
+
+	if (!defined('BOOST_TIMER_TOTAL')) {
+		define('BOOST_TIMER_TOTAL', 2);
+	}
+
+	if (!defined('BOOST_TIMER_CYCLES')) {
+		define('BOOST_TIMER_CYCLES', 3);
+	}
+
+	$GLOBALS['boost_stats_log'] = array();
+
+	boost_timer('unmatched', BOOST_TIMER_END);
+	boost_timer('query', BOOST_TIMER_START);
+	usleep(1000);
+	boost_timer('query', BOOST_TIMER_END);
+	boost_timer('query', BOOST_TIMER_START);
+	usleep(1000);
+	boost_timer('query', BOOST_TIMER_END);
+
+	expect($GLOBALS['boost_stats_log'])->not->toHaveKey('unmatched')
+		->and($GLOBALS['boost_stats_log']['query'][BOOST_TIMER_CYCLES])->toBe(2)
+		->and($GLOBALS['boost_stats_log']['query'][BOOST_TIMER_TOTAL])->toBeGreaterThan(0.0)
+		->and($GLOBALS['boost_stats_log']['query'])->not->toHaveKey(BOOST_TIMER_START);
+});

--- a/tests/Unit/Core/Boost/BoostCoreBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostCoreBehaviorTest.php
@@ -114,6 +114,12 @@ test('Windows cache replacement preserves the new payload and removes its backup
 	}
 });
 
+test('Windows cache replacement rejects a missing source or destination', function () {
+	$missing = sys_get_temp_dir() . '/cacti-boost-missing-' . bin2hex(random_bytes(8));
+
+	expect(boost_replace_cache_file_on_windows($missing . '-source', $missing . '-destination'))->toBeFalse();
+});
+
 test('Boost timer records complete cycles and ignores an unmatched end', function () {
 	if (!defined('BOOST_TIMER_START')) {
 		define('BOOST_TIMER_START', 0);

--- a/tests/Unit/Core/Boost/BoostDaemonHardeningTest.php
+++ b/tests/Unit/Core/Boost/BoostDaemonHardeningTest.php
@@ -7,19 +7,24 @@
  +-------------------------------------------------------------------------+
 */
 
-$boostSource  = file_get_contents(__DIR__ . '/../../../../lib/boost.php');
-$pollerSource = file_get_contents(__DIR__ . '/../../../../lib/poller.php');
-$funcSource   = file_get_contents(__DIR__ . '/../../../../lib/functions.php');
+$boostSource = file_get_contents(__DIR__ . '/../../../../lib/boost.php');
 
-test('boost_graph_set_file uses umask instead of chmod', function () use ($boostSource) {
+expect($boostSource)->not->toBeFalse();
+
+test('boost_graph_set_file delegates cache publication to the atomic writer', function () use ($boostSource) {
 	$start = strpos($boostSource, 'function boost_graph_set_file(');
-	$body = substr($boostSource, $start, 1500);
-	expect($body)->toContain('umask(');
-	expect($body)->not->toContain('chmod($cache_file');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($boostSource, $start, 2500);
+
+	expect($body)->toContain('boost_atomic_write_cache($cache_file, $output)')
+		->and($body)->not->toContain('file_put_contents($cache_file');
 });
 
 test('boost_graph_cache_check casts IDs to int', function () use ($boostSource) {
 	$start = strpos($boostSource, 'function boost_graph_cache_check(');
+	expect($start)->not->toBeFalse();
+
 	$body = substr($boostSource, $start, 500);
 	expect($body)->toContain('$local_graph_id = (int)$local_graph_id');
 	expect($body)->toContain('$rra_id         = (int)$rra_id');
@@ -27,32 +32,30 @@ test('boost_graph_cache_check casts IDs to int', function () use ($boostSource) 
 
 test('boost_graph_set_file casts IDs to int', function () use ($boostSource) {
 	$start = strpos($boostSource, 'function boost_graph_set_file(');
+	expect($start)->not->toBeFalse();
+
 	$body = substr($boostSource, $start, 500);
 	expect($body)->toContain('(int)$local_graph_id');
 	expect($body)->toContain('(int)$rra_id');
 });
 
-test('boost GET_LOCK has retry limit', function () use ($boostSource) {
-	expect($boostSource)->toContain('$max_attempts');
-	expect($boostSource)->toContain('if (++$lock_attempts >= $max_attempts)');
+test('RRD update boundaries reject unsafe paths templates and values', function () use ($boostSource) {
+	$start = strpos($boostSource, 'function boost_rrdtool_function_update(');
+	expect($start)->not->toBeFalse();
+
+	$body = substr($boostSource, $start, 5000);
+
+	expect($body)->toContain('cacti_rrdtool_valid_path($rrd_path)')
+		->and($body)->toContain('cacti_rrdtool_valid_ds_template($rrd_update_template)')
+		->and($body)->toContain('cacti_has_control_chars($rrd_update_values)');
 });
 
-test('exec_with_timeout does not use exec setsid', function () use ($pollerSource) {
-	$start = strpos($pollerSource, 'function exec_with_timeout(');
-	$body = substr($pollerSource, $start, 1000);
-	expect($body)->not->toContain('exec setsid');
-	expect($body)->toContain('proc_open($cmd,');
-});
+test('on-demand processing validates its identifier before building temporary table names', function () use ($boostSource) {
+	$start = strpos($boostSource, 'function boost_process_poller_output(');
+	expect($start)->not->toBeFalse();
 
-test('cacti_unserialize blocks object injection on PHP 5', function () use ($funcSource) {
-	$start = strpos($funcSource, 'function cacti_unserialize(');
-	$body = substr($funcSource, $start, 600);
-	expect($body)->toContain("(O|C):[0-9]+:");
-	expect($body)->toContain("'allowed_classes' => false");
-});
+	$body = substr($boostSource, $start, 1000);
 
-test('cacti_unserialize rejects null and empty input', function () use ($funcSource) {
-	$start = strpos($funcSource, 'function cacti_unserialize(');
-	$body = substr($funcSource, $start, 300);
-	expect($body)->toContain("\$strobj === null || \$strobj === ''");
+	expect($body)->toContain('$local_data_id = (int) $local_data_id;')
+		->and($body)->toContain('if ($local_data_id <= 0)');
 });

--- a/tests/Unit/Core/Boost/BoostDaemonHardeningTest.php
+++ b/tests/Unit/Core/Boost/BoostDaemonHardeningTest.php
@@ -7,9 +7,11 @@
  +-------------------------------------------------------------------------+
 */
 
-$boostSource = file_get_contents(__DIR__ . '/../../../../lib/boost.php');
+$boostPath   = __DIR__ . '/../../../../lib/boost.php';
+$boostSource = file_get_contents($boostPath);
 
 expect($boostSource)->not->toBeFalse();
+require_once $boostPath;
 
 test('boost_graph_set_file delegates cache publication to the atomic writer', function () use ($boostSource) {
 	$start = strpos($boostSource, 'function boost_graph_set_file(');
@@ -50,12 +52,7 @@ test('RRD update boundaries reject unsafe paths templates and values', function 
 		->and($body)->toContain('cacti_has_control_chars($rrd_update_values)');
 });
 
-test('on-demand processing validates its identifier before building temporary table names', function () use ($boostSource) {
-	$start = strpos($boostSource, 'function boost_process_poller_output(');
-	expect($start)->not->toBeFalse();
-
-	$body = substr($boostSource, $start, 1000);
-
-	expect($body)->toContain('$local_data_id = (int) $local_data_id;')
-		->and($body)->toContain('if ($local_data_id <= 0)');
+test('on-demand processing rejects a non-positive identifier before querying', function () {
+	expect(boost_process_poller_output(0))->toBe(-1)
+		->and(boost_process_poller_output('-4'))->toBe(-1);
 });

--- a/tests/Unit/Core/Boost/BoostMetadataCacheTest.php
+++ b/tests/Unit/Core/Boost/BoostMetadataCacheTest.php
@@ -1,0 +1,87 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+
+function boostMetadataFetch($sql, $params = array()) {
+	$GLOBALS['boost_metadata_queries'][] = array($sql, $params);
+
+	if (strpos($sql, 'gti.task_item_id IS NULL') !== false) {
+		return array(array('data_source_name' => 'unused'));
+	}
+
+	return array(array('data_name' => 'input', 'data_source_name' => 'rrd'));
+}
+
+function boostMetadataRekey($rows, $key, $value) {
+	$result = array();
+
+	foreach($rows as $row) {
+		$result[$row[$key]] = $row[$value];
+	}
+
+	return $result;
+}
+
+function boostMetadataLoadFunctions($root) {
+	if (function_exists('boostMetadataUnused')) {
+		return;
+	}
+
+	$source = file_get_contents($root . '/lib/boost.php');
+	$start  = strpos($source, 'function boost_get_unused_data_source_names(');
+	$end    = strpos($source, "\n/**\n * boost_process_poller_output", $start);
+
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$functions = substr($source, $start, $end - $start);
+	$functions = str_replace(array(
+		'boost_get_unused_data_source_names',
+		'boost_get_input_field_names',
+		'db_fetch_assoc_prepared',
+		'array_rekey',
+	), array(
+		'boostMetadataUnused',
+		'boostMetadataFields',
+		'boostMetadataFetch',
+		'boostMetadataRekey',
+	), $functions);
+
+	eval($functions);
+}
+
+beforeEach(function () use ($root) {
+	boostMetadataLoadFunctions($root);
+	$GLOBALS['boost_metadata_queries'] = array();
+});
+
+test('unused data-source metadata is queried once per local data source', function () {
+	expect(boostMetadataUnused(900001))->toBe(array('unused' => 'unused'))
+		->and(boostMetadataUnused(900001))->toBe(array('unused' => 'unused'))
+		->and($GLOBALS['boost_metadata_queries'])->toHaveCount(1);
+});
+
+test('templated and non-templated field maps use separate cached queries', function () {
+	expect(boostMetadataFields(900002, true))->toBe(array('input' => 'rrd'))
+		->and(boostMetadataFields(900002, true))->toBe(array('input' => 'rrd'))
+		->and(boostMetadataFields(900002, false))->toBe(array('input' => 'rrd'))
+		->and(boostMetadataFields(900002, false))->toBe(array('input' => 'rrd'))
+		->and($GLOBALS['boost_metadata_queries'])->toHaveCount(2);
+});
+
+test('invalid local data-source IDs never reach metadata SQL', function () {
+	expect(boostMetadataUnused(0))->toBe(array())
+		->and(boostMetadataFields(-1, true))->toBe(array())
+		->and($GLOBALS['boost_metadata_queries'])->toBe(array());
+});

--- a/tests/Unit/Core/Boost/BoostPollerLifecycleTest.php
+++ b/tests/Unit/Core/Boost/BoostPollerLifecycleTest.php
@@ -138,16 +138,101 @@ test('table rotation and shard preparation fail closed on database errors', func
 
 	expect($body)->toContain('failed to create its interim output table')
 		->and($body)->toContain('failed to rotate its output table')
-		->and($body)->toContain('failed to reset its process-distribution table')
+		->and($body)->toContain('failed to create its process-distribution table')
 		->and($body)->toContain('failed to stage archive data-source identifiers')
 		->and($body)->toContain('failed to assign data sources to a child process');
+});
+
+test('scheduled Boost pages are hard bounded and advance run-scoped primary-key cursors', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function boost_process_local_data_ids(');
+
+	expect($body)->toContain('LIMIT \' . ($max_rows + 1)')
+		->and($body)->toContain('boost_limit_complete_timestamp_page($results, $max_rows)')
+		->and($body)->toContain('SET cursor_time = ?, cursor_rrd_name = ?')
+		->and($body)->toContain('WHERE run_id = ?')
+		->and($body)->not->toContain('WHERE local_data_id <= ?');
+});
+
+test('on-demand Boost defers oversized result sets without deleting them', function () use ($root) {
+	$source = file_get_contents($root . '/lib/boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function boost_process_poller_output(');
+
+	expect($body)->toContain('LIMIT \' . ($max_rows + 1)')
+		->and($body)->toContain('if (cacti_sizeof($results) > $max_rows)')
+		->and($body)->toContain('rows were retained for scheduled processing')
+		->and(strpos($body, 'return -1;'))->toBeLessThan(strpos($body, 'DELETE FROM poller_output_boost'));
+});
+
+test('scheduled and on-demand parsers share cached data-source metadata', function () use ($root) {
+	$boost  = file_get_contents($root . '/lib/boost.php');
+	$poller = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($boost, 'function boost_process_poller_output(');
+
+	expect($boost)->toContain('function boost_get_unused_data_source_names(')
+		->and($boost)->toContain('function boost_get_input_field_names(')
+		->and($body)->toContain('boost_get_unused_data_source_names($local_data_id)')
+		->and($body)->toContain('boost_get_input_field_names($item[\'local_data_id\'], true)')
+		->and($poller)->toContain('boost_get_unused_data_source_names($item[\'local_data_id\'])')
+		->and($poller)->toContain('boost_get_input_field_names($item[\'local_data_id\'], true)');
+});
+
+test('Boost takeover must confirm process death before shared table preparation', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function boost_kill_running_processes(');
+
+	expect($source)->toContain('if (!boost_kill_running_processes())')
+		->and($body)->toContain('cacti_process_still_running')
+		->and($body)->toContain('microtime(true) + max(1, (int) $wait_seconds)')
+		->and($body)->toContain('did not terminate before the takeover deadline')
+		->and($body)->toContain('return false;');
+});
+
+test('legacy RRD locks stop at the configured Boost runtime deadline', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function boost_process_local_data_ids(');
+
+	expect($body)->toContain('microtime(true) + max(1, min(30, (int) $max_run_duration))')
+		->and($body)->toContain('microtime(true) >= $lock_deadline')
+		->and($body)->toContain('timed out acquiring the RRD lock')
+		->and($body)->toContain('return -1;');
+});
+
+test('Boost runtime status uses a numeric start timestamp with legacy fallback', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function boost_prepare_process_table(');
+
+	expect($body)->toContain("read_config_option('boost_poller_started')")
+		->and($body)->toContain("set_config_option('boost_poller_started', \$start_time)")
+		->and($body)->toContain('if (!$previous_start_time && substr_count($boost_poller_status, \'running\'))');
+});
+
+test('only the Boost master mutates global lifecycle status from a signal', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function sig_handler(');
+	$child  = strpos($body, 'if ($child)');
+	$status = strpos($body, "set_config_option('boost_poller_status'");
+	$master = strpos($body, '} else {', $child);
+
+	expect($child)->not->toBeFalse()
+		->and($master)->not->toBeFalse()
+		->and($status)->toBeGreaterThan($master);
 });
 
 test('legacy RRDtool locking acquires each data-source lock only once', function () use ($root) {
 	$source = file_get_contents($root . '/poller_boost.php');
 	$body   = boostLifecycleFunctionBody($source, 'function boost_process_local_data_ids(');
 
-	expect(substr_count($body, "SELECT GET_LOCK('boost.single_ds."))->toBe(1);
+	$flush   = strpos($body, '$flush_ok   = boost_process_output');
+	$release = strpos($body, 'SELECT RELEASE_LOCK', $flush);
+	$acquire = strpos($body, 'SELECT GET_LOCK', $release);
+
+	expect(substr_count($body, "SELECT GET_LOCK('boost.single_ds."))->toBe(1)
+		->and($flush)->not->toBeFalse()
+		->and($release)->toBeGreaterThan($flush)
+		->and($acquire)->toBeGreaterThan($release)
+		->and($body)->toContain("SELECT RELEASE_LOCK('boost.single_ds.\$current_lock')")
+		->and($body)->toContain('if (!$flush_ok)');
 });
 
 test('malformed child statistics are ignored instead of iterated', function () use ($root) {
@@ -164,7 +249,8 @@ test('preparation and completion-record failures are externally visible', functi
 	expect($source)->toContain("set_config_option('boost_poller_status', 'failed - end time:'")
 		->and($source)->toContain('Boost preparation failed; no child processes were launched.')
 		->and($source)->toContain('Boost child could not record its completion status.')
-		->and($source)->toContain('exit($completion_recorded === false ? 1 : 0)');
+		->and($source)->toContain('exit($completion_recorded === false || $rrd_updates < 0 ? 1 : 0)')
+		->and($source)->toContain('exit($exit_code)');
 });
 
 test('child identifiers are positive integers before reaching SQL and process state', function () use ($root) {

--- a/tests/Unit/Core/Boost/BoostPollerLifecycleTest.php
+++ b/tests/Unit/Core/Boost/BoostPollerLifecycleTest.php
@@ -1,0 +1,175 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+
+function boostLifecycleFunctionBody($source, $signature) {
+	$start = strpos($source, $signature);
+
+	if ($start === false) {
+		return '';
+	}
+
+	$end = strpos($source, "\nfunction ", $start + 1);
+
+	return substr($source, $start, $end === false ? null : $end - $start);
+}
+
+test('the parent repairs completion schema before truncating shared completion state', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	expect($source)->not->toBeFalse();
+
+	$repair   = strpos($source, 'boost_ensure_process_table(true)');
+	$truncate = strpos($source, "db_execute('TRUNCATE TABLE poller_output_boost_processes')");
+
+	expect($repair)->not->toBeFalse()
+		->and($truncate)->not->toBeFalse()
+		->and($repair)->toBeLessThan($truncate);
+});
+
+test('the parent waits for both process exit and run-scoped completion', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+
+	expect($source)->toContain('boost_processes_running() > 0 || boost_completed_children($run_id) < $expected_children')
+		->and($source)->toContain('boost_failed_children($run_id)')
+		->and($source)->toContain('$run_complete       = $failed_children == 0 && $completed_children >= $expected_children;');
+});
+
+test('archive tables are dropped only after every child succeeds', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$start  = strpos($source, '$run_complete       =');
+	$drop   = strpos($source, 'DROP TABLE IF EXISTS `$table`', $start);
+
+	expect($start)->not->toBeFalse()
+		->and($drop)->not->toBeFalse();
+
+	$segment = substr($source, $start, $drop - $start);
+
+	expect($segment)->toContain('if (!$run_complete)')
+		->and($segment)->toContain('if ($rrd_updates > 0 && $run_complete)')
+		->and($segment)->toContain("set_config_option('boost_last_run_time', \$last_run_time)");
+});
+
+test('child completion is idempotent within a run and records failures', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function boost_failed_children(');
+
+	expect($source)->toContain('ON DUPLICATE KEY UPDATE status = VALUES(status)')
+		->and($source)->toContain('array($run_id, $child, $rrd_updates)')
+		->and($body)->toContain('WHERE run_id = ?')
+		->and($body)->toContain('CAST(status AS SIGNED) < 0');
+});
+
+test('failed RRD updates retain both scheduled shards and on-demand rows', function () use ($root) {
+	$poller = file_get_contents($root . '/poller_boost.php');
+	$boost  = file_get_contents($root . '/lib/boost.php');
+
+	expect($poller)->toContain('if ($updates_ok && $results !== false)')
+		->and($poller)->toContain('return $updates_ok && $results !== false ? cacti_sizeof($results) : -1;')
+		->and($boost)->toContain('if ($updates_ok && cacti_sizeof($results))')
+		->and($boost)->toContain('return $updates_ok ? cacti_sizeof($results) : -1;');
+});
+
+test('dynamic archive identifiers are validated before select delete analyze and drop use', function () use ($root) {
+	$boost  = file_get_contents($root . '/lib/boost.php');
+	$poller = file_get_contents($root . '/poller_boost.php');
+
+	expect($boost)->toContain("preg_match('/^poller_output_boost_arch_\\d+$/D', \$table)")
+		->and($boost)->toContain("array_filter(\$tableNames, 'boost_is_valid_archive_table')")
+		->and($poller)->toContain('if (boost_is_valid_archive_table($table))')
+		->and($poller)->toContain('DROP TABLE IF EXISTS `$table`');
+});
+
+test('recovery reads are bounded and restore online status even after transfer failure', function () use ($root) {
+	$source = file_get_contents($root . '/poller_recovery.php');
+
+	expect($source)->toContain("LIMIT ' . (int) \$record_limit")
+		->and($source)->toContain('ORDER BY time ASC, local_data_id ASC, rrd_name ASC')
+		->and($source)->not->toContain('if (!$transfer_failed) {')
+		->and($source)->toContain('exit($transfer_failed ? 1 : 0)');
+});
+
+test('RRD creation and update failures cannot acknowledge queued samples', function () use ($root) {
+	$boost  = file_get_contents($root . '/lib/boost.php');
+	$poller = file_get_contents($root . '/poller_boost.php');
+
+	expect($boost)->toContain("return 'ERROR: Unable to create RRD file';")
+		->and($boost)->toContain("rrdtool_execute_path_command('file_exists', \$rrd_path")
+		->and(substr_count($boost, "trim((string) \$return_value) !== 'OK'"))->toBe(2)
+		->and($poller)->toContain("trim((string) \$return_value) !== 'OK'");
+});
+
+test('Boost SQL string literals do not depend on MySQL double-quote mode', function () use ($root) {
+	$unsafe = array(
+		'tasktype = "',
+		'taskname = "',
+		'disabled = "',
+		'LIKE "',
+		'VALUES ("',
+		'SET status = "',
+		'SET status="',
+		'CONCAT(data_template_id, "',
+		'REPLACE(name, "',
+		'end_time="',
+	);
+
+	foreach (array('lib/boost.php', 'poller_boost.php', 'poller_recovery.php') as $file) {
+		$source = file_get_contents($root . '/' . $file);
+
+		foreach ($unsafe as $needle) {
+			expect($source)->not->toContain($needle, $file . ': ' . $needle);
+		}
+	}
+});
+
+test('table rotation and shard preparation fail closed on database errors', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function boost_prepare_process_table(');
+
+	expect($body)->toContain('failed to create its interim output table')
+		->and($body)->toContain('failed to rotate its output table')
+		->and($body)->toContain('failed to reset its process-distribution table')
+		->and($body)->toContain('failed to stage archive data-source identifiers')
+		->and($body)->toContain('failed to assign data sources to a child process');
+});
+
+test('legacy RRDtool locking acquires each data-source lock only once', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function boost_process_local_data_ids(');
+
+	expect(substr_count($body, "SELECT GET_LOCK('boost.single_ds."))->toBe(1);
+});
+
+test('malformed child statistics are ignored instead of iterated', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+	$body   = boostLifecycleFunctionBody($source, 'function boost_log_statistics(');
+
+	expect($body)->toContain("json_decode(\$stat['value'], true)")
+		->and($body)->toContain('if (!is_array($stat))');
+});
+
+test('preparation and completion-record failures are externally visible', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+
+	expect($source)->toContain("set_config_option('boost_poller_status', 'failed - end time:'")
+		->and($source)->toContain('Boost preparation failed; no child processes were launched.')
+		->and($source)->toContain('Boost child could not record its completion status.')
+		->and($source)->toContain('exit($completion_recorded === false ? 1 : 0)');
+});
+
+test('child identifiers are positive integers before reaching SQL and process state', function () use ($root) {
+	$source = file_get_contents($root . '/poller_boost.php');
+
+	expect($source)->toContain("preg_match('/^[1-9]\\d*$/D', \$value)")
+		->and($source)->toContain('$child = (int) $value;');
+});

--- a/tests/Unit/Core/Boost/BoostPollerLifecycleTest.php
+++ b/tests/Unit/Core/Boost/BoostPollerLifecycleTest.php
@@ -90,12 +90,12 @@ test('dynamic archive identifiers are validated before select delete analyze and
 		->and($poller)->toContain('DROP TABLE IF EXISTS `$table`');
 });
 
-test('recovery reads are bounded and restore online status even after transfer failure', function () use ($root) {
+test('recovery reads are bounded and leave recovery status visible after transfer failure', function () use ($root) {
 	$source = file_get_contents($root . '/poller_recovery.php');
 
 	expect($source)->toContain("LIMIT ' . (int) \$record_limit")
 		->and($source)->toContain('ORDER BY time ASC, local_data_id ASC, rrd_name ASC')
-		->and($source)->not->toContain('if (!$transfer_failed) {')
+		->and($source)->toContain('if (!$transfer_failed) {')
 		->and($source)->toContain('exit($transfer_failed ? 1 : 0)');
 });
 

--- a/tests/Unit/Core/Boost/BoostProcessTableUpgradeBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostProcessTableUpgradeBehaviorTest.php
@@ -17,6 +17,7 @@ function boost12TestReset(array $overrides = array()) {
 		'key'      => true,
 		'rows'     => 3,
 		'fail_on'  => '',
+		'appear_on_failure' => '',
 		'sql'      => array(),
 		'logs'     => array(),
 	), $overrides);
@@ -39,6 +40,16 @@ function boost12TestExecute($sql) {
 	$state['sql'][] = $sql;
 
 	if ($state['fail_on'] !== '' && strpos($sql, $state['fail_on']) !== false) {
+		if ($state['appear_on_failure'] === 'table') {
+			$state['table'] = true;
+		} elseif ($state['appear_on_failure'] === 'run_id') {
+			$state['run_id'] = true;
+		} elseif ($state['appear_on_failure'] === 'child_id') {
+			$state['child_id'] = true;
+		} elseif ($state['appear_on_failure'] === 'key') {
+			$state['key'] = true;
+		}
+
 		return false;
 	}
 
@@ -158,4 +169,61 @@ test('runtime recovery fails closed and logs the first schema error', function (
 		->and($GLOBALS['boost12_test_state']['key'])->toBeFalse()
 		->and($GLOBALS['boost12_test_state']['logs'])->toHaveCount(1)
 		->and($GLOBALS['boost12_test_state']['logs'][0][0])->toContain('Unable to add child_id');
+});
+
+test('runtime recovery accepts a concurrent table creator after create reports failure', function () {
+	boost12TestReset(array(
+		'table'             => false,
+		'run_id'            => false,
+		'child_id'          => false,
+		'key'               => false,
+		'fail_on'           => 'CREATE TABLE',
+		'appear_on_failure' => 'table',
+	));
+
+	expect(boost12TestEnsureProcessTable(true))->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['logs'])->toBe(array());
+});
+
+test('runtime recovery accepts a concurrent run_id column repair', function () {
+	boost12TestReset(array(
+		'run_id'            => false,
+		'fail_on'           => 'ADD `run_id`',
+		'appear_on_failure' => 'run_id',
+	));
+
+	expect(boost12TestEnsureProcessTable())->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['logs'])->toBe(array());
+});
+
+test('runtime recovery accepts a concurrent child_id column repair', function () {
+	boost12TestReset(array(
+		'child_id'          => false,
+		'fail_on'           => 'ADD `child_id`',
+		'appear_on_failure' => 'child_id',
+	));
+
+	expect(boost12TestEnsureProcessTable())->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['logs'])->toBe(array());
+});
+
+test('runtime recovery accepts a concurrent unique-key repair', function () {
+	boost12TestReset(array(
+		'key'               => false,
+		'fail_on'           => 'ADD UNIQUE KEY',
+		'appear_on_failure' => 'key',
+	));
+
+	expect(boost12TestEnsureProcessTable(true))->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['rows'])->toBe(0)
+		->and($GLOBALS['boost12_test_state']['logs'])->toBe(array());
+});
+
+test('runtime recovery fails closed when process-row truncation fails', function () {
+	boost12TestReset(array('key' => false, 'fail_on' => 'TRUNCATE TABLE'));
+
+	expect(boost12TestEnsureProcessTable(true))->toBeFalse()
+		->and($GLOBALS['boost12_test_state']['key'])->toBeFalse()
+		->and($GLOBALS['boost12_test_state']['logs'])->toHaveCount(1)
+		->and($GLOBALS['boost12_test_state']['logs'][0][0])->toContain('Unable to truncate');
 });

--- a/tests/Unit/Core/Boost/BoostProcessTableUpgradeBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostProcessTableUpgradeBehaviorTest.php
@@ -18,16 +18,38 @@ function boost12TestReset(array $overrides = array()) {
 		'rows'     => 3,
 		'fail_on'  => '',
 		'appear_on_failure' => '',
+		'table_cache'       => null,
+		'column_cache'      => array(),
 		'sql'      => array(),
 		'logs'     => array(),
 	), $overrides);
 }
 
 function boost12TestTableExists($table) {
-	return $GLOBALS['boost12_test_state']['table'];
+	$state =& $GLOBALS['boost12_test_state'];
+
+	if ($state['table_cache'] === null) {
+		$state['table_cache'] = $state['table'];
+	}
+
+	return $state['table_cache'];
 }
 
 function boost12TestColumnExists($table, $column) {
+	$state =& $GLOBALS['boost12_test_state'];
+
+	if (!array_key_exists($column, $state['column_cache'])) {
+		$state['column_cache'][$column] = $state[$column];
+	}
+
+	return $state['column_cache'][$column];
+}
+
+function boost12TestTableExistsUncached() {
+	return $GLOBALS['boost12_test_state']['table'];
+}
+
+function boost12TestColumnExistsUncached($column) {
 	return $GLOBALS['boost12_test_state'][$column];
 }
 
@@ -105,6 +127,8 @@ function boost12LoadEnsureFunction($root) {
 	$function = substr($source, $start, $end - $start);
 	$function = str_replace(array(
 		'boost_ensure_process_table',
+		'boost_process_table_exists_uncached',
+		'boost_process_column_exists_uncached',
 		'db_table_exists',
 		'db_column_exists',
 		'db_index_exists',
@@ -112,6 +136,8 @@ function boost12LoadEnsureFunction($root) {
 		'cacti_log',
 	), array(
 		'boost12TestEnsureProcessTable',
+		'boost12TestTableExistsUncached',
+		'boost12TestColumnExistsUncached',
 		'boost12TestTableExists',
 		'boost12TestColumnExists',
 		'boost12TestIndexExists',

--- a/tests/Unit/Core/Boost/BoostProcessTableUpgradeBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostProcessTableUpgradeBehaviorTest.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+
+function boost12TestReset(array $overrides = array()) {
+	$GLOBALS['boost12_test_state'] = array_merge(array(
+		'table'    => true,
+		'run_id'   => true,
+		'child_id' => true,
+		'key'      => true,
+		'rows'     => 3,
+		'fail_on'  => '',
+		'sql'      => array(),
+		'logs'     => array(),
+	), $overrides);
+}
+
+function boost12TestTableExists($table) {
+	return $GLOBALS['boost12_test_state']['table'];
+}
+
+function boost12TestColumnExists($table, $column) {
+	return $GLOBALS['boost12_test_state'][$column];
+}
+
+function boost12TestIndexExists($table, $index) {
+	return $GLOBALS['boost12_test_state']['key'];
+}
+
+function boost12TestExecute($sql) {
+	$state =& $GLOBALS['boost12_test_state'];
+	$state['sql'][] = $sql;
+
+	if ($state['fail_on'] !== '' && strpos($sql, $state['fail_on']) !== false) {
+		return false;
+	}
+
+	if (strpos($sql, 'CREATE TABLE') !== false) {
+		$state['table'] = $state['run_id'] = $state['child_id'] = $state['key'] = true;
+	} elseif (strpos($sql, 'ADD `run_id`') !== false) {
+		$state['run_id'] = true;
+	} elseif (strpos($sql, 'ADD `child_id`') !== false) {
+		$state['child_id'] = true;
+	} elseif (strpos($sql, 'TRUNCATE TABLE') !== false) {
+		$state['rows'] = 0;
+	} elseif (strpos($sql, 'ADD UNIQUE KEY') !== false) {
+		$state['key'] = true;
+	}
+
+	return true;
+}
+
+function boost12TestLog($message, $output = false, $facility = '') {
+	$GLOBALS['boost12_test_state']['logs'][] = array($message, $output, $facility);
+}
+
+function boost12LoadEnsureFunction($root) {
+	if (function_exists('boost12TestEnsureProcessTable')) {
+		return;
+	}
+
+	$source = file_get_contents($root . '/lib/boost.php');
+	expect($source)->not->toBeFalse();
+
+	$start = strpos($source, 'function boost_ensure_process_table(');
+	expect($start)->not->toBeFalse();
+
+	$body  = strpos($source, '{', $start);
+	$depth = 0;
+	$end   = false;
+
+	for ($offset = $body, $length = strlen($source); $offset < $length; $offset++) {
+		if ($source[$offset] === '{') {
+			$depth++;
+		} elseif ($source[$offset] === '}') {
+			$depth--;
+
+			if ($depth === 0) {
+				$end = $offset + 1;
+				break;
+			}
+		}
+	}
+
+	expect($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+	$function = str_replace(array(
+		'boost_ensure_process_table',
+		'db_table_exists',
+		'db_column_exists',
+		'db_index_exists',
+		'db_execute',
+		'cacti_log',
+	), array(
+		'boost12TestEnsureProcessTable',
+		'boost12TestTableExists',
+		'boost12TestColumnExists',
+		'boost12TestIndexExists',
+		'boost12TestExecute',
+		'boost12TestLog',
+	), $function);
+
+	eval($function);
+}
+
+beforeEach(function () use ($root) {
+	boost12LoadEnsureFunction($root);
+	boost12TestReset();
+});
+
+test('runtime recovery creates the complete process table when it is missing', function () {
+	boost12TestReset(array('table' => false, 'run_id' => false, 'child_id' => false, 'key' => false));
+
+	expect(boost12TestEnsureProcessTable())->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['sql'])->toHaveCount(1)
+		->and($GLOBALS['boost12_test_state']['sql'][0])->toContain('UNIQUE KEY `run_child` (`run_id`, `child_id`)')
+		->and($GLOBALS['boost12_test_state']['key'])->toBeTrue();
+});
+
+test('runtime recovery is a no-op for a complete process table', function () {
+	expect(boost12TestEnsureProcessTable(true))->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['sql'])->toBe(array())
+		->and($GLOBALS['boost12_test_state']['rows'])->toBe(3);
+});
+
+test('parent recovery adds missing columns without discarding completion rows', function () {
+	boost12TestReset(array('run_id' => false, 'child_id' => false, 'key' => false));
+
+	expect(boost12TestEnsureProcessTable(false))->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['run_id'])->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['child_id'])->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['key'])->toBeFalse()
+		->and($GLOBALS['boost12_test_state']['rows'])->toBe(3);
+});
+
+test('child recovery truncates incompatible rows before adding the unique key', function () {
+	boost12TestReset(array('key' => false));
+
+	expect(boost12TestEnsureProcessTable(true))->toBeTrue()
+		->and($GLOBALS['boost12_test_state']['rows'])->toBe(0)
+		->and($GLOBALS['boost12_test_state']['key'])->toBeTrue()
+		->and(implode("\n", $GLOBALS['boost12_test_state']['sql']))->toContain('TRUNCATE TABLE')
+		->and(implode("\n", $GLOBALS['boost12_test_state']['sql']))->toContain('ADD UNIQUE KEY');
+});
+
+test('runtime recovery fails closed and logs the first schema error', function () {
+	boost12TestReset(array('run_id' => false, 'child_id' => false, 'key' => false, 'fail_on' => 'ADD `child_id`'));
+
+	expect(boost12TestEnsureProcessTable(true))->toBeFalse()
+		->and($GLOBALS['boost12_test_state']['key'])->toBeFalse()
+		->and($GLOBALS['boost12_test_state']['logs'])->toHaveCount(1)
+		->and($GLOBALS['boost12_test_state']['logs'][0][0])->toContain('Unable to add child_id');
+});

--- a/tests/Unit/Core/Boost/BoostProcessTableUpgradeTest.php
+++ b/tests/Unit/Core/Boost/BoostProcessTableUpgradeTest.php
@@ -15,7 +15,7 @@
  * version after the database version. 1.2.32 is already in that map.
  */
 
-$root = dirname(__DIR__, 2);
+$root = dirname(__DIR__, 4);
 
 test('the 1.2.32 upgrade file exists so already-upgraded 1.2.31 installs receive the Boost process columns', function () use ($root) {
 	expect(file_exists($root . '/install/upgrades/1_2_32.php'))->toBeTrue();

--- a/tests/Unit/Core/Boost/BoostProcessTableUpgradeTest.php
+++ b/tests/Unit/Core/Boost/BoostProcessTableUpgradeTest.php
@@ -42,7 +42,7 @@ test('Boost recovers the process-table columns without waiting for an upgrade st
 	$poller = file_get_contents($root . '/poller.php');
 	$child  = file_get_contents($root . '/poller_boost.php');
 
-	expect($boost)->toContain('function boost_ensure_process_table()')
+	expect($boost)->toContain('function boost_ensure_process_table($repair_key = false)')
 		->and($boost)->toContain("db_column_exists('poller_output_boost_processes', 'run_id')")
 		->and($boost)->toContain("db_column_exists('poller_output_boost_processes', 'child_id')")
 		->and($boost)->toContain("db_index_exists('poller_output_boost_processes', 'run_child')")

--- a/tests/Unit/Core/Boost/BoostProcessTableUpgradeTest.php
+++ b/tests/Unit/Core/Boost/BoostProcessTableUpgradeTest.php
@@ -47,5 +47,6 @@ test('Boost recovers the process-table columns without waiting for an upgrade st
 		->and($boost)->toContain("db_column_exists('poller_output_boost_processes', 'child_id')")
 		->and($boost)->toContain("db_index_exists('poller_output_boost_processes', 'run_child')")
 		->and($poller)->toContain('boost_ensure_process_table()')
-		->and($child)->toContain('boost_ensure_process_table()');
+		->and($poller)->not->toContain('boost_ensure_process_table(true)')
+		->and($child)->toContain('boost_ensure_process_table(true)');
 });

--- a/tests/Unit/Core/Boost/BoostRecoveryDeleteBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostRecoveryDeleteBehaviorTest.php
@@ -1,0 +1,125 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+
+function boostRecoveryTestReset(array $overrides = array()) {
+	$GLOBALS['boost_recovery_test_state'] = array_merge(array(
+		'calls'   => array(),
+		'fail_at' => 0,
+	), $overrides);
+}
+
+function boostRecoveryTestExecute($sql, $params, $log, $conn) {
+	$state =& $GLOBALS['boost_recovery_test_state'];
+	$state['calls'][] = array('sql' => $sql, 'params' => $params, 'conn' => $conn);
+
+	return $state['fail_at'] !== count($state['calls']);
+}
+
+function boostRecoveryTestLoadFunction($root) {
+	if (function_exists('boostRecoveryTestDelete')) {
+		return;
+	}
+
+	$source = file_get_contents($root . '/poller_recovery.php');
+	expect($source)->not->toBeFalse();
+
+	$start = strpos($source, 'function recovery_delete_acknowledged_rows(');
+	expect($start)->not->toBeFalse();
+
+	$body  = strpos($source, '{', $start);
+	$depth = 0;
+	$end   = false;
+
+	for ($offset = $body, $length = strlen($source); $offset < $length; $offset++) {
+		if ($source[$offset] === '{') {
+			$depth++;
+		} elseif ($source[$offset] === '}') {
+			$depth--;
+
+			if ($depth === 0) {
+				$end = $offset + 1;
+				break;
+			}
+		}
+	}
+
+	expect($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+	$function = str_replace(array(
+		'recovery_delete_acknowledged_rows',
+		'db_execute_prepared',
+	), array(
+		'boostRecoveryTestDelete',
+		'boostRecoveryTestExecute',
+	), $function);
+
+	eval($function);
+}
+
+function boostRecoveryTestRows($count) {
+	$rows = array();
+
+	for ($index = 1; $index <= $count; $index++) {
+		$rows[] = array(
+			'local_data_id' => $index,
+			'rrd_name'      => 'ds_' . $index,
+			'time'          => sprintf('2026-01-01 00:%02d:%02d', intdiv($index, 60) % 60, $index % 60),
+		);
+	}
+
+	return $rows;
+}
+
+beforeEach(function () use ($root) {
+	boostRecoveryTestLoadFunction($root);
+	boostRecoveryTestReset();
+});
+
+test('an empty acknowledged set performs no delete', function () {
+	expect(boostRecoveryTestDelete(array(), 'local'))->toBeTrue()
+		->and($GLOBALS['boost_recovery_test_state']['calls'])->toBe(array());
+});
+
+test('recovery deletes exact primary-key triples with bound parameters', function () {
+	$rows = boostRecoveryTestRows(2);
+
+	expect(boostRecoveryTestDelete($rows, 'local'))->toBeTrue()
+		->and($GLOBALS['boost_recovery_test_state']['calls'])->toHaveCount(1);
+
+	$call = $GLOBALS['boost_recovery_test_state']['calls'][0];
+
+	expect(substr_count($call['sql'], '(local_data_id = ? AND rrd_name = ? AND time = ?)'))->toBe(2)
+		->and($call['params'])->toBe(array(
+			1, 'ds_1', $rows[0]['time'],
+			2, 'ds_2', $rows[1]['time'],
+		))
+		->and($call['conn'])->toBe('local');
+});
+
+test('recovery chunks exact deletes at five hundred rows', function () {
+	expect(boostRecoveryTestDelete(boostRecoveryTestRows(1001), 'local'))->toBeTrue()
+		->and($GLOBALS['boost_recovery_test_state']['calls'])->toHaveCount(3)
+		->and($GLOBALS['boost_recovery_test_state']['calls'][0]['params'])->toHaveCount(1500)
+		->and($GLOBALS['boost_recovery_test_state']['calls'][1]['params'])->toHaveCount(1500)
+		->and($GLOBALS['boost_recovery_test_state']['calls'][2]['params'])->toHaveCount(3);
+});
+
+test('recovery stops deleting immediately after a failed chunk', function () {
+	boostRecoveryTestReset(array('fail_at' => 2));
+
+	expect(boostRecoveryTestDelete(boostRecoveryTestRows(1200), 'local'))->toBeFalse()
+		->and($GLOBALS['boost_recovery_test_state']['calls'])->toHaveCount(2);
+});

--- a/tests/Unit/Core/Boost/BoostSchedulingBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostSchedulingBehaviorTest.php
@@ -1,0 +1,195 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+
+function boostScheduleTestReset(array $overrides = array()) {
+	$GLOBALS['boost_schedule_test_state'] = array_merge(array(
+		'config' => array(
+			'boost_rrd_update_enable'        => 'on',
+			'boost_rrd_update_system_enable' => 'on',
+			'boost_rrd_update_interval'      => 60,
+			'boost_rrd_update_max_records'   => 1000,
+		),
+		'rows'    => 0,
+		'pollers' => 1,
+		'writes'  => array(),
+	), $overrides);
+}
+
+function boostScheduleTestDebug($message) {
+}
+
+function boostScheduleTestRead($name) {
+	return $GLOBALS['boost_schedule_test_state']['config'][$name] ?? '';
+}
+
+function boostScheduleTestSet($name, $value) {
+	$GLOBALS['boost_schedule_test_state']['config'][$name] = $value;
+	$GLOBALS['boost_schedule_test_state']['writes'][] = array($name, $value);
+}
+
+function boostScheduleTestRows() {
+	return $GLOBALS['boost_schedule_test_state']['rows'];
+}
+
+function boostScheduleTestFetchCell($sql) {
+	return $GLOBALS['boost_schedule_test_state']['pollers'];
+}
+
+function boostScheduleTestLoadFunction($root) {
+	if (function_exists('boostScheduleTestTimeToRun')) {
+		return;
+	}
+
+	$source = file_get_contents($root . '/poller_boost.php');
+	expect($source)->not->toBeFalse();
+
+	$start = strpos($source, 'function boost_time_to_run(');
+	$end   = strpos($source, "\nfunction ", $start + 1);
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+	$function = str_replace(array(
+		'boost_time_to_run',
+		'boost_debug',
+		'read_config_option',
+		'set_config_option',
+		'boost_get_total_rows',
+		'db_fetch_cell',
+	), array(
+		'boostScheduleTestTimeToRun',
+		'boostScheduleTestDebug',
+		'boostScheduleTestRead',
+		'boostScheduleTestSet',
+		'boostScheduleTestRows',
+		'boostScheduleTestFetchCell',
+	), $function);
+
+	eval($function);
+}
+
+beforeEach(function () use ($root) {
+	boostScheduleTestLoadFunction($root);
+	boostScheduleTestReset();
+});
+
+test('an enabled Boost run waits until its configured interval is due', function () {
+	$current = 200000;
+	$last    = $current - 3599;
+
+	expect(boostScheduleTestTimeToRun(false, $current, $last, 0))->toBeFalse();
+});
+
+test('an enabled Boost run starts exactly when its configured interval is due', function () {
+	$current = 200000;
+	$last    = $current - 3600;
+
+	expect(boostScheduleTestTimeToRun(false, $current, $last, 0))->toBeTrue()
+		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_next_run_time', $current));
+});
+
+test('the record threshold starts Boost even before the time interval', function () {
+	boostScheduleTestReset(array(
+		'config' => array(
+			'boost_rrd_update_enable'        => 'on',
+			'boost_rrd_update_system_enable' => 'on',
+			'boost_rrd_update_interval'      => 60,
+			'boost_rrd_update_max_records'   => 1000,
+		),
+		'rows'    => 1001,
+		'pollers' => 1,
+		'writes'  => array(),
+	));
+
+	expect(boostScheduleTestTimeToRun(false, 200000, 199999, 0))->toBeTrue();
+});
+
+test('force starts an enabled Boost run regardless of time and row count', function () {
+	expect(boostScheduleTestTimeToRun(true, 200000, 199999, 0))->toBeTrue();
+});
+
+test('a first enabled run initializes timestamps without immediately running', function () {
+	expect(boostScheduleTestTimeToRun(false, 200000, 0, 0))->toBeFalse()
+		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_last_run_time', 200000))
+		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_next_run_time', 203600));
+});
+
+test('a missing interval consistently defaults to two hours', function () {
+	boostScheduleTestReset(array(
+		'config' => array(
+			'boost_rrd_update_enable'        => 'on',
+			'boost_rrd_update_system_enable' => 'on',
+			'boost_rrd_update_interval'      => '',
+			'boost_rrd_update_max_records'   => 1000,
+		),
+		'rows'    => 0,
+		'pollers' => 1,
+		'writes'  => array(),
+	));
+
+	expect(boostScheduleTestTimeToRun(false, 200000, 0, 0))->toBeFalse()
+		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_rrd_update_interval', 120))
+		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_next_run_time', 207200));
+});
+
+test('disabled Boost stays idle with an empty queue and disables its system flag', function () {
+	boostScheduleTestReset(array(
+		'config' => array(
+			'boost_rrd_update_enable'        => '',
+			'boost_rrd_update_system_enable' => 'on',
+			'boost_rrd_update_interval'      => 60,
+			'boost_rrd_update_max_records'   => 1000,
+		),
+		'rows'    => 0,
+		'pollers' => 1,
+		'writes'  => array(),
+	));
+
+	expect(boostScheduleTestTimeToRun(false, 200000, 190000, 0))->toBeFalse()
+		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_rrd_update_system_enable', ''));
+});
+
+test('disabled Boost still drains queued rows', function () {
+	boostScheduleTestReset(array(
+		'config' => array(
+			'boost_rrd_update_enable'        => '',
+			'boost_rrd_update_system_enable' => '',
+			'boost_rrd_update_interval'      => 60,
+			'boost_rrd_update_max_records'   => 1000,
+		),
+		'rows'    => 1,
+		'pollers' => 1,
+		'writes'  => array(),
+	));
+
+	expect(boostScheduleTestTimeToRun(false, 200000, 190000, 0))->toBeTrue();
+});
+
+test('multiple collectors keep the Boost system flag enabled', function () {
+	boostScheduleTestReset(array(
+		'config' => array(
+			'boost_rrd_update_enable'        => '',
+			'boost_rrd_update_system_enable' => '',
+			'boost_rrd_update_interval'      => 60,
+			'boost_rrd_update_max_records'   => 1000,
+		),
+		'rows'    => 0,
+		'pollers' => 2,
+		'writes'  => array(),
+	));
+
+	expect(boostScheduleTestTimeToRun(false, 200000, 190000, 0))->toBeFalse()
+		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_rrd_update_system_enable', 'on'));
+});

--- a/tests/Unit/Core/Boost/BoostSchedulingBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostSchedulingBehaviorTest.php
@@ -144,6 +144,24 @@ test('a missing interval consistently defaults to two hours', function () {
 		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_next_run_time', 207200));
 });
 
+test('a non-numeric interval consistently defaults to two hours', function () {
+	boostScheduleTestReset(array(
+		'config' => array(
+			'boost_rrd_update_enable'        => 'on',
+			'boost_rrd_update_system_enable' => 'on',
+			'boost_rrd_update_interval'      => 'invalid',
+			'boost_rrd_update_max_records'   => 1000,
+		),
+		'rows'    => 0,
+		'pollers' => 1,
+		'writes'  => array(),
+	));
+
+	expect(boostScheduleTestTimeToRun(false, 200000, 0, 0))->toBeFalse()
+		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_rrd_update_interval', 120))
+		->and($GLOBALS['boost_schedule_test_state']['writes'])->toContain(array('boost_next_run_time', 207200));
+});
+
 test('disabled Boost stays idle with an empty queue and disables its system flag', function () {
 	boostScheduleTestReset(array(
 		'config' => array(

--- a/tests/Unit/Core/Boost/BoostSchemaContractTest.php
+++ b/tests/Unit/Core/Boost/BoostSchemaContractTest.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+
+test('Boost sample identity is enforced by its full primary key', function () use ($root) {
+	$schema = file_get_contents($root . '/cacti.sql');
+
+	expect($schema)->toContain('PRIMARY KEY USING BTREE (`local_data_id`, `time`, `rrd_name`)');
+});
+
+test('recovery ordering has a supporting time index in new and upgraded installs', function () use ($root) {
+	$schema  = file_get_contents($root . '/cacti.sql');
+	$upgrade = file_get_contents($root . '/install/upgrades/1_2_32.php');
+
+	expect($schema)->toContain('KEY `time` (`time`)')
+		->and($upgrade)->toContain("db_install_add_key('poller_output_boost', 'KEY', 'time', array('time'))");
+});
+
+test('child completion identity is run scoped in new and upgraded installs', function () use ($root) {
+	$schema  = file_get_contents($root . '/cacti.sql');
+	$upgrade = file_get_contents($root . '/install/upgrades/1_2_32.php');
+
+	expect($schema)->toContain('UNIQUE KEY `run_child` (`run_id`,`child_id`)')
+		->and($upgrade)->toContain("db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', array('run_id', 'child_id'))");
+});

--- a/tests/Unit/Core/Boost/BoostSchemaContractTest.php
+++ b/tests/Unit/Core/Boost/BoostSchemaContractTest.php
@@ -26,3 +26,13 @@ test('child completion identity is run scoped in new and upgraded installs', fun
 	expect($schema)->toContain('UNIQUE KEY `run_child` (`run_id`,`child_id`)')
 		->and($upgrade)->toContain("db_install_add_key('poller_output_boost_processes', 'UNIQUE', 'run_child', array('run_id', 'child_id'))");
 });
+
+test('Boost distribution ownership and acknowledged cursors are run scoped', function () use ($root) {
+	$schema = file_get_contents($root . '/cacti.sql');
+
+	expect($schema)->toContain('`run_id` char(32) NOT NULL DEFAULT \'\'')
+		->and($schema)->toContain('`cursor_time` timestamp NULL DEFAULT NULL')
+		->and($schema)->toContain('`cursor_rrd_name` varchar(19) NOT NULL DEFAULT \'\'')
+		->and($schema)->toContain('PRIMARY KEY (`run_id`,`local_data_id`)')
+		->and($schema)->toContain('KEY `process_handler` (`run_id`,`process_handler`)');
+});

--- a/tests/Unit/Core/Boost/BoostSchemaContractTest.php
+++ b/tests/Unit/Core/Boost/BoostSchemaContractTest.php
@@ -19,14 +19,6 @@ test('Boost sample identity is enforced by its full primary key', function () us
 	expect($schema)->toContain('PRIMARY KEY USING BTREE (`local_data_id`, `time`, `rrd_name`)');
 });
 
-test('recovery ordering has a supporting time index in new and upgraded installs', function () use ($root) {
-	$schema  = file_get_contents($root . '/cacti.sql');
-	$upgrade = file_get_contents($root . '/install/upgrades/1_2_32.php');
-
-	expect($schema)->toContain('KEY `time` (`time`)')
-		->and($upgrade)->toContain("db_install_add_key('poller_output_boost', 'KEY', 'time', array('time'))");
-});
-
 test('child completion identity is run scoped in new and upgraded installs', function () use ($root) {
 	$schema  = file_get_contents($root . '/cacti.sql');
 	$upgrade = file_get_contents($root . '/install/upgrades/1_2_32.php');

--- a/tests/Unit/Core/Boost/BoostTakeoverBehaviorTest.php
+++ b/tests/Unit/Core/Boost/BoostTakeoverBehaviorTest.php
@@ -1,0 +1,163 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 4);
+
+function boostTakeoverReset(array $overrides = array()) {
+	$GLOBALS['boost_takeover_state'] = array_merge(array(
+		'processes'    => array(),
+		'running'      => array(),
+		'signals'      => array(),
+		'unregistered' => array(),
+		'logs'         => array(),
+		'now'          => 1000.0,
+	), $overrides);
+}
+
+function boostTakeoverFetch($sql, $params = array()) {
+	return $GLOBALS['boost_takeover_state']['processes'];
+}
+
+function boostTakeoverPid() {
+	return 9999;
+}
+
+function boostTakeoverSizeof($value) {
+	return is_countable($value) ? count($value) : 0;
+}
+
+function boostTakeoverIsSystemPid($pid) {
+	return (int) $pid <= 100;
+}
+
+function boostTakeoverStillRunning($pid) {
+	$states =& $GLOBALS['boost_takeover_state']['running'][$pid];
+
+	if (is_array($states)) {
+		return count($states) ? array_shift($states) : false;
+	}
+
+	return (bool) $states;
+}
+
+function boostTakeoverUnregister($tasktype, $taskname, $taskid, $pid) {
+	$GLOBALS['boost_takeover_state']['unregistered'][] = array($tasktype, $taskname, $taskid, $pid);
+}
+
+function boostTakeoverLog($message, $output = false, $facility = '') {
+	$GLOBALS['boost_takeover_state']['logs'][] = $message;
+}
+
+function boostTakeoverKill($pid, $signal) {
+	$GLOBALS['boost_takeover_state']['signals'][] = array($pid, $signal);
+
+	return true;
+}
+
+function boostTakeoverTime($as_float = false) {
+	$GLOBALS['boost_takeover_state']['now'] += 0.25;
+
+	return $GLOBALS['boost_takeover_state']['now'];
+}
+
+function boostTakeoverSleep($microseconds) {
+}
+
+function boostTakeoverLoadFunction($root) {
+	if (function_exists('boostTakeoverStopProcesses')) {
+		return;
+	}
+
+	$source = file_get_contents($root . '/poller_boost.php');
+	$start  = strpos($source, 'function boost_kill_running_processes(');
+	$end    = strpos($source, "\nfunction ", $start + 1);
+
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+	$function = str_replace(array(
+		'boost_kill_running_processes',
+		'db_fetch_assoc_prepared',
+		'getmypid',
+		'cacti_sizeof',
+		'is_system_pid',
+		'cacti_process_still_running',
+		'unregister_process',
+		'cacti_log',
+		'posix_kill',
+		'microtime',
+		'usleep',
+	), array(
+		'boostTakeoverStopProcesses',
+		'boostTakeoverFetch',
+		'boostTakeoverPid',
+		'boostTakeoverSizeof',
+		'boostTakeoverIsSystemPid',
+		'boostTakeoverStillRunning',
+		'boostTakeoverUnregister',
+		'boostTakeoverLog',
+		'boostTakeoverKill',
+		'boostTakeoverTime',
+		'boostTakeoverSleep',
+	), $function);
+
+	eval($function);
+}
+
+beforeEach(function () use ($root) {
+	boostTakeoverLoadFunction($root);
+	boostTakeoverReset();
+});
+
+test('takeover succeeds immediately when no old Boost process is registered', function () {
+	expect(boostTakeoverStopProcesses())->toBeTrue()
+		->and($GLOBALS['boost_takeover_state']['signals'])->toBe(array());
+});
+
+test('takeover removes a stale registration without signaling its recycled PID', function () {
+	$process = array('tasktype' => 'boost', 'taskname' => 'child', 'taskid' => 1, 'pid' => 1200);
+	boostTakeoverReset(array('processes' => array($process), 'running' => array(1200 => false)));
+
+	expect(boostTakeoverStopProcesses())->toBeTrue()
+		->and($GLOBALS['boost_takeover_state']['signals'])->toBe(array())
+		->and($GLOBALS['boost_takeover_state']['unregistered'])->toBe(array(array('boost', 'child', 1, 1200)));
+});
+
+test('takeover waits for confirmed worker death before unregistering it', function () {
+	$process = array('tasktype' => 'boost', 'taskname' => 'child', 'taskid' => 2, 'pid' => 1201);
+	boostTakeoverReset(array('processes' => array($process), 'running' => array(1201 => array(true, true, false))));
+
+	expect(boostTakeoverStopProcesses(2))->toBeTrue()
+		->and($GLOBALS['boost_takeover_state']['signals'])->toBe(array(array(1201, SIGTERM)))
+		->and($GLOBALS['boost_takeover_state']['unregistered'])->toBe(array(array('boost', 'child', 2, 1201)));
+});
+
+test('takeover fails closed while a signaled worker remains alive', function () {
+	$process = array('tasktype' => 'boost', 'taskname' => 'child', 'taskid' => 3, 'pid' => 1202);
+	boostTakeoverReset(array('processes' => array($process), 'running' => array(1202 => true)));
+
+	expect(boostTakeoverStopProcesses(1))->toBeFalse()
+		->and($GLOBALS['boost_takeover_state']['signals'])->toBe(array(array(1202, SIGTERM)))
+		->and($GLOBALS['boost_takeover_state']['unregistered'])->toBe(array())
+		->and(end($GLOBALS['boost_takeover_state']['logs']))->toContain('did not terminate');
+});
+
+test('takeover refuses to signal a reserved system PID', function () {
+	$process = array('tasktype' => 'boost', 'taskname' => 'child', 'taskid' => 4, 'pid' => 42);
+	boostTakeoverReset(array('processes' => array($process)));
+
+	expect(boostTakeoverStopProcesses())->toBeFalse()
+		->and($GLOBALS['boost_takeover_state']['signals'])->toBe(array())
+		->and($GLOBALS['boost_takeover_state']['unregistered'])->toBe(array());
+});

--- a/tests/Unit/Core/Rrd/RrdNullOffsetCfTest.php
+++ b/tests/Unit/Core/Rrd/RrdNullOffsetCfTest.php
@@ -16,6 +16,37 @@
 
 $root = dirname(__DIR__, 4);
 
+function rrdNullOffsetTestCfs(int $local_data_id): array {
+	return match ($local_data_id) {
+		10      => [2, 4],
+		20      => [],
+		default => [1],
+	};
+}
+
+function loadGenerateGraphBestCf(string $root): void {
+	if (function_exists('rrdNullOffsetGenerateGraphBestCf')) {
+		return;
+	}
+
+	$src   = file_get_contents($root . '/lib/functions.php');
+	$start = strpos($src, 'function generate_graph_best_cf(');
+	$end   = strpos($src, '/**', $start);
+
+	expect($src)->not->toBeFalse()
+		->and($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$function = substr($src, $start, $end - $start);
+	$function = str_replace(
+		['generate_graph_best_cf', 'get_rrd_cfs', 'cacti_sizeof'],
+		['rrdNullOffsetGenerateGraphBestCf', 'rrdNullOffsetTestCfs', 'count'],
+		$function
+	);
+
+	eval($function);
+}
+
 test('generate_graph_best_cf initializes the static CF before first use', function () use ($root) {
 	$src = file_get_contents($root . '/lib/functions.php');
 
@@ -31,4 +62,20 @@ test('graph CF caches do not use raw nullable item fields as offsets', function 
 		->and($src)->toContain("\$graph_item['local_data_template_rrd_id'] ?? ''")
 		->and($src)->toContain("\$graph_item['data_template_rrd_id'] ?? ''")
 		->and($src)->toContain('$graph_item[\'cf_reference\'] ?? 1');
+});
+
+test('generate_graph_best_cf returns AVERAGE for a missing data source on every call', function () use ($root) {
+	loadGenerateGraphBestCf($root);
+
+	expect(rrdNullOffsetGenerateGraphBestCf(0, 4))->toBe(1)
+		->and(rrdNullOffsetGenerateGraphBestCf(10, 4))->toBe(4)
+		->and(rrdNullOffsetGenerateGraphBestCf(0, 4))->toBe(1)
+		->and(rrdNullOffsetGenerateGraphBestCf(-1, 2))->toBe(1);
+});
+
+test('generate_graph_best_cf chooses an available fallback and handles no RRA functions', function () use ($root) {
+	loadGenerateGraphBestCf($root);
+
+	expect(rrdNullOffsetGenerateGraphBestCf(10, 8))->toBe(2)
+		->and(rrdNullOffsetGenerateGraphBestCf(20, 8))->toBe(1);
 });

--- a/tests/Unit/Core/Rrd/RrdNullOffsetCfTest.php
+++ b/tests/Unit/Core/Rrd/RrdNullOffsetCfTest.php
@@ -14,14 +14,13 @@
  * names and rrd ids into those arrays.
  */
 
-$root = dirname(__DIR__, 2);
+$root = dirname(__DIR__, 4);
 
 test('generate_graph_best_cf initializes the static CF before first use', function () use ($root) {
 	$src = file_get_contents($root . '/lib/functions.php');
 
 	expect($src)->toContain('static $best_cf = 1;')
-		->and($src)->toContain('if ($local_data_id <= 0) {')
-		->and($src)->toContain("\t\treturn 1;")
+		->and($src)->toMatch('/if \(\$local_data_id <= 0\) \{\s+return 1;/')
 		->and($src)->not->toMatch('/static \$best_cf;\s*$/m');
 });
 

--- a/tests/Unit/RrdNullOffsetCfTest.php
+++ b/tests/Unit/RrdNullOffsetCfTest.php
@@ -20,6 +20,8 @@ test('generate_graph_best_cf initializes the static CF before first use', functi
 	$src = file_get_contents($root . '/lib/functions.php');
 
 	expect($src)->toContain('static $best_cf = 1;')
+		->and($src)->toContain('if ($local_data_id <= 0) {')
+		->and($src)->toContain("\t\treturn 1;")
 		->and($src)->not->toMatch('/static \$best_cf;\s*$/m');
 });
 

--- a/tests/Unit/RrdNullOffsetCfTest.php
+++ b/tests/Unit/RrdNullOffsetCfTest.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * generate_graph_best_cf() kept an uninitialized static. The first call with
+ * local_data_id 0 returned null, which PHP 8.5 then used as a cache-array
+ * offset (issue #7810). Graph items without a data source also pass null
+ * names and rrd ids into those arrays.
+ */
+
+$root = dirname(__DIR__, 2);
+
+test('generate_graph_best_cf initializes the static CF before first use', function () use ($root) {
+	$src = file_get_contents($root . '/lib/functions.php');
+
+	expect($src)->toContain('static $best_cf = 1;')
+		->and($src)->not->toMatch('/static \$best_cf;\s*$/m');
+});
+
+test('graph CF caches do not use raw nullable item fields as offsets', function () use ($root) {
+	$src = file_get_contents($root . '/lib/rrd.php');
+
+	expect($src)->toContain("\$graph_item['data_source_name'] ?? ''")
+		->and($src)->toContain("\$graph_item['local_data_template_rrd_id'] ?? ''")
+		->and($src)->toContain("\$graph_item['data_template_rrd_id'] ?? ''")
+		->and($src)->toContain('$graph_item[\'cf_reference\'] ?? 1');
+});

--- a/tests/Unit/Ui/Html/CactiNonceApplySkinTest.php
+++ b/tests/Unit/Ui/Html/CactiNonceApplySkinTest.php
@@ -13,13 +13,22 @@
  * The resulting ReferenceError aborts the rest of applySkin().
  */
 
-$root = dirname(__DIR__, 2);
+$root = dirname(__DIR__, 4);
 
 test('applySkin does not read cactiNonce unless it is defined', function () use ($root) {
 	$src = file_get_contents($root . '/include/layout.js');
-	$fn  = strstr($src, 'function applySkin()');
-	$fn  = substr($fn, 0, strpos($fn, "\nfunction ", 1));
 
+	expect($src)->toBeString()->not->toBeEmpty();
+
+	$fn = strstr($src, 'function applySkin()');
+
+	expect($fn)->toBeString();
+
+	$end = strpos($fn, "\nfunction ", 1);
+
+	expect($end)->not->toBeFalse();
+
+	$fn    = substr($fn, 0, $end);
 	$guard = strpos($fn, "typeof cactiNonce !== 'undefined'");
 	$use   = strpos($fn, 'nonce: cactiNonce');
 

--- a/tests/integration/BoostProcessTableMariaDbTest.php
+++ b/tests/integration/BoostProcessTableMariaDbTest.php
@@ -1,0 +1,171 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$root = dirname(__DIR__, 2);
+
+function boostMariaDbReset() {
+	$host     = getenv('BOOST_DB_HOST') ?: '127.0.0.1';
+	$port     = getenv('BOOST_DB_PORT') ?: '3306';
+	$database = getenv('BOOST_DB_NAME') ?: 'cacti_boost_contract';
+	$user     = getenv('BOOST_DB_USER') ?: 'root';
+	$password = getenv('BOOST_DB_PASSWORD') ?: '';
+	$socket   = getenv('BOOST_DB_SOCKET');
+	$dsn      = $socket ? "mysql:unix_socket=$socket;dbname=$database;charset=utf8mb4" :
+		"mysql:host=$host;port=$port;dbname=$database;charset=utf8mb4";
+
+	$GLOBALS['boost_mariadb_pdo'] = new PDO(
+		$dsn,
+		$user,
+		$password,
+		array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION)
+	);
+	$GLOBALS['boost_mariadb_cache'] = array('tables' => array(), 'columns' => array());
+	$GLOBALS['boost_mariadb_logs']  = array();
+}
+
+function boostMariaDbFetchCellPrepared($sql, $params = array()) {
+	$statement = $GLOBALS['boost_mariadb_pdo']->prepare($sql);
+	$statement->execute($params);
+
+	return $statement->fetchColumn();
+}
+
+function boostMariaDbTableExists($table) {
+	$cache =& $GLOBALS['boost_mariadb_cache']['tables'];
+
+	if (!array_key_exists($table, $cache)) {
+		$cache[$table] = (bool) boostMariaDbFetchCellPrepared('SELECT COUNT(*)
+			FROM information_schema.TABLES
+			WHERE TABLE_SCHEMA = SCHEMA()
+			AND TABLE_NAME = ?', array($table));
+	}
+
+	return $cache[$table];
+}
+
+function boostMariaDbColumnExists($table, $column) {
+	$cache =& $GLOBALS['boost_mariadb_cache']['columns'];
+	$key = $table . '.' . $column;
+
+	if (!array_key_exists($key, $cache)) {
+		$cache[$key] = (bool) boostMariaDbFetchCellPrepared('SELECT COUNT(*)
+			FROM information_schema.COLUMNS
+			WHERE TABLE_SCHEMA = SCHEMA()
+			AND TABLE_NAME = ?
+			AND COLUMN_NAME = ?', array($table, $column));
+	}
+
+	return $cache[$key];
+}
+
+function boostMariaDbIndexExists($table, $index) {
+	return (bool) boostMariaDbFetchCellPrepared('SELECT COUNT(*)
+		FROM information_schema.STATISTICS
+		WHERE TABLE_SCHEMA = SCHEMA()
+		AND TABLE_NAME = ?
+		AND INDEX_NAME = ?', array($table, $index));
+}
+
+function boostMariaDbExecute($sql) {
+	try {
+		$GLOBALS['boost_mariadb_pdo']->exec($sql);
+
+		return true;
+	} catch (PDOException $e) {
+		return false;
+	}
+}
+
+function boostMariaDbLog($message, $output = false, $facility = '') {
+	$GLOBALS['boost_mariadb_logs'][] = $message;
+}
+
+function boostMariaDbLoadProductionFunctions($root) {
+	if (function_exists('boostMariaDbEnsureProcessTable')) {
+		return;
+	}
+
+	$source = file_get_contents($root . '/lib/boost.php');
+	$start  = strpos($source, 'function boost_process_table_exists_uncached(');
+	$end    = strpos($source, "\n/**\n * boost_array_orderby", $start);
+
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$functions = substr($source, $start, $end - $start);
+	$functions = str_replace(array(
+		'boost_process_table_exists_uncached',
+		'boost_process_column_exists_uncached',
+		'boost_ensure_process_table',
+		'db_fetch_cell_prepared',
+		'db_table_exists',
+		'db_column_exists',
+		'db_index_exists',
+		'db_execute',
+		'cacti_log',
+	), array(
+		'boostMariaDbProcessTableExistsUncached',
+		'boostMariaDbProcessColumnExistsUncached',
+		'boostMariaDbEnsureProcessTable',
+		'boostMariaDbFetchCellPrepared',
+		'boostMariaDbTableExists',
+		'boostMariaDbColumnExists',
+		'boostMariaDbIndexExists',
+		'boostMariaDbExecute',
+		'boostMariaDbLog',
+	), $functions);
+
+	eval($functions);
+}
+
+beforeEach(function () use ($root) {
+	boostMariaDbLoadProductionFunctions($root);
+	boostMariaDbReset();
+	$GLOBALS['boost_mariadb_pdo']->exec('DROP TABLE IF EXISTS poller_output_boost_processes');
+});
+
+afterEach(function () {
+	$GLOBALS['boost_mariadb_pdo']->exec('DROP TABLE IF EXISTS poller_output_boost_processes');
+});
+
+test('runtime repair executes valid process-table DDL on MariaDB', function () {
+	$GLOBALS['boost_mariadb_pdo']->exec('CREATE TABLE poller_output_boost_processes (
+		sock_int_value bigint unsigned NOT NULL AUTO_INCREMENT,
+		status varchar(255) DEFAULT NULL,
+		PRIMARY KEY (sock_int_value)) ENGINE=MEMORY');
+
+	expect(boostMariaDbEnsureProcessTable(true))->toBeTrue()
+		->and(boostMariaDbProcessColumnExistsUncached('run_id'))->toBeTrue()
+		->and(boostMariaDbProcessColumnExistsUncached('child_id'))->toBeTrue()
+		->and(boostMariaDbIndexExists('poller_output_boost_processes', 'run_child'))->toBeTrue()
+		->and($GLOBALS['boost_mariadb_logs'])->toBe(array());
+});
+
+test('uncached recheck accepts a concurrent column repair after cached absence', function () {
+	$GLOBALS['boost_mariadb_pdo']->exec('CREATE TABLE poller_output_boost_processes (
+		sock_int_value bigint unsigned NOT NULL AUTO_INCREMENT,
+		status varchar(255) DEFAULT NULL,
+		PRIMARY KEY (sock_int_value)) ENGINE=MEMORY');
+
+	expect(boostMariaDbTableExists('poller_output_boost_processes'))->toBeTrue()
+		->and(boostMariaDbColumnExists('poller_output_boost_processes', 'run_id'))->toBeFalse();
+
+	$GLOBALS['boost_mariadb_pdo']->exec("ALTER TABLE poller_output_boost_processes
+		ADD run_id char(32) NOT NULL DEFAULT '' AFTER sock_int_value");
+
+	expect(boostMariaDbEnsureProcessTable(true))->toBeTrue()
+		->and(boostMariaDbProcessColumnExistsUncached('run_id'))->toBeTrue()
+		->and(boostMariaDbProcessColumnExistsUncached('child_id'))->toBeTrue()
+		->and(boostMariaDbIndexExists('poller_output_boost_processes', 'run_child'))->toBeTrue()
+		->and($GLOBALS['boost_mariadb_logs'])->toBe(array());
+});

--- a/tests/integration/BoostProcessTableMariaDbTest.php
+++ b/tests/integration/BoostProcessTableMariaDbTest.php
@@ -169,3 +169,19 @@ test('uncached recheck accepts a concurrent column repair after cached absence',
 		->and(boostMariaDbIndexExists('poller_output_boost_processes', 'run_child'))->toBeTrue()
 		->and($GLOBALS['boost_mariadb_logs'])->toBe(array());
 });
+
+test('runtime repair clears duplicate legacy rows before adding the run-child key', function () {
+	$GLOBALS['boost_mariadb_pdo']->exec('CREATE TABLE poller_output_boost_processes (
+		sock_int_value bigint unsigned NOT NULL AUTO_INCREMENT,
+		run_id char(32) NOT NULL DEFAULT \'\',
+		child_id int unsigned NOT NULL DEFAULT 0,
+		status varchar(255) DEFAULT NULL,
+		PRIMARY KEY (sock_int_value)) ENGINE=MEMORY');
+	$GLOBALS['boost_mariadb_pdo']->exec("INSERT INTO poller_output_boost_processes
+		(run_id, child_id, status) VALUES ('', 0, '1'), ('', 0, '2')");
+
+	expect(boostMariaDbEnsureProcessTable(true))->toBeTrue()
+		->and(boostMariaDbIndexExists('poller_output_boost_processes', 'run_child'))->toBeTrue()
+		->and((int) boostMariaDbFetchCellPrepared('SELECT COUNT(*) FROM poller_output_boost_processes'))->toBe(0)
+		->and($GLOBALS['boost_mariadb_logs'])->toBe(array());
+});

--- a/tests/integration/BoostProcessTableMariaDbTest.php
+++ b/tests/integration/BoostProcessTableMariaDbTest.php
@@ -132,10 +132,97 @@ beforeEach(function () use ($root) {
 	boostMariaDbLoadProductionFunctions($root);
 	boostMariaDbReset();
 	$GLOBALS['boost_mariadb_pdo']->exec('DROP TABLE IF EXISTS poller_output_boost_processes');
+	$GLOBALS['boost_mariadb_pdo']->exec('DROP TABLE IF EXISTS poller_output_boost_local_data_ids');
 });
 
 afterEach(function () {
 	$GLOBALS['boost_mariadb_pdo']->exec('DROP TABLE IF EXISTS poller_output_boost_processes');
+	$GLOBALS['boost_mariadb_pdo']->exec('DROP TABLE IF EXISTS poller_output_boost_local_data_ids');
+});
+
+test('run-scoped Boost cursor table executes on MariaDB and advances monotonically', function () {
+	$GLOBALS['boost_mariadb_pdo']->exec("CREATE TABLE poller_output_boost_local_data_ids (
+		run_id char(32) NOT NULL,
+		local_data_id int unsigned NOT NULL default 0,
+		process_handler int unsigned NOT NULL default 0,
+		cursor_time timestamp NULL default NULL,
+		cursor_rrd_name varchar(19) NOT NULL default '',
+		PRIMARY KEY (run_id, local_data_id),
+		INDEX process_handler(run_id, process_handler)) ENGINE=MEMORY");
+	$run_id = str_repeat('a', 32);
+	$insert = $GLOBALS['boost_mariadb_pdo']->prepare('INSERT INTO poller_output_boost_local_data_ids
+		(run_id, local_data_id, process_handler) VALUES (?, ?, ?)');
+	$insert->execute(array($run_id, 42, 3));
+	$update = $GLOBALS['boost_mariadb_pdo']->prepare('UPDATE poller_output_boost_local_data_ids
+		SET cursor_time = ?, cursor_rrd_name = ?
+		WHERE run_id = ? AND local_data_id = ? AND process_handler = ?');
+	$update->execute(array('2026-09-05 12:00:00', 'traffic_out', $run_id, 42, 3));
+	$row = $GLOBALS['boost_mariadb_pdo']->query('SELECT run_id, local_data_id, process_handler,
+		cursor_time, cursor_rrd_name FROM poller_output_boost_local_data_ids')->fetch(PDO::FETCH_ASSOC);
+
+	expect($row['run_id'])->toBe($run_id)
+		->and((int) $row['local_data_id'])->toBe(42)
+		->and((int) $row['process_handler'])->toBe(3)
+		->and($row['cursor_time'])->toBe('2026-09-05 12:00:00')
+		->and($row['cursor_rrd_name'])->toBe('traffic_out');
+});
+
+test('run-scoped cursor predicate pages archive rows in primary-key order', function () {
+	$GLOBALS['boost_mariadb_pdo']->exec("CREATE TABLE poller_output_boost_local_data_ids (
+		run_id char(32) NOT NULL,
+		local_data_id int unsigned NOT NULL default 0,
+		process_handler int unsigned NOT NULL default 0,
+		cursor_time timestamp NULL default NULL,
+		cursor_rrd_name varchar(19) NOT NULL default '',
+		PRIMARY KEY (run_id, local_data_id),
+		INDEX process_handler(run_id, process_handler)) ENGINE=MEMORY");
+	$GLOBALS['boost_mariadb_pdo']->exec('CREATE TEMPORARY TABLE boost_archive (
+		local_data_id int unsigned NOT NULL,
+		rrd_name varchar(19) NOT NULL,
+		time timestamp NOT NULL,
+		output varchar(512) NOT NULL,
+		PRIMARY KEY (local_data_id, time, rrd_name))');
+	$GLOBALS['boost_mariadb_pdo']->exec('CREATE TEMPORARY TABLE data_local (
+		id int unsigned NOT NULL PRIMARY KEY,
+		data_template_id int unsigned NOT NULL)');
+	$run_id = str_repeat('b', 32);
+	$statement = $GLOBALS['boost_mariadb_pdo']->prepare('INSERT INTO poller_output_boost_local_data_ids
+		(run_id, local_data_id, process_handler) VALUES (?, 42, 3)');
+	$statement->execute(array($run_id));
+	$GLOBALS['boost_mariadb_pdo']->exec('INSERT INTO data_local VALUES (42, 7)');
+	$GLOBALS['boost_mariadb_pdo']->exec("INSERT INTO boost_archive VALUES
+		(42, 'a', '2026-09-05 12:00:00', '1'),
+		(42, 'b', '2026-09-05 12:00:00', '2'),
+		(42, 'a', '2026-09-05 12:01:00', '3'),
+		(42, 'b', '2026-09-05 12:01:00', '4')");
+	$query = 'SELECT * FROM (
+		SELECT boost_archive.local_data_id, dl.data_template_id,
+			UNIX_TIMESTAMP(boost_archive.time) AS timestamp,
+			boost_archive.time AS sample_time, boost_archive.rrd_name, boost_archive.output
+		FROM boost_archive
+		INNER JOIN poller_output_boost_local_data_ids AS bpt
+		ON boost_archive.local_data_id = bpt.local_data_id
+		INNER JOIN data_local AS dl ON boost_archive.local_data_id = dl.id
+		WHERE bpt.run_id = ? AND bpt.process_handler = ?
+		AND (bpt.cursor_time IS NULL OR boost_archive.time > bpt.cursor_time
+			OR (boost_archive.time = bpt.cursor_time AND boost_archive.rrd_name > bpt.cursor_rrd_name))
+		) AS page ORDER BY local_data_id, sample_time, rrd_name LIMIT 3';
+	$statement = $GLOBALS['boost_mariadb_pdo']->prepare($query);
+	$statement->execute(array($run_id, 3));
+	$first_page = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+	expect($first_page)->toHaveCount(3)
+		->and(array_column($first_page, 'rrd_name'))->toBe(array('a', 'b', 'a'));
+
+	$statement = $GLOBALS['boost_mariadb_pdo']->prepare('UPDATE poller_output_boost_local_data_ids
+		SET cursor_time = ?, cursor_rrd_name = ? WHERE run_id = ? AND local_data_id = 42');
+	$statement->execute(array('2026-09-05 12:00:00', 'b', $run_id));
+	$statement = $GLOBALS['boost_mariadb_pdo']->prepare($query);
+	$statement->execute(array($run_id, 3));
+	$second_page = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+	expect($second_page)->toHaveCount(2)
+		->and(array_column($second_page, 'rrd_name'))->toBe(array('a', 'b'));
 });
 
 test('runtime repair executes valid process-table DDL on MariaDB', function () {

--- a/tests/js/apply_skin_nonce.test.js
+++ b/tests/js/apply_skin_nonce.test.js
@@ -1,0 +1,122 @@
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const layoutSource = fs.readFileSync(
+	path.join(__dirname, '..', '..', 'include', 'layout.js'),
+	'utf8'
+);
+
+function extractFunction(name) {
+	const start = layoutSource.indexOf(`function ${name}(`);
+	assert.notEqual(start, -1, `${name}() must exist`);
+
+	const bodyStart = layoutSource.indexOf('{', start);
+	let depth = 0;
+
+	for (let offset = bodyStart; offset < layoutSource.length; offset++) {
+		if (layoutSource[offset] === '{') {
+			depth++;
+		} else if (layoutSource[offset] === '}') {
+			depth--;
+
+			if (depth === 0) {
+				return layoutSource.slice(start, offset + 1);
+			}
+		}
+	}
+
+	throw new Error(`Unable to extract ${name}()`);
+}
+
+function loadApplySkin(nonce) {
+	const ajaxSetups = [];
+	const calls = [];
+	let chain;
+
+	chain = new Proxy({}, {
+		get: (_target, property) => {
+			if (property === 'length') {
+				return 0;
+			}
+
+			return (...args) => {
+				if (property === 'attr' && args[0] === 'pathname') {
+					return '/cacti/index.php';
+				}
+
+				if (property === 'map') {
+					return [];
+				}
+
+				return chain;
+			};
+		},
+	});
+
+	const jquery = () => chain;
+	jquery.ajaxSetup = (options) => ajaxSetups.push(options);
+	jquery.Deferred = () => ({ resolve: () => undefined });
+
+	const context = {
+		$: jquery,
+		CsrfMagic: { end: () => calls.push('csrf') },
+		DOMPurify: { sanitize: (value) => value },
+		basename: (value) => path.posix.basename(value),
+		document: {},
+		location: {},
+		pageName: '',
+		shiftPressed: false,
+		theme: 'classic',
+	};
+
+	for (const name of [
+		'setGraphTabs', 'setupSortable', 'setupBreadcrumbs', 'applyTableSizing',
+		'setupPageTimeout', 'setupSpecialKeys', 'setupCollapsible', 'ajaxAnchors',
+		'applySelectorVisibilityAndActions', 'handleTableNav', 'makeFiltersResponsive',
+		'setupResponsiveMenuAndTabs', 'setupButtonStyle', 'keepWindowSize',
+		'displayMessages', 'renderLanguages',
+	]) {
+		context[name] = () => calls.push(name);
+	}
+
+	if (nonce !== undefined) {
+		context.cactiNonce = nonce;
+	}
+
+	vm.createContext(context);
+	vm.runInContext(extractFunction('applySkin'), context, { filename: 'include/layout.js' });
+
+	return { ajaxSetups, calls, context };
+}
+
+test('applySkin completes when cactiNonce is absent', () => {
+	const { ajaxSetups, calls, context } = loadApplySkin();
+
+	assert.doesNotThrow(() => context.applySkin());
+	assert.deepEqual(ajaxSetups, []);
+	assert.ok(calls.includes('renderLanguages'));
+	assert.equal(context.pageName, 'index.php');
+});
+
+test('applySkin forwards a defined callback nonce to jQuery', () => {
+	const { ajaxSetups, calls, context } = loadApplySkin('nonce-value');
+
+	context.applySkin();
+
+	assert.equal(ajaxSetups.length, 1);
+	assert.equal(ajaxSetups[0].nonce, 'nonce-value');
+	assert.ok(calls.includes('renderLanguages'));
+});

--- a/tests/js/apply_skin_nonce.test.js
+++ b/tests/js/apply_skin_nonce.test.js
@@ -87,7 +87,7 @@ function loadApplySkin(nonce) {
 		'setupPageTimeout', 'setupSpecialKeys', 'setupCollapsible', 'ajaxAnchors',
 		'applySelectorVisibilityAndActions', 'handleTableNav', 'makeFiltersResponsive',
 		'setupResponsiveMenuAndTabs', 'setupButtonStyle', 'keepWindowSize',
-		'displayMessages', 'renderLanguages',
+		'displayMessages', 'renderLanguages', 'setupSelectmenuScrollClose',
 	]) {
 		context[name] = () => calls.push(name);
 	}

--- a/tests/phpunit-boost-mariadb.xml
+++ b/tests/phpunit-boost-mariadb.xml
@@ -4,11 +4,8 @@
 		bootstrap="vendor/autoload.php"
 		colors="true">
 	<testsuites>
-		<testsuite name="Boost">
-			<directory suffix="Test.php">./Unit/Core/Boost</directory>
-			<file>./HandOff/BoostDataHandOffTest.php</file>
-			<file>./Unit/Core/Rrd/RrdNullOffsetCfTest.php</file>
-			<file>./Unit/Ui/Html/CactiNonceApplySkinTest.php</file>
+		<testsuite name="Boost MariaDB">
+			<file>./integration/BoostProcessTableMariaDbTest.php</file>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/phpunit-boost.xml
+++ b/tests/phpunit-boost.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+		bootstrap="vendor/autoload.php"
+		colors="true">
+	<testsuites>
+		<testsuite name="Boost">
+			<directory suffix="Test.php">./Unit/Core/Boost</directory>
+			<file>./HandOff/BoostDataHandOffTest.php</file>
+		</testsuite>
+	</testsuites>
+</phpunit>


### PR DESCRIPTION
Inbound 1.2.x correctness and compatibility fixes.

Fixes #7868.
Addresses the reported graph null-offset symptom in #7810; broader PHP 8.5 compatibility remains tracked there.
Fixes #7954.

Boost lifecycle and SQL:
- repairs the run-scoped Boost process table on stamped and legacy installs, including concurrent DDL races through uncached schema rechecks
- fails closed when table rotation, shard preparation, RRD creation/update, child completion, or remote handoff is not acknowledged
- retains archive/shard rows after failed updates and stops staging after the first failed packet chunk
- pages scheduled work with a strict row bound without splitting an RRD timestamp and advances only acknowledged full-primary-key cursors
- scopes distribution ownership to the parent run and refuses to reuse shared state until prior Boost workers are confirmed dead
- defers oversized on-demand result sets to scheduled processing rather than allocating an unbounded PHP result
- bounds recovery batches, preserves exact primary-key deletes, validates poller ownership and dynamic identifiers, and keeps failed recovery visible
- uses bounded exact threshold counts instead of relying on information_schema TABLE_ROWS estimates
- makes Boost SQL string literals compatible with ANSI_QUOTES
- validates child and on-demand identifiers before they reach dynamic SQL or process state
- stores a numeric lifecycle start time with backward-compatible status parsing
- bounds legacy named-lock acquisition, flushes under the correct data-source lock, and stops after the first failed RRD update
- caches shared RRD metadata across bounded pages to avoid page-level N+1 queries
- makes graph cache writes atomic, bounded, cross-platform, and observable without widening the hardened 0640 mode

PHP 8.5 graph correctness:
- graph items without a data source return AVERAGE deterministically
- nullable graph-item fields are not used directly as cache-array offsets

UI initialization:
- applySkin guards an absent cactiNonce and still completes initialization
- select-menu scroll closing is covered alongside the nonce behavior

Verification:
- focused database-free Pest suite: 99 tests on PHP 8.1; also run on PHP 8.3 during development
- live MariaDB contract suite: 5 tests covering cursor DDL/pagination, runtime repair, concurrent repair, and duplicate legacy rows
- Node contract suite: 12 tests
- PHP 8.1 and PHP 8.4 syntax checks, actionlint, diff checks, sink inventory, and architectural hotspot baselines pass
- branch rebased on current 1.2.x; all commits are signed
