### PR TITLE
security: reject LDAP logins that skip a domain bind

### DIFF
--- a/.github/workflows/ldap-e2e.yml
+++ b/.github/workflows/ldap-e2e.yml
@@ -1,0 +1,47 @@
+# +-------------------------------------------------------------------------+
+# | Copyright (C) 2004-2026 The Cacti Group                                 |
+# +-------------------------------------------------------------------------+
+
+name: LDAP login e2e
+
+on:
+  pull_request:
+    paths:
+      - 'lib/ldap.php'
+      - 'lib/auth.php'
+      - 'auth_login.php'
+      - 'user_domains.php'
+      - 'tests/e2e/docker/**'
+      - '.github/workflows/ldap-e2e.yml'
+  push:
+    branches: [1.2.x]
+    paths:
+      - 'lib/ldap.php'
+      - 'lib/auth.php'
+      - 'auth_login.php'
+      - 'user_domains.php'
+      - 'tests/e2e/docker/**'
+      - '.github/workflows/ldap-e2e.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ldap-e2e-1.2-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ldap-login:
+    name: OpenLDAP domain login
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Run LDAP login e2e
+        env:
+          CACTI_E2E_TEST_GLOB: tests/08-ldap-login.sh
+        run: tests/e2e/docker/run.sh

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ Cacti CHANGELOG
 -issue#7506: Close open select menus when their scroll container moves
 -issue#7967: Fail CSP Pest jobs when no tests execute
 -issue: Commit transactions on MySQL as well as MariaDB
+-security: Fail closed on a posted LDAP realm that is not a configured domain
+-security: Keep LDAP directory errors out of the login page
+-security: Demand TLS certificates for new LDAP installs
+-security: Restore the Cacti error handler on LDAP bind-only and empty-password paths
 -security: Update bundled DOMPurify to 3.4.14
 -security: Revoke anonymous access when the guest account is disabled
 -security: Cast graph and device ids to int in get_allowed_* permission filters

