### PR TITLE
security: reject clean-client session cookie failures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ Cacti CHANGELOG
 1.2.x
 -issue#7506: Close open select menus when their scroll container moves
 -issue: Commit transactions on MySQL as well as MariaDB
+-security: Reject clean-client login requests when the session cookie was not accepted
 -security: Update bundled DOMPurify to 3.4.14
 -security: Revoke anonymous access when the guest account is disabled
 -security: Cast graph and device ids to int in get_allowed_* permission filters

--- a/auth_login.php
+++ b/auth_login.php
@@ -50,6 +50,17 @@ $error_msg     = '';                                  // The errors message in c
 /* global variables for exception handling */
 global $error, $error_msg;
 
+/* The IP fallback can validate a login CSRF token when a clean browser rejects
+ * a mis-scoped session cookie. Stop before authenticating so that successful
+ * credentials do not redirect back to a fresh unauthenticated session. */
+if ($auth_method != 2 && get_nfilter_request_var('action') == 'login') {
+	$session_name = session_name();
+
+	if ($session_name !== '' && !isset($_COOKIE[$session_name])) {
+		cacti_session_cookie_failure(!empty($_COOKIE));
+	}
+}
+
 if (get_nfilter_request_var('action') == 'login' || $auth_method == 2) {
 	if ($auth_method > 2 && $frv_realm <= 1) {
 		// User picked 'local' from dropdown;

--- a/include/csrf.php
+++ b/include/csrf.php
@@ -179,7 +179,7 @@ function cacti_session_cookie_failure($write_log = true) {
 	global $config;
 
 	if ($write_log) {
-		cacti_log('ERROR: Browser did not return the Cacti session cookie; verify url_path and cacti_cookie_domain.', false, 'AUTH');
+		cacti_log('ERROR: Browser did not return the Cacti session cookie during CSRF validation; verify url_path and cacti_cookie_domain.', false, 'AUTH');
 		csrf_log(__FUNCTION__, 'Session cookie missing; refusing to redirect into a login loop');
 	}
 

--- a/include/csrf.php
+++ b/include/csrf.php
@@ -175,28 +175,34 @@ function cacti_csrf_external_path_is_safe($path) {
 	return true;
 }
 
-function csrf_error_callback() {
+function cacti_session_cookie_failure($write_log = true) {
 	global $config;
 
+	if ($write_log) {
+		cacti_log('ERROR: Browser did not return the Cacti session cookie; verify url_path and cacti_cookie_domain.', false, 'AUTH');
+		csrf_log(__FUNCTION__, 'Session cookie missing; refusing to redirect into a login loop');
+	}
+
+	while (ob_get_level()) {
+		ob_end_clean();
+	}
+
+	http_response_code(403);
+	header('Content-Type: text/plain; charset=UTF-8');
+	print __('The browser did not return the Cacti session cookie. Ensure cookies are enabled and verify the configured URL path and cookie domain.') . PHP_EOL;
+	print __('Return to Cacti: %s', $config['url_path'] . 'index.php') . PHP_EOL;
+	exit;
+}
+
+function csrf_error_callback() {
 	$session_name = session_name();
 
-	// Only treat this as a misconfigured cookie domain when the client returned
-	// cookies but not ours. A request carrying no cookies at all is an unattended
-	// scanner rather than a browser in a login loop, and logging those would let
-	// anonymous traffic write to cacti.log unthrottled.
-	if ($session_name !== '' && !empty($_COOKIE) && !isset($_COOKIE[$session_name])) {
-		cacti_log('ERROR: Browser did not return the Cacti session cookie during CSRF validation; verify url_path and cacti_cookie_domain.', false, 'AUTH');
-		csrf_log(__FUNCTION__, 'Session cookie missing; refusing to redirect into a login loop');
-
-		while (ob_get_level()) {
-			ob_end_clean();
-		}
-
-		http_response_code(403);
-		header('Content-Type: text/plain; charset=UTF-8');
-		print __('The browser did not return the Cacti session cookie. Ensure cookies are enabled and verify the configured URL path and cookie domain.') . PHP_EOL;
-		print __('Return to Cacti: %s', $config['url_path'] . 'index.php') . PHP_EOL;
-		exit;
+	// A clean browser may return no cookies when it rejects a mis-scoped session
+	// cookie. Refuse the redirect loop in that case as well, but only write the
+	// diagnostic log when the client returned some other cookie so anonymous
+	// cookie-less requests cannot amplify cacti.log.
+	if ($session_name !== '' && !isset($_COOKIE[$session_name])) {
+		cacti_session_cookie_failure(!empty($_COOKIE));
 	}
 
 	// Resolve session fixation for PHP 5.4

--- a/tests/Unit/Security/Session/SessionCookieFailureTest.php
+++ b/tests/Unit/Security/Session/SessionCookieFailureTest.php
@@ -18,9 +18,18 @@ test('a missing session cookie stops the CSRF redirect loop', function () use ($
 
 	expect($start)->not->toBeFalse()
 		->and($body)->toContain("!isset(\$_COOKIE[\$session_name])")
-		->and($body)->toContain('http_response_code(403);')
-		->and($body)->toContain('Session cookie missing; refusing to redirect into a login loop')
-		->and(strpos($body, 'http_response_code(403);'))->toBeLessThan(strpos($body, "header('Location: '"));
+		->and($body)->not->toContain("!empty(\$_COOKIE) && !isset(\$_COOKIE[\$session_name])")
+		->and($body)->toContain('cacti_session_cookie_failure(!empty($_COOKIE));')
+		->and(strpos($body, 'cacti_session_cookie_failure('))->toBeLessThan(strpos($body, "header('Location: '"));
+});
+
+test('cookie-less clients receive the response without unbounded logging', function () use ($csrfSource) {
+	$loginSource = file_get_contents(dirname(__DIR__, 4) . '/auth_login.php');
+
+	expect($loginSource)->toContain("!isset(\$_COOKIE[\$session_name])")
+		->and($loginSource)->toContain('cacti_session_cookie_failure(!empty($_COOKIE));')
+		->and($csrfSource)->toContain('if ($write_log) {')
+		->and($csrfSource)->toContain('http_response_code(403);');
 });
 
 test('the missing-cookie response gives actionable configuration guidance', function () use ($csrfSource) {

--- a/tests/e2e/docker/tests/07-session-cookie-failure.sh
+++ b/tests/e2e/docker/tests/07-session-cookie-failure.sh
@@ -14,10 +14,7 @@ DC=(docker compose -f docker-compose.yml)
 sleep 3
 "${DC[@]}" exec -T cacti-master rm -f /tmp/c07.jar /tmp/c07_form /tmp/c07_headers /tmp/c07_response
 
-# An unrelated host-only cookie suppresses csrf-magic's IP fallback, matching
-# a normal browser which already has timezone or preference cookies.
 "${DC[@]}" exec -T cacti-master curl -sS \
-	-b 'probe=1' \
 	-c /tmp/c07.jar \
 	-o /tmp/c07_form \
 	http://127.0.0.1/index.php
@@ -34,8 +31,7 @@ if [ -z "$CSRF" ]; then
 	exit 1
 fi
 
-STATUS=$("${DC[@]}" exec -T cacti-master curl -sS \
-	-b 'probe=1' \
+	STATUS=$("${DC[@]}" exec -T cacti-master curl -sS \
 	-b /tmp/c07.jar \
 	-c /tmp/c07.jar \
 	-D /tmp/c07_headers \

--- a/tests/e2e/docker/tests/07-session-cookie-failure.sh
+++ b/tests/e2e/docker/tests/07-session-cookie-failure.sh
@@ -12,7 +12,7 @@ DC=(docker compose -f docker-compose.yml)
 	'printf '\''%s\n'\'' "\$cacti_cookie_domain = '\''example.com'\'';" >> /var/www/html/include/config.php'
 # php.ini-production caches file timestamps for two seconds.
 sleep 3
-"${DC[@]}" exec -T cacti-master rm -f /tmp/c07.jar /tmp/c07_form /tmp/c07_headers /tmp/c07_response
+"${DC[@]}" exec -T cacti-master rm -f /tmp/c07.jar /tmp/c07_form /tmp/c07_headers /tmp/c07_response /tmp/c07_logged_response
 
 "${DC[@]}" exec -T cacti-master curl -sS \
 	-c /tmp/c07.jar \
@@ -31,8 +31,11 @@ if [ -z "$CSRF" ]; then
 	exit 1
 fi
 
-	STATUS=$("${DC[@]}" exec -T cacti-master curl -sS \
-	-b 'probe=1' \
+LOG_MESSAGE='Browser did not return the Cacti session cookie during CSRF validation'
+LOG_COUNT_BEFORE=$("${DC[@]}" exec -T cacti-master sh -c \
+	"grep -cF '$LOG_MESSAGE' /var/www/html/log/cacti.log || true")
+
+STATUS=$("${DC[@]}" exec -T cacti-master curl -sS \
 	-b /tmp/c07.jar \
 	-c /tmp/c07.jar \
 	-D /tmp/c07_headers \
@@ -57,11 +60,36 @@ if ! "${DC[@]}" exec -T cacti-master grep -q \
 	exit 1
 fi
 
-if ! "${DC[@]}" exec -T cacti-master grep -q \
-	'Browser did not return the Cacti session cookie during CSRF validation' \
-	/var/www/html/log/cacti.log; then
-	echo 'FAIL: missing session cookie was not logged' >&2
+LOG_COUNT_AFTER_CLEAN=$("${DC[@]}" exec -T cacti-master sh -c \
+	"grep -cF '$LOG_MESSAGE' /var/www/html/log/cacti.log || true")
+if [ "$LOG_COUNT_AFTER_CLEAN" != "$LOG_COUNT_BEFORE" ]; then
+	echo 'FAIL: a cookie-less login attempt amplified the diagnostic log' >&2
 	exit 1
 fi
 
-echo 'PASS: rejected session cookie returns an actionable 403 without redirecting'
+LOGGED_STATUS=$("${DC[@]}" exec -T cacti-master curl -sS \
+	-b 'probe=1' \
+	-b /tmp/c07.jar \
+	-c /tmp/c07.jar \
+	-o /tmp/c07_logged_response \
+	-w '%{http_code}' \
+	--data-urlencode 'action=login' \
+	--data-urlencode 'login_username=admin' \
+	--data-urlencode 'login_password=cacti-e2e-admin' \
+	--data-urlencode "__csrf_magic=$CSRF" \
+	--data-urlencode 'realm=local' \
+	http://127.0.0.1/index.php)
+
+if [ "$LOGGED_STATUS" != '403' ]; then
+	echo "FAIL: other-cookie request returned HTTP $LOGGED_STATUS instead of 403" >&2
+	exit 1
+fi
+
+LOG_COUNT_AFTER_COOKIE=$("${DC[@]}" exec -T cacti-master sh -c \
+	"grep -cF '$LOG_MESSAGE' /var/www/html/log/cacti.log || true")
+if [ "$LOG_COUNT_AFTER_COOKIE" -le "$LOG_COUNT_AFTER_CLEAN" ]; then
+	echo 'FAIL: missing session cookie was not logged when another cookie was present' >&2
+	exit 1
+fi
+
+echo 'PASS: rejected session cookie returns an actionable 403 with bounded logging'

--- a/tests/e2e/docker/tests/07-session-cookie-failure.sh
+++ b/tests/e2e/docker/tests/07-session-cookie-failure.sh
@@ -32,6 +32,7 @@ if [ -z "$CSRF" ]; then
 fi
 
 	STATUS=$("${DC[@]}" exec -T cacti-master curl -sS \
+	-b 'probe=1' \
 	-b /tmp/c07.jar \
 	-c /tmp/c07.jar \
 	-D /tmp/c07_headers \


### PR DESCRIPTION
Completes the 1.2.x session-cookie loop fix for clean browsers that reject the Cacti session cookie and therefore return no cookies at all.

The CSRF IP fallback can validate the login token in that state. This patch stops before authentication and returns the existing controlled 403 response, preventing a successful login from redirecting into a fresh unauthenticated session. Cookie-less probes still do not write unbounded log entries; diagnostic logging remains limited to clients that returned another cookie.

Verification:
- PHP 8.4 syntax checks pass
- focused Pest session-cookie suite: 6 passed
- Docker regression now exercises a genuinely clean cookie jar
- sink inventory matches baseline
- no new architectural hotspots
- git diff --check passes