### PR TITLE
security: resolve open code scanning alerts

### DIFF
--- a/.github/workflows/script-coverage.yml
+++ b/.github/workflows/script-coverage.yml
@@ -61,10 +61,12 @@ jobs:
       - name: Enforce line coverage
         env:
           XDEBUG_MODE: coverage
+          PHPUNIT_CONFIG: ${{ inputs.phpunit-config }}
+          MIN_COVERAGE: ${{ inputs.min-coverage }}
         run: |
           set -euo pipefail
           include/vendor/bin/pest --colors=never \
-            --configuration=${{ inputs.phpunit-config }} \
+            --configuration="$PHPUNIT_CONFIG" \
             --coverage \
             --coverage-text \
-            --min=${{ inputs.min-coverage }}
+            --min="$MIN_COVERAGE"

--- a/aggregate_graphs.php
+++ b/aggregate_graphs.php
@@ -1194,9 +1194,9 @@ function graph_edit() : bool {
 				<td id='rrdtoolinfo' class='left' style='padding-left:15px;max-width:900px;overflow:scroll'>
 					<div style='overflow:auto;'>
 						<span class='textInfo'><?php print __('RRDtool Command:'); ?></span><br>
-						<?php print @rrdtool_function_graph(grv('id'), 1, $graph_data_array, '', $null_param, $_SESSION[SESS_USER_ID]); ?>
+						<pre class='monoSpace tableRow left'><?php print htmle(@rrdtool_function_graph(grv('id'), 1, $graph_data_array, '', $null_param, $_SESSION[SESS_USER_ID])); ?></pre>
 						<span class='textInfo'><?php print __('RRDtool Says:'); ?></span><br><?php unset($graph_data_array['print_source']); ?>
-						<pre class='monoSpace tableRow left'><?php print(POLLER_ID == 1 ? @rrdtool_function_graph(grv('id'), 1, $graph_data_array, '', $null_param, $_SESSION[SESS_USER_ID]) : __esc('Not Checked')); ?></pre>
+						<pre class='monoSpace tableRow left'><?php print(POLLER_ID == 1 ? htmle(@rrdtool_function_graph(grv('id'), 1, $graph_data_array, '', $null_param, $_SESSION[SESS_USER_ID])) : __esc('Not Checked')); ?></pre>
 					</div>
 					<script type='text/javascript'>
 						$(function() {
@@ -1425,8 +1425,8 @@ function graph_edit() : bool {
 		print "<div id='classic'>";
 
 		?>
-		<input type='hidden' id='graph_template_graph_id' name='graph_template_graph_id' value='<?php print(cacti_sizeof($graphs) ? $graphs['id'] : '0'); ?>'>
-		<input type='hidden' id='local_graph_template_graph_id' name='local_graph_template_graph_id' value='<?php print(cacti_sizeof($graphs) ? $graphs['local_graph_template_graph_id'] : '0'); ?>'>
+		<input type='hidden' id='graph_template_graph_id' name='graph_template_graph_id' value='<?php print(cacti_sizeof($graphs) ? (int) $graphs['id'] : 0); ?>'>
+		<input type='hidden' id='local_graph_template_graph_id' name='local_graph_template_graph_id' value='<?php print(cacti_sizeof($graphs) ? (int) $graphs['local_graph_template_graph_id'] : 0); ?>'>
 		<?php
 
 		if (empty($graphs['graph_template_id'])) {
@@ -1657,7 +1657,7 @@ function aggregate_items() : void {
 
 	?>
 	<script type='text/javascript'>
-		var totalItems = <?php print $total_items; ?>;
+		var totalItems = <?php print (int) $total_items; ?>;
 
 		$(function() {
 			if (totalItems == 0) {
@@ -1727,7 +1727,7 @@ function aggregate_items() : void {
 
 	html_start_box('', '100%', false, 3, 'center', '');
 
-	$nav = html_nav_bar('aggregate_graphs.php?action=edit&tab=items&id=' . gfrv('id'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Graphs'), 'page', 'main');
+	$nav = html_nav_bar('aggregate_graphs.php?action=edit&tab=items&id=' . gfrv('id'), MAX_DISPLAY_PAGES, (int) grv('page'), $rows, $total_rows, 5, __('Graphs'), 'page', 'main');
 
 	print $nav;
 
@@ -2061,7 +2061,7 @@ function aggregate_graph() : void {
 		]
 	];
 
-	$nav = html_nav_bar('aggregate_graphs.php', MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Aggregate Graphs'), 'page', 'main');
+	$nav = html_nav_bar('aggregate_graphs.php', MAX_DISPLAY_PAGES, (int) grv('page'), $rows, $total_rows, 5, __('Aggregate Graphs'), 'page', 'main');
 
 	form_start('aggregate_graphs.php', 'chk');
 

--- a/color_templates.php
+++ b/color_templates.php
@@ -495,7 +495,7 @@ function color_item_remove_confirm() : void {
 		<td class='topBoxAlt'>
 			<p><?php print __('Click \'Continue\' to delete the following Color Template Color.'); ?></p>
 			<p><?php print __('Color Name:'); ?> '<?php print htmle($template['name']); ?>'<br>
-			<?php print __('Color Hex:'); ?><strong><?php print $color_hex; ?></p>
+			<?php print __('Color Hex:'); ?><strong><?php print htmle($color_hex); ?></p>
 		</td>
 	</tr>
 	<tr>
@@ -516,13 +516,13 @@ function color_item_remove_confirm() : void {
 		$('#continue').click(function(data) {
 			var options = {
 				url: 'color_templates.php?action=item_remove',
-				redirect: 'color_templates.php?action=template_edit&color_template_id=<?php print grv('id'); ?>'
+				redirect: 'color_templates.php?action=template_edit&color_template_id=<?php print (int) grv('id'); ?>'
 			}
 
 			var data = {
 				__csrf_magic: csrfMagicToken,
-				color_id: <?php print grv('color_id'); ?>,
-				id: <?php print grv('id'); ?>
+				color_id: <?php print (int) grv('color_id'); ?>,
+				id: <?php print (int) grv('id'); ?>
 			}
 
 			postUrl(options, data);
@@ -806,7 +806,7 @@ function color_template() : void {
 		$sql_where");
 
 	$sql_order = get_order_string();
-	$sql_limit = ' LIMIT ' . ($rows * (grv('page') - 1)) . ',' . $rows;
+	$sql_limit = ' LIMIT ' . ((int) $rows * ((int) grv('page') - 1)) . ',' . (int) $rows;
 
 	$template_list = db_fetch_assoc("SELECT *
 		FROM color_templates AS ct
@@ -814,7 +814,7 @@ function color_template() : void {
 		$sql_order
 		$sql_limit");
 
-	$nav = html_nav_bar('color_templates.php', MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Color Templates'), 'page', 'main');
+	$nav = html_nav_bar('color_templates.php', MAX_DISPLAY_PAGES, (int) grv('page'), $rows, $total_rows, 5, __('Color Templates'), 'page', 'main');
 
 	form_start('color_templates.php', 'chk');
 

--- a/graph_templates.php
+++ b/graph_templates.php
@@ -1737,7 +1737,7 @@ function graph_templates() : void {
 		]
 	];
 
-	$nav = html_nav_bar('graph_templates.php?filter=' . grv('filter'), MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Graph Templates'), 'page', 'main');
+	$nav = html_nav_bar('graph_templates.php?filter=' . rawurlencode(grv('filter')), MAX_DISPLAY_PAGES, (int) grv('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Graph Templates'), 'page', 'main');
 
 	form_start('graph_templates.php', 'chk');
 
@@ -1902,10 +1902,10 @@ function input_edit() : void {
 
 			print '<td>';
 
-			$name = $start_bold . __esc('Item #%s', $i + 1) . ': ' . $graph_item_types[$item['graph_type_id']] . ' (' . $consolidation_functions[$item['consolidation_function_id']] . ')' . $end_bold;
+			$name = $start_bold . __esc('Item #%s', $i + 1) . ': ' . htmle($graph_item_types[$item['graph_type_id']]) . ' (' . htmle($consolidation_functions[$item['consolidation_function_id']]) . ')' . $end_bold;
 
 			form_checkbox('i_' . $item['graph_templates_item_id'], $old_value, '', '', '', grv('graph_template_id'));
-			print "<label for='i_" . $item['graph_templates_item_id'] . "'>" . $name . '</label>';
+			print "<label for='i_" . (int) $item['graph_templates_item_id'] . "'>" . $name . '</label>';
 
 			print '</td>';
 

--- a/graphs.php
+++ b/graphs.php
@@ -987,7 +987,7 @@ function draw_item_filter(bool $render = false, array $host = []) : void {
 function item_edit() : void {
 	global $struct_graph_item, $graph_item_types, $consolidation_functions;
 
-	$id = (!ierv('id') ? '&id=' . grv('id') : '');
+	$id = (!ierv('id') ? '&id=' . (int) gfrv('id') : '');
 
 	$host = db_fetch_row_prepared('SELECT hostname
 		FROM host
@@ -1256,7 +1256,7 @@ function item_edit() : void {
 
 		function applyFilter() {
 			strURL = 'graphs.php?action=item_edit<?php print $id; ?>' +
-				'&local_graph_id=<?php print grv('local_graph_id'); ?>' +
+				'&local_graph_id=<?php print (int) gfrv('local_graph_id'); ?>' +
 				'&data_template_id=' + $('#data_template_id').val() +
 				'&host_id=' + $('#host_id').val();
 
@@ -2676,7 +2676,7 @@ function graph_edit() : void {
 	<script type='text/javascript'>
 
 	var locked         = <?php print($locked ? 'true' : 'false'); ?>;
-	var imageSource    = '<?php print $graph['src']; ?>';
+	var imageSource    = <?php print json_encode($graph['src'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT); ?>;
 	var originalWidth  = null;
 	var originalHeight = null;
 
@@ -2980,7 +2980,7 @@ function graphs() : void {
 
 	$graph_list = db_fetch_assoc_prepared($sql, $merged_params);
 
-	$nav = html_nav_bar('graphs.php', MAX_DISPLAY_PAGES, grv('page'), $rows, $total_rows, 5, __('Graphs'), 'page', 'main');
+	$nav = html_nav_bar('graphs.php', MAX_DISPLAY_PAGES, (int) grv('page'), $rows, $total_rows, 5, __('Graphs'), 'page', 'main');
 
 	form_start('graphs.php', 'chk');
 

--- a/lib/html.php
+++ b/lib/html.php
@@ -604,9 +604,15 @@ function graph_drilldown_icons(int $local_graph_id, string $type = 'graph_button
  */
 function html_nav_bar(string $base_url, int $max_pages, int $current_page, int $rows_per_page, int $total_rows,
 	int $colspan = 30, string $object = '', string $page_var = 'page', string $return_to = '', bool $page_count = true) : string {
+	if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$]*$/', $page_var)) {
+		$page_var = 'page';
+	}
+
 	if ($object == '') {
 		$object = __('Rows');
 	}
+
+	$object = htmle($object);
 
 	if ($total_rows >= $rows_per_page && $page_count) {
 		if (substr_count($base_url, '?') == 0) {
@@ -662,7 +668,8 @@ function html_nav_bar(string $base_url, int $max_pages, int $current_page, int $
 				$return_to = 'main';
 			}
 
-			$url  = $base_url . $page_var;
+			$url            = cacti_js_encode($base_url . $page_var);
+			$return_to_json = cacti_js_encode($return_to);
 			$nav .= "<script type='text/javascript' " . CactiSecureHeaders::getNonceAttribute() . ">
 			function goto$page_var(pageNo) {
 				if (typeof url_graph === 'function') {
@@ -671,11 +678,11 @@ function html_nav_bar(string $base_url, int $max_pages, int $current_page, int $
 					var url_add='';
 				};
 
-				strURL = '$url='+pageNo+url_add;
+				strURL = $url + '=' + pageNo + url_add;
 
 				loadUrl({
 					url: strURL,
-					elementId: '$return_to',
+					elementId: $return_to_json,
 				});
 			}</script>";
 		}

--- a/lib/html_utility.php
+++ b/lib/html_utility.php
@@ -1825,6 +1825,10 @@ function display_tooltip(string $text) : string {
  * @return string The HTML for the pagination control.
  */
 function get_page_list(int $current_page, int $pages_per_screen, int $rows_per_page, int $total_rows, string $url, string $page_var = 'page', string $return_to = '') : string {
+	if (!preg_match('/^[A-Za-z_$][A-Za-z0-9_$]*$/', $page_var)) {
+		$page_var = 'page';
+	}
+
 	// By current design, $pages_per_screen means number of page no in mid of nav bar
 	// when $total_pages is larger than $pages_per_screen + 2(first and last)
 	// So actual $pages_per_screen should be $pages_per_screen+2
@@ -1913,7 +1917,8 @@ function get_page_list(int $current_page, int $pages_per_screen, int $rows_per_p
 		$return_to = 'main';
 	}
 
-	$url .= $page_var;
+	$url_json       = cacti_js_encode($url . $page_var);
+	$return_to_json = cacti_js_encode($return_to);
 	$url_page_select .= "<script type='text/javascript'>
 	function goto$page_var(pageNo) {
 		if (typeof url_graph === 'function') {
@@ -1922,11 +1927,11 @@ function get_page_list(int $current_page, int $pages_per_screen, int $rows_per_p
 			var url_add='';
 		};
 
-		strURL = '$url='+pageNo+url_add;
+		strURL = $url_json + '=' + pageNo + url_add;
 
 		loadUrl({
 			url: strURL,
-			elementId: '$return_to',
+			elementId: $return_to_json,
 		});
 	}</script>";
 

--- a/package_import.php
+++ b/package_import.php
@@ -414,7 +414,7 @@ function form_actions() : void {
 		<td class='saveRow'>
 			" . html_hidden_input('action', 'actions') . '
 			' . html_hidden_input('import_state', $import_state) . '
-			' . html_hidden_input('drp_action', gfrv('drp_action')) . "
+			' . html_hidden_input('drp_action', grv('drp_action')) . "
 			$save_html
 		</td>
 	</tr>";

--- a/package_import.php
+++ b/package_import.php
@@ -414,7 +414,7 @@ function form_actions() : void {
 		<td class='saveRow'>
 			" . html_hidden_input('action', 'actions') . '
 			' . html_hidden_input('import_state', $import_state) . '
-			' . html_hidden_input('drp_action', gnrv('drp_action')) . "
+			' . html_hidden_input('drp_action', gfrv('drp_action')) . "
 			$save_html
 		</td>
 	</tr>";
@@ -769,7 +769,9 @@ function package_diff_file() : void {
 
 			$renderer = new Diff_Renderer_Html_Inline;
 
-			print '<body>' . $diff->render($renderer) . '</body></html>';
+			// Diff_Renderer_Html_Inline::formatLines() HTML-escapes every input
+			// line before adding its own <ins>/<del> markup.
+			print '<body>' . $diff->render($renderer) . '</body></html>'; // nosemgrep: cacti-request-var-echoed-unescaped
 		} else {
 			print 'New file does not exist';
 		}

--- a/tests/Unit/Security/Xss/HtmlEscapeTest.php
+++ b/tests/Unit/Security/Xss/HtmlEscapeTest.php
@@ -228,6 +228,28 @@ test('html input helpers preserve zero values', function () {
 		->and(html_text_input('rfilter', '0'))->toContain("value='0'");
 });
 
+test('html navigation encodes script values and confines callback identifiers', function () {
+	$result = html_nav_bar(
+		"graphs.php?filter=';</script><script>alert(1)</script>&",
+		10,
+		2,
+		10,
+		100,
+		5,
+		'<img src=x onerror=alert(1)>',
+		"page');alert(1);//",
+		"main');alert(1);//"
+	);
+	$label_result = html_nav_bar('graphs.php', 10, 1, 10, 5, 5, '<img src=x onerror=alert(1)>');
+
+	expect($result)->toContain('function gotopage(pageNo)')
+		->and($result)->toContain('\\u003C\\/script\\u003E')
+		->and($result)->toContain('\\u0027')
+		->and($label_result)->toContain('&lt;img src=x onerror=alert(1)&gt;')
+		->and($result)->not->toContain('</script><script>alert(1)</script>')
+		->and($result)->not->toContain("elementId: 'main');alert(1);//'");
+});
+
 // =====================================================================
 // html_split_string tests
 // =====================================================================

--- a/tests/Unit/Security/Xss/PackageDiffRendererTest.php
+++ b/tests/Unit/Security/Xss/PackageDiffRendererTest.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 4) . '/include/vendor/phpdiff/Diff.php';
+require_once dirname(__DIR__, 4) . '/include/vendor/phpdiff/Renderer/Html/Inline.php';
+
+test('package inline diffs escape file content before adding markup', function () {
+	$payload  = "</td></tr></table><script>alert('xss')</script>";
+	$diff     = new Diff(['safe'], [$payload]);
+	$renderer = new Diff_Renderer_Html_Inline();
+	$html     = $diff->render($renderer);
+
+	expect($html)->toContain('&lt;script&gt;')
+		->and($html)->toContain('&lt;/script&gt;')
+		->and($html)->not->toContain('<script>')
+		->and($html)->not->toContain('</table><script>');
+});

--- a/tests/security/semgrep/cacti-security.php
+++ b/tests/security/semgrep/cacti-security.php
@@ -31,6 +31,10 @@ $g = db_fetch_assoc('SELECT * FROM host WHERE id = ' . gfrv('id'));
 // ok: cacti-request-var-in-sql
 $g2 = db_fetch_assoc('SELECT * FROM host WHERE ' . array_to_sql_or(gnrv('ids'), 'id'));
 
+$unsafe_column = gnrv('column');
+// ruleid: cacti-request-var-in-sql
+$g3 = db_fetch_assoc('SELECT * FROM host WHERE ' . array_to_sql_or([1], $unsafe_column));
+
 // ---- cacti-request-var-in-shell-or-rrdtool ----
 
 // ruleid: cacti-request-var-in-shell-or-rrdtool

--- a/tests/security/semgrep/cacti-security.php
+++ b/tests/security/semgrep/cacti-security.php
@@ -28,6 +28,8 @@ $f = db_fetch_row('SELECT x FROM t WHERE name = ' . db_qstr(gnrv('name')));
 // ok: cacti-request-var-in-sql
 $g = db_fetch_assoc('SELECT * FROM host WHERE id = ' . gfrv('id'));
 
+// ok: cacti-request-var-in-sql
+$g2 = db_fetch_assoc('SELECT * FROM host WHERE ' . array_to_sql_or(gnrv('ids'), 'id'));
 
 // ---- cacti-request-var-in-shell-or-rrdtool ----
 
@@ -43,7 +45,6 @@ $i = shell_exec('snmpget ' . cacti_escapeshellarg(gnrv('community')) . ' host');
 // ok: cacti-request-var-in-shell-or-rrdtool
 $j = exec('rrdtool tune ' . intval(grv('max')));
 
-
 // ---- cacti-request-var-echoed-unescaped ----
 
 // ruleid: cacti-request-var-echoed-unescaped
@@ -57,3 +58,12 @@ print '<div>' . htmle(grv('name')) . '</div>';
 
 // ok: cacti-request-var-echoed-unescaped
 print '<td>' . filter_value(grv('name'), grv('filter')) . '</td>';
+
+// ok: cacti-request-var-echoed-unescaped
+print html_hidden_input('action', gnrv('action'));
+
+// ok: cacti-request-var-echoed-unescaped
+print html_nav_bar('graphs.php', 10, grv('page'), 30, 300);
+
+// ok: cacti-request-var-echoed-unescaped
+print "<div id='" . clean_up_name(gnrv('tab')) . "'>";

--- a/tests/security/semgrep/cacti-security.php
+++ b/tests/security/semgrep/cacti-security.php
@@ -29,7 +29,7 @@ $f = db_fetch_row('SELECT x FROM t WHERE name = ' . db_qstr(gnrv('name')));
 $g = db_fetch_assoc('SELECT * FROM host WHERE id = ' . gfrv('id'));
 
 // ok: cacti-request-var-in-sql
-$g2 = db_fetch_assoc('SELECT * FROM host WHERE ' . array_to_sql_or(gnrv('ids'), 'id'));
+$g2 = db_fetch_assoc('SELECT * FROM host WHERE ' . array_to_sql_or((array) gnrv('ids'), 'id'));
 
 $unsafe_column = gnrv('column');
 // ruleid: cacti-request-var-in-sql

--- a/tests/security/semgrep/cacti-security.yml
+++ b/tests/security/semgrep/cacti-security.yml
@@ -38,8 +38,13 @@ rules:
       - pattern: db_qstr(...)
       - pattern: db_qstr_rlike(...)
       - pattern: sanitize_sql_column(...)
-      # array_to_sql_or() quotes each value with db_qstr().
-      - pattern: array_to_sql_or(...)
+      # array_to_sql_or() quotes each value with db_qstr(), but does not
+      # sanitize its column argument. Only a literal identifier is safe.
+      - patterns:
+          - pattern: array_to_sql_or($VALUES, $COLUMN)
+          - metavariable-regex:
+              metavariable: $COLUMN
+              regex: ^['"][A-Za-z0-9_.]+['"]$
       # gfrv()/get_filter_request_var() are only SQL-safe here when they enforce numeric types
       - pattern: gfrv($NAME)
       - pattern: gfrv($NAME, FILTER_VALIDATE_INT, ...)

--- a/tests/security/semgrep/cacti-security.yml
+++ b/tests/security/semgrep/cacti-security.yml
@@ -38,6 +38,8 @@ rules:
       - pattern: db_qstr(...)
       - pattern: db_qstr_rlike(...)
       - pattern: sanitize_sql_column(...)
+      # array_to_sql_or() quotes each value with db_qstr().
+      - pattern: array_to_sql_or(...)
       # gfrv()/get_filter_request_var() are only SQL-safe here when they enforce numeric types
       - pattern: gfrv($NAME)
       - pattern: gfrv($NAME, FILTER_VALIDATE_INT, ...)
@@ -133,6 +135,11 @@ rules:
       # filter_value() escapes values, link targets, and titles before adding
       # optional highlighting markup.
       - pattern: filter_value(...)
+      # These helpers return context-escaped markup and have dedicated unit tests.
+      - pattern: html_hidden_input(...)
+      - pattern: html_nav_bar(...)
+      # clean_up_name() confines values to ASCII letters, digits, and underscores.
+      - pattern: clean_up_name(...)
       - pattern: intval(...)
       - pattern: (int) $X
     pattern-sinks:


### PR DESCRIPTION
## Summary

- remove reusable-workflow input interpolation from the coverage shell step and pass values through quoted environment variables
- escape RRDtool debug output, numeric/attribute output, graph URLs, package diff output contracts, and shared pagination JavaScript values
- teach the Cacti Semgrep rules about verified sanitizers such as `array_to_sql_or()`, `html_hidden_input()`, `html_nav_bar()`, and `clean_up_name()`
- add regression coverage for pagination script injection and package diff HTML escaping

## Code-scanning findings

Addresses all 43 alerts currently open on `develop`, including the GitHub Actions shell-injection alert:
https://github.com/Cacti/cacti/security/code-scanning/607

The other 42 alerts are the Cacti request-to-SQL and request-to-output findings on the five touched PHP entry points. Actionable sinks were hardened; false positives now terminate at helpers whose escaping/quoting contracts are directly tested.

## Validation

- PHP 8.3.33 via `mise`
- Unit suite: 2,063 passed, 4 skipped, 6,134 assertions
- targeted XSS tests: 35 passed, 73 assertions
- Semgrep PR target scan: 0 findings across all 7 changed production PHP files
- Semgrep rule self-tests: 3/3 passed
- Semgrep `p/ci` scan of `script-coverage.yml`: 0 findings
- PHP lint, PHP CS Fixer, PHPStan, workflow policy, Composer validation, sink inventory, architectural hotspots, and SQL interpolation ratchet: passed

The first Unit run hit the local 128 MB process ceiling; the complete result above used `memory_limit=512M`, matching the repository static-analysis convention.