--- a/include/global_settings.php
+++ b/include/global_settings.php
@@ -1770,7 +1770,7 @@ $settings = array(
 			'friendly_name' => __('TLS Certificate Requirements'),
 			'description' => __('Should LDAP verify TLS Certificates when received by the Client.'),
 			'method' => 'drop_array',
-			'default' => LDAP_OPT_X_TLS_NEVER,
+			'default' => LDAP_OPT_X_TLS_DEMAND,
 			'array' => $ldap_tls_cert_req
 		),
 		'ldap_referrals' => array(

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -3853,7 +3853,7 @@ function ldap_login_process($username) {
 function domains_login_process($username) {
 	global $realm, $error, $error_msg;
 
-	$realm    = get_nfilter_request_var('realm');
+	$realm    = (int) get_nfilter_request_var('realm');
 	$password = get_nfilter_request_var('login_password');
 
 	if ($username == '') {
@@ -3861,6 +3861,15 @@ function domains_login_process($username) {
 		$error_msg = __('Access Denied!  Login Failed.');
 
 		cacti_log('LOGIN FAILED: Empty Domains Username provided', false, 'AUTH');
+
+		return array();
+	}
+
+	if (!array_key_exists($realm, get_auth_realms(true))) {
+		$error     = true;
+		$error_msg = __('Access Denied!  Login Failed.');
+
+		cacti_log(sprintf("LOGIN FAILED: Unknown Login Realm '%s' provided for user '%s' from IP address %s", $realm, $username, get_client_addr()), false, 'AUTH');
 
 		return array();
 	}
@@ -3873,25 +3882,23 @@ function domains_login_process($username) {
 
 	$user = array();
 
-	// realm >= 3: domain realms start at 3; > 3 allowed realm=3 to skip LDAP bind (GHSA-3jj2-v5ch-wmq5)
-	if ($realm >= 3 && $password != '') {
+	if ($realm >= 1000 && $password != '') {
 		/* get user DN */
 		$ldap_dn_search_response = domains_ldap_search_dn($username, $realm);
-		if ($ldap_dn_search_response['error_num'] == '0') {
+		if (is_array($ldap_dn_search_response) && $ldap_dn_search_response['error_num'] == '0') {
 			$ldap_dn = $ldap_dn_search_response['dn'];
 		} else {
-			/* error searching */
 			$error     = true;
-			$error_msg = __('LDAP Search Error: %s', $ldap_dn_search_response['error_text']);
+			$error_msg = __('Access Denied!  Login Failed.');
 
-			cacti_log('LOGIN FAILED: LDAP Error: ' . $ldap_dn_search_response['error_text'], false, 'AUTH');
+			cacti_log('LOGIN FAILED: LDAP Error: ' . (is_array($ldap_dn_search_response) ? $ldap_dn_search_response['error_text'] : 'No LDAP configuration for realm'), false, 'AUTH');
 		}
 
 		if (!$error) {
 			/* auth user with LDAP */
 			$ldap_auth_response = domains_ldap_auth($username, $password, $ldap_dn, $realm);
 
-			if ($ldap_auth_response['error_num'] == '0') {
+			if (is_array($ldap_auth_response) && $ldap_auth_response['error_num'] == '0') {
 				/* User ok */
 				$domain_name = db_fetch_cell_prepared('SELECT domain_name
 					FROM user_domains
@@ -3959,7 +3966,7 @@ function domains_login_process($username) {
 
 								user_copy($user_template['username'], $username, 0, $realm, false, $data_override);
 							} else {
-								cacti_log('LOGIN: fields not found ' . $ldap_cn_search_response[0] . 'code: ' . $ldap_cn_search_response['error_num'], false, 'AUTH');
+								cacti_log('LOGIN: fields not found code: ' . (is_array($ldap_cn_search_response) ? $ldap_cn_search_response['error_num'] : ''), false, 'AUTH');
 								user_copy($user_template['username'], $username, 0, $realm);
 							}
 						} else {
@@ -3980,17 +3987,20 @@ function domains_login_process($username) {
 						cacti_log("LOGIN FAILED: Template user id '" . $template_user . "' does not exist.", false, 'AUTH');
 					}
 				}
+
+				if (!$error && !cacti_sizeof($user)) {
+					$error     = true;
+					$error_msg = __('Access Denied!  Domain template is not configured.  Please contact your Administrator.');
+
+					cacti_log("LOGIN FAILED: LDAP user '" . $username . "' authenticated but the domain has no template and no existing account.", false, 'AUTH');
+				}
 			} else {
-				/* error */
 				$error     = true;
-				$error_msg = __('Access Denied!  LDAP Error: %s', $ldap_auth_response['error_text']);
+				$error_msg = __('Access Denied!  Login Failed.');
 
-				cacti_log('LOGIN FAILED: LDAP Error: ' . $ldap_auth_response['error_text'], false, 'AUTH');
+				cacti_log('LOGIN FAILED: LDAP Error: ' . (is_array($ldap_auth_response) ? $ldap_auth_response['error_text'] : 'No LDAP configuration for realm'), false, 'AUTH');
 
-				/* error_text is a string; the correct field for the numeric
-				 * bind-failure code is error_num (mirrors the check in
-				 * ldap_login_process at line ~3818).  GHSA-2px8-gvmq-85f3 */
-				if ($ldap_auth_response['error_num'] == 1) {
+				if (is_array($ldap_auth_response) && $ldap_auth_response['error_num'] == 1) {
 					auth_process_lockout($username, $realm);
 				}
 			}
@@ -4003,6 +4013,11 @@ function domains_login_process($username) {
 		cacti_log(sprintf('LOGIN FAILED: LDAP No password provided for user %s', $username), false, 'AUTH');
 
 		auth_process_lockout($username, $realm);
+	} else {
+		$error     = true;
+		$error_msg = __('Access Denied!  Login Failed.');
+
+		cacti_log(sprintf("LOGIN FAILED: Login Realm '%s' is not an LDAP domain for user '%s' from IP address %s", $realm, $username, get_client_addr()), false, 'AUTH');
 	}
 
 	return $user;

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -3853,7 +3853,7 @@ function ldap_login_process($username) {
 function domains_login_process($username) {
 	global $realm, $error, $error_msg;
 
-	$realm    = (int) get_nfilter_request_var('realm');
+	$realm    = get_filter_request_var('realm');
 	$password = get_nfilter_request_var('login_password');
 
 	if ($username == '') {

--- a/lib/ldap.php
+++ b/lib/ldap.php
@@ -577,7 +577,7 @@ class Ldap {
 			}
 
 			$bind_timeout = read_config_option('ldap_bind_timeout');
-			if (defined('LDAP_OPT_TIMELIMIT')) {
+			if (defined('LDAP_OPT_TIMEOUT')) {
 				cacti_log("NOTE: Setting Bind Timeout to $bind_timeout seconds", false, 'AUTH', $this->debug);
 				ldap_set_option($ldap_conn, LDAP_OPT_TIMEOUT, $bind_timeout);
 			}
@@ -651,6 +651,9 @@ class Ldap {
 		$this->dn = str_replace('<username>', $safe_username, $this->dn);
 
 		if ($this->password == '') {
+			ldap_close($ldap_conn);
+			$this->RestoreCactiHandler();
+
 			return LdapError::GetErrorDetails(LdapError::EmptyPassword);
 		}
 
@@ -668,13 +671,7 @@ class Ldap {
 						$ldap_group_response = Ldap::isUserInLDAPGroup($ldap_conn, $this->search_base, $this->group_dn, $this->dn);
 					}
 				} elseif ($this->group_member_type == 2) {
-					/* Do a lookup to find this user's true DN. */
-					/* ldap_exop_whoami is not yet included in PHP. For reference, the
-					 * feature request: http://bugs.php.net/bug.php?id=42060
-					 * And the patch against latest PHP release:
-					 * http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/databases/php-ldap/files/ldap-ctrl-exop.patch
-					*/
-					$filter = cacti_ldap_filter('(|(uid=<dn>)(cn=<dn>)(userPrincipalName=<dn>))', array('dn' => $this->dn));
+					$filter = cacti_ldap_filter('(|(uid=<username>)(cn=<username>)(userPrincipalName=<username>))', array('username' => $this->username));
 					$true_dn_result = ldap_search($ldap_conn, $this->search_base, $filter, array('dn'));
 					$first_entry    = ldap_first_entry($ldap_conn, $true_dn_result);
 
@@ -890,12 +887,18 @@ class Ldap {
 			/* Just bind mode, make dn and return */
 			$output = LdapError::GetErrorDetails(LdapError::Success);
 			$output['dn'] = $this->dn;
+			ldap_close($ldap_conn);
+			$this->RestoreCactiHandler();
+
 			return $output;
 		} elseif ($this->mode == '2') {
 			/* Specific */
 			if (empty($this->specific_dn) || empty($this->specific_password)) {
 				$output = LdapError::GetErrorDetails(LdapError::UndefinedDnOrPassword);
 				$output['dn'] = $this->dn;
+				ldap_close($ldap_conn);
+				$this->RestoreCactiHandler();
+
 				return $output;
 			}
 		} elseif ($this->mode == '1'){
@@ -919,7 +922,7 @@ class Ldap {
 				$ldap_entries =  ldap_get_entries($ldap_conn, $ldap_results);
 
 				/* We find 1 entries */
-				if ($ldap_entries['count'] == 1) {
+				if ($ldap_entries !== false && isset($ldap_entries['count']) && $ldap_entries['count'] == 1) {
 					$output = LdapError::GetErrorDetails(LdapError::Success);
 					// check if we got an full username entry
 					if (array_key_exists($this->cn[0], $ldap_entries[0])) {
@@ -934,8 +937,10 @@ class Ldap {
 					} else {
 						$output['cn'][$this->cn[1]] = '';
 					}
-				} else {
+				} elseif (is_array($ldap_entries) && isset($ldap_entries['count']) && $ldap_entries['count'] > 1) {
 					$output = LdapError::GetErrorDetails(LdapError::SearchFoundMultiUser);
+				} else {
+					$output = LdapError::GetErrorDetails(LdapError::SearchFoundNoUser);
 				}
 			} else {
 				/* no search results, user not found*/

--- a/lib/ldap.php
+++ b/lib/ldap.php
@@ -1012,13 +1012,12 @@ class Ldap {
  * @return string The assembled, injection-safe LDAP filter
  */
 function cacti_ldap_filter($template, $vars) {
-	$result = $template;
+	$map = array();
 
 	foreach ($vars as $key => $value) {
-		$escaped = ldap_escape((string) $value, '', LDAP_ESCAPE_FILTER);
-		$result  = str_replace('<' . $key . '>', $escaped, $result);
+		$map['<' . $key . '>'] = ldap_escape((string) $value, '', LDAP_ESCAPE_FILTER);
 	}
 
-	return $result;
+	return strtr($template, $map);
 }
 

--- a/tests/Helpers/DomainsLoginProcessHarness.php
+++ b/tests/Helpers/DomainsLoginProcessHarness.php
@@ -1,0 +1,270 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Run the shipped domains_login_process() in a child process with LDAP and
+ * database calls stubbed. Request values come from get_nfilter_request_var().
+ *
+ * @param array<string, mixed> $scenario
+ *
+ * @return array<string, mixed>
+ */
+function cacti_test_load_cacti_ldap_filter(string $src) : void {
+	if (function_exists('cacti_ldap_filter')) {
+		return;
+	}
+
+	$start = strpos($src, 'function cacti_ldap_filter(');
+
+	if ($start === false) {
+		throw new RuntimeException('cacti_ldap_filter() not found');
+	}
+
+	$depth = 0;
+	$len   = strlen($src);
+
+	for ($i = strpos($src, '{', $start); $i < $len; $i++) {
+		if ($src[$i] === '{') {
+			$depth++;
+		} elseif ($src[$i] === '}') {
+			$depth--;
+
+			if ($depth === 0) {
+				eval(substr($src, $start, $i - $start + 1));
+
+				return;
+			}
+		}
+	}
+
+	throw new RuntimeException('cacti_ldap_filter() is unbalanced');
+}
+
+function cacti_test_run_domains_login_process_1_2(array $scenario) : array {
+	$root = dirname(__DIR__, 2);
+	$src  = file_get_contents($root . '/lib/auth.php');
+	$start = strpos($src, 'function domains_login_process(');
+
+	if ($start === false) {
+		throw new RuntimeException('domains_login_process() not found');
+	}
+
+	$depth = 0;
+	$len   = strlen($src);
+
+	for ($i = strpos($src, '{', $start); $i < $len; $i++) {
+		if ($src[$i] === '{') {
+			$depth++;
+		} elseif ($src[$i] === '}') {
+			$depth--;
+
+			if ($depth === 0) {
+				$body = substr($src, $start, $i - $start + 1);
+
+				break;
+			}
+		}
+	}
+
+	if (!isset($body)) {
+		throw new RuntimeException('domains_login_process() is unbalanced');
+	}
+
+	$harness = <<<'PHP'
+<?php
+$scenario = json_decode($argv[1], true);
+
+$GLOBALS['req']              = $scenario['request'];
+$GLOBALS['domains']          = $scenario['domains'];
+$GLOBALS['ldap_ok']          = $scenario['ldap_ok'];
+$GLOBALS['search_ok']        = $scenario['search_ok'];
+$GLOBALS['search_false']     = $scenario['search_false'];
+$GLOBALS['auth_false']       = $scenario['auth_false'];
+$GLOBALS['auth_error_num']   = $scenario['auth_error_num'];
+$GLOBALS['user_row']         = $scenario['user_row'];
+$GLOBALS['after_copy_row']   = $scenario['after_copy_row'];
+$GLOBALS['template_user']    = $scenario['template_user'];
+$GLOBALS['template_row']     = $scenario['template_row'];
+$GLOBALS['cn_full_name']     = $scenario['cn_full_name'];
+$GLOBALS['cn_email']         = $scenario['cn_email'];
+$GLOBALS['cn_response']      = $scenario['cn_response'];
+$GLOBALS['lockout']          = $scenario['lockout'];
+$GLOBALS['copied']           = false;
+$GLOBALS['ldap_calls']       = 0;
+$GLOBALS['lockout_calls']    = 0;
+$GLOBALS['copy_calls']       = 0;
+
+$realm     = 0;
+$error     = false;
+$error_msg = '';
+
+function get_nfilter_request_var($name, $default = '') {
+	return $GLOBALS['req'][$name] ?? $default;
+}
+
+function __(...$args) {
+	return vsprintf((string) $args[0], array_slice($args, 1));
+}
+
+function get_client_addr() {
+	return '203.0.113.9';
+}
+
+function cacti_log(...$args) {
+}
+
+function cacti_sizeof($array) {
+	return is_array($array) ? count($array) : 0;
+}
+
+function get_auth_realms($login = false) {
+	$realms = array('0' => array('name' => 'Local', 'selected' => false));
+
+	foreach ($GLOBALS['domains'] as $domain_id) {
+		$realms[1000 + $domain_id] = array('name' => 'Domain ' . $domain_id, 'selected' => false);
+	}
+
+	return $realms;
+}
+
+function auth_checkclear_lockout($username, $realm) {
+}
+
+function auth_process_lockout_check($username, $realm) {
+	return !empty($GLOBALS['lockout']);
+}
+
+function auth_process_lockout($username, $realm) {
+	$GLOBALS['lockout_calls']++;
+}
+
+function domains_ldap_search_dn($username, $realm) {
+	$GLOBALS['ldap_calls']++;
+
+	if (!empty($GLOBALS['search_false'])) {
+		return false;
+	}
+
+	if (empty($GLOBALS['search_ok'])) {
+		return array('error_num' => '14', 'error_text' => 'Unable to find users DN');
+	}
+
+	return array('error_num' => '0', 'error_text' => '', 'dn' => 'uid=' . $username . ',dc=example,dc=com');
+}
+
+function domains_ldap_auth($username, $password = '', $dn = '', $realm = 0) {
+	$GLOBALS['ldap_calls']++;
+
+	if (!empty($GLOBALS['auth_false'])) {
+		return false;
+	}
+
+	if (!empty($GLOBALS['ldap_ok'])) {
+		return array('error_num' => '0', 'error_text' => '');
+	}
+
+	return array('error_num' => $GLOBALS['auth_error_num'], 'error_text' => 'Authentication Failure');
+}
+
+function domains_ldap_search_cn($username, $cn, $realm) {
+	return $GLOBALS['cn_response'];
+}
+
+function user_copy(...$args) {
+	$GLOBALS['copy_calls']++;
+	$GLOBALS['copied'] = true;
+
+	return true;
+}
+
+function db_fetch_row_prepared($sql, $params = array()) {
+	if (strpos($sql, 'WHERE username = ?') !== false) {
+		if (!empty($GLOBALS['copied']) && is_array($GLOBALS['after_copy_row'])) {
+			return $GLOBALS['after_copy_row'];
+		}
+
+		return $GLOBALS['user_row'];
+	}
+
+	if (strpos($sql, 'WHERE id = ?') !== false) {
+		return $GLOBALS['template_row'];
+	}
+
+	return array();
+}
+
+function db_fetch_cell_prepared($sql, $params = array()) {
+	if (strpos($sql, 'domain_name') !== false) {
+		return 'ExampleDomain';
+	}
+
+	if (strpos($sql, 'user_id') !== false) {
+		return $GLOBALS['template_user'];
+	}
+
+	if (strpos($sql, 'cn_full_name') !== false) {
+		return $GLOBALS['cn_full_name'];
+	}
+
+	if (strpos($sql, 'cn_email') !== false) {
+		return $GLOBALS['cn_email'];
+	}
+
+	if (strpos($sql, 'username') !== false) {
+		return 'template';
+	}
+
+	return 0;
+}
+
+PHP;
+
+	$harness .= $body . "\n\n";
+	$harness .= '$user = domains_login_process($scenario[\'username\']);' . "\n";
+	$harness .= 'print json_encode([' . "\n";
+	$harness .= "\t'error'         => \$error,\n";
+	$harness .= "\t'error_msg'     => \$error_msg,\n";
+	$harness .= "\t'user'          => \$user,\n";
+	$harness .= "\t'ldap_calls'    => \$GLOBALS['ldap_calls'],\n";
+	$harness .= "\t'lockout_calls' => \$GLOBALS['lockout_calls'],\n";
+	$harness .= "\t'copy_calls'    => \$GLOBALS['copy_calls']\n";
+	$harness .= ']);' . "\n";
+
+	$file = tempnam(sys_get_temp_dir(), 'cacti_login_');
+	file_put_contents($file, $harness);
+
+	$scenario += [
+		'username'        => 'attacker',
+		'request'         => [],
+		'domains'         => [1],
+		'ldap_ok'         => true,
+		'search_ok'       => true,
+		'search_false'    => false,
+		'auth_false'      => false,
+		'auth_error_num'  => 1,
+		'user_row'        => [],
+		'after_copy_row'  => ['id' => 9, 'username' => 'attacker', 'realm' => 1001],
+		'template_user'   => 0,
+		'template_row'    => [],
+		'cn_full_name'    => '',
+		'cn_email'        => '',
+		'cn_response'     => ['error_num' => '0'],
+		'lockout'         => false,
+	];
+
+	$cmd = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($file) . ' ' . escapeshellarg(json_encode($scenario)) . ' 2>&1';
+	$output = shell_exec($cmd);
+	unlink($file);
+
+	$result = json_decode((string) $output, true);
+
+	if (!is_array($result)) {
+		throw new RuntimeException('harness failed: ' . $output);
+	}
+
+	return $result;
+}

--- a/tests/Helpers/DomainsLoginProcessHarness.php
+++ b/tests/Helpers/DomainsLoginProcessHarness.php
@@ -34,6 +34,7 @@ function cacti_test_load_cacti_ldap_filter(string $src) : void {
 			$depth--;
 
 			if ($depth === 0) {
+				// nosemgrep: php.lang.security.eval-use.eval-use -- test-only evaluation of a repository-owned function
 				eval(substr($src, $start, $i - $start + 1));
 
 				return;

--- a/tests/Unit/Security/Auth/DomainsLoginRealmValidationTest.php
+++ b/tests/Unit/Security/Auth/DomainsLoginRealmValidationTest.php
@@ -1,0 +1,216 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 3) . '/Helpers/DomainsLoginProcessHarness.php';
+
+test('an empty username is rejected before LDAP', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'username' => '',
+		'request'  => ['realm' => '1001', 'login_password' => 'x'],
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['user'])->toBe([])
+		->and($result['ldap_calls'])->toBe(0);
+});
+
+test('a realm the dropdown never offered is rejected instead of falling through', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request' => ['realm' => '2', 'login_password' => 'anything'],
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['user'])->toBe([])
+		->and($result['ldap_calls'])->toBe(0);
+});
+
+test('the local realm with a password is not treated as an LDAP domain', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request' => ['realm' => '0', 'login_password' => 'anything'],
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['error_msg'])->toContain('Login Failed')
+		->and($result['ldap_calls'])->toBe(0);
+});
+
+test('a missing or non-numeric realm is rejected', function () {
+	foreach ([[], ['realm' => ''], ['realm' => 'ldap'], ['realm' => '-1'], ['realm' => '1500']] as $realm) {
+		$result = cacti_test_run_domains_login_process_1_2([
+			'request' => $realm + ['login_password' => 'anything'],
+		]);
+
+		expect($result['error'])->toBeTrue()
+			->and($result['ldap_calls'])->toBe(0);
+	}
+});
+
+test('a locked account returns before any bind', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request' => ['realm' => '1001', 'login_password' => 'x'],
+		'lockout' => true,
+	]);
+
+	expect($result['error'])->toBeFalse()
+		->and($result['user'])->toBe([])
+		->and($result['ldap_calls'])->toBe(0);
+});
+
+test('a search that returns no LDAP row fails closed without page diagnostics', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request'      => ['realm' => '1001', 'login_password' => 'x'],
+		'search_false' => true,
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['error_msg'])->toBe('Access Denied!  Login Failed.')
+		->and($result['error_msg'])->not->toContain('Unable to find');
+});
+
+test('a failed DN search fails closed without leaking the directory error', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request'   => ['realm' => '1001', 'login_password' => 'x'],
+		'search_ok' => false,
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['error_msg'])->toBe('Access Denied!  Login Failed.');
+});
+
+test('a valid domain login still authenticates and returns the account', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'username' => 'alice',
+		'request'  => ['realm' => '1001', 'login_password' => 'correct-horse'],
+		'ldap_ok'  => true,
+		'user_row' => ['id' => 7, 'username' => 'alice', 'realm' => 1001, 'enabled' => 'on'],
+	]);
+
+	expect($result['error'])->toBeFalse()
+		->and($result['user']['id'])->toBe(7)
+		->and($result['ldap_calls'])->toBe(2);
+});
+
+test('a bad password fails with a generic message and counts toward lockout', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'username' => 'alice',
+		'request'  => ['realm' => '1001', 'login_password' => 'wrong'],
+		'ldap_ok'  => false,
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['error_msg'])->toBe('Access Denied!  Login Failed.')
+		->and($result['lockout_calls'])->toBe(1);
+});
+
+test('a non-credential LDAP bind failure does not lock the account', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request'        => ['realm' => '1001', 'login_password' => 'x'],
+		'ldap_ok'        => false,
+		'auth_error_num' => 9,
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['lockout_calls'])->toBe(0);
+});
+
+test('a bind that returns no array fails closed', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request'    => ['realm' => '1001', 'login_password' => 'x'],
+		'auth_false' => true,
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['lockout_calls'])->toBe(0);
+});
+
+test('LDAP success with no account and no domain template is rejected', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request'       => ['realm' => '1001', 'login_password' => 'x'],
+		'ldap_ok'       => true,
+		'user_row'      => [],
+		'template_user' => 0,
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['error_msg'])->toContain('Domain template is not configured')
+		->and($result['copy_calls'])->toBe(0);
+});
+
+test('LDAP success copies the domain template when the account is new', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'username'       => 'bob',
+		'request'        => ['realm' => '1001', 'login_password' => 'x'],
+		'user_row'       => [],
+		'template_user'  => 4,
+		'template_row'   => ['id' => 4, 'username' => 'template'],
+		'after_copy_row' => ['id' => 22, 'username' => 'bob', 'realm' => 1001],
+	]);
+
+	expect($result['error'])->toBeFalse()
+		->and($result['copy_calls'])->toBe(1)
+		->and($result['user']['id'])->toBe(22);
+});
+
+test('a missing template user id is an error', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request'       => ['realm' => '1001', 'login_password' => 'x'],
+		'user_row'      => [],
+		'template_user' => 4,
+		'template_row'  => [],
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['error_msg'])->toContain('Template user id')
+		->and($result['copy_calls'])->toBe(0);
+});
+
+test('CN attributes override the copied full name and email when present', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'username'       => 'carol',
+		'request'        => ['realm' => '1001', 'login_password' => 'x'],
+		'user_row'       => [],
+		'template_user'  => 4,
+		'template_row'   => ['id' => 4, 'username' => 'template'],
+		'cn_full_name'   => 'displayName',
+		'cn_email'       => 'mail',
+		'cn_response'    => [
+			'error_num' => '0',
+			'cn'        => ['displayName' => 'Carol', 'mail' => 'carol@example.com'],
+		],
+		'after_copy_row' => ['id' => 23, 'username' => 'carol', 'realm' => 1001],
+	]);
+
+	expect($result['error'])->toBeFalse()
+		->and($result['copy_calls'])->toBe(1)
+		->and($result['user']['id'])->toBe(23);
+});
+
+test('a CN search without cn still copies the template', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request'        => ['realm' => '1001', 'login_password' => 'x'],
+		'user_row'       => [],
+		'template_user'  => 4,
+		'template_row'   => ['id' => 4, 'username' => 'template'],
+		'cn_full_name'   => 'displayName',
+		'cn_response'    => ['error_num' => '13'],
+		'after_copy_row' => ['id' => 24, 'username' => 'attacker', 'realm' => 1001],
+	]);
+
+	expect($result['error'])->toBeFalse()
+		->and($result['copy_calls'])->toBe(1);
+});
+
+test('an empty password on a valid domain keeps its own error path', function () {
+	$result = cacti_test_run_domains_login_process_1_2([
+		'request' => ['realm' => '1001', 'login_password' => ''],
+	]);
+
+	expect($result['error'])->toBeTrue()
+		->and($result['error_msg'])->toContain('No password provided')
+		->and($result['lockout_calls'])->toBe(1)
+		->and($result['ldap_calls'])->toBe(0);
+});

