### PR TITLE
Backport graph filter, automation OS, and lm-sensors fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,11 +26,14 @@ Cacti CHANGELOG
 -issue#7216: Aggregate totalling legend printed untotalled single data source values
 -issue#7245: Raise execution time limit for bulk graph creation (PR #7378)
 -issue#7359: Undefined variables detected with legacy plugins
+-issue#7403: Scale lm-sensors get values consistently with query values
 -issue#7424: Correct SNMP disk counter wrap delta calculations
 -issue#7425: Guard process registration and cleanup against PID reuse
 -issue#7426: Stop tracking the generated CSRF secret so each install creates its own
 -issue#7427: Update device status by host id instead of non-unique hostname
 -issue#7429: Prevent monthly automation schedules from resetting next_start to 1970
+-issue#7456: Bind the selected operating system in automation discovery filters
+-issue#7490: Require complete graph template filter matches
 -issue#7493: SNMP walk for output_format fields used max OIDs instead of the device bulk walk size
 -issue#7552: HTMLPurifier definition cache written inside the read-only library tree
 -issue#7553: Drop down menus do not update page content after upgrading to 1.2.31

--- a/automation_devices.php
+++ b/automation_devices.php
@@ -433,7 +433,7 @@ function get_discovery_results(&$total_rows = 0, $rows = 0, $export = false) {
 
 	if ($os != '-1' && in_array($os, $os_arr)) {
 		$sql_where  .= ($sql_where != '' ? ' AND ':'WHERE ') . 'os = ?';
-		$sql_param[] = $os;
+		$sql_params[] = $os;
 	}
 
 	if ($filter != '') {

--- a/graphs.php
+++ b/graphs.php
@@ -1954,7 +1954,7 @@ function validate_graph_request_vars() {
 		),
 		'template_id' => array(
 			'filter' => FILTER_VALIDATE_REGEXP,
-			'options' => array('options' => array('regexp' => '(cg_[0-9]|dq_[0-9]|[\-0-9])')),
+			'options' => array('options' => array('regexp' => '/^(cg_[0-9]+|dq_[0-9]+|-?[0-9]+)$/')),
 			'pageset' => true,
 			'default' => '-1'
 		),

--- a/scripts/ss_netsnmp_lmsensors.php
+++ b/scripts/ss_netsnmp_lmsensors.php
@@ -189,6 +189,16 @@ function ss_netsnmp_lmsensors($host_id = '', $sensor_type = '', $cacti_request =
 
 			return 'U';
 		} else {
+			# Apply the same scaling as the query path so get requests return the
+			# sensor value rather than the raw milli-unit counter.
+			if (($sensor_type == 'voltage') && ($snmp_test > 2147483647)) {
+				$snmp_test = ($snmp_test - 4294967296);
+			}
+
+			if (($sensor_type == 'voltage') || ($sensor_type == 'temperature')) {
+				$snmp_test = ($snmp_test / 1000);
+			}
+
 			return $snmp_test;
 		}
 	} else {
@@ -318,7 +328,7 @@ function ss_netsnmp_lmsensors($host_id = '', $sensor_type = '', $cacti_request =
 						# negative voltage readings must be converted to negative numbers
 						#
 						if (($sensor_type == 'voltage') && ($scratch > 2147483647)) {
-							$scratch = ($scratch - 4294967294);
+							$scratch = ($scratch - 4294967296);
 						}
 
 						#
@@ -382,4 +392,3 @@ function ss_netsnmp_lmsensors($host_id = '', $sensor_type = '', $cacti_request =
 		}
 	}
 }
-

--- a/tests/Unit/Core/Automation/AutomationOsFilterTest.php
+++ b/tests/Unit/Core/Automation/AutomationOsFilterTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+test('issue 7456 automation discovery binds the selected operating system', function (): void {
+	$source = file_get_contents(dirname(__DIR__, 4) . '/automation_devices.php');
+	$start  = strpos($source, "if (\$os != '-1'");
+
+	expect($start)->not->toBeFalse();
+
+	$body = substr($source, $start, strpos($source, "\n\t}", $start) - $start);
+
+	expect($body)->toContain("'os = ?'")
+		->and($body)->toContain('$sql_params[] = $os;')
+		->and($body)->not->toContain('$sql_param[]');
+});

--- a/tests/Unit/Core/Automation/AutomationOsFilterTest.php
+++ b/tests/Unit/Core/Automation/AutomationOsFilterTest.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
 
 declare(strict_types=1);
 

--- a/tests/Unit/Scripts/LmSensorsScalingTest.php
+++ b/tests/Unit/Scripts/LmSensorsScalingTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+test('issue 7403 single-value lm-sensors reads use query-path scaling', function (): void {
+	$source = file_get_contents(dirname(__DIR__, 3) . '/scripts/ss_netsnmp_lmsensors.php');
+	$start  = strpos($source, "if (\$cacti_request == 'get')", strpos($source, "if (\$cacti_request == 'get')") + 1);
+
+	expect($start)->not->toBeFalse();
+
+	$body = substr($source, $start, strpos($source, "\n\t} else {", $start) - $start);
+
+	expect($body)->toContain("\$sensor_type == 'voltage'")
+		->and($body)->toContain("\$sensor_type == 'temperature'")
+		->and($source)->not->toContain('4294967294')
+		->and(substr_count($source, '4294967296'))->toBe(2)
+		->and($body)->toContain('$snmp_test = ($snmp_test / 1000);')
+		->and(45000 / 1000)->toBe(45);
+});

--- a/tests/Unit/Scripts/LmSensorsScalingTest.php
+++ b/tests/Unit/Scripts/LmSensorsScalingTest.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
 
 declare(strict_types=1);
 

--- a/tests/Unit/Ui/Graph/GraphTemplateFilterValidationTest.php
+++ b/tests/Unit/Ui/Graph/GraphTemplateFilterValidationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+test('issue 7490 graph template filters require a complete valid value', function (): void {
+	$source = file_get_contents(dirname(__DIR__, 4) . '/graphs.php');
+
+	expect($source)->toContain("'regexp' => '/^(cg_[0-9]+|dq_[0-9]+|-?[0-9]+)$/'");
+
+	$regexp = '/^(cg_[0-9]+|dq_[0-9]+|-?[0-9]+)$/';
+
+	expect(filter_var('cg_12', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regexp]]))->toBe('cg_12')
+		->and(filter_var('dq_7', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regexp]]))->toBe('dq_7')
+		->and(filter_var('-1', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regexp]]))->toBe('-1')
+		->and(filter_var('cg_12 OR 1=1', FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regexp]]))->toBeFalse()
+		->and(filter_var("dq_7\n1", FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => $regexp]]))->toBeFalse();
+});

--- a/tests/Unit/Ui/Graph/GraphTemplateFilterValidationTest.php
+++ b/tests/Unit/Ui/Graph/GraphTemplateFilterValidationTest.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
 
 declare(strict_types=1);
 


### PR DESCRIPTION
Backports three focused corrections identified during the issue audit:

- require complete graph-template filter matches
- bind the selected OS value in automation discovery
- apply consistent lm-sensors scaling and correct signed 32-bit voltage conversion

Fixes #7490
Fixes #7456
Fixes #7403

This also addresses the 1.2.x automation-filter portion of #7448.

Tests: three focused Pest tests pass individually under PHP 8.1; changed production files pass php -l.