### PR TITLE
1.2.x: Close detached select menus on scroll

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.2.x
+-issue#7506: Close open select menus when their scroll container moves
 -issue: Commit transactions on MySQL as well as MariaDB
 -security: Update bundled DOMPurify to 3.4.14
 -security: Revoke anonymous access when the guest account is disabled

--- a/include/layout.js
+++ b/include/layout.js
@@ -791,6 +791,10 @@ function setupSelectmenuScrollClose() {
 		.add(window)
 		.off('scroll.cactiSelectmenu')
 		.on('scroll.cactiSelectmenu', function() {
+			if (!$('.ui-selectmenu-open').length) {
+				return;
+			}
+
 			$('select').each(function() {
 				if ($(this).selectmenu('instance') !== undefined) {
 					$(this).selectmenu('close');

--- a/include/layout.js
+++ b/include/layout.js
@@ -784,6 +784,21 @@ function handleTableNav() {
 	});
 }
 
+/** setupSelectmenuScrollClose - Close open select menus when their scroll
+ *  container moves so the detached menu cannot remain over unrelated fields. */
+function setupSelectmenuScrollClose() {
+	$('.cactiConsoleContentArea, .cactiGraphContentArea, .cactiGraphContentAreaPreview, .cactiTreeNavigationArea')
+		.add(window)
+		.off('scroll.cactiSelectmenu')
+		.on('scroll.cactiSelectmenu', function() {
+			$('select').each(function() {
+				if ($(this).selectmenu('instance') !== undefined) {
+					$(this).selectmenu('close');
+				}
+			});
+		});
+}
+
 /** applySkin - This function re-asserts all javascript behavior to a page
  *  that can't be set using a live attribute 'on()' */
 function applySkin() {
@@ -845,6 +860,8 @@ function applySkin() {
 	if (typeof themeReady == 'function') {
 		themeReady();
 	}
+
+	setupSelectmenuScrollClose();
 
 	makeFiltersResponsive();
 

--- a/tests/js/selectmenu_scroll.test.js
+++ b/tests/js/selectmenu_scroll.test.js
@@ -51,6 +51,8 @@ test('scroll handlers close initialized select menus without duplicate bindings'
 	const windowObject = {};
 	const selects = [{ initialized: true, closes: 0 }, { initialized: false, closes: 0 }];
 	let boundEvent;
+	let menuOpen = true;
+	let selectScans = 0;
 	let scrollHandler;
 	let selectedContainers;
 
@@ -79,9 +81,15 @@ test('scroll handlers close initialized select menus without duplicate bindings'
 		}
 
 		if (selector === 'select') {
+			selectScans++;
+
 			return {
 				each: (callback) => selects.forEach(select => callback.call(select))
 			};
+		}
+
+		if (selector === '.ui-selectmenu-open') {
+			return { length: menuOpen ? 1 : 0 };
 		}
 
 		return {
@@ -109,6 +117,11 @@ test('scroll handlers close initialized select menus without duplicate bindings'
 	scrollHandler();
 	assert.equal(selects[0].closes, 1);
 	assert.equal(selects[1].closes, 0);
+	assert.equal(selectScans, 1);
+
+	menuOpen = false;
+	scrollHandler();
+	assert.equal(selectScans, 1);
 });
 
 test('applySkin binds scroll handling after theme widgets initialize', () => {

--- a/tests/js/selectmenu_scroll.test.js
+++ b/tests/js/selectmenu_scroll.test.js
@@ -1,0 +1,120 @@
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const layoutSource = fs.readFileSync(
+	path.join(__dirname, '..', '..', 'include', 'layout.js'),
+	'utf8'
+);
+
+function extractFunction(name) {
+	const start = layoutSource.indexOf(`function ${name}(`);
+
+	assert.notEqual(start, -1, `${name}() must exist`);
+
+	const bodyStart = layoutSource.indexOf('{', start);
+	let depth = 0;
+
+	for (let offset = bodyStart; offset < layoutSource.length; offset++) {
+		if (layoutSource[offset] === '{') {
+			depth++;
+		} else if (layoutSource[offset] === '}') {
+			depth--;
+
+			if (depth === 0) {
+				return layoutSource.slice(start, offset + 1);
+			}
+		}
+	}
+
+	throw new Error(`Unable to extract ${name}()`);
+}
+
+test('scroll handlers close initialized select menus without duplicate bindings', () => {
+	const windowObject = {};
+	const selects = [{ initialized: true, closes: 0 }, { initialized: false, closes: 0 }];
+	let boundEvent;
+	let scrollHandler;
+	let selectedContainers;
+
+	function jquery(selector) {
+		if (typeof selector === 'string' && selector.startsWith('.cactiConsoleContentArea')) {
+			selectedContainers = selector;
+
+			return {
+				add: (target) => {
+					assert.equal(target, windowObject);
+
+					return {
+						off: (event) => {
+							assert.equal(event, 'scroll.cactiSelectmenu');
+
+							return {
+								on: (bound, handler) => {
+									boundEvent = bound;
+									scrollHandler = handler;
+								}
+							};
+						}
+					};
+				}
+			};
+		}
+
+		if (selector === 'select') {
+			return {
+				each: (callback) => selects.forEach(select => callback.call(select))
+			};
+		}
+
+		return {
+			selectmenu: (action) => {
+				if (action === 'instance') {
+					return selector.initialized ? {} : undefined;
+				}
+
+				assert.equal(action, 'close');
+				selector.closes++;
+			}
+		};
+	}
+
+	const context = vm.createContext({ $: jquery, window: windowObject });
+	vm.runInContext(extractFunction('setupSelectmenuScrollClose'), context, { filename: 'include/layout.js' });
+	context.setupSelectmenuScrollClose();
+
+	assert.match(selectedContainers, /\.cactiConsoleContentArea/);
+	assert.match(selectedContainers, /\.cactiGraphContentArea/);
+	assert.match(selectedContainers, /\.cactiTreeNavigationArea/);
+	assert.equal(boundEvent, 'scroll.cactiSelectmenu');
+	assert.equal(typeof scrollHandler, 'function');
+
+	scrollHandler();
+	assert.equal(selects[0].closes, 1);
+	assert.equal(selects[1].closes, 0);
+});
+
+test('applySkin binds scroll handling after theme widgets initialize', () => {
+	const themeReadyPosition = layoutSource.indexOf('themeReady();');
+	const setupPosition = layoutSource.indexOf('setupSelectmenuScrollClose();', themeReadyPosition);
+
+	assert.notEqual(themeReadyPosition, -1);
+	assert.ok(setupPosition > themeReadyPosition);
+});


### PR DESCRIPTION
## Summary

- close initialized jQuery UI selectmenus when the window or a Cacti content/navigation scroll container moves
- bind the handler after theme widgets initialize
- namespace and replace the handler when `applySkin()` runs again, avoiding duplicate bindings after AJAX navigation
- cover the binding, initialized-widget guard, close behavior, and initialization order

Addresses #7506

## Docker reproduction

Using real jQuery UI and Dark/Modern theme assets in Playwright Chromium, on both `release/1.2.31` and unmodified current `1.2.x`:

- scrolling `.cactiConsoleContentArea` by 100px moved the select button from `top=185` to `top=85`
- the open menu remained at `top=186`
- the resulting 100px attachment drift reproduced the report

On this branch, the same Docker browser probe closes the menu after scrolling in both themes, so no detached overlay remains.

## Validation

- Docker Playwright browser probe: Dark and Modern pass
- focused Node unit suite: 2 tests passed
- full Docker Node contract suite: 10 tests passed
- `git diff --check` passes

## Release metadata

- target: `1.2.x`
- milestone: `v1.2.32`
- type: bug
- area: UI
- risk: low; affects only open selectmenu behavior during scrolling

A develop counterpart will follow because the behavior is shared across maintained branches.