--- a/tests/Unit/Security/Ldap/CactiLdapFilterTest.php
+++ b/tests/Unit/Security/Ldap/CactiLdapFilterTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+require_once dirname(__DIR__, 3) . '/Helpers/DomainsLoginProcessHarness.php';
+
+$cactiLdapFilterSource = file_get_contents(dirname(__DIR__, 4) . '/lib/ldap.php');
+
+test('cacti_ldap_filter is defined in lib/ldap.php', function () use ($cactiLdapFilterSource) {
+	expect(strpos($cactiLdapFilterSource, 'function cacti_ldap_filter('))->not->toBeFalse();
+});
+
+test('cacti_ldap_filter escapes parentheses asterisks and backslashes', function () use ($cactiLdapFilterSource) {
+	cacti_test_load_cacti_ldap_filter($cactiLdapFilterSource);
+
+	$filter = cacti_ldap_filter('(uid=<username>)', ['username' => 'a)(|(uid=*']);
+
+	expect($filter)->toBe('(uid=' . ldap_escape('a)(|(uid=*', '', LDAP_ESCAPE_FILTER) . ')');
+	expect($filter)->not->toContain('(|(uid=*');
+});
+
+test('cacti_ldap_filter substitutes every placeholder independently', function () use ($cactiLdapFilterSource) {
+	cacti_test_load_cacti_ldap_filter($cactiLdapFilterSource);
+
+	$filter = cacti_ldap_filter(
+		'(&(distinguishedName=<user>)(memberOf:1.2.840.113556.1.4.1941:=<group>))',
+		['user' => 'cn=alice,dc=ex', 'group' => 'cn=admins,dc=ex']
+	);
+
+	expect($filter)->toContain('distinguishedName=' . ldap_escape('cn=alice,dc=ex', '', LDAP_ESCAPE_FILTER));
+	expect($filter)->toContain('1941:=' . ldap_escape('cn=admins,dc=ex', '', LDAP_ESCAPE_FILTER));
+});
+
+test('cacti_ldap_filter stringifies non-string values before escaping', function () use ($cactiLdapFilterSource) {
+	cacti_test_load_cacti_ldap_filter($cactiLdapFilterSource);
+
+	expect(cacti_ldap_filter('(uid=<id>)', ['id' => 42]))->toBe('(uid=42)');
+});

