### PR TITLE
security: harden CLI process and temporary-file handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ Cacti CHANGELOG
 -issue#7506: Close open select menus when their scroll container moves
 -issue#7967: Fail CSP Pest jobs when no tests execute
 -issue: Commit transactions on MySQL as well as MariaDB
+-security: Harden CLI shell arguments, database credentials, and temporary RRD files
 -security: Update bundled DOMPurify to 3.4.14
 -security: Revoke anonymous access when the guest account is disabled
 -security: Cast graph and device ids to int in get_allowed_* permission filters

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -140,19 +140,11 @@ if (cacti_sizeof($parms)) {
 
 
 /**
- * audit_database_defaults_file - writes the database credentials to a private
- * file for --defaults-extra-file.
+ * audit_database_option_value - quote and escape a MySQL option-file value
  *
- * The password is deliberately kept off the command line. Anything passed as
- * an argument is readable from the process list by every local user for the
- * lifetime of the command.
+ * @param  mixed $value The value to encode.
  *
- * @param  string $username The database user.
- * @param  string $password The database password.
- * @param  string $hostname The database host.
- * @param  string $port     The database port.
- *
- * @return string|false The path to the file, or false when it cannot be created.
+ * @return string|false The encoded value, or false when it contains a NUL byte.
  */
 function audit_database_option_value($value) {
 	$value = (string) $value;
@@ -170,6 +162,21 @@ function audit_database_option_value($value) {
 	)) . '"';
 }
 
