### PR TITLE
Forward-port data query source guard

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,6 @@ Cacti CHANGELOG
 -issue#7969: Align Rocky Linux compatibility checks with the supported PHP runtime
 -issue: Fail closed when OAuth callback state is absent or mismatched
 -issue#7959: Stop source checkouts from loading a partial Composer dependency tree
--issue#7809: Avoid reading a missing source key on output-only data query fields
 -issue#7775: Add plugin-extensible notification API
 -issue#7746: Make PHP 8.1 dependency builds reproducible
 -issue#7672: Block loopback/link-local SSRF targets in call_remote_data_collector
@@ -182,6 +181,7 @@ Cacti CHANGELOG
 -issue#7355: Add a JUNIPER-MIB jnxOperatingTable script data query for RE and FPC health
 -issue#7355: Add an F5-BIGIP-SYSTEM-MIB script data query for per-CPU utilization
 -issue#7904: Device changes are silently skipped when --bulk_walk is passed to change_device.php
+-issue#7809: Avoid reading a missing source key on output-only data query fields
 -feature#7884: Manage front-end JavaScript libraries with npm and Dependabot
 -feature#7884: Build release artifacts from managed dependencies, including DOMPurify 3.4.14 and phpseclib 4, and a reduced runtime tree
 -feature#7835: Add cacti_snmp_session_from_host() to build SNMP sessions from a device row

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ Cacti CHANGELOG
 -issue#7969: Align Rocky Linux compatibility checks with the supported PHP runtime
 -issue: Fail closed when OAuth callback state is absent or mismatched
 -issue#7959: Stop source checkouts from loading a partial Composer dependency tree
+-issue#7809: Avoid reading a missing source key on output-only data query fields
 -issue#7775: Add plugin-extensible notification API
 -issue#7746: Make PHP 8.1 dependency builds reproducible
 -issue#7672: Block loopback/link-local SSRF targets in call_remote_data_collector