--- a/tests/Unit/Security/Ldap/CactiLdapFilterTest.php
+++ b/tests/Unit/Security/Ldap/CactiLdapFilterTest.php
@@ -39,3 +39,12 @@ test('cacti_ldap_filter stringifies non-string values before escaping', function
 
 	expect(cacti_ldap_filter('(uid=<id>)', ['id' => 42]))->toBe('(uid=42)');
 });
+
+test('a value is never rescanned as another placeholder', function () use ($cactiLdapFilterSource) {
+	cacti_test_load_cacti_ldap_filter($cactiLdapFilterSource);
+
+	$filter = cacti_ldap_filter('(&(a=<x>)(b=<y>))', ['x' => '<y>', 'y' => 'secret']);
+
+	expect($filter)->toBe('(&(a=<y>)(b=secret))');
+	expect($filter)->not->toContain('(a=secret)');
+});

--- a/tests/Unit/Security/Ldap/LdapAuthHardeningTest.php
+++ b/tests/Unit/Security/Ldap/LdapAuthHardeningTest.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+*/
+
+$repoRoot   = dirname(__DIR__, 4);
+$ldapSource = file_get_contents($repoRoot . '/lib/ldap.php');
+$authSource = file_get_contents($repoRoot . '/lib/auth.php');
+$settings   = file_get_contents($repoRoot . '/include/global_settings.php');
+
+test('domains_login_process rejects a realm that is not on the login dropdown', function () use ($authSource) {
+	$start = strpos($authSource, 'function domains_login_process(');
+	expect($start)->not->toBeFalse();
+	$body = substr($authSource, $start, 8000);
+
+	expect($body)->toContain('get_auth_realms(true)');
+	expect($body)->toContain('Unknown Login Realm');
+});
+
+test('domains_login_process fails closed when the posted realm is not an LDAP domain', function () use ($authSource) {
+	$start = strpos($authSource, 'function domains_login_process(');
+	$body  = substr($authSource, $start, 8000);
+
+	expect($body)->toContain("Login Realm '%s' is not an LDAP domain");
+	expect($body)->not->toContain('$realm >= 3 && $password != \'\'');
+});
+
+test('domains_login_process does not interpolate LDAP error_text into the login page', function () use ($authSource) {
+	$start = strpos($authSource, 'function domains_login_process(');
+	$body  = substr($authSource, $start, 8000);
+
+	expect($body)->not->toContain("__('LDAP Search Error: %s'");
+	expect($body)->not->toContain("__('Access Denied!  LDAP Error: %s'");
+});
+
+test('domains_login_process fails when LDAP succeeded but the domain has no template and no user', function () use ($authSource) {
+	$start = strpos($authSource, 'function domains_login_process(');
+	$body  = substr($authSource, $start, 8000);
+
+	expect($body)->toContain('Domain template is not configured');
+});
+
+test('domains_login_process does not log a missing cn search index', function () use ($authSource) {
+	$start = strpos($authSource, 'function domains_login_process(');
+	$body  = substr($authSource, $start, 8000);
+
+	expect($body)->not->toContain('$ldap_cn_search_response[0]');
+});
+
+test('Authenticate restores the Cacti handler on an empty password', function () use ($ldapSource) {
+	$start = strpos($ldapSource, 'function Authenticate()');
+	expect($start)->not->toBeFalse();
+	$body  = substr($ldapSource, $start, 8000);
+	$empty = strpos($body, "password == ''");
+	expect($empty)->not->toBeFalse();
+
+	expect(substr($body, $empty, 400))->toContain('RestoreCactiHandler');
+});
+
+test('Getcn restores the Cacti handler on bind-only mode', function () use ($ldapSource) {
+	$start = strpos($ldapSource, 'function Getcn()');
+	expect($start)->not->toBeFalse();
+	$body = substr($ldapSource, $start, 4000);
+	$mode = strpos($body, "mode == '0'");
+	expect($mode)->not->toBeFalse();
+
+	expect(substr($body, $mode, 350))->toContain('RestoreCactiHandler');
+});
+
+test('Getcn distinguishes no user from many users', function () use ($ldapSource) {
+	$start = strpos($ldapSource, 'function Getcn()');
+	$body  = substr($ldapSource, $start, 4000);
+
+	expect($body)->toContain('LdapError::SearchFoundNoUser)');
+	expect($body)->toContain('LdapError::SearchFoundMultiUser)');
+});
+
+test('username group membership searches uid cn and UPN with the login name', function () use ($ldapSource) {
+	$start = strpos($ldapSource, 'function Authenticate()');
+	$body  = substr($ldapSource, $start, 8000);
+
+	expect($body)->toContain("cacti_ldap_filter('(|(uid=<username>)(cn=<username>)(userPrincipalName=<username>))'");
+	expect($body)->toContain("'username' => \$this->username");
+});
+
+test('bind timeout is gated on LDAP_OPT_TIMEOUT', function () use ($ldapSource) {
+	expect($ldapSource)->toContain("defined('LDAP_OPT_TIMEOUT')");
+});
+
+test('new LDAP installs demand a valid TLS certificate', function () use ($settings) {
+	expect($settings)->toContain("'default' => LDAP_OPT_X_TLS_DEMAND");
+	expect($settings)->not->toContain("'default' => LDAP_OPT_X_TLS_NEVER");
+});

