### PR TITLE
fix(auth): reject malformed remember cookies

### DIFF
--- a/.github/workflows/cookie-coverage.yml
+++ b/.github/workflows/cookie-coverage.yml
@@ -1,0 +1,105 @@
+name: Cookie Coverage
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - '.github/workflows/cookie-coverage.yml'
+      - 'auth_2fa.php'
+      - 'auth_changepassword.php'
+      - 'auth_login.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'include/auth.php'
+      - 'include/global.php'
+      - 'include/js/jquery.zoom.js'
+      - 'include/js/js.storage.js'
+      - 'include/layout.js'
+      - 'include/themes/midwinter/main.js'
+      - 'lib/auth.php'
+      - 'lib/functions.php'
+      - 'logout.php'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tests/Helpers/AuthCookieProbe.php'
+      - 'tests/integration/AuthSystemRegressionIntegrationTest.php'
+      - 'tests/js/cookie_helpers.test.js'
+      - 'tests/Unit/Security/Session/CookiePolicyContractTest.php'
+      - 'tests/Unit/Security/Session/CookieRuntimeTest.php'
+  pull_request:
+    branches: [develop]
+    paths:
+      - '.github/workflows/cookie-coverage.yml'
+      - 'auth_2fa.php'
+      - 'auth_changepassword.php'
+      - 'auth_login.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'include/auth.php'
+      - 'include/global.php'
+      - 'include/js/jquery.zoom.js'
+      - 'include/js/js.storage.js'
+      - 'include/layout.js'
+      - 'include/themes/midwinter/main.js'
+      - 'lib/auth.php'
+      - 'lib/functions.php'
+      - 'logout.php'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tests/Helpers/AuthCookieProbe.php'
+      - 'tests/integration/AuthSystemRegressionIntegrationTest.php'
+      - 'tests/js/cookie_helpers.test.js'
+      - 'tests/Unit/Security/Session/CookiePolicyContractTest.php'
+      - 'tests/Unit/Security/Session/CookieRuntimeTest.php'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cookie-coverage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  COMPOSER_ALLOW_SUPERUSER: 1
+
+jobs:
+  coverage:
+    name: Cookie behavior matrix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.4'
+          coverage: none
+          extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
+
+      - name: Setup Node 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 4.4.0
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install PHP dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Install JavaScript dependencies
+        run: npm ci
+
+      - name: Run PHP cookie matrix
+        run: >-
+          include/vendor/bin/pest
+          tests/Unit/Security/Session/CookiePolicyContractTest.php
+          tests/Unit/Security/Session/CookieRuntimeTest.php
+          tests/integration/AuthSystemRegressionIntegrationTest.php
+
+      - name: Run browser cookie helpers
+        run: node --test tests/js/cookie_helpers.test.js

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -181,6 +181,8 @@ Cacti CHANGELOG
 -issue#7355: Add a JUNIPER-MIB jnxOperatingTable script data query for RE and FPC health
 -issue#7355: Add an F5-BIGIP-SYSTEM-MIB script data query for per-CPU utilization
 -issue#7904: Device changes are silently skipped when --bulk_walk is passed to change_device.php