--- a/lib/data_query.php
+++ b/lib/data_query.php
@@ -1229,7 +1229,7 @@ function query_snmp_host(int $host_id, int $snmp_query_id) : bool {
 	rewrite_snmp_enum_value(null);
 
 	foreach ($snmp_queries['fields'] as $field_name => $field_array) {
-		if ($field_array['source'] != 'index' && ($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') && $field_array['method'] != 'get' &&
+		if (($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') && $field_array['source'] != 'index' && $field_array['method'] != 'get' &&
 			(isset($field_array['rewrite_index']) || isset($field_array['oid_suffix']))) {
 			$field_array['method'] = 'get';
 			debug_log_insert('data_query', __esc('Fixing wrong \'method\' field for \'%s\' since \'rewrite_index\' or \'oid_suffix\' is defined', $field_name));

--- a/tests/Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php
+++ b/tests/Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php
@@ -11,7 +11,7 @@
  * Regression test for #7809.
  *
  * query_snmp_host() iterates every data query field, including output-only
- * fields that carry no 'source' key. The pre-processing guard read
+ * fields that carry no 'source' key. Before the fix, the pre-processing guard read
  * $field_array['source'] as its left-most term, so PHP raised
  * "Undefined array key source" for every output field before the direction
  * test could short-circuit. Testing the direction first reads 'source' only

--- a/tests/Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php
+++ b/tests/Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+/*
+ * Regression test for #7809.
+ *
+ * query_snmp_host() iterates every data query field, including output-only
+ * fields that carry no 'source' key. The pre-processing guard read
+ * $field_array['source'] as its left-most term, so PHP raised
+ * "Undefined array key source" for every output field before the direction
+ * test could short-circuit. Testing the direction first reads 'source' only
+ * for input fields, which always define it.
+ */
+
+function _data_query_source_7809() {
+	$path = dirname(__DIR__, 4) . '/lib/data_query.php';
+	$src  = file_get_contents($path);
+
+	expect($src)->not->toBeFalse('Failed to read lib/data_query.php');
+
+	return $src;
+}
+
+test('#7809: the method-fix guard tests direction before reading source', function () {
+	$src = _data_query_source_7809();
+
+	$needle = 'if ((' . '$field_array' . "['direction'] == 'input' || " . '$field_array' . "['direction'] == 'input-output') && " . '$field_array' . "['source'] != 'index'";
+	$start  = strpos($src, $needle);
+
+	expect($start)->not->toBeFalse(
+		"query_snmp_host() must test direction before reading \$field_array['source'] so output-only fields short-circuit"
+	);
+
+	// The old ordering (source first) must be gone.
+	$oldNeedle = 'if (' . '$field_array' . "['source'] != 'index' && (" . '$field_array' . "['direction'] == 'input'";
+	$old       = strpos($src, $oldNeedle);
+	expect($old)->toBeFalse('the source-first ordering must not remain');
+});
+
+test('#7809: an output-only field does not read a missing source key', function () {
+	// Mirrors the real guard. An output field carries direction=output and no source.
+	$field_array = [
+		'direction' => 'output',
+		'method'    => 'walk',
+	];
+
+	$warned = false;
+	set_error_handler(function ($errno, $errstr) use (&$warned) {
+		if (stripos($errstr, 'source') !== false) {
+			$warned = true;
+		}
+
+		return true;
+	});
+
+	$hit =
+		($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') &&
+		$field_array['source'] != 'index' &&
+		$field_array['method'] != 'get' &&
+		(isset($field_array['rewrite_index']) || isset($field_array['oid_suffix']));
+
+	restore_error_handler();
+
+	expect($warned)->toBeFalse('output-only field must not trigger an undefined source-key warning');
+	expect($hit)->toBeFalse('output-only field must not enter the input method-fix branch');
+});
+
+test('#7809: an input field still enters the branch when it should', function () {
+	$field_array = [
+		'direction'     => 'input',
+		'source'        => 'value',
+		'method'        => 'walk',
+		'rewrite_index' => '.1',
+	];
+
+	$hit =
+		($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') &&
+		$field_array['source'] != 'index' &&
+		$field_array['method'] != 'get' &&
+		(isset($field_array['rewrite_index']) || isset($field_array['oid_suffix']));
+
+	expect($hit)->toBeTrue('input field with rewrite_index must still be corrected to method=get');
+});

--- a/tests/Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php
+++ b/tests/Unit/DataCollection/DataQuery/DataQuerySourceKeyTest.php
@@ -52,20 +52,24 @@ test('#7809: an output-only field does not read a missing source key', function 
 
 	$warned = false;
 	set_error_handler(function ($errno, $errstr) use (&$warned) {
-		if (stripos($errstr, 'source') !== false) {
+		if ($errno === E_WARNING && stripos($errstr, 'source') !== false) {
 			$warned = true;
+
+			return true;
 		}
 
-		return true;
-	});
+		return false;
+	}, E_WARNING);
 
-	$hit =
-		($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') &&
-		$field_array['source'] != 'index' &&
-		$field_array['method'] != 'get' &&
-		(isset($field_array['rewrite_index']) || isset($field_array['oid_suffix']));
-
-	restore_error_handler();
+	try {
+		$hit =
+			($field_array['direction'] == 'input' || $field_array['direction'] == 'input-output') &&
+			$field_array['source'] != 'index' &&
+			$field_array['method'] != 'get' &&
+			(isset($field_array['rewrite_index']) || isset($field_array['oid_suffix']));
+	} finally {
+		restore_error_handler();
+	}
 
 	expect($warned)->toBeFalse('output-only field must not trigger an undefined source-key warning');
 	expect($hit)->toBeFalse('output-only field must not enter the input method-fix branch');


### PR DESCRIPTION
Forward-ports the 1.2.x fix for output-only SNMP data-query fields. The guard now checks field direction before reading source, avoiding an undefined-array-key warning without changing input-field behavior.

Fixes #7809

Tests: 3 Pest tests / 6 assertions pass under PHP 8.3. PHP CS Fixer and scoped PHPStan pass.