--- a/tests/Unit/Security/Ldap/LdapRegressionTest.php
+++ b/tests/Unit/Security/Ldap/LdapRegressionTest.php
@@ -60,5 +60,5 @@ test('GHSA-pmgm: cacti_ldap_filter escapes each variable with ldap_escape', func
 
 	$body = substr($ldapSource, $start, 600);
 	expect($body)->toContain("ldap_escape((string) \$value, '', LDAP_ESCAPE_FILTER)");
-	expect($body)->toContain("str_replace('<' . \$key . '>', \$escaped, \$result)");
+	expect($body)->toContain('return strtr($template, $map);');
 });

--- a/tests/e2e/docker/README.md
+++ b/tests/e2e/docker/README.md
@@ -44,6 +44,7 @@ By default the master Cacti UI binds to `127.0.0.1:8088`. To use a different por
 | `04-realm-enforcement.sh` | (a) `grep -RnE 'function (cacti_realm_check\|realm_allowed\|dispatch_realm\|check_user_realm)\b'` matches nothing in `lib/` or `include/`. (b) The seeded `lowpriv` user is denied on `/user_admin.php`, `/settings.php`, `/host.php`. | A parallel realm-check helper being reintroduced (the earlier `lib/cacti_dispatch.php`) or admin pages skipping `is_realm_allowed()`. |
 | `06-csrf-secret-lifecycle.sh` | The installer stores a random secret in `settings`, creates no secret below the web root, and the login form receives a derived token. | Secret lifecycle or installer-to-browser handoff regressions. |
 | `07-session-cookie-failure.sh` | A login POST whose configured session-cookie domain is rejected returns an actionable 403 and log entry. | A missing session cookie being hidden by the CSRF redirect loop. |
