### PR TITLE
fix: substitute LDAP filter placeholders in a single pass

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 
 1.2.x
 -issue#7506: Close open select menus when their scroll container moves
+-issue: Substitute LDAP filter placeholders in a single pass
 -issue: Commit transactions on MySQL as well as MariaDB
 -security: Update bundled DOMPurify to 3.4.14
 -security: Revoke anonymous access when the guest account is disabled

--- a/lib/ldap.php
+++ b/lib/ldap.php
@@ -1007,13 +1007,15 @@ class Ldap {
  * @return string The assembled, injection-safe LDAP filter
  */
 function cacti_ldap_filter($template, $vars) {
-	$result = $template;
+	$map = array();
 
 	foreach ($vars as $key => $value) {
-		$escaped = ldap_escape((string) $value, '', LDAP_ESCAPE_FILTER);
-		$result  = str_replace('<' . $key . '>', $escaped, $result);
+		$map['<' . $key . '>'] = ldap_escape((string) $value, '', LDAP_ESCAPE_FILTER);
 	}
 
-	return $result;
+	/* One pass. LDAP_ESCAPE_FILTER leaves '<' and '>' alone, so substituting in a
+	 * loop would let the text inserted for one key be rescanned as another key's
+	 * placeholder. */
+	return strtr($template, $map);
 }
 

--- a/tests/Unit/Security/Ldap/LdapFilterSubstitutionTest.php
+++ b/tests/Unit/Security/Ldap/LdapFilterSubstitutionTest.php
@@ -24,6 +24,12 @@
 
 require_once __DIR__ . '/../../../../lib/ldap.php';
 
+beforeEach(function () {
+	if (!function_exists('ldap_escape') || !defined('LDAP_ESCAPE_FILTER')) {
+		$this->markTestSkipped('The LDAP extension is not available.');
+	}
+});
+
 test('a plain value is substituted unchanged', function () {
 	expect(cacti_ldap_filter('(uid=<user>)', array('user' => 'alice')))->toBe('(uid=alice)');
 });

--- a/tests/Unit/Security/Ldap/LdapFilterSubstitutionTest.php
+++ b/tests/Unit/Security/Ldap/LdapFilterSubstitutionTest.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * cacti_ldap_filter() substitutes every placeholder in one pass. Substituting
+ * one key at a time into the accumulating result would let the text inserted
+ * for one key be rescanned as another key's placeholder, because
+ * LDAP_ESCAPE_FILTER leaves '<' and '>' intact.
+ *
+ * These tests call the function rather than matching against the text of
+ * lib/ldap.php, so they fail if the behaviour regresses however it is written.
+ */
+
+require_once __DIR__ . '/../../../../lib/ldap.php';
+
+test('a plain value is substituted unchanged', function () {
+	expect(cacti_ldap_filter('(uid=<user>)', array('user' => 'alice')))->toBe('(uid=alice)');
+});
+
+test('a repeated placeholder is substituted at every position', function () {
+	expect(cacti_ldap_filter('(|(uid=<dn>)(cn=<dn>))', array('dn' => 'bob')))
+		->toBe('(|(uid=bob)(cn=bob))');
+});
+
+test('filter metacharacters are escaped', function ($raw, $escaped) {
+	expect(cacti_ldap_filter('(uid=<user>)', array('user' => $raw)))->toBe('(uid=' . $escaped . ')');
+})->with(array(
+	array('a*b',   'a\\2ab'),
+	array('a(b)c', 'a\\28b\\29c'),
+	array('x\\y',  'x\\5cy'),
+));
+
+test('a value cannot close the filter and append a clause', function () {
+	$filter = cacti_ldap_filter('(&(uid=<user>)(objectClass=person))', array('user' => 'a)(uid=*'));
+
+	expect($filter)->toBe('(&(uid=a\\29\\28uid=\\2a)(objectClass=person))');
+	expect(substr_count($filter, '(uid='))->toBe(1);
+});
+
+test('a value is never rescanned as another placeholder', function () {
+	$filter = cacti_ldap_filter('(&(a=<x>)(b=<y>))', array('x' => '<y>', 'y' => 'secret'));
+
+	expect($filter)->toBe('(&(a=<y>)(b=secret))');
+	expect($filter)->not->toContain('(a=secret)');
+});
+
+test('a value naming a real placeholder survives as a literal', function () {
+	$filter = cacti_ldap_filter(
+		'(&(distinguishedName=<user>)(memberOf:1.2.840.113556.1.4.1941:=<group>))',
+		array('user' => '<group>', 'group' => 'CN=Domain Admins,DC=x')
+	);
+
+	expect($filter)->toBe('(&(distinguishedName=<group>)(memberOf:1.2.840.113556.1.4.1941:=CN=Domain Admins,DC=x))');
+});
+
+test('an empty variable list returns the template unchanged', function () {
+	expect(cacti_ldap_filter('(uid=<user>)', array()))->toBe('(uid=<user>)');
+});
+
+test('a value with a __toString is coerced before escaping', function () {
+	$value = new class {
+		public function __toString() {
+			return 'a*b';
+		}
+	};
+
+	expect(cacti_ldap_filter('(uid=<user>)', array('user' => $value)))->toBe('(uid=a\\2ab)');
+});
+
+test('an unknown placeholder is left alone', function () {
+	expect(cacti_ldap_filter('(uid=<user>)', array('other' => 'x')))->toBe('(uid=<user>)');
+});

--- a/tests/Unit/Security/Ldap/LdapRegressionTest.php
+++ b/tests/Unit/Security/Ldap/LdapRegressionTest.php
@@ -60,5 +60,8 @@ test('GHSA-pmgm: cacti_ldap_filter escapes each variable with ldap_escape', func
 
 	$body = substr($ldapSource, $start, 600);
 	expect($body)->toContain("ldap_escape((string) \$value, '', LDAP_ESCAPE_FILTER)");
-	expect($body)->toContain("str_replace('<' . \$key . '>', \$escaped, \$result)");
+
+	// How the substitution is performed is asserted behaviourally in
+	// LdapFilterSubstitutionTest, so it is not pinned to an implementation
+	// here as well.
 });


