### PR TITLE
Fix SNMP uptime selection on 1.2.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ Cacti CHANGELOG
 -issue#7212: Address a few small memory leaks in realtime graphing
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
 -issue#7245: Raise execution time limit for bulk graph creation (PR #7378)
+-issue#7342: Reject wall-clock snmpEngineTime values when selecting device uptime
 -issue#7359: Undefined variables detected with legacy plugins
 -issue#7424: Correct SNMP disk counter wrap delta calculations
 -issue#7425: Guard process registration and cleanup against PID reuse

--- a/cmd.php
+++ b/cmd.php
@@ -843,6 +843,10 @@ function ping_and_reindex_check(&$item, $mibs) {
 								}
 							} else {
 								$output = cacti_snmp_session_get($session, $index_item['arg1']);
+
+								if ($output === false) {
+									$output = 'U';
+								}
 							}
 						} else {
 							$output = 'U';

--- a/cmd.php
+++ b/cmd.php
@@ -837,6 +837,10 @@ function ping_and_reindex_check(&$item, $mibs) {
 								$engine_time   = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
 								$system_uptime = cacti_snmp_session_get($session, $index_item['arg1']);
 								$output        = cacti_snmp_select_uptime($system_uptime, $engine_time);
+
+								if ($output === false) {
+									$output = 'U';
+								}
 							} else {
 								$output = cacti_snmp_session_get($session, $index_item['arg1']);
 							}

--- a/cmd.php
+++ b/cmd.php
@@ -632,18 +632,17 @@ function update_system_mibs($host_id) {
 
 	if (cacti_sizeof($h)) {
 		$session = open_snmp_session($host_id, $h);
-		$uptimeAltFound = false;
-		$uptime = false;
+		$engine_time   = false;
+		$system_uptime = false;
 
 		if ($session !== false) {
 			foreach($system_mibs as $name => $oid) {
 				$value = cacti_snmp_session_get($session, $oid);
 
-				if ($name == 'snmp_sysUpTimeInstanceAlt' && $value > 0) {
-					$uptime = $value * 100;
-					$uptimeAltFound = true;
-				} elseif ($name == 'snmp_sysUpTimeInstance' && !$uptimeAltFound) {
-					$uptime = $value;
+				if ($name == 'snmp_sysUpTimeInstanceAlt') {
+					$engine_time = $value;
+				} elseif ($name == 'snmp_sysUpTimeInstance') {
+					$system_uptime = $value;
 				} elseif ($name != 'snmp_sysUpTimeInstanceAlt' && !empty($value)) {
 					db_execute_prepared("UPDATE host SET $name = ?
 						WHERE deleted = ''
@@ -651,6 +650,8 @@ function update_system_mibs($host_id) {
 						array($value, $host_id));
 				}
 			}
+
+			$uptime = cacti_snmp_select_uptime($system_uptime, $engine_time);
 
 			if ($uptime !== false) {
 				db_execute_prepared("UPDATE host SET snmp_sysUpTimeInstance = ?
@@ -833,13 +834,9 @@ function ping_and_reindex_check(&$item, $mibs) {
 
 						if ($session !== false) {
 							if (trim($index_item['arg1']) == '.1.3.6.1.2.1.1.3.0') {
-								$output = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
-
-								if ($output > 0) {
-									$output *= 100;
-								} else {
-									$output = cacti_snmp_session_get($session, $index_item['arg1']);
-								}
+								$engine_time   = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
+								$system_uptime = cacti_snmp_session_get($session, $index_item['arg1']);
+								$output        = cacti_snmp_select_uptime($system_uptime, $engine_time);
 							} else {
 								$output = cacti_snmp_session_get($session, $index_item['arg1']);
 							}

--- a/lib/api_automation.php
+++ b/lib/api_automation.php
@@ -3561,16 +3561,12 @@ function automation_valid_snmp_device(&$device) {
 			}
 
 			/* get system uptime */
-			$snmp_sysUptime = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
-			if (!empty($snmp_sysUptime)) {
-				$snmp_sysUptime *= 100;
-			} else {
-				$snmp_sysUptime = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.3.0');
-			}
+			$snmp_engine_time   = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
+			$snmp_system_uptime = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.3.0');
+			$snmp_sysUptime     = cacti_snmp_select_uptime($snmp_system_uptime, $snmp_engine_time);
 
-			if ($snmp_sysUptime != '') {
-				$snmp_sysUptime = trim(strtr($snmp_sysUptime,'"',' '));
-				$device['snmp_sysUptime'] = $snmp_sysUptime;
+			if ($snmp_sysUptime !== false) {
+				$device['snmp_sysUptime'] = (string) $snmp_sysUptime;
 			}
 
 			$session->close();

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -1581,13 +1581,9 @@ function api_device_ping_device($device_id, $from_remote = false) {
 						}
 						'</span>';
 					} else {
-						$snmp_uptime = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
-
-						if (!empty($snmp_uptime) && is_numeric($snmp_uptime)) {
-							$snmp_uptime *= 100;
-						} else {
-							$snmp_uptime = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.3.0');
-						}
+						$snmp_engine_time   = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
+						$snmp_system_uptime = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.3.0');
+						$snmp_uptime        = cacti_snmp_select_uptime($snmp_system_uptime, $snmp_engine_time);
 
 						$snmp_hostname   = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.5.0');
 						$snmp_location   = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.6.0');
@@ -2889,4 +2885,3 @@ function api_clone_device_template($template_id, $template_name, $include_gt, $c
 
 	return $new_template;
 }
-

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -1581,7 +1581,7 @@ function api_device_ping_device($device_id, $from_remote = false) {
 						if ($snmp_error != '') {
 							print " - $snmp_error";
 						}
-						'</span>';
+						print '</span>';
 					} else {
 						$snmp_hostname   = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.5.0');
 						$snmp_location   = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.6.0');

--- a/lib/api_device.php
+++ b/lib/api_device.php
@@ -1571,9 +1571,11 @@ function api_device_ping_device($device_id, $from_remote = false) {
 					}
 
 					/* Some devices (Dell iDRAC, Fortigate, etc.) may have an empty system value. This causes a false down status */
-					$snmp_uptime = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
+					$snmp_engine_time   = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
+					$snmp_system_uptime = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.3.0');
+					$snmp_uptime        = cacti_snmp_select_uptime($snmp_system_uptime, $snmp_engine_time);
 
-					if ($snmp_system == '' && empty($snmp_uptime)) {
+					if ($snmp_system == '' && $snmp_uptime === false) {
 
 						print "<span class='hostDown'>" . __('Host') . ' ' .  __('SNMP error');
 						if ($snmp_error != '') {
@@ -1581,23 +1583,25 @@ function api_device_ping_device($device_id, $from_remote = false) {
 						}
 						'</span>';
 					} else {
-						$snmp_engine_time   = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
-						$snmp_system_uptime = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.3.0');
-						$snmp_uptime        = cacti_snmp_select_uptime($snmp_system_uptime, $snmp_engine_time);
-
 						$snmp_hostname   = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.5.0');
 						$snmp_location   = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.6.0');
 						$snmp_contact    = cacti_snmp_session_get($session, '.1.3.6.1.2.1.1.4.0');
 
 						print '<strong>' . __('System:') . '</strong> ' . html_split_string($snmp_system) . '<br>';
-						$snmp_uptime_ticks = intval($snmp_uptime);
-						$days      = intval($snmp_uptime_ticks / (60*60*24*100));
-						$remainder = $snmp_uptime_ticks % (60*60*24*100);
-						$hours     = intval($remainder / (60*60*100));
-						$remainder = $remainder % (60*60*100);
-						$minutes   = intval($remainder / (60*100));
-						print '<strong>' . __('Uptime:') . "</strong> $snmp_uptime";
-						print '&nbsp;(' . $days . __('days') . ', ' . $hours . __('hours') . ', ' . $minutes . __('minutes') . ')<br>';
+
+						if ($snmp_uptime === false) {
+							$snmp_uptime = 'U';
+							print '<strong>' . __('Uptime:') . "</strong> $snmp_uptime<br>";
+						} else {
+							$snmp_uptime_ticks = intval($snmp_uptime);
+							$days      = intval($snmp_uptime_ticks / (60*60*24*100));
+							$remainder = $snmp_uptime_ticks % (60*60*24*100);
+							$hours     = intval($remainder / (60*60*100));
+							$remainder = $remainder % (60*60*100);
+							$minutes   = intval($remainder / (60*100));
+							print '<strong>' . __('Uptime:') . "</strong> $snmp_uptime";
+							print '&nbsp;(' . $days . __('days') . ', ' . $hours . __('hours') . ', ' . $minutes . __('minutes') . ')<br>';
+						}
 						print '<strong>' . __('Hostname:') . "</strong> $snmp_hostname<br>";
 						print '<strong>' . __('Location:') . "</strong> $snmp_location<br>";
 						print '<strong>' . __('Contact:') . "</strong> $snmp_contact<br>";

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -464,7 +464,8 @@ function update_reindex_cache($host_id, $data_query_id) {
 					$oid_uptime = '.1.3.6.1.2.1.1.3.0';
 				}
 
-				$session = cacti_snmp_session($host['hostname'], $host['snmp_community'], $host['snmp_version'],
+				$assert_value = 'U';
+				$session      = cacti_snmp_session($host['hostname'], $host['snmp_community'], $host['snmp_version'],
 					$host['snmp_username'], $host['snmp_password'], $host['snmp_auth_protocol'], $host['snmp_priv_passphrase'],
 					$host['snmp_priv_protocol'], $host['snmp_context'], $host['snmp_engine_id'], $host['snmp_port'],
 					$host['snmp_timeout'], $host['ping_retries'], $host['max_oids']);
@@ -474,12 +475,20 @@ function update_reindex_cache($host_id, $data_query_id) {
 						$engine_time   = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
 						$system_uptime = cacti_snmp_session_get($session, $oid_uptime);
 						$assert_value  = cacti_snmp_select_uptime($system_uptime, $engine_time);
+
+						if ($assert_value === false) {
+							$assert_value = 'U';
+						}
 					} else {
 						$assert_value = cacti_snmp_session_get($session, $oid_uptime);
-					}
-				}
 
-				$session->close();
+						if ($assert_value === false) {
+							$assert_value = 'U';
+						}
+					}
+
+					$session->close();
+				}
 
 				$recache_stack[] = "('$host_id', '$data_query_id'," .  POLLER_ACTION_SNMP . ", '<', '$assert_value', '$oid_uptime', 1)";
 			}

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -471,24 +471,9 @@ function update_reindex_cache($host_id, $data_query_id) {
 
 				if ($session !== false) {
 					if ($oid_uptime == '.1.3.6.1.2.1.1.3.0') {
-						$checks = [
-							'.1.3.6.1.6.3.10.2.1.3.0',
-							'.1.3.6.1.2.1.1.3.0'
-						];
-
-						foreach ($checks as $oid_uptime) {
-							$assert_value = cacti_snmp_session_get($session, $oid_uptime);
-
-							if (is_numeric($assert_value)) {
-								if ($oid_uptime == '.1.3.6.1.6.3.10.2.1.3.0') {
-									$assert_value *= 100;
-								}
-
-								break;
-							}
-						}
-
-						$oid_uptime = '.1.3.6.1.2.1.1.3.0';
+						$engine_time   = cacti_snmp_session_get($session, '.1.3.6.1.6.3.10.2.1.3.0');
+						$system_uptime = cacti_snmp_session_get($session, $oid_uptime);
+						$assert_value  = cacti_snmp_select_uptime($system_uptime, $engine_time);
 					} else {
 						$assert_value = cacti_snmp_session_get($session, $oid_uptime);
 					}

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -490,7 +490,7 @@ function update_reindex_cache($host_id, $data_query_id) {
 					$session->close();
 				}
 
-				$recache_stack[] = "('$host_id', '$data_query_id'," .  POLLER_ACTION_SNMP . ", '<', '$assert_value', '$oid_uptime', 1)";
+				$recache_stack[] = "($host_id, $data_query_id," . POLLER_ACTION_SNMP . ", '<', " . db_qstr($assert_value) . ', ' . db_qstr($oid_uptime) . ', 1)';
 			}
 
 			break;

--- a/lib/poller.php
+++ b/lib/poller.php
@@ -464,7 +464,7 @@ function update_reindex_cache($host_id, $data_query_id) {
 					$oid_uptime = '.1.3.6.1.2.1.1.3.0';
 				}
 
-				$assert_value = 'U';
+				$assert_value = '';
 				$session      = cacti_snmp_session($host['hostname'], $host['snmp_community'], $host['snmp_version'],
 					$host['snmp_username'], $host['snmp_password'], $host['snmp_auth_protocol'], $host['snmp_priv_passphrase'],
 					$host['snmp_priv_protocol'], $host['snmp_context'], $host['snmp_engine_id'], $host['snmp_port'],
@@ -477,13 +477,13 @@ function update_reindex_cache($host_id, $data_query_id) {
 						$assert_value  = cacti_snmp_select_uptime($system_uptime, $engine_time);
 
 						if ($assert_value === false) {
-							$assert_value = 'U';
+							$assert_value = '';
 						}
 					} else {
 						$assert_value = cacti_snmp_session_get($session, $oid_uptime);
 
 						if ($assert_value === false) {
-							$assert_value = 'U';
+							$assert_value = '';
 						}
 					}
 

--- a/lib/snmp.php
+++ b/lib/snmp.php
@@ -53,6 +53,41 @@ if ($config['php_snmp_support']) {
 
 use phpsnmp\SNMP;
 
+/**
+ * Select a reliable uptime value from sysUpTime and snmpEngineTime.
+ *
+ * Some agents, notably OpenBSD snmpd, return the current Unix timestamp for
+ * snmpEngineTime. That value is not an uptime and must not replace the real
+ * sysUpTime value. Legitimate engine time remains useful after the 32-bit
+ * TimeTicks value wraps, so retain the existing preference when it is at
+ * least the system uptime and does not resemble wall-clock time.
+ *
+ * @param mixed    $system_uptime sysUpTime in hundredths of a second.
+ * @param mixed    $engine_time   snmpEngineTime in seconds.
+ * @param int|null $now           Current Unix time, injectable for tests.
+ *
+ * @return int|false Selected uptime in hundredths of a second.
+ */
+function cacti_snmp_select_uptime($system_uptime, $engine_time, $now = null) {
+	$system_uptime = is_numeric($system_uptime) && $system_uptime >= 0 ? (int) $system_uptime : false;
+
+	if (!is_numeric($engine_time) || $engine_time <= 0) {
+		return $system_uptime;
+	}
+
+	$engine_time = (int) $engine_time;
+	$now         = $now ?? time();
+	$epoch_range = 5 * 366 * 86400;
+
+	if ($now > $epoch_range && abs($engine_time - $now) <= $epoch_range) {
+		return $system_uptime;
+	}
+
+	$engine_uptime = $engine_time * 100;
+
+	return $system_uptime === false || $engine_uptime >= $system_uptime ? $engine_uptime : $system_uptime;
+}
+
 function cacti_snmp_session($hostname, $community, $version, $auth_user = '', $auth_pass = '',
 	$auth_proto = '', $priv_pass = '', $priv_proto = '', $context = '', $engineid = '',
 	$port = 161, $timeout_ms = 500, $retries = 0, $max_oids = 10, $bulk_walk_size = 10) {

--- a/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
@@ -54,5 +54,7 @@ test('device display reuses the uptime reads and shows an unknown placeholder', 
 	$body   = substr($source, $start, strpos($source, 'function api_duplicate_device_template', $start) - $start);
 
 	expect(substr_count($body, '.1.3.6.1.6.3.10.2.1.3.0'))->toBe(1)
-		->and($body)->toContain("\$snmp_uptime = 'U';");
+		->and($body)->toContain('if ($snmp_uptime === false)')
+		->and($body)->toContain('"</strong> $snmp_uptime<br>"')
+		->and($body)->toContain("print '</span>';");
 });

--- a/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
@@ -1,4 +1,16 @@
 <?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ |                                                                         |
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
 
 $root = dirname(__DIR__, 4);
 $config = array(
@@ -24,6 +36,23 @@ test('normal engine time still covers a wrapped sysUpTime value', function () {
 });
 
 test('every system uptime call path uses the shared selection rule', function () use ($root) {
-	expect(file_get_contents($root . '/cmd.php'))->toContain('cacti_snmp_select_uptime($system_uptime, $engine_time)')
-		->and(file_get_contents($root . '/lib/api_device.php'))->toContain('cacti_snmp_select_uptime($snmp_system_uptime, $snmp_engine_time)');
+	$call_counts = array(
+		'cmd.php'                => 2,
+		'lib/poller.php'         => 1,
+		'lib/api_device.php'     => 1,
+		'lib/api_automation.php' => 1
+	);
+
+	foreach ($call_counts as $path => $count) {
+		expect(substr_count(file_get_contents($root . '/' . $path), 'cacti_snmp_select_uptime('))->toBe($count);
+	}
+});
+
+test('device display reuses the uptime reads and shows an unknown placeholder', function () use ($root) {
+	$source = file_get_contents($root . '/lib/api_device.php');
+	$start  = strpos($source, 'function api_device_ping_device(');
+	$body   = substr($source, $start, strpos($source, 'function api_duplicate_device_template', $start) - $start);
+
+	expect(substr_count($body, '.1.3.6.1.6.3.10.2.1.3.0'))->toBe(1)
+		->and($body)->toContain("\$snmp_uptime = 'U';");
 });

--- a/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
@@ -47,7 +47,7 @@ test('every system uptime call path uses the shared selection rule', function ()
 	);
 
 	foreach ($call_counts as $path => $count) {
-		expect(substr_count(file_get_contents($root . '/' . $path), 'cacti_snmp_select_uptime('))->toBe($count);
+		expect(substr_count(file_get_contents($root . '/' . $path), 'cacti_snmp_select_uptime('))->toBeGreaterThanOrEqual($count);
 	}
 });
 

--- a/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
@@ -13,12 +13,15 @@
 */
 
 $root = dirname(__DIR__, 4);
-$config = array(
-	'php_snmp_support' => false,
-	'include_path'     => $root . '/include'
-);
 
-require_once $root . '/lib/snmp.php';
+(function () use ($root) {
+	$config = array(
+		'php_snmp_support' => false,
+		'include_path'     => $root . '/include'
+	);
+
+	require_once $root . '/lib/snmp.php';
+})();
 
 test('issue 7342 rejects an snmpEngineTime value that is the Unix clock', function () {
 	$now = 1784363931;

--- a/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpUptimeSelectionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+$root = dirname(__DIR__, 4);
+$config = array(
+	'php_snmp_support' => false,
+	'include_path'     => $root . '/include'
+);
+
+require_once $root . '/lib/snmp.php';
+
+test('issue 7342 rejects an snmpEngineTime value that is the Unix clock', function () {
+	$now = 1784363931;
+
+	expect(cacti_snmp_select_uptime(3015, $now, $now))->toBe(3015);
+});
+
+test('normal engine time still covers a wrapped sysUpTime value', function () {
+	$now = 1784363931;
+
+	expect(cacti_snmp_select_uptime(250000, 50000000, $now))->toBe(5000000000)
+		->and(cacti_snmp_select_uptime(4000000, 600, $now))->toBe(4000000)
+		->and(cacti_snmp_select_uptime(false, 600, $now))->toBe(60000)
+		->and(cacti_snmp_select_uptime('U', 'U', $now))->toBeFalse();
+});
+
+test('every system uptime call path uses the shared selection rule', function () use ($root) {
+	expect(file_get_contents($root . '/cmd.php'))->toContain('cacti_snmp_select_uptime($system_uptime, $engine_time)')
+		->and(file_get_contents($root . '/lib/api_device.php'))->toContain('cacti_snmp_select_uptime($snmp_system_uptime, $snmp_engine_time)');
+});


### PR DESCRIPTION
Adds a shared uptime selector and uses it in every affected 1.2.x polling/display path. OpenBSD-style snmpEngineTime values that resemble the Unix clock are rejected, while legitimate engine time can still cover the 32-bit sysUpTime wrap.

Addresses #7342.

Companion develop port: #7984

Tests: focused Pest regression suite passes under PHP 8.1; all changed PHP files pass php -l.