+| `08-ldap-login.sh` | Valid `realm=1001` LDAP credentials reach the app layout; a bad or empty password stays on login; `realm=2` does not create a `user_auth` row. | Domain auth skipping the LDAP bind and falling through to the global template. |
 
 ## Debugging a failure
 
@@ -63,6 +64,7 @@ By default the master Cacti UI binds to `127.0.0.1:8088`. To use a different por
 | --- | --- | --- |
 | `admin` | `cacti-e2e-admin` | full |
 | `lowpriv` | `cacti-e2e-lowpriv` | none |
+| `ldapuser` | `ldap-e2e-pass` (OpenLDAP, realm 1001) | copy of admin realms |
 
 Passwords are hashed with `password_hash($pw, PASSWORD_DEFAULT)` inside the
 master container so the algorithm matches the running PHP build.

--- a/tests/e2e/docker/docker-compose.yml
+++ b/tests/e2e/docker/docker-compose.yml
@@ -2,6 +2,26 @@
 # All services share an internal network; only cacti-master is published to the host.
 
 services:
+  openldap:
+    image: osixia/openldap:1.5.0
+    container_name: cacti-e2e-openldap
+    command: --copy-service
+    environment:
+      LDAP_ORGANISATION: Cacti E2E
+      LDAP_DOMAIN: example.org
+      LDAP_ADMIN_PASSWORD: adminpassword
+      LDAP_TLS: "false"
+    volumes:
+      - ./ldap/50-e2e.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/50-e2e.ldif:ro
+    healthcheck:
+      test: ["CMD", "ldapsearch", "-x", "-H", "ldap://127.0.0.1:389", "-b", "dc=example,dc=org", "-D", "cn=admin,dc=example,dc=org", "-w", "adminpassword", "-LLL", "cn=ldapuser"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+    networks:
+      - cacti-e2e
+
   cacti-db:
     image: mariadb:10.11
     container_name: cacti-e2e-db
@@ -38,6 +58,8 @@ services:
       REMOTE_POLLER_HOST: cacti-poller
     depends_on:
       cacti-db:
+        condition: service_healthy
+      openldap:
         condition: service_healthy
     volumes:
       # The harness directory is .dockerignore'd from the COPY layer to keep

--- a/tests/e2e/docker/ldap/50-e2e.ldif
+++ b/tests/e2e/docker/ldap/50-e2e.ldif
@@ -1,0 +1,14 @@
+dn: ou=users,dc=example,dc=org
+objectClass: organizationalUnit
+ou: users
+
+dn: cn=ldapuser,ou=users,dc=example,dc=org
+objectClass: inetOrgPerson
+objectClass: posixAccount
+cn: ldapuser
+sn: User
+uid: ldapuser
+uidNumber: 10001
+gidNumber: 10001
+homeDirectory: /home/ldapuser
+userPassword: ldap-e2e-pass

--- a/tests/e2e/docker/setup.sh
+++ b/tests/e2e/docker/setup.sh
@@ -93,4 +93,20 @@ LOWPRIV_HASH=$("${DC[@]}" exec -T cacti-master php -r 'echo password_hash("cacti
     DELETE FROM user_auth_perms WHERE user_id=1000;
 "
 
+# Domain auth (auth_method=4) plus one LDAP domain bound to the OpenLDAP
+# service. user_template is left as the admin account so a forged realm that
+# skips the bind would provision a user — the 08-ldap-login test asserts it
+# does not. The LDAP account is pre-created in user_auth with realm 1001.
+echo "[setup] seeding LDAP domain auth"
+LDAP_HASH=$("${DC[@]}" exec -T cacti-master php -r 'echo password_hash("unused-local-hash", PASSWORD_DEFAULT);')
+printf "%s\n" \
+	"INSERT INTO settings (name, value) VALUES ('auth_method', '4') ON DUPLICATE KEY UPDATE value='4';" \
+	"INSERT INTO settings (name, value) VALUES ('guest_user', '0') ON DUPLICATE KEY UPDATE value='0';" \
+	"INSERT INTO settings (name, value) VALUES ('user_template', '1') ON DUPLICATE KEY UPDATE value='1';" \
+	"INSERT INTO user_domains (domain_id, domain_name, type, enabled, defdomain, user_id) VALUES (1, 'E2E LDAP', 1, 'on', 1, 0) ON DUPLICATE KEY UPDATE domain_name=VALUES(domain_name), enabled='on', defdomain=1, user_id=0;" \
+	"INSERT INTO user_domains_ldap (domain_id, server, port, port_ssl, proto_version, encryption, referrals, mode, dn, group_require, group_dn, group_attrib, group_member_type, search_base, search_filter, specific_dn, specific_password, cn_full_name, cn_email) VALUES (1, 'openldap', 389, 636, 3, 0, 0, 0, 'cn=<username>,ou=users,dc=example,dc=org', '', '', '', 0, 'ou=users,dc=example,dc=org', '(cn=<username>)', '', '', '', '') ON DUPLICATE KEY UPDATE server=VALUES(server), port=VALUES(port), dn=VALUES(dn), mode=VALUES(mode), encryption=VALUES(encryption);" \
+	"INSERT INTO user_auth (id, username, password, realm, full_name, must_change_password, password_change, show_tree, show_list, show_preview, graph_settings, login_opts, policy_graphs, policy_trees, policy_hosts, policy_graph_templates, enabled, lastchange, lastlogin, password_history, locked, failed_attempts, lastfail, reset_perms) VALUES (1001, 'ldapuser', '${LDAP_HASH}', 1001, 'LDAP E2E User', '', '', 'on', 'on', 'on', 'on', 1, 2, 2, 2, 2, 'on', -1, -1, '-1', '', 0, 0, 0) ON DUPLICATE KEY UPDATE password=VALUES(password), realm=1001, enabled='on';" \
+	"INSERT INTO user_auth_realm (user_id, realm_id) SELECT 1001, realm_id FROM user_auth_realm WHERE user_id=1 ON DUPLICATE KEY UPDATE user_id=VALUES(user_id);" \
+	| "${DC[@]}" exec -T cacti-db mariadb -ucactiuser -pcactiuser cacti
+
 echo "[setup] complete"

--- a/tests/e2e/docker/tests/08-ldap-login.sh
+++ b/tests/e2e/docker/tests/08-ldap-login.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# LDAP domain login through index.php against the OpenLDAP service.
+#
+# Asserts a real bind succeeds, a bad password stays on the login page, an
+# empty password stays on the login page, and a posted realm of 2 (the old
+# skip-the-bind hole) does not create a session or a user_auth row.
+set -euo pipefail
+IFS=$'\n\t'
+
+: "${CACTI_E2E_PORT:=8088}"
+
+cd "$(dirname "$0")/.."
+
+DC=(docker compose -f docker-compose.yml)
+
+run_curl() {
+	"${DC[@]}" exec -T cacti-master curl -sS -b "$1" -c "$1" "${@:2}"
+}
+
+login_post() {
+	local jar="$1"
+	shift
+
+	"${DC[@]}" exec -T cacti-master rm -f "$jar"
+
+	run_curl "$jar" -L -o /tmp/ldap_form 'http://127.0.0.1/index.php'
+	local csrf
+	csrf=$("${DC[@]}" exec -T cacti-master php /var/www/html/tests/e2e/docker/probes/extract_csrf.php /tmp/ldap_form || true)
+	if [ -z "$csrf" ]; then
+		echo "FAIL: could not extract __csrf_magic token from index.php" >&2
+		exit 1
+	fi
+
+	run_curl "$jar" -L \
+		-o /tmp/ldap_post \
+		-w '%{url_effective}' \
+		--data-urlencode "action=login" \
+		--data-urlencode "__csrf_magic=$csrf" \
+		"$@" \
+		'http://127.0.0.1/index.php'
+}
+
+body_is_login_page() {
+	"${DC[@]}" exec -T cacti-master grep -q '<title>Login to Cacti</title>' /tmp/ldap_post
+}
+
+body_has_app_layout() {
+	"${DC[@]}" exec -T cacti-master grep -qE "id='main_logo'|id=\"main_logo\"|class='cactiPageHead'|class=\"cactiPageHead\"" /tmp/ldap_post
+}
+
+echo "[08] valid LDAP credentials with realm 1001 log in"
+FINAL_URL=$(login_post /tmp/c08_ok.jar \
+	--data-urlencode "login_username=ldapuser" \
+	--data-urlencode "login_password=ldap-e2e-pass" \
+	--data-urlencode "realm=1001")
+if echo "$FINAL_URL" | grep -q 'auth_login\.php'; then
+	echo "FAIL: valid LDAP login redirected to auth_login.php ($FINAL_URL)" >&2
+	exit 1
+fi
+if body_is_login_page; then
+	echo "FAIL: valid LDAP login still rendered the login page" >&2
+	"${DC[@]}" exec -T cacti-master head -c 800 /tmp/ldap_post >&2 || true
+	exit 1
+fi
+if ! body_has_app_layout; then
+	echo "FAIL: valid LDAP login missing application layout marker" >&2
+	"${DC[@]}" exec -T cacti-master head -c 800 /tmp/ldap_post >&2 || true
+	exit 1
+fi
+
+echo "[08] wrong LDAP password stays on the login page"
+login_post /tmp/c08_bad.jar \
+	--data-urlencode "login_username=ldapuser" \
+	--data-urlencode "login_password=wrong-password" \
+	--data-urlencode "realm=1001" >/dev/null
+if ! body_is_login_page; then
+	echo "FAIL: bad LDAP password did not stay on the login page" >&2
+	exit 1
+fi
+
+echo "[08] empty LDAP password stays on the login page"
+login_post /tmp/c08_empty.jar \
+	--data-urlencode "login_username=ldapuser" \
+	--data-urlencode "login_password=" \
+	--data-urlencode "realm=1001" >/dev/null
+if ! body_is_login_page; then
+	echo "FAIL: empty LDAP password did not stay on the login page" >&2
+	exit 1
+fi
+
+echo "[08] forged realm 2 does not skip the bind"
+BEFORE=$("${DC[@]}" exec -T cacti-db mariadb -ucactiuser -pcactiuser cacti -Nse \
+	"SELECT COUNT(*) FROM user_auth WHERE username='attacker'")
+login_post /tmp/c08_forge.jar \
+	--data-urlencode "login_username=attacker" \
+	--data-urlencode "login_password=anything" \
+	--data-urlencode "realm=2" >/dev/null
+if ! body_is_login_page; then
+	echo "FAIL: forged realm 2 left the login page — bind skip is back" >&2
+	exit 1
+fi
+AFTER=$("${DC[@]}" exec -T cacti-db mariadb -ucactiuser -pcactiuser cacti -Nse \
+	"SELECT COUNT(*) FROM user_auth WHERE username='attacker'")
+if [ "$AFTER" != "$BEFORE" ]; then
+	echo "FAIL: forged realm 2 created a user_auth row (before=$BEFORE after=$AFTER)" >&2
+	exit 1
+fi
+
+echo "PASS: LDAP login bind, rejection, and forged-realm paths"


### PR DESCRIPTION
Posted LDAP realms that are not in `user_domains` no longer skip the bind and fall through to the global template or guest account.

Also keeps directory errors off the login page, demands TLS certificates for new installs, restores the Cacti error handler on empty-password and bind-only LDAP paths, searches username group membership with the login name, and substitutes LDAP filter placeholders in a single `strtr()` pass.

E2E: OpenLDAP in `tests/e2e/docker`, `08-ldap-login.sh` (valid bind, bad/empty password, forged `realm=2`).

Develop counterpart: #8009.