### PR TITLE
hardening: escape LDAP filter and DN values on develop

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Cacti CHANGELOG
 -issue#7969: Restore excluded integration and mutation regression coverage
 -issue#7969: Align Rocky Linux compatibility checks with the supported PHP runtime
 -issue: Fail closed when OAuth callback state is absent or mismatched
+-issue#7964: Escape LDAP filter and DN values rather than deleting characters from the username
 -issue#7959: Stop source checkouts from loading a partial Composer dependency tree
 -issue#7775: Add plugin-extensible notification API
 -issue#7746: Make PHP 8.1 dependency builds reproducible

--- a/lib/ldap.php
+++ b/lib/ldap.php
@@ -449,6 +449,31 @@ abstract class LdapError {
 	}
 }
 
+/**
+ * cacti_ldap_filter - assemble an LDAP filter from a template and variables.
+ *
+ * Each placeholder in $template (for example <username>) is replaced with the
+ * ldap_escape()'d value from $vars, so a value carrying filter metacharacters
+ * is matched as a literal instead of altering the filter.
+ *
+ * @param string $template Filter template with <key> placeholders
+ * @param array  $vars     Associative array of key => value pairs
+ *
+ * @return string The assembled filter
+ */
+function cacti_ldap_filter(string $template, array $vars) : string {
+	$map = [];
+
+	foreach ($vars as $key => $value) {
+		$map['<' . $key . '>'] = ldap_escape((string) $value, '', LDAP_ESCAPE_FILTER);
+	}
+
+	// One pass. LDAP_ESCAPE_FILTER leaves '<' and '>' alone, so substituting in a
+	// loop would let the text inserted for one key be rescanned as another key's
+	// placeholder.
+	return strtr($template, $map);
+}
+
 class Ldap {
 	public string $dn;
 	private array $connection = [];
@@ -758,11 +783,14 @@ class Ldap {
 
 		$ldap_conn = $this->connection['ldap_conn'];
 
-		// Decode username, and remove bad characters
-		$this->username = html_entity_decode($this->username, $this->GetMask(), 'UTF-8');
-		$this->username = str_replace(['&', '|', '(', ')', '*', '>', '<', '!', '='], '', $this->username);
-		$this->password = html_entity_decode($this->password, $this->GetMask(), 'UTF-8');
-		$this->dn       = str_replace('<username>', $this->username, $this->dn);
+		// Decode username, then escape it for DN context.  Keep an unescaped copy of
+		// the assembled DN as well: the true-dn lookup below is a filter, and
+		// escaping an already DN-escaped value a second time cannot match anything.
+		$this->username   = html_entity_decode($this->username, $this->GetMask(), 'UTF-8');
+		$safe_username_dn = ldap_escape($this->username, '', LDAP_ESCAPE_DN);
+		$this->password   = html_entity_decode($this->password, $this->GetMask(), 'UTF-8');
+		$raw_dn           = str_replace('<username>', $this->username, $this->dn);
+		$this->dn         = str_replace('<username>', $safe_username_dn, $this->dn);
 
 		if ($this->password == '') {
 			return LdapError::GetErrorDetails(LdapError::EmptyPassword);
@@ -791,7 +819,8 @@ class Ldap {
 					 * And the patch against latest PHP release:
 					 * http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/databases/php-ldap/files/ldap-ctrl-exop.patch
 					 */
-					$true_dn_result = ldap_search($ldap_conn, $this->search_base, '(|(uid=' . $this->dn . ')(cn=' . $this->dn . ')(userPrincipalName=' . $this->dn . '))', ['dn']);
+					$true_dn_filter = cacti_ldap_filter('(|(uid=<dn>)(cn=<dn>)(userPrincipalName=<dn>))', ['dn' => $raw_dn]);
+					$true_dn_result = ldap_search($ldap_conn, $this->search_base, $true_dn_filter, ['dn']);
 					$first_entry    = ldap_first_entry($ldap_conn, $true_dn_result);
 
 					// we will test in two ways
@@ -894,10 +923,11 @@ class Ldap {
 
 		$ldap_conn = $this->connection['ldap_conn'];
 
-		// Decode username, and remove bad characters
-		$this->username = html_entity_decode($this->username, $this->GetMask(), 'UTF-8');
-		$this->username = str_replace(['&', '|', '(', ')', '*', '>', '<', '!', '='], '', $this->username);
-		$this->dn       = str_replace('<username>', $this->username, $this->dn);
+		// Decode username, then escape it separately for DN and filter contexts.
+		$this->username       = html_entity_decode($this->username, $this->GetMask(), 'UTF-8');
+		$safe_username_dn     = ldap_escape($this->username, '', LDAP_ESCAPE_DN);
+		$safe_username_filter = ldap_escape($this->username, '', LDAP_ESCAPE_FILTER);
+		$this->dn             = str_replace('<username>', $safe_username_dn, $this->dn);
 
 		if ($this->mode == 0) {
 			// Just bind mode, make dn and return
@@ -924,7 +954,7 @@ class Ldap {
 			$this->specific_password = '';
 		}
 
-		$this->search_filter = str_replace('<username>', $this->username, $this->search_filter);
+		$this->search_filter = str_replace('<username>', $safe_username_filter, $this->search_filter);
 
 		// Fix encoding on ldap specific search DN and password
 		$this->specific_password = html_entity_decode($this->specific_password, $this->GetMask(), 'UTF-8');
@@ -1014,10 +1044,11 @@ class Ldap {
 
 		$ldap_conn = $this->connection['ldap_conn'];
 
-		// Decode username, and remove bad characters
-		$this->username = html_entity_decode($this->username, $this->GetMask(), 'UTF-8');
-		$this->username = str_replace(['&', '|', '(', ')', '*', '>', '<', '!', '='], '', $this->username);
-		$this->dn       = str_replace('<username>', $this->username, $this->dn);
+		// Decode username, then escape it separately for DN and filter contexts.
+		$this->username       = html_entity_decode($this->username, $this->GetMask(), 'UTF-8');
+		$safe_username_dn     = ldap_escape($this->username, '', LDAP_ESCAPE_DN);
+		$safe_username_filter = ldap_escape($this->username, '', LDAP_ESCAPE_FILTER);
+		$this->dn             = str_replace('<username>', $safe_username_dn, $this->dn);
 
 		if ($this->mode == 0) {
 			// Just bind mode, make dn and return
@@ -1041,7 +1072,7 @@ class Ldap {
 			$this->specific_password = '';
 		}
 
-		$this->search_filter = str_replace('<username>', $this->username, $this->search_filter);
+		$this->search_filter = str_replace('<username>', $safe_username_filter, $this->search_filter);
 
 		// Fix encoding on ldap specific search DN and password
 		$this->specific_password = html_entity_decode($this->specific_password, $this->GetMask(), 'UTF-8');
@@ -1116,7 +1147,10 @@ class Ldap {
 	}
 
 	function isUserInLDAPGroup(object $ldapConn, string $ldapbasedn, string $groupDN, string $ldapUser) : bool {
-		$query       = "(&(distinguishedName=$ldapUser)(memberOf:1.2.840.113556.1.4.1941:=$groupDN))";
+		$query       = cacti_ldap_filter(
+			'(&(distinguishedName=<user>)(memberOf:1.2.840.113556.1.4.1941:=<group>))',
+			['user' => $ldapUser, 'group' => $groupDN]
+		);
 		$ldapSearch  = ldap_search($ldapConn, $ldapbasedn, $query, ['dn']);
 
 		if ($ldapSearch) {

--- a/tests/Unit/Security/Ldap/LdapFilterEscapingTest.php
+++ b/tests/Unit/Security/Ldap/LdapFilterEscapingTest.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * cacti_ldap_filter() assembles LDAP filters from a template so a username
+ * carrying filter metacharacters is matched as a literal rather than changing
+ * the filter's structure. These tests call the function; they do not inspect
+ * the text of lib/ldap.php, because a source match certifies spelling rather
+ * than behaviour.
+ */
+
+require_once CACTI_PATH_LIBRARY . '/ldap.php';
+
+test('a plain username passes through unchanged', function () {
+	expect(cacti_ldap_filter('(uid=<user>)', ['user' => 'alice']))->toBe('(uid=alice)');
+});
+
+test('a repeated placeholder is substituted at every position', function () {
+	$filter = cacti_ldap_filter('(|(uid=<dn>)(cn=<dn>)(userPrincipalName=<dn>))', ['dn' => 'bob']);
+
+	expect($filter)->toBe('(|(uid=bob)(cn=bob)(userPrincipalName=bob))');
+});
+
+test('filter metacharacters are escaped, not deleted', function (string $raw, string $escaped) {
+	expect(cacti_ldap_filter('(uid=<user>)', ['user' => $raw]))->toBe('(uid=' . $escaped . ')');
+})->with([
+	['a*b',   'a\\2ab'],
+	['a(b)c', 'a\\28b\\29c'],
+	['x\\y',  'x\\5cy'],
+	['a&b',   'a&b'],
+]);
+
+test('a value cannot close the filter and append a clause', function () {
+	$filter = cacti_ldap_filter('(&(uid=<user>)(objectClass=person))', ['user' => 'a)(uid=*']);
+
+	// The parenthesis and asterisk survive as escaped literals, so the filter
+	// still has exactly the two clauses the template declared.
+	expect($filter)->toBe('(&(uid=a\\29\\28uid=\\2a)(objectClass=person))');
+	expect(substr_count($filter, '(uid='))->toBe(1);
+});
+
+test('a value is never rescanned as another placeholder', function () {
+	// LDAP_ESCAPE_FILTER leaves '<' and '>' intact, so substituting one key at a
+	// time into the accumulating result would let the text inserted for <x> be
+	// picked up as the <y> placeholder on the next iteration.
+	$filter = cacti_ldap_filter('(&(a=<x>)(b=<y>))', ['x' => '<y>', 'y' => 'secret']);
+
+	expect($filter)->toBe('(&(a=<y>)(b=secret))');
+	expect($filter)->not->toContain('(a=secret)');
+});
+
+test('a value carrying a real placeholder name survives as a literal', function () {
+	$filter = cacti_ldap_filter(
+		'(&(distinguishedName=<user>)(memberOf:1.2.840.113556.1.4.1941:=<group>))',
+		['user' => '<group>', 'group' => 'CN=Domain Admins,DC=x']
+	);
+
+	expect($filter)->toBe('(&(distinguishedName=<group>)(memberOf:1.2.840.113556.1.4.1941:=CN=Domain Admins,DC=x))');
+});
+
+test('an unknown placeholder is left alone', function () {
+	expect(cacti_ldap_filter('(uid=<user>)', ['other' => 'x']))->toBe('(uid=<user>)');
+});
+
+test('non-string values are coerced before escaping', function () {
+	expect(cacti_ldap_filter('(uidNumber=<n>)', ['n' => 1234]))->toBe('(uidNumber=1234)');
+});
+
+/*
+ * DN context has its own reserved set, so it needs LDAP_ESCAPE_DN rather than
+ * the filter escaper. A comma terminates an RDN, which is why it has to be
+ * escaped rather than passed through.
+ */
+test('DN reserved characters are escaped for DN context', function (string $raw, string $escaped) {
+	expect(ldap_escape($raw, '', LDAP_ESCAPE_DN))->toBe($escaped);
+})->with([
+	['a,ou=other', 'a\\2cou\\3dother'],
+	['a+b',        'a\\2bb'],
+	['x\\y',       'x\\5cy'],
+]);


### PR DESCRIPTION
Fixes #7964.

`lib/ldap.php` on `1.2.x` escapes untrusted values before they reach an LDAP filter or DN. `develop` does not. This ports that handling across so the two branches agree.

## What develop does today

Three sites, `Authenticate()`, `Search()` and `Getcn()`, delete a fixed set of characters from the username:

```php
$this->username = str_replace(['&', '|', '(', ')', '*', '>', '<', '!', '='], '', $this->username);
$this->dn       = str_replace('<username>', $this->username, $this->dn);
```

Deleting rather than escaping has a visible cost. A directory whose usernames legally contain any of those characters cannot authenticate those accounts, because the value that reaches the bind is not the value the user typed:

```
input          reaches the directory as
a*b       ->   ab
a(b)c     ->   abc
```

The blocklist also leaves DN-reserved characters in place. `,` `+` `"` `\` and `;` all mean something in a DN, and a comma terminates an RDN, so it changes the structure of the assembled bind DN rather than travelling as data.

Two filters are built by concatenation, so they depend entirely on that blocklist having run several hundred lines earlier:

```php
lib/ldap.php:794   '(|(uid=' . $this->dn . ')(cn=' . $this->dn . ')(userPrincipalName=' . $this->dn . '))'
lib/ldap.php:1119  "(&(distinguishedName=$ldapUser)(memberOf:1.2.840.113556.1.4.1941:=$groupDN))"
```

## What this changes

Adopts the `1.2.x` handling verbatim.

- Adds `cacti_ldap_filter()`, which substitutes `<key>` placeholders with `ldap_escape()`d values.
- Replaces the blocklist at all three sites with two context-correct values, `ldap_escape(..., LDAP_ESCAPE_DN)` for DN substitution and `ldap_escape(..., LDAP_ESCAPE_FILTER)` for `search_filter`.
- Routes the two concatenated filters through the helper.

Result on the same inputs:

```
input          reaches the directory as
a*b       ->   a\2ab          (matches the account named a*b)
a(b)c     ->   a\28b\29c      (matches the account named a(b)c)
x\y       ->   x\5cy          (previously passed through unescaped)
a,ou=x    ->   a\2cou\3dx     in DN context
```

Accounts that could not previously log in now can, and every value is carried as a literal.

## Tests

`tests/Unit/Security/Ldap/LdapFilterEscapingTest.php`, 12 cases. These call `cacti_ldap_filter()` and assert its output. They deliberately do not match against the text of `lib/ldap.php`: a source match certifies spelling rather than behaviour, and would not notice the function being absent.

```
Tests:    12 passed (13 assertions)
```

Existing suite unaffected:

```
include/vendor/bin/pest --filter="Auth|Ldap|Login"
Tests:    142 passed (354 assertions)
```

`php -l` clean, `php-cs-fixer` clean against the repository config.

## Note for reviewers

The three `str_replace()` blocklists are removed rather than kept alongside the escaping, which is how `1.2.x` does it. Keeping both would preserve the username corruption shown above, since the characters would be deleted before `ldap_escape()` ever saw them.

## Known gap, stated rather than papered over

These tests pin `cacti_ldap_filter()`'s behaviour. They do not pin that
`Authenticate()`, `Search()`, `Getcn()` and the two filter sites actually call
it, so a later refactor could unpick the call sites and leave the suite green.

The obvious way to close that is a source match asserting the call sites appear
in `lib/ldap.php`, and that is deliberately not done here. The existing
`1.2.x` LDAP test is four such assertions, and that is exactly why the handling
being absent from `develop` went unnoticed: a source match can only observe the
branch it lives on.

Closing it properly needs the call sites exercised against a real directory. I
am building that separately as an LDAP end-to-end suite with a seeded OpenLDAP
service, intended for both branches, and it will assert outcomes rather than
text.


Fixes #7464.