### PR TITLE
fix(automation): use server timezone for schedules

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.x
+-issue#7385: Keep Automation Network schedule times in the server timezone
 -issue#7506: Close open select menus when their scroll container moves
 -issue: Commit transactions on MySQL as well as MariaDB
 -security: Update bundled DOMPurify to 3.4.14

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -850,6 +850,7 @@ function network_edit() {
 			stepMinute: 5,
 			timeFormat: 'HH:mm',
 			dateFormat: 'yy-mm-dd',
+			timezone: <?php print intval(date('Z') / 60); ?>,
 			minDateTime: new Date(<?php print date("Y") . ', ' . (date("m")-1) . ', ' . date("d, H") . ', ' . date('i', ceil(time()/300)*300) . ', 0, 0';?>)
 		});
 
@@ -1282,4 +1283,3 @@ function networks_filter() {
 	</tr>
 	<?php
 }
-

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -850,6 +850,8 @@ function network_edit() {
 			stepMinute: 5,
 			timeFormat: 'HH:mm',
 			dateFormat: 'yy-mm-dd',
+			// The add-on uses this offset only to translate its Now action.
+			// start_at itself is submitted and stored as a server wall-time string.
 			timezone: <?php print intval(date('Z') / 60); ?>,
 			minDateTime: new Date(<?php print date("Y") . ', ' . (date("m")-1) . ', ' . date("d, H") . ', ' . date('i', ceil(time()/300)*300) . ', 0, 0';?>)
 		});

--- a/automation_networks.php
+++ b/automation_networks.php
@@ -850,8 +850,8 @@ function network_edit() {
 			stepMinute: 5,
 			timeFormat: 'HH:mm',
 			dateFormat: 'yy-mm-dd',
-			// The add-on uses this offset only to translate its Now action.
-			// start_at itself is submitted and stored as a server wall-time string.
+			// Use the current server offset so the add-on's Now action matches the
+			// server wall time. start_at is submitted and stored as a wall-time string.
 			timezone: <?php print intval(date('Z') / 60); ?>,
 			minDateTime: new Date(<?php print date("Y") . ', ' . (date("m")-1) . ', ' . date("d, H") . ', ' . date('i', ceil(time()/300)*300) . ', 0, 0';?>)
 		});

--- a/tests/js/automation_network_timezone.test.js
+++ b/tests/js/automation_network_timezone.test.js
@@ -1,0 +1,60 @@
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(
+	path.join(__dirname, '..', '..', 'automation_networks.php'),
+	'utf8'
+);
+
+function timepickerNow(epoch, serverOffsetMinutes) {
+	const selected = new Date(epoch);
+
+	/* This is the bundled timepicker add-on's Now-button conversion. */
+	selected.setMinutes(
+		selected.getMinutes() + selected.getTimezoneOffset() + serverOffsetMinutes
+	);
+
+	return {
+		hour: selected.getHours(),
+		minute: selected.getMinutes(),
+	};
+}
+
+test('Automation Network picker receives the current server offset', () => {
+	const picker = source.match(/\$\('#start_at'\)\.datetimepicker\(\{[\s\S]*?\n\t\t\}\);/);
+
+	assert.notEqual(picker, null, 'start_at datetimepicker configuration must exist');
+	assert.match(picker[0], /timezone:\s*<\?php print intval\(date\('Z'\) \/ 60\); \?>,/);
+});
+
+test('Now uses UTC server wall time in a browser two hours east', () => {
+	assert.equal(process.env.TZ, 'Europe/Amsterdam');
+	assert.deepEqual(
+		timepickerNow('2026-07-23T12:00:00Z', 0),
+		{ hour: 12, minute: 0 }
+	);
+});
+
+test('Now supports server timezones with half-hour offsets', () => {
+	assert.deepEqual(
+		timepickerNow('2026-07-23T12:00:00Z', 330),
+		{ hour: 17, minute: 30 }
+	);
+});

