### PR TITLE
Fix detached select menus on scroll

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,6 @@
 Cacti CHANGELOG
 
 1.3.0-dev
--issue#7506: Close open select menus when their scroll container moves
 -security: Escape path_dsstats_log before it reaches the dsstats poller shell redirect
 -security: Revoke anonymous access when the guest account is disabled
 -security: Cast graph and device ids to int in get_allowed_* permission filters
@@ -44,6 +43,7 @@ Cacti CHANGELOG
 -issue#7517: Consolidate htmx loader and renderer abstraction global.php includes
 -issue#7515: Consolidate image conversion and notification payload hardening
 -issue#7513: Scope build context to docker/ so it builds standalone
+-issue#7506: Close open select menus when their scroll container moves
 -issue#7502: Guard null messages array in raise_message()
 -issue#7438: Validate measure/order before ORDER BY concatenation in get_allowed_graphs()
 -issue#7432: Correct KILL CONNECTION typo in db_close

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Cacti CHANGELOG
 
 1.3.0-dev
+-issue#7506: Close open select menus when their scroll container moves
 -security: Escape path_dsstats_log before it reaches the dsstats poller shell redirect
 -security: Revoke anonymous access when the guest account is disabled
 -security: Cast graph and device ids to int in get_allowed_* permission filters