### PR DESCRIPTION
`cacti_ldap_filter()` substitutes one key at a time into the accumulating
result. `LDAP_ESCAPE_FILTER` does not escape `<` or `>`, so the text inserted
for one key is still present, unescaped, when the next key is processed and can
be matched as that key's placeholder.

```php
foreach ($vars as $key => $value) {
	$escaped = ldap_escape((string) $value, '', LDAP_ESCAPE_FILTER);
	$result  = str_replace('<' . $key . '>', $escaped, $result);
}
```

Reproduced against the current file:

```
cacti_ldap_filter('(&(a=<x>)(b=<y>))', ['x' => '<y>', 'y' => 'secret'])
  ->  (&(a=secret)(b=secret))
```

The value supplied for `x` was replaced by the value supplied for `y`.

Building the map first and substituting once with `strtr()` closes it, since
replacement text is never rescanned:

```
  ->  (&(a=<y>)(b=secret))
```

Output is unchanged for every value that does not itself contain a placeholder
name, which is every caller in the tree today.

## Reachability

Not reachable end to end at present. The only two-placeholder caller is
`isUserInLDAPGroup()`, whose `$ldapUser` arrives as `$this->dn` after
`ldap_escape(..., LDAP_ESCAPE_DN)`, and that escaper does turn `<` into `\3c`.
The defect is in the shared helper rather than in the caller, so the next
placeholder added inherits it silently.

## Tests

`tests/Unit/Security/Ldap/LdapFilterSubstitutionTest.php`, eleven cases. They
call the function and assert its output, including the rescanning case above,
an empty `$vars` array, and a value whose `__toString()` returns a string
containing a filter metacharacter.

`LdapRegressionTest.php` asserted on the literal `str_replace` line this change
removes, so that assertion is dropped. Its `ldap_escape` assertion stays. How
the substitution is performed is now covered behaviourally rather than by
matching implementation text in two files.

## Verification note

The Pest suite could not be executed locally: `tests/phpunit.xml` bootstraps
`include/global.php`, which requires a database connection. All eleven
assertions were therefore verified standalone against the patched
`lib/ldap.php`, and all pass.

That bootstrap dependency is worth a separate look. `pest` exits 0 after the
connection failure, so a job that invokes it without a database reports success
having run no assertions at all.