--- a/tests/js/automation_network_timezone.test.js
+++ b/tests/js/automation_network_timezone.test.js
@@ -38,7 +38,7 @@ function timepickerNow(epoch, serverOffsetMinutes) {
 }
 
 test('Automation Network picker receives the current server offset', () => {
-	const picker = source.match(/\$\('#start_at'\)\.datetimepicker\(\{[\s\S]*?\n\t\t\}\);/);
+	const picker = source.match(/\$\('#start_at'\)\.datetimepicker\(\{[\s\S]*?\}\);/);
 
 	assert.notEqual(picker, null, 'start_at datetimepicker configuration must exist');
 	assert.match(picker[0], /timezone:\s*<\?php print intval\(date\('Z'\) \/ 60\); \?>,/);

--- a/tests/js/automation_network_timezone.test.js
+++ b/tests/js/automation_network_timezone.test.js
@@ -63,8 +63,19 @@ test('Now uses UTC server wall time in a browser two hours east', () => {
 });
 
 test('Now supports server timezones with half-hour offsets', () => {
-	assert.deepEqual(
-		timepickerNow('2026-07-23T12:00:00Z', 330),
-		{ hour: 17, minute: 30 }
-	);
+	const originalTimezone = process.env.TZ;
+
+	try {
+		process.env.TZ = 'UTC';
+		assert.deepEqual(
+			timepickerNow('2026-07-23T12:00:00Z', 330),
+			{ hour: 17, minute: 30 }
+		);
+	} finally {
+		if (originalTimezone === undefined) {
+			delete process.env.TZ;
+		} else {
+			process.env.TZ = originalTimezone;
+		}
+	}
 });

--- a/tests/js/automation_network_timezone.test.js
+++ b/tests/js/automation_network_timezone.test.js
@@ -41,7 +41,10 @@ test('Automation Network Now action receives the current server offset', () => {
 	const picker = source.match(/\$\('#start_at'\)\.datetimepicker\(\{[\s\S]*?\}\);/);
 
 	assert.notEqual(picker, null, 'start_at datetimepicker configuration must exist');
-	assert.match(picker[0], /timezone:\s*<\?php print intval\(date\('Z'\) \/ 60\); \?>,/);
+	assert.match(
+		picker[0],
+		/timezone\s*:\s*<\?php\s+print\s+intval\s*\(\s*date\s*\(\s*'Z'\s*\)\s*\/\s*60\s*\)\s*;\s*\?>\s*,/
+	);
 });
 
 test('Now uses UTC server wall time in a browser two hours east', () => {

--- a/tests/js/automation_network_timezone.test.js
+++ b/tests/js/automation_network_timezone.test.js
@@ -45,11 +45,17 @@ test('Automation Network picker receives the current server offset', () => {
 });
 
 test('Now uses UTC server wall time in a browser two hours east', () => {
-	assert.equal(process.env.TZ, 'Europe/Amsterdam');
-	assert.deepEqual(
-		timepickerNow('2026-07-23T12:00:00Z', 0),
-		{ hour: 12, minute: 0 }
-	);
+	const originalTimezone = process.env.TZ;
+
+	try {
+		process.env.TZ = 'Europe/Amsterdam';
+		assert.deepEqual(
+			timepickerNow('2026-07-23T12:00:00Z', 0),
+			{ hour: 12, minute: 0 }
+		);
+	} finally {
+		process.env.TZ = originalTimezone;
+	}
 });
 
 test('Now supports server timezones with half-hour offsets', () => {

--- a/tests/js/automation_network_timezone.test.js
+++ b/tests/js/automation_network_timezone.test.js
@@ -54,7 +54,11 @@ test('Now uses UTC server wall time in a browser two hours east', () => {
 			{ hour: 12, minute: 0 }
 		);
 	} finally {
-		process.env.TZ = originalTimezone;
+		if (originalTimezone === undefined) {
+			delete process.env.TZ;
+		} else {
+			process.env.TZ = originalTimezone;
+		}
 	}
 });
 

--- a/tests/js/automation_network_timezone.test.js
+++ b/tests/js/automation_network_timezone.test.js
@@ -41,8 +41,6 @@ test('Automation Network Now action receives the current server offset', () => {
 	const picker = source.match(/\$\('#start_at'\)\.datetimepicker\(\{[\s\S]*?\}\);/);
 
 	assert.notEqual(picker, null, 'start_at datetimepicker configuration must exist');
-	assert.match(picker[0], /add-on uses this offset only to translate its Now action/);
-	assert.match(picker[0], /submitted and stored as a server wall-time string/);
 	assert.match(picker[0], /timezone:\s*<\?php print intval\(date\('Z'\) \/ 60\); \?>,/);
 });
 

--- a/tests/js/automation_network_timezone.test.js
+++ b/tests/js/automation_network_timezone.test.js
@@ -37,10 +37,12 @@ function timepickerNow(epoch, serverOffsetMinutes) {
 	};
 }
 
-test('Automation Network picker receives the current server offset', () => {
+test('Automation Network Now action receives the current server offset', () => {
 	const picker = source.match(/\$\('#start_at'\)\.datetimepicker\(\{[\s\S]*?\}\);/);
 
 	assert.notEqual(picker, null, 'start_at datetimepicker configuration must exist');
+	assert.match(picker[0], /add-on uses this offset only to translate its Now action/);
+	assert.match(picker[0], /submitted and stored as a server wall-time string/);
 	assert.match(picker[0], /timezone:\s*<\?php print intval\(date\('Z'\) \/ 60\); \?>,/);
 });
 


### PR DESCRIPTION
Addresses #7385 for the 1.2.x release line.

## Summary

- configure the Automation Network datetime picker with the server timezone offset
- make the picker Now action produce the same wall time the server-side scheduler stores and compares
- cover browser/server offset mismatches and half-hour server timezones

## Docker reproduction

On untouched 1.2.x commit 1bb567876, a browser in Europe/Amsterdam submitting to a UTC scheduler selected 14:00 for a 12:00 UTC instant, reproducing the reported +120-minute drift.

## Validation

- pre-fix Docker regression: expected failure
- patched Docker Node suite: 11 passed
- focused timezone tests: 3 passed
- Docker PHP 8.1 syntax check: clean
- git diff --check: clean

The issue also applies to develop, so this PR deliberately does not close it.