### PR TITLE
1.2.x: Clarify missing SNMP notification receivers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Cacti CHANGELOG
 
 1.2.x
 -issue#7506: Close open select menus when their scroll container moves
+-issue#7812: Clarify that missing SNMP notification receivers need no action when traps are disabled
 -issue: Commit transactions on MySQL as well as MariaDB
 -security: Update bundled DOMPurify to 3.4.14
 -security: Revoke anonymous access when the guest account is disabled

--- a/lib/snmpagent.php
+++ b/lib/snmpagent.php
@@ -840,7 +840,7 @@ function snmpagent_notification($notification, $mib, $varbinds, $severity = SNMP
 
 	if (cacti_sizeof($notification_managers) == 0) {
 		/* No receivers found for the message, record it to the cacti.log */
-		cacti_log('WARNING: No notification receivers configured for event: ' . $notification . ' (' . $mib . '), severity: ' . $snmpagent_event_severity[$severity], false, 'SNMPAGENT', POLLER_VERBOSITY_NONE);
+		cacti_log('NOTICE: No SNMP notification receivers are configured for event: ' . $notification . ' (' . $mib . '), severity: ' . $snmpagent_event_severity[$severity] . '. Configure receivers under Console > Utilities > SNMP Agent Utilities > SNMP Notification Receivers, or ignore this notice when SNMP traps are intentionally disabled.', false, 'SNMPAGENT', POLLER_VERBOSITY_NONE);
 		if (!in_array($severity, array(SNMPAGENT_EVENT_SEVERITY_HIGH, SNMPAGENT_EVENT_SEVERITY_CRITICAL))) {
 			/* Prevent log spam of messages lower than a high severity */
 			$config['snmpagent']['notifications']['ignore'][$notification] = 1;
@@ -999,4 +999,3 @@ function snmpagent_notification($notification, $mib, $varbinds, $severity = SNMP
 		return false;
 	}
 }
-

--- a/lib/snmpagent.php
+++ b/lib/snmpagent.php
@@ -840,7 +840,7 @@ function snmpagent_notification($notification, $mib, $varbinds, $severity = SNMP
 
 	if (cacti_sizeof($notification_managers) == 0) {
 		/* No receivers found for the message, record it to the cacti.log */
-		cacti_log('NOTICE: No SNMP notification receivers are configured for event: ' . $notification . ' (' . $mib . '), severity: ' . $snmpagent_event_severity[$severity] . '. Configure receivers under Console > Utilities > SNMP Agent Utilities > SNMP Notification Receivers, or ignore this notice when SNMP traps are intentionally disabled.', false, 'SNMPAGENT', POLLER_VERBOSITY_NONE);
+		cacti_log('NOTICE: No enabled SNMP notification receivers are configured for event: ' . $notification . ' (' . $mib . '), severity: ' . $snmpagent_event_severity[$severity] . '. Configure or enable receivers under Console > Utilities > SNMP Agent Utilities > SNMP Notification Receivers, or ignore this notice when SNMP traps are intentionally disabled.', false, 'SNMPAGENT', POLLER_VERBOSITY_NONE);
 		if (!in_array($severity, array(SNMPAGENT_EVENT_SEVERITY_HIGH, SNMPAGENT_EVENT_SEVERITY_CRITICAL))) {
 			/* Prevent log spam of messages lower than a high severity */
 			$config['snmpagent']['notifications']['ignore'][$notification] = 1;

--- a/tests/Unit/DataCollection/Snmp/SnmpAgentNotificationReceiverTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpAgentNotificationReceiverTest.php
@@ -79,6 +79,7 @@ test('missing receivers produce an actionable notice', function () {
 	expect($result)->toBeFalse()
 		->and($GLOBALS['snmpagent_notification_logs'])->toHaveCount(1)
 		->and($GLOBALS['snmpagent_notification_logs'][0][0])->toStartWith('NOTICE:')
+		->and($GLOBALS['snmpagent_notification_logs'][0][0])->toContain('No enabled SNMP notification receivers')
 		->and($GLOBALS['snmpagent_notification_logs'][0][0])->toContain('Console > Utilities > SNMP Agent Utilities > SNMP Notification Receivers')
 		->and($GLOBALS['snmpagent_notification_logs'][0][0])->toContain('ignore this notice when SNMP traps are intentionally disabled')
 		->and($GLOBALS['snmpagent_notification_logs'][0][2])->toBe('SNMPAGENT')

--- a/tests/Unit/DataCollection/Snmp/SnmpAgentNotificationReceiverTest.php
+++ b/tests/Unit/DataCollection/Snmp/SnmpAgentNotificationReceiverTest.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace SnmpAgentNotificationReceiverTest;
+
+const SNMPAGENT_EVENT_SEVERITY_LOW      = 1;
+const SNMPAGENT_EVENT_SEVERITY_MEDIUM   = 2;
+const SNMPAGENT_EVENT_SEVERITY_HIGH     = 3;
+const SNMPAGENT_EVENT_SEVERITY_CRITICAL = 4;
+const POLLER_VERBOSITY_NONE             = 1;
+
+$GLOBALS['config']                      = array();
+$GLOBALS['snmpagent_notification_logs'] = array();
+$GLOBALS['snmpagent_event_severity']    = array(
+	SNMPAGENT_EVENT_SEVERITY_LOW      => 'low',
+	SNMPAGENT_EVENT_SEVERITY_MEDIUM   => 'medium',
+	SNMPAGENT_EVENT_SEVERITY_HIGH     => 'high',
+	SNMPAGENT_EVENT_SEVERITY_CRITICAL => 'critical'
+);
+
+function read_config_option($name) {
+	return $name == 'path_snmptrap' ? '/usr/bin/snmptrap' : '';
+}
+
+function db_fetch_cell_prepared($sql, $params) {
+	return '.1.3.6.1.4.1.500.1';
+}
+
+function db_fetch_assoc_prepared($sql, $params) {
+	return array();
+}
+
+function cacti_sizeof($value) {
+	return is_countable($value) ? count($value) : 0;
+}
+
+function cacti_log($message, $output, $environ, $level) {
+	$GLOBALS['snmpagent_notification_logs'][] = array($message, $output, $environ, $level);
+
+	return true;
+}
+
+$source = file_get_contents(dirname(__DIR__, 4) . '/lib/snmpagent.php');
+
+if ($source === false) {
+	throw new \RuntimeException('Unable to read lib/snmpagent.php for the notification receiver test.');
+}
+
+if (preg_match('/function snmpagent_notification\(.*?^}\R/ms', $source, $matches) !== 1) {
+	throw new \RuntimeException('Unable to extract snmpagent_notification() for the notification receiver test.');
+}
+
+eval('namespace SnmpAgentNotificationReceiverTest;' . $matches[0]);
+
+beforeEach(function () {
+	$GLOBALS['config']                      = array();
+	$GLOBALS['snmpagent_notification_logs'] = array();
+});
+
+test('missing receivers produce an actionable notice', function () {
+	$result = snmpagent_notification(
+		'cactiNotifyDeviceFailedPoll',
+		'CACTI-MIB',
+		array(),
+		SNMPAGENT_EVENT_SEVERITY_MEDIUM
+	);
+
+	expect($result)->toBeFalse()
+		->and($GLOBALS['snmpagent_notification_logs'])->toHaveCount(1)
+		->and($GLOBALS['snmpagent_notification_logs'][0][0])->toStartWith('NOTICE:')
+		->and($GLOBALS['snmpagent_notification_logs'][0][0])->toContain('Console > Utilities > SNMP Agent Utilities > SNMP Notification Receivers')
+		->and($GLOBALS['snmpagent_notification_logs'][0][0])->toContain('ignore this notice when SNMP traps are intentionally disabled')
+		->and($GLOBALS['snmpagent_notification_logs'][0][2])->toBe('SNMPAGENT')
+		->and($GLOBALS['snmpagent_notification_logs'][0][3])->toBe(POLLER_VERBOSITY_NONE);
+});
+
+test('medium-severity missing receiver notices remain suppressed after the first event', function () {
+	snmpagent_notification('cactiNotifyDeviceFailedPoll', 'CACTI-MIB', array(), SNMPAGENT_EVENT_SEVERITY_MEDIUM);
+	snmpagent_notification('cactiNotifyDeviceFailedPoll', 'CACTI-MIB', array(), SNMPAGENT_EVENT_SEVERITY_MEDIUM);
+
+	expect($GLOBALS['snmpagent_notification_logs'])->toHaveCount(1)
+		->and($GLOBALS['config']['snmpagent']['notifications']['ignore']['cactiNotifyDeviceFailedPoll'])->toBe(1);
+});
+
+test('high-severity missing receiver notices are not suppressed', function () {
+	snmpagent_notification('cactiNotifyDeviceDown', 'CACTI-MIB', array(), SNMPAGENT_EVENT_SEVERITY_HIGH);
+	snmpagent_notification('cactiNotifyDeviceDown', 'CACTI-MIB', array(), SNMPAGENT_EVENT_SEVERITY_HIGH);
+
+	expect($GLOBALS['snmpagent_notification_logs'])->toHaveCount(2)
+		->and($GLOBALS['config']['snmpagent']['notifications']['ignore']['cactiNotifyDeviceDown'] ?? null)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- log an informational `NOTICE` instead of an ambiguous `WARNING` when an SNMP event has no enabled receiver
- point administrators to Console > Utilities > SNMP Agent Utilities > SNMP Notification Receivers
- state that no action is needed when SNMP traps are intentionally disabled
- preserve the existing per-process suppression policy for low/medium events and repeated logging for high/critical events

Fixes #7812

## Docker reproduction

On the unmodified `1.2.x` tip (`1bb567876`), PHP 8.1 invoked the real `snmpagent_notification()` with a known event OID and an empty receiver query. It returned `false` and emitted the reported ambiguous warning:

```
WARNING: No notification receivers configured for event: cactiNotifyDeviceFailedPoll (CACTI-MIB), severity: medium
```

The same probe on this branch emits an actionable notice instead.

## Validation

- Docker PHP 8.1 syntax checks pass for production and test files
- Docker PHP 8.1 runtime probe returns `false` and emits the new notice
- Docker PHP 8.4 focused SNMP suite: 21 tests, 56 assertions passed
- new unit coverage verifies actionable text, medium-event suppression, and non-suppression of high-severity events
- `git diff --check` passes

## Release metadata

- target: `1.2.x`
- milestone: `v1.2.32`
- type: bug
- area: SNMP/logging
- risk: low; log text/severity only, with existing delivery and suppression behavior unchanged