--- a/include/layout.js
+++ b/include/layout.js
@@ -940,6 +940,10 @@ function setupSelectmenuScrollClose() {
 		.add(window)
 		.off('scroll.cactiSelectmenu')
 		.on('scroll.cactiSelectmenu', function () {
+			if (!$('.ui-selectmenu-open').length) {
+				return;
+			}
+
 			$('select').each(function () {
 				if ($(this).selectmenu('instance') !== undefined) {
 					$(this).selectmenu('close');

--- a/include/layout.js
+++ b/include/layout.js
@@ -932,6 +932,23 @@ function cactiReturnTo(href) {
 }
 
 /**
+ * setupSelectmenuScrollClose - Close open select menus when their scroll
+ * container moves so the detached menu cannot remain over unrelated fields.
+ */
+function setupSelectmenuScrollClose() {
+	$('.cactiConsoleContentArea, .cactiGraphContentArea, .cactiGraphContentAreaPreview, .cactiTreeNavigationArea')
+		.add(window)
+		.off('scroll.cactiSelectmenu')
+		.on('scroll.cactiSelectmenu', function () {
+			$('select').each(function () {
+				if ($(this).selectmenu('instance') !== undefined) {
+					$(this).selectmenu('close');
+				}
+			});
+		});
+}
+
+/**
  * applySkin - This function re-asserts all javascript behavior to a page
  * that can't be set using a live attribute 'on()'
  */
@@ -1010,6 +1027,8 @@ function applySkin() {
 	if (typeof themeReady == 'function') {
 		themeReady();
 	}
+
+	setupSelectmenuScrollClose();
 
 	makeFiltersResponsive();
 

--- a/tests/js/selectmenu_scroll.test.js
+++ b/tests/js/selectmenu_scroll.test.js
@@ -51,6 +51,8 @@ test('scroll handlers close initialized select menus without duplicate bindings'
 	const windowObject = {};
 	const selects = [{ initialized: true, closes: 0 }, { initialized: false, closes: 0 }];
 	let boundEvent;
+	let menuOpen = true;
+	let selectScans = 0;
 	let scrollHandler;
 	let selectedContainers;
 
@@ -79,9 +81,15 @@ test('scroll handlers close initialized select menus without duplicate bindings'
 		}
 
 		if (selector === 'select') {
+			selectScans++;
+
 			return {
 				each: (callback) => selects.forEach(select => callback.call(select))
 			};
+		}
+
+		if (selector === '.ui-selectmenu-open') {
+			return { length: menuOpen ? 1 : 0 };
 		}
 
 		return {
@@ -109,6 +117,11 @@ test('scroll handlers close initialized select menus without duplicate bindings'
 	scrollHandler();
 	assert.equal(selects[0].closes, 1);
 	assert.equal(selects[1].closes, 0);
+	assert.equal(selectScans, 1);
+
+	menuOpen = false;
+	scrollHandler();
+	assert.equal(selectScans, 1);
 });
 
 test('applySkin binds scroll handling after theme widgets initialize', () => {

--- a/tests/js/selectmenu_scroll.test.js
+++ b/tests/js/selectmenu_scroll.test.js
@@ -1,0 +1,120 @@
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const layoutSource = fs.readFileSync(
+	path.join(__dirname, '..', '..', 'include', 'layout.js'),
+	'utf8'
+);
+
+function extractFunction(name) {
+	const start = layoutSource.indexOf(`function ${name}(`);
+
+	assert.notEqual(start, -1, `${name}() must exist`);
+
+	const bodyStart = layoutSource.indexOf('{', start);
+	let depth = 0;
+
+	for (let offset = bodyStart; offset < layoutSource.length; offset++) {
+		if (layoutSource[offset] === '{') {
+			depth++;
+		} else if (layoutSource[offset] === '}') {
+			depth--;
+
+			if (depth === 0) {
+				return layoutSource.slice(start, offset + 1);
+			}
+		}
+	}
+
+	throw new Error(`Unable to extract ${name}()`);
+}
+
+test('scroll handlers close initialized select menus without duplicate bindings', () => {
+	const windowObject = {};
+	const selects = [{ initialized: true, closes: 0 }, { initialized: false, closes: 0 }];
+	let boundEvent;
+	let scrollHandler;
+	let selectedContainers;
+
+	function jquery(selector) {
+		if (typeof selector === 'string' && selector.startsWith('.cactiConsoleContentArea')) {
+			selectedContainers = selector;
+
+			return {
+				add: (target) => {
+					assert.equal(target, windowObject);
+
+					return {
+						off: (event) => {
+							assert.equal(event, 'scroll.cactiSelectmenu');
+
+							return {
+								on: (bound, handler) => {
+									boundEvent = bound;
+									scrollHandler = handler;
+								}
+							};
+						}
+					};
+				}
+			};
+		}
+
+		if (selector === 'select') {
+			return {
+				each: (callback) => selects.forEach(select => callback.call(select))
+			};
+		}
+
+		return {
+			selectmenu: (action) => {
+				if (action === 'instance') {
+					return selector.initialized ? {} : undefined;
+				}
+
+				assert.equal(action, 'close');
+				selector.closes++;
+			}
+		};
+	}
+
+	const context = vm.createContext({ $: jquery, window: windowObject });
+	vm.runInContext(extractFunction('setupSelectmenuScrollClose'), context, { filename: 'include/layout.js' });
+	context.setupSelectmenuScrollClose();
+
+	assert.match(selectedContainers, /\.cactiConsoleContentArea/);
+	assert.match(selectedContainers, /\.cactiGraphContentArea/);
+	assert.match(selectedContainers, /\.cactiTreeNavigationArea/);
+	assert.equal(boundEvent, 'scroll.cactiSelectmenu');
+	assert.equal(typeof scrollHandler, 'function');
+
+	scrollHandler();
+	assert.equal(selects[0].closes, 1);
+	assert.equal(selects[1].closes, 0);
+});
+
+test('applySkin binds scroll handling after theme widgets initialize', () => {
+	const themeReadyPosition = layoutSource.indexOf('themeReady();');
+	const setupPosition = layoutSource.indexOf('setupSelectmenuScrollClose();', themeReadyPosition);
+
+	assert.notEqual(themeReadyPosition, -1);
+	assert.ok(setupPosition > themeReadyPosition);
+});


### PR DESCRIPTION
## Summary

- close initialized jQuery UI selectmenus when the window or a Cacti content/navigation scroll container moves
- bind after theme widget initialization and replace the namespaced handler after AJAX navigation
- add executable JS coverage for binding, initialized-widget detection, close behavior, and initialization order

Addresses #7506

This is the `develop` counterpart to the release-focused 1.2.x fix in #7999.

## Docker validation

A Playwright Chromium probe using the real Dark/Modern theme assets reproduced a 100px detachment before the fix: the select button moved with `.cactiConsoleContentArea`, while its open menu did not. With this branch's production helper loaded, the menu closes on scroll in both themes.

- focused Node suite: 2 tests passed
- full develop Node contract suite: 14 tests passed
- Docker browser probe: Dark and Modern pass
- `git diff --check` passes

## Metadata

- target: `develop` / 1.3
- milestone: `v1.3.0`
- type: bug
- area: UI
- risk: low; only open selectmenus are affected during scrolling