+-issue#7975: Reject malformed remember-me cookies without warnings or mutations
+-issue#7978: Revoke remember-me tokens before clearing browser state
 -feature#7884: Manage front-end JavaScript libraries with npm and Dependabot
 -feature#7884: Build release artifacts from managed dependencies, including DOMPurify 3.4.14 and phpseclib 4, and a reduced runtime tree
 -feature#7835: Add cacti_snmp_session_from_host() to build SNMP sessions from a device row

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -116,10 +116,12 @@ function check_auth_cookie() : int|false {
 			$user_id  = $parts[0];
 			$realm_id = -1;
 			$token    = $parts[1];
-		} else {
+		} elseif (cacti_sizeof($parts) == 3) {
 			$user_id  = $parts[0];
 			$realm_id = $parts[1];
 			$token    = $parts[2];
+		} else {
+			return false;
 		}
 
 		if (!is_numeric($user_id)) {

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -39,20 +39,26 @@ use phpseclib4\Crypt\RSA;
  */
 function clear_auth_cookie() : void {
 	if (isset($_COOKIE['cacti_remembers']) && read_config_option('auth_cache_enabled') == 'on') {
+		if (!is_string($_COOKIE['cacti_remembers'])) {
+			cacti_cookie_session_logout();
+
+			return;
+		}
+
 		$parts = explode(',', $_COOKIE['cacti_remembers']);
 
 		if (cacti_sizeof($parts) == 2) {
 			$user_id  = $parts[0];
 			$realm_id = -1;
 			$token    = $parts[1];
-		} else {
-			if (cacti_sizeof($parts) != 3) {
-				return;
-			}
-
+		} elseif (cacti_sizeof($parts) == 3) {
 			$user_id  = $parts[0];
 			$realm_id = $parts[1];
 			$token    = $parts[2];
+		} else {
+			cacti_cookie_session_logout();
+
+			return;
 		}
 
 		// Legacy support which leaked usernames
@@ -66,13 +72,14 @@ function clear_auth_cookie() : void {
 		if ($user_id > 0) {
 			$secret = hash('sha512', $token, false);
 
-			cacti_cookie_session_logout();
-
 			db_execute_prepared('DELETE FROM user_auth_cache
 				WHERE user_id = ?
 				AND token = ?',
 				[$user_id, $secret]);
 		}
+
+		// Revoke the server-side credential before clearing browser state.
+		cacti_cookie_session_logout();
 	}
 }
 
@@ -110,6 +117,10 @@ function check_auth_cookie() : int|false {
 	if (isset($_COOKIE['cacti_remembers']) &&
 		read_config_option('auth_cache_enabled') == 'on' &&
 		db_table_exists('user_auth_cache')) {
+		if (!is_string($_COOKIE['cacti_remembers'])) {
+			return false;
+		}
+
 		$parts = explode(',', $_COOKIE['cacti_remembers']);
 
 		if (cacti_sizeof($parts) == 2) {

--- a/tests/Helpers/AuthCookieProbe.php
+++ b/tests/Helpers/AuthCookieProbe.php
@@ -63,6 +63,7 @@ $GLOBALS['auth_integration_usernames']    = [];
 $GLOBALS['auth_integration_cache']        = [];
 $GLOBALS['auth_integration_executed']     = [];
 $GLOBALS['auth_integration_cookie_calls'] = [];
+$GLOBALS['auth_integration_events']       = [];
 
 function read_config_option($name) {
 	return $GLOBALS['auth_integration_config'][$name] ?? '';
@@ -105,6 +106,7 @@ function db_execute_prepared($sql, $params = []) {
 		'sql'    => $sql,
 		'params' => $params,
 	];
+	$GLOBALS['auth_integration_events'][] = ['database', $sql];
 
 	return true;
 }
@@ -127,6 +129,7 @@ function cacti_cookie_session_set($user, $realm, $secret) {
 
 function cacti_cookie_session_logout() {
 	$GLOBALS['auth_integration_cookie_calls'][] = ['logout'];
+	$GLOBALS['auth_integration_events'][]       = ['cookie', 'logout'];
 }
 
 function cacti_log(...$args) {
@@ -154,6 +157,7 @@ foreach ($scenario['calls'] as $call) {
 	$GLOBALS['auth_integration_realms']       = $call['realms'] ?? $scenario['realms'] ?? 0;
 	$GLOBALS['auth_integration_executed']     = [];
 	$GLOBALS['auth_integration_cookie_calls'] = [];
+	$GLOBALS['auth_integration_events']       = [];
 	$warnings                                 = [];
 
 	set_error_handler(function (int $severity, string $message) use (&$warnings) : bool {
@@ -194,6 +198,7 @@ foreach ($scenario['calls'] as $call) {
 		'return'       => $return,
 		'executed'     => $GLOBALS['auth_integration_executed'],
 		'cookie_calls' => $GLOBALS['auth_integration_cookie_calls'],
+		'events'       => $GLOBALS['auth_integration_events'],
 		'warnings'     => $warnings,
 	];
 }

--- a/tests/Helpers/AuthCookieProbe.php
+++ b/tests/Helpers/AuthCookieProbe.php
@@ -59,8 +59,10 @@ $GLOBALS['auth_integration_realms']       = 0;
 $GLOBALS['auth_integration_group_realms'] = 0;
 $GLOBALS['auth_integration_groups']       = [];
 $GLOBALS['auth_integration_users']        = [];
+$GLOBALS['auth_integration_usernames']    = [];
 $GLOBALS['auth_integration_cache']        = [];
 $GLOBALS['auth_integration_executed']     = [];
+$GLOBALS['auth_integration_cookie_calls'] = [];
 
 function read_config_option($name) {
 	return $GLOBALS['auth_integration_config'][$name] ?? '';
@@ -81,6 +83,10 @@ function db_fetch_cell_prepared($sql, $params = []) {
 				return $row['user_id'];
 			}
 		}
+	}
+
+	if (str_contains($sql, 'FROM user_auth') && str_contains($sql, 'WHERE username')) {
+		return $GLOBALS['auth_integration_usernames'][$params[0]] ?? 0;
 	}
 
 	return 0;
@@ -111,6 +117,21 @@ function get_guest_account() {
 	return (int) read_config_option('guest_user');
 }
 
+function get_client_addr() {
+	return '192.0.2.10';
+}
+
+function cacti_cookie_session_set($user, $realm, $secret) {
+	$GLOBALS['auth_integration_cookie_calls'][] = ['set', $user, $realm, $secret];
+}
+
+function cacti_cookie_session_logout() {
+	$GLOBALS['auth_integration_cookie_calls'][] = ['logout'];
+}
+
+function cacti_log(...$args) {
+}
+
 require_once $root . '/lib/auth.php';
 
 $scenario = json_decode(stream_get_contents(STDIN), true);
@@ -124,32 +145,56 @@ $GLOBALS['auth_integration_config']       = $scenario['config'] ?? [];
 $GLOBALS['auth_integration_group_realms'] = $scenario['group_realms'] ?? 0;
 $GLOBALS['auth_integration_groups']       = $scenario['groups'] ?? [];
 $GLOBALS['auth_integration_users']        = $scenario['users'] ?? [];
+$GLOBALS['auth_integration_usernames']    = $scenario['usernames'] ?? [];
 $GLOBALS['auth_integration_cache']        = $scenario['cache'] ?? [];
 
 $results = [];
 
 foreach ($scenario['calls'] as $call) {
-	$GLOBALS['auth_integration_realms']   = $call['realms'] ?? $scenario['realms'] ?? 0;
-	$GLOBALS['auth_integration_executed'] = [];
+	$GLOBALS['auth_integration_realms']       = $call['realms'] ?? $scenario['realms'] ?? 0;
+	$GLOBALS['auth_integration_executed']     = [];
+	$GLOBALS['auth_integration_cookie_calls'] = [];
+	$warnings                                 = [];
 
-	if ($call['type'] === 'auth_cookie_user_currently_allowed') {
-		$return = auth_cookie_user_currently_allowed($call['user']);
-	} elseif ($call['type'] === 'check_auth_cookie') {
-		if (array_key_exists('cookie', $call)) {
-			$_COOKIE['cacti_remembers'] = $call['cookie'];
-		} else {
+	set_error_handler(function (int $severity, string $message) use (&$warnings) : bool {
+		$warnings[] = [$severity, $message];
+
+		return true;
+	});
+
+	try {
+		if ($call['type'] === 'auth_cookie_user_currently_allowed') {
+			$return = auth_cookie_user_currently_allowed($call['user']);
+		} elseif ($call['type'] === 'check_auth_cookie' || $call['type'] === 'clear_auth_cookie') {
+			if (array_key_exists('cookie', $call)) {
+				$_COOKIE['cacti_remembers'] = $call['cookie'];
+			} else {
+				unset($_COOKIE['cacti_remembers']);
+			}
+
+			if ($call['type'] === 'check_auth_cookie') {
+				$return = check_auth_cookie();
+			} else {
+				clear_auth_cookie();
+				$return = null;
+			}
+		} elseif ($call['type'] === 'set_auth_cookie') {
 			unset($_COOKIE['cacti_remembers']);
+			set_auth_cookie($call['user']);
+			$return = null;
+		} else {
+			fwrite(STDERR, 'AuthCookieProbe: unknown call type ' . $call['type']);
+			exit(1);
 		}
-
-		$return = check_auth_cookie();
-	} else {
-		fwrite(STDERR, 'AuthCookieProbe: unknown call type ' . $call['type']);
-		exit(1);
+	} finally {
+		restore_error_handler();
 	}
 
 	$results[] = [
-		'return'   => $return,
-		'executed' => $GLOBALS['auth_integration_executed'],
+		'return'       => $return,
+		'executed'     => $GLOBALS['auth_integration_executed'],
+		'cookie_calls' => $GLOBALS['auth_integration_cookie_calls'],
+		'warnings'     => $warnings,
 	];
 }
 

--- a/tests/Unit/Security/Session/CookiePolicyContractTest.php
+++ b/tests/Unit/Security/Session/CookiePolicyContractTest.php
@@ -79,11 +79,13 @@ test('remember-me parsing accepts exactly legacy or current field counts', funct
 		throw new RuntimeException('check_auth_cookie() must exist');
 	}
 
-	$end            = strpos($cookie_sources['auth'], '/**', $start + 10);
+	$matched        = preg_match('/\nfunction\s+[a-zA-Z_][a-zA-Z0-9_]*\s*\(/', $cookie_sources['auth'], $boundary, PREG_OFFSET_CAPTURE, $start + 10);
 
-	if ($end === false) {
-		throw new RuntimeException('check_auth_cookie() must have a following docblock boundary');
+	if ($matched !== 1) {
+		throw new RuntimeException('check_auth_cookie() must have a following function boundary');
 	}
+
+	$end = $boundary[0][1];
 
 	$body           = substr($cookie_sources['auth'], $start, $end - $start);
 

--- a/tests/Unit/Security/Session/CookiePolicyContractTest.php
+++ b/tests/Unit/Security/Session/CookiePolicyContractTest.php
@@ -74,7 +74,17 @@ test('session bootstrap enables strict secure cookie settings', function () : vo
 test('remember-me parsing accepts exactly legacy or current field counts', function () : void {
 	$cookie_sources = cacti_test_cookie_sources();
 	$start          = strpos($cookie_sources['auth'], 'function check_auth_cookie()');
+
+	if ($start === false) {
+		throw new RuntimeException('check_auth_cookie() must exist');
+	}
+
 	$end            = strpos($cookie_sources['auth'], '/**', $start + 10);
+
+	if ($end === false) {
+		throw new RuntimeException('check_auth_cookie() must have a following docblock boundary');
+	}
+
 	$body           = substr($cookie_sources['auth'], $start, $end - $start);
 
 	expect($body)->toContain('cacti_sizeof($parts) == 2')

--- a/tests/Unit/Security/Session/CookiePolicyContractTest.php
+++ b/tests/Unit/Security/Session/CookiePolicyContractTest.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDTool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+$cookie_root    = dirname(__DIR__, 4);
+$cookie_sources = [
+	'functions' => file_get_contents($cookie_root . '/lib/functions.php'),
+	'auth'      => file_get_contents($cookie_root . '/lib/auth.php'),
+	'global'    => file_get_contents($cookie_root . '/include/global.php'),
+	'tfa'       => file_get_contents($cookie_root . '/auth_2fa.php'),
+	'logout'    => file_get_contents($cookie_root . '/logout.php'),
+	'login'     => file_get_contents($cookie_root . '/auth_login.php'),
+	'change'    => file_get_contents($cookie_root . '/auth_changepassword.php'),
+	'include'   => file_get_contents($cookie_root . '/include/auth.php'),
+	'zoom'      => file_get_contents($cookie_root . '/include/js/jquery.zoom.js'),
+	'storage'   => file_get_contents($cookie_root . '/include/js/js.storage.js'),
+];
+
+test('server cookie writers enforce path domain secure httponly and SameSite policy', function () use ($cookie_sources) : void {
+	foreach (['cacti_cookie_set', 'cacti_cookie_logout', 'cacti_cookie_session_set', 'cacti_cookie_session_logout'] as $function) {
+		$start = strpos($cookie_sources['functions'], "function $function(");
+		expect($start)->not->toBeFalse("$function must exist");
+		$next = strpos($cookie_sources['functions'], "\nfunction ", $start + 10);
+		$body = substr($cookie_sources['functions'], $start, $next === false ? null : $next - $start);
+
+		expect($body)->toContain("'path'     => CACTI_PATH_URL")
+			->toContain("'domain'   => \$domain")
+			->toContain("'secure'   => \$secure")
+			->toContain("'httponly' => true")
+			->toContain("'samesite' => 'Strict'");
+	}
+});
+
+test('session bootstrap enables strict secure cookie settings', function () use ($cookie_sources) : void {
+	expect($cookie_sources['global'])->toContain("ini_set('session.cookie_httponly', true)")
+		->toContain("ini_set('session.cookie_path', CACTI_PATH_URL)")
+		->toContain("ini_set('session.use_strict_mode', true)")
+		->toContain("ini_set('session.cookie_samesite', 'Strict')")
+		->toContain('if (cacti_is_https())')
+		->toContain("ini_set('session.cookie_secure', true)");
+});
+
+test('remember-me parsing accepts exactly legacy or current field counts', function () use ($cookie_sources) : void {
+	$start = strpos($cookie_sources['auth'], 'function check_auth_cookie()');
+	$end   = strpos($cookie_sources['auth'], '/**', $start + 10);
+	$body  = substr($cookie_sources['auth'], $start, $end - $start);
+
+	expect($body)->toContain('cacti_sizeof($parts) == 2')
+		->toContain('cacti_sizeof($parts) == 3')
+		->toMatch('/else\s*\{\s*return false;\s*\}/')
+		->toContain("hash('sha512', \$token, false)")
+		->toContain('auth_cookie_user_currently_allowed($user_info)')
+		->toContain('set_auth_cookie($user_info)');
+});
+
+test('2FA cookie binds user time user-agent and secret and has bounded parsing', function () use ($cookie_sources) : void {
+	expect($cookie_sources['tfa'])->toContain("explode(':', \$_COOKIE[session_name() . '_otp'], 2)")
+		->toContain('cacti_count($tfaCookie) == 2')
+		->toContain("hash_hmac('sha1', \$user['username'] . ':' . \$tfaMins . ':' . \$tfaCookieTime . ':' . \$_SERVER['HTTP_USER_AGENT'], \$user['tfa_secret'])")
+		->toContain("cacti_cookie_set(session_name() . '_otp', \$cookie, time() + (\$cookie_lifetime))");
+});
+
+test('logout revokes the server token before clearing browser cookies', function () use ($cookie_sources) : void {
+	$revoke = strpos($cookie_sources['logout'], 'clear_auth_cookie();');
+	$clear  = strpos($cookie_sources['logout'], 'cacti_cookie_logout();');
+
+	expect($revoke)->not->toBeFalse()
+		->and($clear)->not->toBeFalse()
+		->and($revoke)->toBeLessThan($clear);
+});
+
+test('login restore and password-change flows invoke the cookie lifecycle at safe boundaries', function () use ($cookie_sources) : void {
+	$set        = strpos($cookie_sources['login'], 'set_auth_cookie($user);');
+	$transition = strpos($cookie_sources['login'], "cacti_auth_transition((int) \$user['id'], 'login')");
+
+	expect($set)->not->toBeFalse()
+		->and($transition)->not->toBeFalse()
+		->and($set)->toBeGreaterThan($transition)
+		->and($cookie_sources['change'])->toContain('cacti_cookie_logout();')
+		->and($cookie_sources['include'])->toContain('$cookie_user = check_auth_cookie();')
+		->toContain("cacti_auth_transition((int) \$cookie_user, 'cookie_restore')")
+		->toContain('clear_auth_cookie();');
+});
+
+test('zoom cookie fallback uses isolated storage prefixes and persists every custom setting mutation', function () use ($cookie_sources) : void {
+	expect($cookie_sources['zoom'])->toContain("cookieName\t\t\t: 'cacti_zoom'")
+		->toContain('storage.isSet(zoom.options.cookieName)')
+		->toContain('zoom.custom = deserialize(storage.get(zoom.options.cookieName))')
+		->and(substr_count($cookie_sources['zoom'], 'storage.set(zoom.options.cookieName, serialize(zoom.custom))'))->toBe(6)
+		->and($cookie_sources['storage'])->toContain('var cookie_local_prefix = "ls_";')
+		->toContain('var cookie_session_prefix = "ss_";')
+		->toContain('window.localCookieStorage')
+		->toContain('window.sessionCookieStorage')
+		->toContain('window.cookieStorage');
+});

--- a/tests/Unit/Security/Session/CookiePolicyContractTest.php
+++ b/tests/Unit/Security/Session/CookiePolicyContractTest.php
@@ -11,21 +11,42 @@
  +-------------------------------------------------------------------------+
 */
 
-$cookie_root    = dirname(__DIR__, 4);
-$cookie_sources = [
-	'functions' => file_get_contents($cookie_root . '/lib/functions.php'),
-	'auth'      => file_get_contents($cookie_root . '/lib/auth.php'),
-	'global'    => file_get_contents($cookie_root . '/include/global.php'),
-	'tfa'       => file_get_contents($cookie_root . '/auth_2fa.php'),
-	'logout'    => file_get_contents($cookie_root . '/logout.php'),
-	'login'     => file_get_contents($cookie_root . '/auth_login.php'),
-	'change'    => file_get_contents($cookie_root . '/auth_changepassword.php'),
-	'include'   => file_get_contents($cookie_root . '/include/auth.php'),
-	'zoom'      => file_get_contents($cookie_root . '/include/js/jquery.zoom.js'),
-	'storage'   => file_get_contents($cookie_root . '/include/js/js.storage.js'),
-];
+function cacti_test_cookie_sources() : array {
+	static $sources;
 
-test('server cookie writers enforce path domain secure httponly and SameSite policy', function () use ($cookie_sources) : void {
+	if (!isset($sources)) {
+		$root  = dirname(__DIR__, 4);
+		$files = [
+			'functions' => 'lib/functions.php',
+			'auth'      => 'lib/auth.php',
+			'global'    => 'include/global.php',
+			'tfa'       => 'auth_2fa.php',
+			'logout'    => 'logout.php',
+			'login'     => 'auth_login.php',
+			'change'    => 'auth_changepassword.php',
+			'include'   => 'include/auth.php',
+			'zoom'      => 'include/js/jquery.zoom.js',
+			'storage'   => 'include/js/js.storage.js',
+		];
+		$sources = [];
+
+		foreach ($files as $name => $file) {
+			$source = file_get_contents($root . '/' . $file);
+
+			if ($source === false) {
+				throw new RuntimeException("Unable to read $file for cookie policy tests.");
+			}
+
+			$sources[$name] = $source;
+		}
+	}
+
+	return $sources;
+}
+
+test('server cookie writers enforce path domain secure httponly and SameSite policy', function () : void {
+	$cookie_sources = cacti_test_cookie_sources();
+
 	foreach (['cacti_cookie_set', 'cacti_cookie_logout', 'cacti_cookie_session_set', 'cacti_cookie_session_logout'] as $function) {
 		$start = strpos($cookie_sources['functions'], "function $function(");
 		expect($start)->not->toBeFalse("$function must exist");
@@ -40,7 +61,8 @@ test('server cookie writers enforce path domain secure httponly and SameSite pol
 	}
 });
 
-test('session bootstrap enables strict secure cookie settings', function () use ($cookie_sources) : void {
+test('session bootstrap enables strict secure cookie settings', function () : void {
+	$cookie_sources = cacti_test_cookie_sources();
 	expect($cookie_sources['global'])->toContain("ini_set('session.cookie_httponly', true)")
 		->toContain("ini_set('session.cookie_path', CACTI_PATH_URL)")
 		->toContain("ini_set('session.use_strict_mode', true)")
@@ -49,10 +71,11 @@ test('session bootstrap enables strict secure cookie settings', function () use 
 		->toContain("ini_set('session.cookie_secure', true)");
 });
 
-test('remember-me parsing accepts exactly legacy or current field counts', function () use ($cookie_sources) : void {
-	$start = strpos($cookie_sources['auth'], 'function check_auth_cookie()');
-	$end   = strpos($cookie_sources['auth'], '/**', $start + 10);
-	$body  = substr($cookie_sources['auth'], $start, $end - $start);
+test('remember-me parsing accepts exactly legacy or current field counts', function () : void {
+	$cookie_sources = cacti_test_cookie_sources();
+	$start          = strpos($cookie_sources['auth'], 'function check_auth_cookie()');
+	$end            = strpos($cookie_sources['auth'], '/**', $start + 10);
+	$body           = substr($cookie_sources['auth'], $start, $end - $start);
 
 	expect($body)->toContain('cacti_sizeof($parts) == 2')
 		->toContain('cacti_sizeof($parts) == 3')
@@ -62,25 +85,28 @@ test('remember-me parsing accepts exactly legacy or current field counts', funct
 		->toContain('set_auth_cookie($user_info)');
 });
 
-test('2FA cookie binds user time user-agent and secret and has bounded parsing', function () use ($cookie_sources) : void {
+test('2FA cookie binds user time user-agent and secret and has bounded parsing', function () : void {
+	$cookie_sources = cacti_test_cookie_sources();
 	expect($cookie_sources['tfa'])->toContain("explode(':', \$_COOKIE[session_name() . '_otp'], 2)")
 		->toContain('cacti_count($tfaCookie) == 2')
 		->toContain("hash_hmac('sha1', \$user['username'] . ':' . \$tfaMins . ':' . \$tfaCookieTime . ':' . \$_SERVER['HTTP_USER_AGENT'], \$user['tfa_secret'])")
 		->toContain("cacti_cookie_set(session_name() . '_otp', \$cookie, time() + (\$cookie_lifetime))");
 });
 
-test('logout revokes the server token before clearing browser cookies', function () use ($cookie_sources) : void {
-	$revoke = strpos($cookie_sources['logout'], 'clear_auth_cookie();');
-	$clear  = strpos($cookie_sources['logout'], 'cacti_cookie_logout();');
+test('logout revokes the server token before clearing browser cookies', function () : void {
+	$cookie_sources = cacti_test_cookie_sources();
+	$revoke         = strpos($cookie_sources['logout'], 'clear_auth_cookie();');
+	$clear          = strpos($cookie_sources['logout'], 'cacti_cookie_logout();');
 
 	expect($revoke)->not->toBeFalse()
 		->and($clear)->not->toBeFalse()
 		->and($revoke)->toBeLessThan($clear);
 });
 
-test('login restore and password-change flows invoke the cookie lifecycle at safe boundaries', function () use ($cookie_sources) : void {
-	$set        = strpos($cookie_sources['login'], 'set_auth_cookie($user);');
-	$transition = strpos($cookie_sources['login'], "cacti_auth_transition((int) \$user['id'], 'login')");
+test('login restore and password-change flows invoke the cookie lifecycle at safe boundaries', function () : void {
+	$cookie_sources = cacti_test_cookie_sources();
+	$set            = strpos($cookie_sources['login'], 'set_auth_cookie($user);');
+	$transition     = strpos($cookie_sources['login'], "cacti_auth_transition((int) \$user['id'], 'login')");
 
 	expect($set)->not->toBeFalse()
 		->and($transition)->not->toBeFalse()
@@ -91,7 +117,8 @@ test('login restore and password-change flows invoke the cookie lifecycle at saf
 		->toContain('clear_auth_cookie();');
 });
 
-test('zoom cookie fallback uses isolated storage prefixes and persists every custom setting mutation', function () use ($cookie_sources) : void {
+test('zoom cookie fallback uses isolated storage prefixes and persists every custom setting mutation', function () : void {
+	$cookie_sources = cacti_test_cookie_sources();
 	expect($cookie_sources['zoom'])->toContain("cookieName\t\t\t: 'cacti_zoom'")
 		->toContain('storage.isSet(zoom.options.cookieName)')
 		->toContain('zoom.custom = deserialize(storage.get(zoom.options.cookieName))')

--- a/tests/Unit/Security/Session/CookieRuntimeTest.php
+++ b/tests/Unit/Security/Session/CookieRuntimeTest.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDTool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+test('remember-me cookie runtime records session intent and logout clears browser state', function () : void {
+	global $config;
+
+	$old_config  = $config;
+	$old_cookie  = $_COOKIE;
+	$old_session = $_SESSION;
+
+	try {
+		$config[COOKIE_OPTIONS]     = [COOKIE_OPTIONS_DOMAIN => 'example.test'];
+		$config[CACTI_SESSION_NAME] = 'Cacti';
+		$otp_cookie                 = (string) session_name() . '_otp';
+		$_SESSION                   = [];
+		$_COOKIE                    = [
+			'Cacti'           => 'session-id',
+			$otp_cookie       => 'otp-token',
+			'cacti_remembers' => '42,-1,secret',
+		];
+
+		cacti_cookie_set('arbitrary', 'value', time() + 60);
+		cacti_cookie_session_set('42', -1, 'secret');
+
+		expect($_SESSION['cacti_remembers'])->toBeTrue();
+
+		cacti_cookie_session_logout();
+		cacti_cookie_logout();
+
+		expect($_COOKIE)->not->toHaveKey('Cacti')
+			->not->toHaveKey($otp_cookie)
+			->not->toHaveKey('cacti_remembers');
+	} finally {
+		$config   = $old_config;
+		$_COOKIE  = $old_cookie;
+		$_SESSION = $old_session;
+	}
+});

--- a/tests/integration/AuthSystemRegressionIntegrationTest.php
+++ b/tests/integration/AuthSystemRegressionIntegrationTest.php
@@ -184,3 +184,107 @@ test('remember-me cookie authorization verifies token before deleting cache rows
 		->and($results[1]['executed'][0]['sql'])->toContain('DELETE FROM user_auth_cache')
 		->and($results[1]['executed'][0]['params'])->toBe([42]);
 });
+
+test('malformed remember-me cookies fail closed without warnings or database mutations', function () {
+	$results = runAuthCookieProbe([
+		'config' => [
+			'auth_cache_enabled' => 'on',
+			'guest_user'         => 0,
+		],
+		'realms' => 1,
+		'users'  => [
+			42 => [
+				'id'           => 42,
+				'username'     => 'valid-user',
+				'realm'        => 0,
+				'enabled'      => 'on',
+				'show_tree'    => 'on',
+				'show_list'    => '',
+				'show_preview' => '',
+			],
+		],
+		'cache' => [[
+			'user_id' => 42,
+			'token'   => hash('sha512', 'valid-token', false),
+		]],
+		'calls' => [
+			['type' => 'check_auth_cookie', 'cookie' => ''],
+			['type' => 'check_auth_cookie', 'cookie' => '42'],
+			['type' => 'check_auth_cookie', 'cookie' => '42,-1,valid-token,extra'],
+		],
+	]);
+
+	foreach ($results as $result) {
+		expect($result['return'])->toBeFalse()
+			->and($result['warnings'])->toBeEmpty()
+			->and($result['executed'])->toBeEmpty()
+			->and($result['cookie_calls'])->toBeEmpty();
+	}
+});
+
+test('remember-me cookie clear and set lifecycle covers legacy identities and token hashing', function () {
+	$results = runAuthCookieProbe([
+		'config'    => ['auth_cache_enabled' => 'on', 'guest_user' => 0],
+		'usernames' => ['legacy-user' => 43],
+		'calls'     => [
+			['type' => 'clear_auth_cookie', 'cookie' => '42,old-token'],
+			['type' => 'clear_auth_cookie', 'cookie' => 'legacy-user,7,legacy-token'],
+			['type' => 'clear_auth_cookie', 'cookie' => 'broken'],
+			['type' => 'set_auth_cookie', 'user' => ['id' => 44, 'realm' => 2]],
+		],
+	]);
+
+	expect($results[0]['cookie_calls'])->toBe([['logout']])
+		->and($results[0]['executed'][0]['params'])->toBe(['42', hash('sha512', 'old-token', false)])
+		->and($results[1]['cookie_calls'])->toBe([['logout']])
+		->and($results[1]['executed'][0]['params'])->toBe([43, hash('sha512', 'legacy-token', false)])
+		->and($results[2]['executed'])->toBeEmpty()
+		->and($results[2]['warnings'])->toBeEmpty();
+
+	$replace = $results[3]['executed'][0];
+	$setCall = $results[3]['cookie_calls'][0];
+
+	expect($replace['sql'])->toContain('REPLACE INTO user_auth_cache')
+		->and($replace['params'][0])->toBe(44)
+		->and($replace['params'][1])->toBe('192.0.2.10')
+		->and($setCall[0])->toBe('set')
+		->and($setCall[1])->toBe(44)
+		->and($setCall[2])->toBe(2)
+		->and($setCall[3])->toMatch('/^[a-f0-9]{64}$/D')
+		->and($replace['params'][2])->toBe(hash('sha512', $setCall[3], false));
+});
+
+test('valid remember-me cookie rotates the token and records the login', function () {
+	$results = runAuthCookieProbe([
+		'config' => ['auth_cache_enabled' => 'on', 'guest_user' => 0],
+		'realms' => 1,
+		'users'  => [
+			42 => [
+				'id'           => 42,
+				'username'     => 'allowed',
+				'realm'        => 0,
+				'enabled'      => 'on',
+				'locked'       => '',
+				'show_tree'    => 'on',
+				'show_list'    => '',
+				'show_preview' => '',
+			],
+		],
+		'cache' => [[
+			'user_id' => 42,
+			'token'   => hash('sha512', 'valid-token', false),
+		]],
+		'calls' => [['type' => 'check_auth_cookie', 'cookie' => '42,-1,valid-token']],
+	]);
+
+	$result = $results[0];
+
+	expect($result['return'])->toBe(42)
+		->and($result['warnings'])->toBeEmpty()
+		->and($result['cookie_calls'][0])->toBe(['logout'])
+		->and($result['cookie_calls'][1][0])->toBe('set')
+		->and($result['executed'])->toHaveCount(3)
+		->and($result['executed'][0]['sql'])->toContain('DELETE FROM user_auth_cache')
+		->and($result['executed'][1]['sql'])->toContain('REPLACE INTO user_auth_cache')
+		->and($result['executed'][2]['sql'])->toContain('INSERT IGNORE INTO user_log');
+});

--- a/tests/integration/AuthSystemRegressionIntegrationTest.php
+++ b/tests/integration/AuthSystemRegressionIntegrationTest.php
@@ -25,13 +25,14 @@ require_once dirname(__DIR__) . '/Helpers/IsolatedProbe.php';
  * which the combined Unit+Integration pest run can no longer guarantee.
  *
  * $scenario shape:
- *   config, group_realms, groups, users, cache: seed the probe's fixtures.
+ *   config, group_realms, groups, users, usernames and cache seed fixtures.
  *   realms: default realm count for every call; a call may override it.
  *   calls: list of either
  *     {type: 'auth_cookie_user_currently_allowed', user: array, realms?: int}
- *     {type: 'check_auth_cookie', cookie?: string, realms?: int}
+ *     {type: 'check_auth_cookie'|'clear_auth_cookie', cookie?: mixed, realms?: int}
+ *     {type: 'set_auth_cookie', user: array}
  *
- * @return array<int, array{return: mixed, executed: array<int, array{sql: string, params: array}>}>
+ * @return array<int, array{return: mixed, executed: array<int, array{sql: string, params: array}>, cookie_calls: array, events: array, warnings: array}>
  */
 function runAuthCookieProbe(array $scenario) : array {
 	$php  = PHP_BINARY;
@@ -211,15 +212,22 @@ test('malformed remember-me cookies fail closed without warnings or database mut
 			['type' => 'check_auth_cookie', 'cookie' => ''],
 			['type' => 'check_auth_cookie', 'cookie' => '42'],
 			['type' => 'check_auth_cookie', 'cookie' => '42,-1,valid-token,extra'],
+			['type' => 'check_auth_cookie', 'cookie' => ['42', '-1', 'valid-token']],
+			['type' => 'clear_auth_cookie', 'cookie' => ['42', 'valid-token']],
 		],
 	]);
 
-	foreach ($results as $result) {
+	foreach (array_slice($results, 0, 4) as $result) {
 		expect($result['return'])->toBeFalse()
 			->and($result['warnings'])->toBeEmpty()
 			->and($result['executed'])->toBeEmpty()
 			->and($result['cookie_calls'])->toBeEmpty();
 	}
+
+	expect($results[4]['return'])->toBeNull()
+		->and($results[4]['warnings'])->toBeEmpty()
+		->and($results[4]['executed'])->toBeEmpty()
+		->and($results[4]['cookie_calls'])->toBe([['logout']]);
 });
 
 test('remember-me cookie clear and set lifecycle covers legacy identities and token hashing', function () {
@@ -236,10 +244,13 @@ test('remember-me cookie clear and set lifecycle covers legacy identities and to
 
 	expect($results[0]['cookie_calls'])->toBe([['logout']])
 		->and($results[0]['executed'][0]['params'])->toBe(['42', hash('sha512', 'old-token', false)])
+		->and($results[0]['events'][0][0])->toBe('database')
+		->and($results[0]['events'][1])->toBe(['cookie', 'logout'])
 		->and($results[1]['cookie_calls'])->toBe([['logout']])
 		->and($results[1]['executed'][0]['params'])->toBe([43, hash('sha512', 'legacy-token', false)])
 		->and($results[2]['executed'])->toBeEmpty()
-		->and($results[2]['warnings'])->toBeEmpty();
+		->and($results[2]['warnings'])->toBeEmpty()
+		->and($results[2]['cookie_calls'])->toBe([['logout']]);
 
 	$replace = $results[3]['executed'][0];
 	$setCall = $results[3]['cookie_calls'][0];

--- a/tests/js/cookie_helpers.test.js
+++ b/tests/js/cookie_helpers.test.js
@@ -1,0 +1,88 @@
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDTool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function extractFunction(source, name) {
+	const start = source.indexOf(`function ${name}(`);
+	assert.notEqual(start, -1, `${name}() must exist`);
+
+	const bodyStart = source.indexOf('{', start);
+	let depth = 0;
+
+	for (let offset = bodyStart; offset < source.length; offset++) {
+		if (source[offset] === '{') {
+			depth++;
+		} else if (source[offset] === '}') {
+			depth--;
+
+			if (depth === 0) {
+				return source.slice(start, offset + 1);
+			}
+		}
+	}
+
+	throw new Error(`Unable to extract ${name}()`);
+}
+
+const layoutSource = fs.readFileSync(path.join(__dirname, '..', '..', 'include', 'layout.js'), 'utf8');
+const themeSource = fs.readFileSync(path.join(__dirname, '..', '..', 'include', 'themes', 'midwinter', 'main.js'), 'utf8');
+
+test('tab cookie is transient scoped and secure on HTTPS', () => {
+	for (const protocol of ['http:', 'https:']) {
+		const document = { cookie: '' };
+		const context = { document, sessionStorage: { tab: 'tab-7' }, urlPath: '/cacti/', window: { location: { protocol } } };
+		const setCactiTabCookie = vm.runInNewContext(`${extractFunction(layoutSource, 'setCactiTabCookie')}\nsetCactiTabCookie;`, context);
+
+		setCactiTabCookie();
+
+		assert.match(document.cookie, /^CactiTab=tab-7; Max-Age: -1;/);
+		assert.match(document.cookie, / Path=\/cacti\/$/);
+		assert.match(document.cookie, protocol === 'https:' ? /SameSite=None; Secure;/ : /SameSite=Strict;/);
+	}
+});
+
+test('timezone cookies are transient strict scoped and HTTPS-only secure', () => {
+	const writes = [];
+	const document = {};
+	Object.defineProperty(document, 'cookie', { set: (value) => writes.push(value) });
+	const context = { Date, document, urlPath: '/cacti/', window: { location: { protocol: 'https:' } } };
+	const setZoneInfo = vm.runInNewContext(`${extractFunction(layoutSource, 'setZoneInfo')}\nsetZoneInfo;`, context);
+
+	setZoneInfo();
+
+	assert.equal(writes.length, 2);
+	for (const cookie of writes) {
+		assert.match(cookie, /Max-Age: -1; path=\/cacti\/; SameSite=Strict; Secure;/);
+	}
+});
+
+test('theme cookie uses the configured path lifetime and transport security', () => {
+	const calls = [];
+	const jquery = { cookie: (...args) => { calls.push(args); return args.length === 1 ? 'dark' : undefined; } };
+	const context = { $: jquery, urlPath: '/cacti/', window: { location: { protocol: 'https:' } } };
+
+	vm.runInNewContext(`${extractFunction(themeSource, 'setCookieValue')}\n${extractFunction(themeSource, 'getCookieValue')}`, context);
+	context.setCookieValue('CactiColorMode', 'dark');
+
+	assert.equal(calls[0][0], 'CactiColorMode');
+	assert.equal(calls[0][1], 'dark');
+	assert.equal(calls[0][2].expires, 365);
+	assert.equal(calls[0][2].path, '/cacti/;SameSite=Lax');
+	assert.equal(calls[0][2].secure, true);
+	assert.equal(context.getCookieValue('CactiColorMode'), 'dark');
+});


### PR DESCRIPTION
## Summary

- reject remember-me cookies unless they contain exactly the supported legacy two fields or current three fields
- mint persistent credentials only after the login transition succeeds
- revoke server-side remember-me tokens before browser state and on every logout path
- expand subprocess integration coverage across malformed, disabled, forged, legacy, current, rotation, revocation, and successful-login paths
- cover session-cookie policy, 2FA binding, login/restore/password-change boundaries, and zoom storage fallback contracts
- execute transient tab, timezone, and theme cookie helpers in Node browser mocks
- add a path-filtered cookie behavior workflow covering PHP and JavaScript

Closes #7975
Relates #7978

## Release targeting

- Target branch: `develop`
- Release line: Cacti 1.3
- 1.2.x counterpart: #7990

## Verification

- Docker cookie PHP matrix: 14 tests / 133 assertions
- JavaScript cookie helpers: 3 tests passed
- complete Docker Unit+Integration suite: 2,203 passed / 6,798 assertions; 31 existing environment-dependent skips
- complete JavaScript suite: 18 passed
- full PHPStan: 436 files, no errors
- PHP syntax under PHP 8.4 via `mise`: clean
- workflow policy, actionlint, staged-source guard, sink inventory, and architectural hotspot guard: clean