### PR TITLE
ci: restore develop dependency compatibility

### DIFF
--- a/.github/workflows/cli-coverage.yml
+++ b/.github/workflows/cli-coverage.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup locked PHP dependencies
         uses: ./.github/actions/setup-php-composer
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: xdebug
           extensions: intl, mysql, gd, ldap, gmp, xml, curl, json, mbstring
           dependency-mode: locked-cli-coverage

--- a/.github/workflows/rocky-linux.yml
+++ b/.github/workflows/rocky-linux.yml
@@ -31,9 +31,9 @@ jobs:
             --workdir /workspace \
             rockylinux@sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6 \
             bash -euo pipefail -c '
-              dnf -y module enable php:8.2
+              dnf -y module enable php:8.3
               dnf -y install php-cli php-common php-curl php-gd php-intl php-mbstring php-mysqlnd php-xml php-zip
               php --version
-              php -r '\''exit(version_compare(PHP_VERSION, "8.2.0", ">=") ? 0 : 1);'\''
+              php -r '\''exit(version_compare(PHP_VERSION, "8.3.0", ">=") ? 0 : 1);'\''
               find . \( -path ./vendor -o -path ./include/vendor \) -prune -o -type f -name "*.php" -print0 | xargs -0 -r -n1 php -l
             '

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "jstree": "3.3.17",
         "lzjs": "1.3.1",
         "pace-js": "1.2.4",
-        "screenfull": "6.0.2",
+        "screenfull": "5.2.0",
         "tablesorter": "2.32.0"
       },
       "devDependencies": {
@@ -1211,12 +1211,12 @@
       "license": "MIT"
     },
     "node_modules/screenfull": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-6.0.2.tgz",
-      "integrity": "sha512-AQdy8s4WhNvUZ6P8F6PB21tSPIYKniic+Ogx0AacBMjKP1GUHN2E9URxQHtCusiwxudnCKkdy4GrHXPPJSkCCw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
       "license": "MIT",
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=0.10.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jstree": "3.3.17",
     "lzjs": "1.3.1",
     "pace-js": "1.2.4",
-    "screenfull": "6.0.2",
+    "screenfull": "5.2.0",
     "tablesorter": "2.32.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- pin screenfull to the latest classic-browser-compatible release expected by the asset sync
- move the remaining develop CLI coverage job to the PHP 8.3 project floor
- move the Rocky Linux syntax check to PHP 8.3

## Why

The screenfull 6.0.2 update is ESM-only and no longer ships dist/screenfull.js, causing npm ci to fail before most develop CI jobs can run. Develop also requires PHP ^8.3, while two base workflows still selected PHP 8.2.

## Validation

- mise exec node@22 -- npm ci
- mise exec node@22 -- npm test (17 passed)
- mise exec node@22 -- npm run test:coverage (100% lines, branches, and functions)
- mise exec node@22 -- npm audit --audit-level=high (0 vulnerabilities)
- actionlint on both edited workflows
- pinned Rocky Linux container installs and runs PHP 8.3.33
- git diff --check