### PR TITLE
ci(csp): fail closed on empty Pest runs

### DIFF
--- a/.github/workflows/csp-e2e.yml
+++ b/.github/workflows/csp-e2e.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4
 
-      - name: Setup PHP 7.4
+      - name: Setup PHP 8.1
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231  # v2.31.1
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl, json, openssl, curl, xml
           coverage: none
 
@@ -51,7 +51,14 @@ jobs:
 
       - name: Run Pest unit tests
         working-directory: tests
-        run: ./vendor/bin/pest Unit/Security/Csp/HeadersSecureTest.php Unit/Security/Csp/CspReportEndpointTest.php
+        run: |
+          ./vendor/bin/pest \
+            --bootstrap=./bootstrap-unit.php \
+            --log-junit="$RUNNER_TEMP/csp-unit.xml" \
+            Unit/Security/Csp/
+          # PHP variables must not expand in the shell.
+          # shellcheck disable=SC2016
+          php -r '$xml = simplexml_load_file($argv[1]); $tests = 0; foreach ($xml->testsuite as $suite) { $tests += (int) $suite["tests"]; } if ($tests < 1) { fwrite(STDERR, "No CSP unit tests executed\n"); exit(1); }' "$RUNNER_TEMP/csp-unit.xml"
 
   integration:
     name: Integration tests (php -S harness)
@@ -60,10 +67,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4
 
-      - name: Setup PHP 7.4
+      - name: Setup PHP 8.1
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231  # v2.31.1
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl, json, openssl, curl, xml
           coverage: none
 
@@ -73,7 +80,14 @@ jobs:
 
       - name: Run Pest integration tests
         working-directory: tests
-        run: ./vendor/bin/pest integration/
+        run: |
+          ./vendor/bin/pest \
+            --bootstrap=./bootstrap-unit.php \
+            --log-junit="$RUNNER_TEMP/csp-integration.xml" \
+            integration/ContentSecurityPolicyTest.php
+          # PHP variables must not expand in the shell.
+          # shellcheck disable=SC2016
+          php -r '$xml = simplexml_load_file($argv[1]); $tests = 0; foreach ($xml->testsuite as $suite) { $tests += (int) $suite["tests"]; } if ($tests < 1) { fwrite(STDERR, "No CSP integration tests executed\n"); exit(1); }' "$RUNNER_TEMP/csp-integration.xml"
 
   e2e:
     name: Playwright E2E (docker-compose + Playwright)

--- a/.github/workflows/csp-e2e.yml
+++ b/.github/workflows/csp-e2e.yml
@@ -58,7 +58,7 @@ jobs:
             Unit/Security/Csp/
           # PHP variables must not expand in the shell.
           # shellcheck disable=SC2016
-          php -r '$xml = simplexml_load_file($argv[1]); $tests = 0; foreach ($xml->testsuite as $suite) { $tests += (int) $suite["tests"]; } if ($tests < 1) { fwrite(STDERR, "No CSP unit tests executed\n"); exit(1); }' "$RUNNER_TEMP/csp-unit.xml"
+          php -r '$xml = is_file($argv[1]) ? @simplexml_load_file($argv[1]) : false; $tests = $xml === false ? false : $xml->xpath("//testcase"); if (!is_array($tests) || count($tests) < 1) { fwrite(STDERR, "Missing, invalid, or empty CSP unit test report\n"); exit(1); }' "$RUNNER_TEMP/csp-unit.xml"
 
   integration:
     name: Integration tests (php -S harness)
@@ -87,7 +87,7 @@ jobs:
             integration/ContentSecurityPolicyTest.php
           # PHP variables must not expand in the shell.
           # shellcheck disable=SC2016
-          php -r '$xml = simplexml_load_file($argv[1]); $tests = 0; foreach ($xml->testsuite as $suite) { $tests += (int) $suite["tests"]; } if ($tests < 1) { fwrite(STDERR, "No CSP integration tests executed\n"); exit(1); }' "$RUNNER_TEMP/csp-integration.xml"
+          php -r '$xml = is_file($argv[1]) ? @simplexml_load_file($argv[1]) : false; $tests = $xml === false ? false : $xml->xpath("//testcase"); if (!is_array($tests) || count($tests) < 1) { fwrite(STDERR, "Missing, invalid, or empty CSP integration test report\n"); exit(1); }' "$RUNNER_TEMP/csp-integration.xml"
 
   e2e:
     name: Playwright E2E (docker-compose + Playwright)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 
 1.2.x
 -issue#7506: Close open select menus when their scroll container moves
+-issue#7967: Fail CSP Pest jobs when no tests execute
 -issue: Commit transactions on MySQL as well as MariaDB
 -security: Update bundled DOMPurify to 3.4.14
 -security: Revoke anonymous access when the guest account is disabled


### PR DESCRIPTION
Closes #7967.

## Summary

- run the CSP unit and integration jobs with the existing database-free unit bootstrap
- target PHP 8.1, the supported runtime floor for the 1.2 branch
- scope the integration job to the CSP integration harness
- write JUnit results and fail when the executed test count is zero

## Docker reproduction

On untouched 1.2.x commit 1bb567876, the existing CSP Pest command printed the database connection fatal page, executed no tests, and exited 0.

## Validation

- Docker PHP 8.1 CSP unit suite: 23 passed
- Docker PHP 8.1 CSP integration suite: 8 passed
- synthetic zero-test JUnit report: guard exits nonzero
- actionlint: clean
- git diff --check: clean