+/**
+ * audit_database_defaults_file - writes the database credentials to a private
+ * file for --defaults-extra-file.
+ *
+ * The password is deliberately kept off the command line. Anything passed as
+ * an argument is readable from the process list by every local user for the
+ * lifetime of the command.
+ *
+ * @param  string $username The database user.
+ * @param  string $password The database password.
+ * @param  string $hostname The database host.
+ * @param  string $port     The database port.
+ *
+ * @return string|false The path to the file, or false when it cannot be created.
+ */
 function audit_database_defaults_file($username, $password, $hostname, $port) {
 	$path = tempnam(sys_get_temp_dir(), 'cacti_audit_');
 	$include_port = $hostname != 'localhost';

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -154,8 +154,25 @@ if (cacti_sizeof($parms)) {
  *
  * @return string|false The path to the file, or false when it cannot be created.
  */
+function audit_database_option_value($value) {
+	$value = (string) $value;
+
+	if (strpos($value, "\0") !== false) {
+		return false;
+	}
+
+	return '"' . strtr($value, array(
+		'\\' => '\\\\',
+		'"'  => '\\"',
+		"\n" => '\\n',
+		"\r" => '\\r',
+		"\t" => '\\t'
+	)) . '"';
+}
+
 function audit_database_defaults_file($username, $password, $hostname, $port) {
 	$path = tempnam(sys_get_temp_dir(), 'cacti_audit_');
+	$include_port = $hostname != 'localhost';
 
 	if ($path === false) {
 		return false;
@@ -168,12 +185,23 @@ function audit_database_defaults_file($username, $password, $hostname, $port) {
 		return false;
 	}
 
+	$username = audit_database_option_value($username);
+	$password = audit_database_option_value($password);
+	$hostname = audit_database_option_value($hostname);
+	$port     = audit_database_option_value($port);
+
+	if ($username === false || $password === false || $hostname === false || $port === false) {
+		unlink($path);
+
+		return false;
+	}
+
 	$contents  = '[client]' . PHP_EOL;
 	$contents .= 'user=' . $username . PHP_EOL;
 	$contents .= 'password=' . $password . PHP_EOL;
 	$contents .= 'host=' . $hostname . PHP_EOL;
 
-	if ($hostname != 'localhost') {
+	if ($include_port) {
 		$contents .= 'port=' . $port . PHP_EOL;
 	}
 
@@ -189,14 +217,21 @@ function audit_database_defaults_file($username, $password, $hostname, $port) {
 function upgrade_database() {
 	global $config;
 
-	$start = microtime(true);
+	$php_binary = read_config_option('path_php_binary');
+	$start      = microtime(true);
+
+	if ($php_binary == '') {
+		$php_binary = PHP_BINARY;
+	}
 
 	cacti_log('NOTE: Upgrading Cacti, this will take a few minutes.', true, 'UPGRADE');
 
 	$return_var = 0;
 	$output     = array();
 
-	exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
+	exec(cacti_escapeshellarg($php_binary) . ' ' .
+		cacti_escapeshellarg($config['base_path'] . '/cli/upgrade_database.php') .
+		' --debug', $output, $return_var);
 
 	$end = microtime(true);
 
@@ -287,7 +322,9 @@ function upgrade_database() {
 							$return_var = 0;
 							$output     = array();
 
-							exec('php ' . $config['base_path'] . '/plugins/' . $pname . '/database_upgrade.php --type=large --force-ver=' . $old, $output, $return_var);
+							exec(cacti_escapeshellarg($php_binary) . ' ' .
+								cacti_escapeshellarg($plugin . '/database_upgrade.php') .
+								' --type=large --force-ver=' . cacti_escapeshellarg($old), $output, $return_var);
 
 							if ($return_var == 0) {
 								print implode(PHP_EOL, $output) . PHP_EOL;
@@ -1082,7 +1119,7 @@ function create_tables($load = true) {
 		} elseif (file_exists('/usr/local/bin/mysql')) {
 			$db_shell = '/usr/local/bin/mysql';
 		} else {
-			$db_shell = shell_exec('which mysql');
+				$db_shell = trim((string) shell_exec('which mysql'));
 
 			if ($db_shell == '') {
 				print 'FATAL: mysql or mariadb command not found' . PHP_EOL;
@@ -1101,7 +1138,7 @@ function create_tables($load = true) {
 				exit(1);
 			}
 
-			exec($db_shell .
+			exec(cacti_escapeshellarg($db_shell) .
 				' --defaults-extra-file=' . cacti_escapeshellarg($defaults_file) .
 				' ' . cacti_escapeshellarg($database_default) .
 				' < ' . cacti_escapeshellarg($config['base_path'] . '/docs/audit_schema.sql'), $output, $error);

--- a/cli/audit_database.php
+++ b/cli/audit_database.php
@@ -1119,7 +1119,7 @@ function create_tables($load = true) {
 		} elseif (file_exists('/usr/local/bin/mysql')) {
 			$db_shell = '/usr/local/bin/mysql';
 		} else {
-				$db_shell = trim((string) shell_exec('which mysql'));
+			$db_shell = trim((string) shell_exec('which mysql'));
 
 			if ($db_shell == '') {
 				print 'FATAL: mysql or mariadb command not found' . PHP_EOL;

--- a/cli/batchgapfix.php
+++ b/cli/batchgapfix.php
@@ -58,7 +58,7 @@ $method     = 'fill';
 $avgnan     = 'last';
 $start_time = false;
 $end_time   = false;
-$php_bin    = read_config_option('path_php_binary');
+$php_bin    = (string) read_config_option('path_php_binary');
 
 /* install signal handlers for UNIX types only */
 if (function_exists('pcntl_signal')) {
@@ -286,20 +286,28 @@ if ($child == 0) {
 
 	// Fork Child Binaries
 	for($i = 1; $i <= $threads; $i++) {
-		$command = sprintf("%s/cli/batchgapfix.php --start='%s' --end='%s' --method=%s --avgnan=%s --child=%s" . ($force ? ' --force':'') . ($debug ? ' --debug':''),
-			$config['base_path'],
-			$start_date,
-			$end_date,
-			$method,
-			$avgnan,
-			$i
+		$args = array(
+			$config['base_path'] . '/cli/batchgapfix.php',
+			'--start=' . $start_date,
+			'--end=' . $end_date,
+			'--method=' . $method,
+			'--avgnan=' . $avgnan,
+			'--child=' . $i
 		);
+
+		if ($force) {
+			$args[] = '--force';
+		}
+
+		if ($debug) {
+			$args[] = '--debug';
+		}
 
 		$now = date('H:i:s');
 
-		printf("NOTE: %s, Exec in Background: %s %s" . PHP_EOL, $now, $php_bin, $command);
+		printf("NOTE: %s, Exec in Background: %s %s" . PHP_EOL, $now, $php_bin, implode(' ', $args));
 
-		exec_background($php_bin, $command);
+		exec_background($php_bin, $args);
 	}
 
 	$start = microtime(true);
@@ -367,14 +375,14 @@ if ($child == 0) {
 		$return_var = 0;
 
 		// Format the command
-		$command = sprintf("%s -q %s/cli/removespikes.php --rrdfile='%s' --outlier-start='%s' --outlier-end='%s' --method=%s --avgnan=%s",
-			$php_bin,
-			$config['base_path'],
-			$rrdfile['data_source_path'],
-			$start_date,
-			$end_date,
-			$method,
-			$avgnan
+		$command = sprintf('%s -q %s --rrdfile=%s --outlier-start=%s --outlier-end=%s --method=%s --avgnan=%s',
+			cacti_escapeshellarg($php_bin),
+			cacti_escapeshellarg($config['base_path'] . '/cli/removespikes.php'),
+			cacti_escapeshellarg($rrdfile['data_source_path']),
+			cacti_escapeshellarg($start_date),
+			cacti_escapeshellarg($end_date),
+			cacti_escapeshellarg($method),
+			cacti_escapeshellarg($avgnan)
 		);
 
 		db_execute_prepared('UPDATE graph_local_spikekill
@@ -467,4 +475,3 @@ function display_help() {
 	print '   --force                         - Kill the current running batch gap fill and start over.' . PHP_EOL;
 	print '   --debug                         - Higher tracing level for select utilities.' . PHP_EOL . PHP_EOL;
 }
-

--- a/cli/batchgapfix.php
+++ b/cli/batchgapfix.php
@@ -60,6 +60,10 @@ $start_time = false;
 $end_time   = false;
 $php_bin    = (string) read_config_option('path_php_binary');
 
+if ($php_bin === '') {
+	$php_bin = PHP_BINARY;
+}
+
 /* install signal handlers for UNIX types only */
 if (function_exists('pcntl_signal')) {
 	pcntl_signal(SIGTERM, 'sig_handler');

--- a/cli/float_rrdfiles.php
+++ b/cli/float_rrdfiles.php
@@ -345,9 +345,11 @@ function float_rrdfile($rrd_path, $local_data_id, $step, $start_time, $end_time)
 			}
 
 			$fp = fopen($tmp_file, 'w');
+			$lf = false;
 
 			if ($seebug) {
-				$lf = fopen('php://stderr', 'w');
+				$lf     = @fopen('php://stderr', 'w');
+				$seebug = is_resource($lf);
 			}
 
 			if (is_resource($fp)) {

--- a/cli/float_rrdfiles.php
+++ b/cli/float_rrdfiles.php
@@ -315,7 +315,7 @@ function float_rrdfile($rrd_path, $local_data_id, $step, $start_time, $end_time)
 	static $tmp_dir     = false;
 
 	if ($rrdtool_bin === false) {
-		$rrdtool_bin = read_config_option('path_rrdtool');
+		$rrdtool_bin = (string) read_config_option('path_rrdtool');
 	}
 
 	if ($tmp_dir === false) {
@@ -323,11 +323,9 @@ function float_rrdfile($rrd_path, $local_data_id, $step, $start_time, $end_time)
 	}
 
 	$delta_time = $end_time - $start_time;
-	$tmp_file   = $tmp_dir . '/' . $local_data_id . '.xml';
-
 	$return     = 0;
 	$output     = array();
-	$command    = "$rrdtool_bin dump $rrd_path";
+	$command    = cacti_escapeshellarg($rrdtool_bin) . ' dump ' . cacti_escapeshellarg($rrd_path);
 	$db_prefix  = '                       ';
 
 	if (file_exists($rrd_path)) {
@@ -339,10 +337,17 @@ function float_rrdfile($rrd_path, $local_data_id, $step, $start_time, $end_time)
 				return false;
 			}
 
+			$tmp_file = tempnam($tmp_dir, 'cacti_float_');
+
+			if ($tmp_file === false) {
+				cacti_log('WARNING: Unable to create a private temporary RRD XML file', false, 'RFLOAT');
+				return false;
+			}
+
 			$fp = fopen($tmp_file, 'w');
 
 			if ($seebug) {
-				$lf = fopen(sys_get_temp_dir() . '/cacti_float_rrdfiles.log', 'a');
+				$lf = fopen('php://stderr', 'w');
 			}
 
 			if (is_resource($fp)) {
@@ -438,24 +443,32 @@ function float_rrdfile($rrd_path, $local_data_id, $step, $start_time, $end_time)
 				/* restore the file */
 				$return  = 0;
 				$output  = array();
-				$command = "$rrdtool_bin restore -f $tmp_file $rrd_path";
+				$command = cacti_escapeshellarg($rrdtool_bin) . ' restore -f ' . cacti_escapeshellarg($tmp_file) . ' ' . cacti_escapeshellarg($rrd_path);
 
 				$response = exec($command, $output, $return);
 
 				if ($return == 0) {
 					cacti_log(sprintf('NOTE: Range floated for RRDfile %s', $rrd_path), false, 'RFLOAT');
+					unlink($tmp_file);
+
+					if ($seebug && is_resource($lf)) {
+						fclose($lf);
+					}
+
 					return true;
 				} else {
 					cacti_log(sprintf('WARNING: Range float FAILED for RRDfile %s.  Message is %s', $rrd_path, $response), false, 'RFLOAT');
-					return false;
-				}
-
-				if (!$seebug) {
 					unlink($tmp_file);
-					fclose($lf);
+
+					if ($seebug && is_resource($lf)) {
+						fclose($lf);
+					}
+
+					return false;
 				}
 			} else {
 				cacti_log(sprintf('WARNING: Unable to open file %s for writing', $tmp_file), false, 'RFLOAT');
+				unlink($tmp_file);
 				return false;
 			}
 		} else {
@@ -602,12 +615,27 @@ function float_launch_child($thread_id, $step, $start_time, $end_time) {
 	global $config, $seebug;
 
 	$php_binary = read_config_option('path_php_binary');
+	$args       = array(
+		$config['base_path'] . '/cli/float_rrdfiles.php',
+		'--type=child',
+		'--child=' . $thread_id,
+		'--start=' . $start_time,
+		'--end=' . $end_time
+	);
+
+	if ($step !== false) {
+		$args[] = '--step=' . $step;
+	}
+
+	if ($seebug) {
+		$args[] = '--debug';
+	}
 
 	float_debug(sprintf('Launching Float Data Process Number %s for Type %s', $thread_id, 'child'));
 
 	cacti_log(sprintf('NOTE: Launching Float Data Number %s for Type %s', $thread_id, 'child'), false, 'RFLOAT', POLLER_VERBOSITY_MEDIUM);
 
-	exec_background($php_binary, $config['base_path'] . "/cli/float_rrdfiles.php --type=child --child=$thread_id --start=$start_time --end=$end_time" . ($step !== false ? ' --step=' . $step:'') . ($seebug ? ' --debug':''));
+	exec_background($php_binary, $args);
 }
 
 /**

--- a/cli/float_rrdfiles.php
+++ b/cli/float_rrdfiles.php
@@ -316,6 +316,10 @@ function float_rrdfile($rrd_path, $local_data_id, $step, $start_time, $end_time)
 
 	if ($rrdtool_bin === false) {
 		$rrdtool_bin = (string) read_config_option('path_rrdtool');
+
+		if ($rrdtool_bin === '') {
+			$rrdtool_bin = 'rrdtool';
+		}
 	}
 
 	if ($tmp_dir === false) {
@@ -616,7 +620,12 @@ function float_master_handler($forcerun, $resume, $host_id, $host_template_id, $
 function float_launch_child($thread_id, $step, $start_time, $end_time) {
 	global $config, $seebug;
 
-	$php_binary = read_config_option('path_php_binary');
+	$php_binary = (string) read_config_option('path_php_binary');
+
+	if ($php_binary === '') {
+		$php_binary = PHP_BINARY;
+	}
+
 	$args       = array(
 		$config['base_path'] . '/cli/float_rrdfiles.php',
 		'--type=child',

--- a/cli/update_heartbeat.php
+++ b/cli/update_heartbeat.php
@@ -242,15 +242,22 @@ if (!$force) {
 }
 
 $i = 0;
+
+$rrdtool_bin = read_config_option('path_rrdtool');
+
+if ($rrdtool_bin == '') {
+	$rrdtool_bin = 'rrdtool';
+}
+
 if (cacti_sizeof($rrdfiles)) {
 	foreach($rrdfiles as $f) {
 		if (file_exists($f['rrd'])) {
-			$command = sprintf("rrdtool tune %s ", $f['rrd']);
+			$command = cacti_escapeshellarg($rrdtool_bin) . ' tune ' . cacti_escapeshellarg($f['rrd']);
 
 			$data_sources = explode(',', $f['data_sources']);
 
 			foreach($data_sources as $ds) {
-				$command .= " --heartbeat $ds:$new_heartbeat";
+				$command .= ' --heartbeat ' . cacti_escapeshellarg($ds . ':' . $new_heartbeat);
 			}
 
 			$output      = array();
@@ -358,4 +365,3 @@ function debug($message) {
 		print "DEBUG: " . trim($message) . "\n";
 	}
 }
-

--- a/tests/Unit/Security/Shell/CliMaintenanceHardeningTest.php
+++ b/tests/Unit/Security/Shell/CliMaintenanceHardeningTest.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$base                  = dirname(__DIR__, 4);
+$auditDatabaseSource   = file_get_contents($base . '/cli/audit_database.php');
+$batchgapfixSource     = file_get_contents($base . '/cli/batchgapfix.php');
+$floatRrdfilesSource   = file_get_contents($base . '/cli/float_rrdfiles.php');
+$updateHeartbeatSource = file_get_contents($base . '/cli/update_heartbeat.php');
+
+test('database sourced RRD paths are escaped before shell execution', function () use ($batchgapfixSource, $floatRrdfilesSource, $updateHeartbeatSource) {
+	expect($batchgapfixSource)->toContain('cacti_escapeshellarg($rrdfile[\'data_source_path\'])')
+		->and($batchgapfixSource)->toContain('exec_background($php_bin, $args)')
+		->and($floatRrdfilesSource)->toContain("cacti_escapeshellarg(\$rrdtool_bin) . ' dump ' . cacti_escapeshellarg(\$rrd_path)")
+		->and($floatRrdfilesSource)->toContain("cacti_escapeshellarg(\$tmp_file) . ' ' . cacti_escapeshellarg(\$rrd_path)")
+		->and($updateHeartbeatSource)->toContain("cacti_escapeshellarg(\$f['rrd'])")
+		->and($updateHeartbeatSource)->toContain("cacti_escapeshellarg(\$ds . ':' . \$new_heartbeat)");
+});
+
+test('CLI subprocesses pass background arguments as arrays', function () use ($batchgapfixSource, $floatRrdfilesSource) {
+	expect($batchgapfixSource)->toContain('exec_background($php_bin, $args)')
+		->and($floatRrdfilesSource)->toContain('exec_background($php_binary, $args)');
+});
+
+test('float rrdfiles uses a private temporary file and reachable cleanup', function () use ($floatRrdfilesSource) {
+	expect($floatRrdfilesSource)->toContain("tempnam(\$tmp_dir, 'cacti_float_')")
+		->and($floatRrdfilesSource)->not->toContain("\$tmp_dir . '/' . \$local_data_id . '.xml'")
+		->and(substr_count($floatRrdfilesSource, 'unlink($tmp_file);'))->toBeGreaterThanOrEqual(3)
+		->and($floatRrdfilesSource)->not->toContain("cacti_float_rrdfiles.log");
+});
+
+test('mysql option file values are quoted and escaped', function () use ($auditDatabaseSource) {
+	preg_match('/function audit_database_option_value\(.*?^}\R/ms', $auditDatabaseSource, $matches);
+
+	expect($matches)->toHaveKey(0);
+
+	eval($matches[0]);
+
+	expect(audit_database_option_value('abc#def;ghi'))->toBe('"abc#def;ghi"')
+		->and(audit_database_option_value("line\nnext"))->toBe('"line\\nnext"')
+		->and(audit_database_option_value('a"b\\c'))->toBe('"a\\"b\\\\c"')
+		->and(audit_database_option_value("bad\0value"))->toBeFalse();
+});

--- a/tests/Unit/Security/Shell/CliMaintenanceHardeningTest.php
+++ b/tests/Unit/Security/Shell/CliMaintenanceHardeningTest.php
@@ -41,7 +41,7 @@ test('mysql option file values are quoted and escaped', function () use ($auditD
 
 	expect($matches)->toHaveKey(0);
 
-	eval($matches[0]);
+	eval($matches[0]); // nosemgrep: php.lang.security.eval-use.eval-use
 
 	expect(audit_database_option_value('abc#def;ghi'))->toBe('"abc#def;ghi"')
 		->and(audit_database_option_value("line\nnext"))->toBe('"line\\nnext"')

--- a/tests/Unit/Security/Shell/CliMaintenanceHardeningTest.php
+++ b/tests/Unit/Security/Shell/CliMaintenanceHardeningTest.php
@@ -24,7 +24,9 @@ test('database sourced RRD paths are escaped before shell execution', function (
 
 test('CLI subprocesses pass background arguments as arrays', function () use ($batchgapfixSource, $floatRrdfilesSource) {
 	expect($batchgapfixSource)->toContain('exec_background($php_bin, $args)')
-		->and($floatRrdfilesSource)->toContain('exec_background($php_binary, $args)');
+		->and($floatRrdfilesSource)->toContain('exec_background($php_binary, $args)')
+		->and($batchgapfixSource)->toContain('$php_bin = PHP_BINARY;')
+		->and($floatRrdfilesSource)->toContain('$php_binary = PHP_BINARY;');
 });
 
 test('float rrdfiles uses a private temporary file and reachable cleanup', function () use ($floatRrdfilesSource) {
@@ -33,6 +35,7 @@ test('float rrdfiles uses a private temporary file and reachable cleanup', funct
 		->and(substr_count($floatRrdfilesSource, 'unlink($tmp_file);'))->toBeGreaterThanOrEqual(3)
 		->and($floatRrdfilesSource)->toContain('$lf = false;')
 		->and($floatRrdfilesSource)->toContain('$seebug = is_resource($lf);')
+		->and($floatRrdfilesSource)->toContain("\$rrdtool_bin = 'rrdtool';")
 		->and($floatRrdfilesSource)->not->toContain("cacti_float_rrdfiles.log");
 });
 
@@ -40,6 +43,8 @@ test('mysql option file values are quoted and escaped', function () use ($auditD
 	preg_match('/function audit_database_option_value\(.*?^}\R/ms', $auditDatabaseSource, $matches);
 
 	expect($matches)->toHaveKey(0);
+	expect($auditDatabaseSource)->toContain('audit_database_option_value - quote and escape a MySQL option-file value')
+		->and($auditDatabaseSource)->toContain('audit_database_defaults_file - writes the database credentials');
 
 	eval($matches[0]); // nosemgrep: php.lang.security.eval-use.eval-use
 

--- a/tests/Unit/Security/Shell/CliMaintenanceHardeningTest.php
+++ b/tests/Unit/Security/Shell/CliMaintenanceHardeningTest.php
@@ -31,6 +31,8 @@ test('float rrdfiles uses a private temporary file and reachable cleanup', funct
 	expect($floatRrdfilesSource)->toContain("tempnam(\$tmp_dir, 'cacti_float_')")
 		->and($floatRrdfilesSource)->not->toContain("\$tmp_dir . '/' . \$local_data_id . '.xml'")
 		->and(substr_count($floatRrdfilesSource, 'unlink($tmp_file);'))->toBeGreaterThanOrEqual(3)
+		->and($floatRrdfilesSource)->toContain('$lf = false;')
+		->and($floatRrdfilesSource)->toContain('$seebug = is_resource($lf);')
 		->and($floatRrdfilesSource)->not->toContain("cacti_float_rrdfiles.log");
 });
 

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -1,6 +1,6 @@
 class	location	match
 cmd_exec	./cactid.php:102		exec('pgrep -a php | grep cactid.php', $output);
-cmd_exec	./cli/audit_database.php:1122					$db_shell = trim((string) shell_exec('which mysql'));
+cmd_exec	./cli/audit_database.php:1122				$db_shell = trim((string) shell_exec('which mysql'));
 cmd_exec	./cli/audit_database.php:1141				exec(cacti_escapeshellarg($db_shell) .
 cmd_exec	./cli/audit_database.php:232		exec(cacti_escapeshellarg($php_binary) . ' ' .
 cmd_exec	./cli/audit_database.php:325								exec(cacti_escapeshellarg($php_binary) . ' ' .

--- a/tests/security/baselines/architectural_hotspots.baseline.tsv
+++ b/tests/security/baselines/architectural_hotspots.baseline.tsv
@@ -1,9 +1,9 @@
 class	location	match
 cmd_exec	./cactid.php:102		exec('pgrep -a php | grep cactid.php', $output);
-cmd_exec	./cli/audit_database.php:1085				$db_shell = shell_exec('which mysql');
-cmd_exec	./cli/audit_database.php:1104				exec($db_shell .
-cmd_exec	./cli/audit_database.php:199		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
-cmd_exec	./cli/audit_database.php:290								exec('php ' . $config['base_path'] . '/plugins/' . $pname . '/database_upgrade.php --type=large --force-ver=' . $old, $output, $return_var);
+cmd_exec	./cli/audit_database.php:1122					$db_shell = trim((string) shell_exec('which mysql'));
+cmd_exec	./cli/audit_database.php:1141				exec(cacti_escapeshellarg($db_shell) .
+cmd_exec	./cli/audit_database.php:232		exec(cacti_escapeshellarg($php_binary) . ' ' .
+cmd_exec	./cli/audit_database.php:325								exec(cacti_escapeshellarg($php_binary) . ' ' .
 cmd_exec	./cli/batchgapfix.php:388			exec($command, $output, $return_var);
 cmd_exec	./cli/float_rrdfiles.php:335				$response = exec($command, $output, $return);
 cmd_exec	./cli/float_rrdfiles.php:443					$response = exec($command, $output, $return);

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -1,8 +1,9 @@
 category	location	match
 cmd_exec	./cactid.php:102		exec('pgrep -a php | grep cactid.php', $output);
-cmd_exec	./cli/audit_database.php:1085				$db_shell = shell_exec('which mysql');
-cmd_exec	./cli/audit_database.php:1104				exec($db_shell .
-cmd_exec	./cli/audit_database.php:199		exec('php ' . $config['base_path'] . '/cli/upgrade_database.php --debug', $output, $return_var);
+cmd_exec	./cli/audit_database.php:1122					$db_shell = trim((string) shell_exec('which mysql'));
+cmd_exec	./cli/audit_database.php:1141				exec(cacti_escapeshellarg($db_shell) .
+cmd_exec	./cli/audit_database.php:232		exec(cacti_escapeshellarg($php_binary) . ' ' .
+cmd_exec	./cli/audit_database.php:325								exec(cacti_escapeshellarg($php_binary) . ' ' .
 cmd_exec	./cli/batchgapfix.php:388			exec($command, $output, $return_var);
 cmd_exec	./cli/float_rrdfiles.php:335				$response = exec($command, $output, $return);
 cmd_exec	./cli/float_rrdfiles.php:443					$response = exec($command, $output, $return);
@@ -535,7 +536,7 @@ fs_write	./cactid.php:99		$STDERR = fopen('/dev/null', 'wb');
 fs_write	./cli/audit_database.php:180		if (file_put_contents($path, $contents) === false) {
 fs_write	./cli/change_device.php:987		$fh = fopen($file, 'r');
 fs_write	./cli/float_rrdfiles.php:342				$fp = fopen($tmp_file, 'w');
-fs_write	./cli/float_rrdfiles.php:345					$lf = fopen(sys_get_temp_dir() . '/cacti_float_rrdfiles.log', 'a');
+fs_write	./cli/float_rrdfiles.php:350					$lf = fopen('php://stderr', 'w');
 fs_write	./cli/import_package.php:159				$fp   = fopen($filename, 'r');
 fs_write	./cli/import_template.php:121				$fp = fopen($filename,'r');
 fs_write	./cli/input_whitelist.php:188			file_put_contents($config['input_whitelist'], json_encode($input));

--- a/tests/security/baselines/sink_inventory.baseline.tsv
+++ b/tests/security/baselines/sink_inventory.baseline.tsv
@@ -1,6 +1,6 @@
 category	location	match
 cmd_exec	./cactid.php:102		exec('pgrep -a php | grep cactid.php', $output);
-cmd_exec	./cli/audit_database.php:1122					$db_shell = trim((string) shell_exec('which mysql'));
+cmd_exec	./cli/audit_database.php:1122				$db_shell = trim((string) shell_exec('which mysql'));
 cmd_exec	./cli/audit_database.php:1141				exec(cacti_escapeshellarg($db_shell) .
 cmd_exec	./cli/audit_database.php:232		exec(cacti_escapeshellarg($php_binary) . ' ' .
 cmd_exec	./cli/audit_database.php:325								exec(cacti_escapeshellarg($php_binary) . ' ' .
@@ -535,8 +535,8 @@ fs_write	./cactid.php:110		$STDERR = fopen('null', 'wb');
 fs_write	./cactid.php:99		$STDERR = fopen('/dev/null', 'wb');
 fs_write	./cli/audit_database.php:180		if (file_put_contents($path, $contents) === false) {
 fs_write	./cli/change_device.php:987		$fh = fopen($file, 'r');
-fs_write	./cli/float_rrdfiles.php:342				$fp = fopen($tmp_file, 'w');
-fs_write	./cli/float_rrdfiles.php:350					$lf = fopen('php://stderr', 'w');
+fs_write	./cli/float_rrdfiles.php:347				$fp = fopen($tmp_file, 'w');
+fs_write	./cli/float_rrdfiles.php:351					$lf     = @fopen('php://stderr', 'w');
 fs_write	./cli/import_package.php:159				$fp   = fopen($filename, 'r');
 fs_write	./cli/import_template.php:121				$fp = fopen($filename,'r');
 fs_write	./cli/input_whitelist.php:188			file_put_contents($config['input_whitelist'], json_encode($input));


### PR DESCRIPTION
Backports the remaining CLI process-boundary hardening identified in the 1.2.x security review.

Changes:
- pass background child arguments as arrays so exec_background escapes each value
- quote executable paths and all database-derived RRD, date, method, and heartbeat arguments
- keep MySQL credentials in a mode-0600 defaults file with MySQL option-value escaping and NUL rejection
- replace predictable RRD XML and debug paths with tempnam and stderr
- make every temporary-file cleanup path reachable
- refresh only the reviewed command/file sink signatures

Verification:
- PHP 8.4 syntax checks pass for every changed PHP file
- focused Pest security suite: 4 passed
- sink inventory matches baseline
- no new architectural hotspots
- git diff --check passes