### PR TITLE
refactor(rrd): introduce typed service boundaries

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -228,6 +228,10 @@ jobs:
       run: composer run-script phpstan
       working-directory: .
 
+    - name: Run PHPStan at Level 8 on RRD code
+      run: composer run-script phpstan-rrd
+      working-directory: .
+
     - name: Run Pest Unit Tests
       run: composer run-script test
       working-directory: .

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "symfony/lock": "^7.4",
         "symfony/mailer": "^7.4",
         "symfony/notifier": "^7.4",
+        "symfony/options-resolver": "^7.4",
         "symfony/process": "^7.4",
         "symfony/validator": "^7.4"
     },
@@ -78,13 +79,14 @@
     "scripts": {
         "lint": "phplint --no-cache --exclude=include/vendor --exclude=plugins ",
         "phpstan": "phpstan analyse ",
-        "phpstan-rrd": "phpstan analyse lib/rrd.php lib/Rrd ",
+        "phpstan-rrd": "phpstan analyse --memory-limit=1G lib/rrd.php lib/Rrd ",
         "php-cs-fixer": "php-cs-fixer fix --allow-unsupported-php-version=yes --dry-run --diff --config=./.php-cs-fixer.php ",
         "phpcsfixer": "@php-cs-fixer",
         "hardening-patterns": "php tests/tools/check_hardening_patterns.php",
         "vendor-policy": "php tests/tools/check_vendor_policy.php",
         "php-cs-fixit": "php-cs-fixer fix ",
         "test:cli-coverage": "@php include/vendor/bin/pest --configuration=phpunit-cli-coverage.xml --coverage --coverage-text --min=100",
+        "test:rrd-coverage": "@php include/vendor/bin/pest --configuration=phpunit-rrd-components.xml --coverage --coverage-text --min=100",
         "install-hooks": "bash -c 'install -m 755 tests/tools/pre-commit \"$(git rev-parse --git-path hooks/pre-commit)\"'",
         "test": "include/vendor/bin/pest --display-warnings",
         "sink-guard": "bash tests/security/verify_sink_inventory.sh",
@@ -120,7 +122,8 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {
-            "Cacti\\Console\\": "lib/Console/"
+            "Cacti\\Console\\": "lib/Console/",
+            "Cacti\\Rrd\\": "lib/Rrd/"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
     "scripts": {
         "lint": "phplint --no-cache --exclude=include/vendor --exclude=plugins ",
         "phpstan": "phpstan analyse ",
+        "phpstan-rrd": "phpstan analyse lib/rrd.php lib/Rrd ",
         "php-cs-fixer": "php-cs-fixer fix --allow-unsupported-php-version=yes --dry-run --diff --config=./.php-cs-fixer.php ",
         "phpcsfixer": "@php-cs-fixer",
         "hardening-patterns": "php tests/tools/check_hardening_patterns.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33ddeb7d701bf817126ad36feb9a92e0",
+    "content-hash": "f7efda5b7ca0f8ca56853cb3a620c423",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -2828,6 +2828,77 @@
                 }
             ],
             "time": "2026-08-21T17:40:08+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -8069,77 +8140,6 @@
                 }
             ],
             "time": "2026-06-05T06:23:12+00:00"
-        },
-        {
-            "name": "symfony/options-resolver",
-            "version": "v7.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
-                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\OptionsResolver\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an improved replacement for the array_replace PHP function",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "config",
-                "configuration",
-                "options"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-php81",

--- a/lib/Rrd/DataSource/FetchCommandBuilder.php
+++ b/lib/Rrd/DataSource/FetchCommandBuilder.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd\DataSource;
+
+use Cacti\Rrd\RrdCommand;
+
+final class FetchCommandBuilder {
+	private const CONSOLIDATION_FUNCTIONS = ['AVERAGE', 'MIN', 'MAX', 'LAST'];
+
+	public function build(string $path, string $consolidationFunction, int $start, int $end, int $resolution = 0): RrdCommand {
+		$cf = strtoupper($consolidationFunction);
+
+		if (!in_array($cf, self::CONSOLIDATION_FUNCTIONS, true)) {
+			$cf = 'AVERAGE';
+		}
+
+		$arguments = [$path, $cf, '-s', (string) $start, '-e', (string) $end];
+
+		if ($resolution > 0) {
+			$arguments[] = '-r';
+			$arguments[] = (string) $resolution;
+		}
+
+		return new RrdCommand('fetch', $arguments);
+	}
+}

--- a/lib/Rrd/DataSource/TuneCommandBuilder.php
+++ b/lib/Rrd/DataSource/TuneCommandBuilder.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd\DataSource;
+
+use Cacti\Rrd\RrdCommand;
+
+final class TuneCommandBuilder {
+	/**
+	 * @param array<string, string> $options RRDtool option => unescaped value
+	 */
+	public function build(string $path, array $options): ?RrdCommand {
+		$arguments = [$path];
+
+		foreach ($options as $option => $value) {
+			if ($value === '') {
+				continue;
+			}
+
+			$arguments[] = $option;
+			$arguments[] = $value;
+		}
+
+		return count($arguments) === 1 ? null : new RrdCommand('tune', $arguments);
+	}
+}

--- a/lib/Rrd/DataSource/UpdateCommandBuilder.php
+++ b/lib/Rrd/DataSource/UpdateCommandBuilder.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd\DataSource;
+
+use Cacti\Rrd\RrdCommand;
+
+final class UpdateCommandBuilder {
+	public function build(string $path, string $template, string $values, bool $skipPastUpdates): RrdCommand {
+		$arguments = [$path];
+
+		if ($skipPastUpdates) {
+			$arguments[] = '--skip-past-updates';
+		}
+
+		$arguments[] = '--template';
+		$arguments[] = $template;
+		$arguments[] = $values;
+
+		return new RrdCommand('update', $arguments);
+	}
+}

--- a/lib/Rrd/Graph/GraphOptions.php
+++ b/lib/Rrd/Graph/GraphOptions.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd\Graph;
+
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class GraphOptions {
+	private const FLAG_OPTIONS = [
+		'export',
+		'export_csv',
+		'get_error',
+		'graph_nolegend',
+		'graphv',
+		'print_source',
+	];
+
+	private const PATH_OPTIONS = [
+		'export_filename',
+		'export_realtime',
+		'output_filename',
+	];
+
+	/**
+	 * Normalize the options owned by the RRD graph service while retaining
+	 * extension values consumed by plugin hooks.
+	 *
+	 * @param array<string, mixed> $options
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function resolve(array $options): array {
+		$resolver = new OptionsResolver();
+		$known    = array_merge(self::FLAG_OPTIONS, self::PATH_OPTIONS, [
+			'graph_end',
+			'graph_height',
+			'graph_start',
+			'graph_theme',
+			'graph_width',
+			'image_format',
+			'output_flag',
+		]);
+
+		$resolver->setDefined($known);
+
+		foreach (self::FLAG_OPTIONS as $name) {
+			$resolver->setAllowedTypes($name, ['bool', 'int', 'string']);
+		}
+
+		foreach (self::PATH_OPTIONS as $name) {
+			$resolver->setAllowedTypes($name, 'string');
+		}
+
+		foreach (['graph_start', 'graph_end', 'output_flag'] as $name) {
+			$resolver->setAllowedTypes($name, ['int', 'float', 'string']);
+			$resolver->setNormalizer($name, static fn (Options $unused, mixed $value): int => self::normalizeInteger($name, $value));
+		}
+
+		foreach (['graph_height', 'graph_width'] as $name) {
+			$resolver->setAllowedTypes($name, ['int', 'float', 'string']);
+			$resolver->setNormalizer($name, static fn (Options $unused, mixed $value): int|float => self::normalizeNumber($name, $value));
+		}
+
+		foreach (['graph_theme', 'image_format'] as $name) {
+			$resolver->setAllowedTypes($name, 'string');
+		}
+
+		$resolver->setAllowedValues('image_format', ['png', 'svg+xml']);
+		$resolver->setAllowedValues('output_flag', static fn (mixed $value): bool => filter_var($value, FILTER_VALIDATE_INT) !== false && in_array((int) $value, [0, 1, 2, 3, 4, 5], true));
+
+		$knownOptions = array_intersect_key($options, array_flip($known));
+		$resolved     = $resolver->resolve($knownOptions);
+
+		return array_replace($options, $resolved);
+	}
+
+	private static function normalizeInteger(string $name, mixed $value): int {
+		if (is_int($value)) {
+			return $value;
+		}
+
+		if ((is_string($value) || is_float($value)) && filter_var($value, FILTER_VALIDATE_INT) !== false) {
+			return (int) $value;
+		}
+
+		throw new InvalidOptionsException("The '$name' option must be an integer.");
+	}
+
+	private static function normalizeNumber(string $name, mixed $value): int|float {
+		if ((is_int($value) || is_float($value)) && is_finite((float) $value)) {
+			$number = $value;
+		} elseif (is_string($value) && is_numeric($value) && is_finite((float) $value)) {
+			$number = str_contains($value, '.') ? (float) $value : (int) $value;
+		} else {
+			throw new InvalidOptionsException("The '$name' option must be a finite number.");
+		}
+
+		if ($number <= 0) {
+			throw new InvalidOptionsException("The '$name' option must be greater than zero.");
+		}
+
+		return $number;
+	}
+}

--- a/lib/Rrd/LocalRrdTransport.php
+++ b/lib/Rrd/LocalRrdTransport.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+use Symfony\Component\Process\Process;
+use Throwable;
+
+/**
+ * Executes a structured RRDtool command without invoking an operating-system
+ * shell. Symfony owns process lifecycle and concurrent output collection.
+ */
+final class LocalRrdTransport implements RrdTransport {
+	public function __construct(
+		private readonly string $binary,
+	) {
+	}
+
+	public function execute(RrdCommand $command): RrdProcessResult {
+		try {
+			$process = new Process($command->toArgv($this->binary));
+
+			// Preserve the previous RRDtool execution contract, which had no timeout.
+			$process->setTimeout(null);
+			$exitCode = $process->run();
+		} catch (Throwable $exception) {
+			throw new RrdTransportException(
+				'Unable to execute RRDtool: ' . $exception->getMessage(),
+				(int) $exception->getCode(),
+				$exception
+			);
+		}
+
+		return new RrdProcessResult(
+			$process->getOutput(),
+			$process->getErrorOutput(),
+			$exitCode
+		);
+	}
+}

--- a/lib/Rrd/RrdCommand.php
+++ b/lib/Rrd/RrdCommand.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+use InvalidArgumentException;
+
+/**
+ * An RRDtool operation and its unescaped argument values.
+ *
+ * Keeping arguments separate allows local execution to bypass the shell. A
+ * transport that uses RRDtool's line protocol can serialize the same command
+ * with the quoting rules required by that protocol.
+ */
+final class RrdCommand {
+	/**
+	 * @param list<string> $arguments
+	 */
+	public function __construct(
+		public readonly string $operation,
+		public readonly array $arguments = [],
+	) {
+		$this->assertValidToken($operation, 'operation', false);
+
+		if (!array_is_list($arguments)) {
+			throw new InvalidArgumentException('RRDtool arguments must be a list.');
+		}
+
+		foreach ($arguments as $argument) {
+			$this->assertValidToken($argument, 'argument', true);
+		}
+	}
+
+	/**
+	 * @param array<array-key, scalar|null> $tokens
+	 */
+	public static function fromList(array $tokens): self {
+		$tokens = array_values(array_map(
+			static fn (mixed $token): string => (string) $token,
+			$tokens
+		));
+
+		$operation = array_shift($tokens);
+
+		if ($operation === null) {
+			throw new InvalidArgumentException('An RRDtool command requires an operation.');
+		}
+
+		return new self($operation, $tokens);
+	}
+
+	/**
+	 * @return non-empty-list<string>
+	 */
+	public function toArgv(string $binary): array {
+		$this->assertValidToken($binary, 'binary path', false);
+
+		return [$binary, $this->operation, ...$this->arguments];
+	}
+
+	private function assertValidToken(string $token, string $description, bool $allowEmpty): void {
+		if (!$allowEmpty && $token === '') {
+			throw new InvalidArgumentException("RRDtool $description cannot be empty.");
+		}
+
+		if (!$allowEmpty && preg_match('/\s/', $token) === 1) {
+			throw new InvalidArgumentException("RRDtool $description cannot contain whitespace.");
+		}
+
+		if (preg_match('/[\x00-\x1f\x7f]/', $token) === 1) {
+			throw new InvalidArgumentException("RRDtool $description contains a control character.");
+		}
+	}
+}

--- a/lib/Rrd/RrdCommandSerializer.php
+++ b/lib/Rrd/RrdCommandSerializer.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+final class RrdCommandSerializer {
+	/**
+	 * Serialize a command for RRDtool's line-oriented stdin/proxy protocol.
+	 *
+	 * @param callable(string): string $escapeArgument
+	 */
+	public function forLineProtocol(RrdCommand $command, callable $escapeArgument): string {
+		if ($command->arguments === []) {
+			return $command->operation;
+		}
+
+		return $command->operation . ' ' . implode(' ', array_map(
+			$escapeArgument,
+			$command->arguments
+		));
+	}
+}

--- a/lib/Rrd/RrdProcessResult.php
+++ b/lib/Rrd/RrdProcessResult.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+final class RrdProcessResult {
+	public function __construct(
+		public readonly string $stdout,
+		public readonly string $stderr,
+		public readonly int $exitCode,
+	) {
+	}
+
+	public function succeeded(): bool {
+		return $this->exitCode === 0;
+	}
+
+	public function outputWithErrors(): string {
+		return $this->stdout . $this->stderr;
+	}
+}

--- a/lib/Rrd/RrdTransport.php
+++ b/lib/Rrd/RrdTransport.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+interface RrdTransport {
+	public function execute(RrdCommand $command): RrdProcessResult;
+}

--- a/lib/Rrd/RrdTransportException.php
+++ b/lib/Rrd/RrdTransportException.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+namespace Cacti\Rrd;
+
+use RuntimeException;
+
+final class RrdTransportException extends RuntimeException {
+}

--- a/lib/rrd.php
+++ b/lib/rrd.php
@@ -23,6 +23,12 @@
 */
 
 require_once(__DIR__ . '/rrd_graph_item.php');
+require_once(__DIR__ . '/Rrd/RrdCommand.php');
+require_once(__DIR__ . '/Rrd/RrdCommandSerializer.php');
+require_once(__DIR__ . '/Rrd/DataSource/FetchCommandBuilder.php');
+require_once(__DIR__ . '/Rrd/DataSource/TuneCommandBuilder.php');
+require_once(__DIR__ . '/Rrd/DataSource/UpdateCommandBuilder.php');
+require_once(__DIR__ . '/Rrd/Graph/GraphOptions.php');
 
 use phpseclib4\Crypt\Rijndael;
 use phpseclib4\Crypt\RSA;
@@ -848,20 +854,22 @@ function rrdtool_command_log_context(string $command_line) : string {
  *
  * @return string|false A command suitable for stdin conversion, or false
  */
-function rrdtool_build_command(array $command) : string|false {
-	$operation = array_shift($command);
+function rrdtool_build_command(array|\Cacti\Rrd\RrdCommand $command) : string|false {
+	try {
+		if (is_array($command)) {
+			foreach ($command as $token) {
+				if (!is_string($token)) {
+					return false;
+				}
+			}
 
-	if (!is_string($operation) || $operation === '') {
+			$command = \Cacti\Rrd\RrdCommand::fromList($command);
+		}
+
+		return (new \Cacti\Rrd\RrdCommandSerializer())->forLineProtocol($command, 'cacti_escapeshellarg');
+	} catch (InvalidArgumentException) {
 		return false;
 	}
-
-	foreach ($command as $argument) {
-		if (!is_string($argument)) {
-			return false;
-		}
-	}
-
-	return $operation . ($command === [] ? '' : ' ' . implode(' ', array_map('cacti_escapeshellarg', $command)));
 }
 
 /**
@@ -1106,19 +1114,18 @@ function rrdtool_format_result(array $result, int $output_flag) : mixed {
 /**
  * Execute an RRDtool command and return the output.
  *
- * @param string|array $command_line  The RRDtool command to execute.  An array is quoted here,
- *                                    one element per argument.  A caller passing a string quotes
- *                                    each variable argument with cacti_escapeshellarg() as it
- *                                    builds the line; the assembled line is never quoted
- * @param bool         $log_to_stdout Whether to echo output to stdout
- * @param int          $output_flag   Output format constant (RRDTOOL_OUTPUT_*)
- * @param mixed        $rrdtool_pipe  An open RRDtool pipe resource, or null
- * @param string       $logopt        Logging context identifier
+ * @param string|array|\Cacti\Rrd\RrdCommand $command_line  The RRDtool command to execute. Arrays
+ *                                                          and command objects keep arguments
+ *                                                          isolated until line-protocol serialization
+ * @param bool                               $log_to_stdout Whether to echo output to stdout
+ * @param int                                $output_flag   Output format constant (RRDTOOL_OUTPUT_*)
+ * @param mixed                              $rrdtool_pipe  An open RRDtool pipe resource, or null
+ * @param string                             $logopt        Logging context identifier
  *
  * @return mixed The command output in the requested format
  */
-function __rrd_execute(string|array $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdtool_pipe = null, string $logopt = 'WEBLOG') : mixed {
-	if (is_array($command_line)) {
+function __rrd_execute(string|array|\Cacti\Rrd\RrdCommand $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdtool_pipe = null, string $logopt = 'WEBLOG') : mixed {
+	if (is_array($command_line) || $command_line instanceof \Cacti\Rrd\RrdCommand) {
 		$command_line = rrdtool_build_command($command_line);
 
 		if ($command_line === false) {
@@ -1210,16 +1217,16 @@ function rrdtool_trim_output(string &$output) : void {
 /**
  * Execute an RRDtool command through the remote proxy.
  *
- * @param string|array $command_line  RRDtool command string, or one string argument per array element
- * @param bool         $log_to_stdout Whether to echo log output
- * @param int          $output_flag   Requested RRDTOOL_OUTPUT_* result mode
- * @param mixed        $rrdp          Existing proxy connection tuple, or an empty value
- * @param string       $logopt        Logging context identifier
+ * @param string|array|\Cacti\Rrd\RrdCommand $command_line  RRDtool command string, argument list, or command object
+ * @param bool                               $log_to_stdout Whether to echo log output
+ * @param int                                $output_flag   Requested RRDTOOL_OUTPUT_* result mode
+ * @param mixed                              $rrdp          Existing proxy connection tuple, or an empty value
+ * @param string                             $logopt        Logging context identifier
  *
  * @return mixed Output in the requested mode, or false when transport/protocol validation fails
  */
-function __rrd_proxy_execute(string|array $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdp = '', string $logopt = 'WEBLOG') : mixed {
-	if (is_array($command_line)) {
+function __rrd_proxy_execute(string|array|\Cacti\Rrd\RrdCommand $command_line, bool $log_to_stdout, int $output_flag = RRDTOOL_OUTPUT_STDOUT, mixed $rrdp = '', string $logopt = 'WEBLOG') : mixed {
+	if (is_array($command_line) || $command_line instanceof \Cacti\Rrd\RrdCommand) {
 		$command_line = rrdtool_build_command($command_line);
 
 		if ($command_line === false) {
@@ -1761,13 +1768,14 @@ function rrdtool_function_update(array $update_cache_array, mixed $rrdtool_pipe 
 					$rrd_update_values .= $value;
 				}
 
-				if (cacti_version_compare(get_rrdtool_version(), '1.5', '>=')) {
-					$update_options = '--skip-past-updates';
-				} else {
-					$update_options = '';
-				}
+				$command = (new \Cacti\Rrd\DataSource\UpdateCommandBuilder())->build(
+					$rrd_path,
+					$rrd_update_template,
+					$rrd_update_values,
+					cacti_version_compare(get_rrdtool_version(), '1.5', '>=')
+				);
 
-				$update_result = rrdtool_execute('update ' . cacti_escapeshellarg($rrd_path) . " $update_options --template $rrd_update_template $rrd_update_values", true, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'POLLER');
+				$update_result = rrdtool_execute($command, true, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe, 'POLLER');
 
 				if ($update_result !== false) {
 					$rrds_processed++;
@@ -1790,32 +1798,34 @@ function rrdtool_function_tune(array $rrd_tune_array) : void {
 	$data_source_type = $data_source_types[$rrd_tune_array['data-source-type']];
 	$data_source_path = get_data_source_path($rrd_tune_array['data_source_id'], true);
 
-	$rrd_tune = '';
+	$options = [];
 
 	if ($rrd_tune_array['heartbeat'] != '') {
-		$rrd_tune .= ' --heartbeat ' . cacti_escapeshellarg($data_source_name . ':' . $rrd_tune_array['heartbeat']);
+		$options['--heartbeat'] = $data_source_name . ':' . $rrd_tune_array['heartbeat'];
 	}
 
 	if ($rrd_tune_array['minimum'] != '') {
-		$rrd_tune .= ' --minimum ' . cacti_escapeshellarg($data_source_name . ':' . $rrd_tune_array['minimum']);
+		$options['--minimum'] = $data_source_name . ':' . $rrd_tune_array['minimum'];
 	}
 
 	if ($rrd_tune_array['maximum'] != '') {
-		$rrd_tune .= ' --maximum ' . cacti_escapeshellarg($data_source_name . ':' . $rrd_tune_array['maximum']);
+		$options['--maximum'] = $data_source_name . ':' . $rrd_tune_array['maximum'];
 	}
 
 	if ($rrd_tune_array['data-source-type'] != '') {
-		$rrd_tune .= ' --data-source-type ' . cacti_escapeshellarg($data_source_name . ':' . $data_source_type);
+		$options['--data-source-type'] = $data_source_name . ':' . $data_source_type;
 	}
 
 	if ($rrd_tune_array['data-source-rename'] != '') {
-		$rrd_tune .= ' --data-source-rename ' . cacti_escapeshellarg($data_source_name . ':' . $rrd_tune_array['data-source-rename']);
+		$options['--data-source-rename'] = $data_source_name . ':' . $rrd_tune_array['data-source-rename'];
 	}
 
-	if ($rrd_tune != '') {
+	$command = (new \Cacti\Rrd\DataSource\TuneCommandBuilder())->build($data_source_path, $options);
+
+	if ($command !== null) {
 		if (file_exists($data_source_path) == true) {
 			$result = rrdtool_execute(
-				'tune ' . cacti_escapeshellarg($data_source_path) . $rrd_tune,
+				$command,
 				false,
 				RRDTOOL_OUTPUT_BOOLEAN,
 				null,
@@ -1890,19 +1900,15 @@ function rrdtool_function_fetch(int $local_data_id, int $start_time, int $end_ti
 	// update the rrdfile if performing a fetch
 	boost_fetch_cache_check($local_data_id, $rrdtool_pipe);
 
-	// rrdtool consolidation function is a fixed keyword set; never pass it through unchecked
-	if (!in_array($cf, ['AVERAGE', 'MIN', 'MAX', 'LAST'], true)) {
-		$cf = 'AVERAGE';
-	}
+	$command = (new \Cacti\Rrd\DataSource\FetchCommandBuilder())->build(
+		$data_source_path,
+		$cf,
+		$start_time,
+		$end_time,
+		$resolution
+	);
 
-	// build and run the rrdtool fetch command with all of our data
-	$cmd_line = 'fetch ' . cacti_escapeshellarg($data_source_path) . " $cf -s $start_time -e $end_time";
-
-	if ($resolution > 0) {
-		$cmd_line .= " -r $resolution";
-	}
-
-	$output = rrdtool_execute($cmd_line, false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe);
+	$output = rrdtool_execute($command, false, RRDTOOL_OUTPUT_STDOUT, $rrdtool_pipe);
 
 	if (!is_string($output)) {
 		return $fetch_array;
@@ -2321,6 +2327,14 @@ function rrdtool_function_graph(int $local_graph_id, mixed $rra_id, array $graph
 	include_once(CACTI_PATH_LIBRARY . '/boost.php');
 	include_once(CACTI_PATH_LIBRARY . '/xml.php');
 	include(CACTI_PATH_INCLUDE . '/global_arrays.php');
+
+	try {
+		$graph_data_array = \Cacti\Rrd\Graph\GraphOptions::resolve($graph_data_array);
+	} catch (Symfony\Component\OptionsResolver\Exception\InvalidOptionsException $exception) {
+		cacti_log('ERROR: Invalid RRDtool graph options: ' . $exception->getMessage(), false, 'RRDTOOL');
+
+		return 'ERROR: Invalid graph options';
+	}
 
 	/* prevent command injection
 	 * This function prepares an rrdtool graph statement to be executed by the web server.

--- a/phpunit-rrd-components.xml
+++ b/phpunit-rrd-components.xml
@@ -1,0 +1,15 @@
+<phpunit beStrictAboutOutputDuringTests="false">
+    <source>
+        <include>
+            <directory suffix=".php">lib/Rrd</directory>
+        </include>
+    </source>
+    <testsuites>
+        <testsuite name="RRDtool component coverage">
+            <file>tests/Unit/Core/Rrd/RrdCommandTest.php</file>
+            <file>tests/Unit/Core/Rrd/LocalRrdTransportTest.php</file>
+            <file>tests/Unit/Core/Rrd/DataSourceCommandBuilderTest.php</file>
+            <file>tests/Unit/Core/Rrd/GraphOptionsTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Unit/Core/Rrd/DataSourceCommandBuilderTest.php
+++ b/tests/Unit/Core/Rrd/DataSourceCommandBuilderTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Cacti\Rrd\DataSource\FetchCommandBuilder;
+use Cacti\Rrd\DataSource\TuneCommandBuilder;
+use Cacti\Rrd\DataSource\UpdateCommandBuilder;
+
+$rrdRoot = dirname(__DIR__, 4) . '/lib/Rrd';
+
+require_once "$rrdRoot/RrdCommand.php";
+require_once "$rrdRoot/DataSource/FetchCommandBuilder.php";
+require_once "$rrdRoot/DataSource/TuneCommandBuilder.php";
+require_once "$rrdRoot/DataSource/UpdateCommandBuilder.php";
+
+test('fetch builder creates validated commands with optional resolution', function () {
+	$builder = new FetchCommandBuilder();
+
+	expect($builder->build('/tmp/a file.rrd', 'max', -600, 0, 60)->arguments)
+		->toBe(['/tmp/a file.rrd', 'MAX', '-s', '-600', '-e', '0', '-r', '60'])
+		->and($builder->build('/tmp/a.rrd', 'malicious', 1, 2)->arguments)
+		->toBe(['/tmp/a.rrd', 'AVERAGE', '-s', '1', '-e', '2']);
+});
+
+test('update builder controls skip-past-updates as a discrete argument', function () {
+	$builder = new UpdateCommandBuilder();
+
+	expect($builder->build('/tmp/a.rrd', 'in:out', '10:1:2', true)->arguments)
+		->toBe(['/tmp/a.rrd', '--skip-past-updates', '--template', 'in:out', '10:1:2'])
+		->and($builder->build('/tmp/a.rrd', 'in', 'N:U', false)->arguments)
+		->toBe(['/tmp/a.rrd', '--template', 'in', 'N:U']);
+});
+
+test('tune builder omits empty settings and returns null when there is no work', function () {
+	$builder = new TuneCommandBuilder();
+
+	expect($builder->build('/tmp/a.rrd', []))->toBeNull();
+
+	$command = $builder->build('/tmp/a.rrd', [
+		'--heartbeat' => 'traffic_in:600',
+		'--maximum'   => '',
+		'--minimum'   => 'traffic_in:0',
+	]);
+
+	expect($command)->not->toBeNull()
+		->and($command->arguments)->toBe([
+			'/tmp/a.rrd',
+			'--heartbeat',
+			'traffic_in:600',
+			'--minimum',
+			'traffic_in:0',
+		]);
+});

--- a/tests/Unit/Core/Rrd/GraphOptionsTest.php
+++ b/tests/Unit/Core/Rrd/GraphOptionsTest.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Cacti\Rrd\Graph\GraphOptions;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+
+require_once dirname(__DIR__, 4) . '/lib/Rrd/Graph/GraphOptions.php';
+
+test('graph options retain plugin values and normalize scalar inputs', function () {
+	$options = GraphOptions::resolve([
+		'export'          => '1',
+		'export_filename' => '/tmp/export.png',
+		'graph_end'       => 200.0,
+		'graph_height'    => '125.5',
+		'graph_start'     => '100',
+		'graph_theme'     => 'classic',
+		'graph_width'     => 425,
+		'image_format'    => 'png',
+		'output_flag'     => '3',
+		'plugin_option'   => 'retained',
+	]);
+
+	expect($options)->toMatchArray([
+		'export'          => '1',
+		'export_filename' => '/tmp/export.png',
+		'graph_end'       => 200,
+		'graph_height'    => 125.5,
+		'graph_start'     => 100,
+		'graph_width'     => 425,
+		'output_flag'     => 3,
+		'plugin_option'   => 'retained',
+	]);
+});
+
+test('graph options accept every supported flag and path type', function () {
+	$options = GraphOptions::resolve([
+		'export'          => true,
+		'export_csv'      => 1,
+		'get_error'       => 'true',
+		'graph_nolegend'  => false,
+		'graph_start'     => 10,
+		'graphv'          => 0,
+		'print_source'    => '0',
+		'export_filename' => '',
+		'export_realtime' => '/tmp/realtime.png',
+		'output_filename' => '/tmp/output.png',
+		'image_format'    => 'svg+xml',
+	]);
+
+	expect($options)->toHaveCount(11)
+		->and(GraphOptions::resolve([]))->toBe([]);
+});
+
+test('graph options reject invalid integers', function (mixed $value) {
+	GraphOptions::resolve(['graph_start' => $value]);
+})->with([1.5, 'not-an-integer'])->throws(InvalidOptionsException::class);
+
+test('graph options reject invalid dimensions', function (mixed $value) {
+	GraphOptions::resolve(['graph_width' => $value]);
+})->with([NAN, 'not-a-number'])->throws(InvalidOptionsException::class);
+
+test('graph option constraints reject invalid boundary values', function (array $options) {
+	GraphOptions::resolve($options);
+})->with([
+	[['graph_height' => 0]],
+	[['image_format' => 'gif']],
+	[['output_flag' => 6]],
+])->throws(InvalidOptionsException::class);

--- a/tests/Unit/Core/Rrd/LocalRrdTransportTest.php
+++ b/tests/Unit/Core/Rrd/LocalRrdTransportTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Cacti\Rrd\LocalRrdTransport;
+use Cacti\Rrd\RrdCommand;
+
+$rrdRoot = dirname(__DIR__, 4) . '/lib/Rrd';
+
+require_once "$rrdRoot/RrdCommand.php";
+require_once "$rrdRoot/RrdProcessResult.php";
+require_once "$rrdRoot/RrdTransport.php";
+require_once "$rrdRoot/RrdTransportException.php";
+require_once "$rrdRoot/LocalRrdTransport.php";
+
+test('local transport captures stdout stderr and exit status', function () {
+	$transport = new LocalRrdTransport(PHP_BINARY);
+	$command   = new RrdCommand('-r', [
+		'fwrite(STDOUT, $argv[1]); fwrite(STDERR, $argv[2]); exit(7);',
+		'standard output',
+		'standard error',
+	]);
+
+	$result = $transport->execute($command);
+
+	expect($result->stdout)->toBe('standard output')
+		->and($result->stderr)->toBe('standard error')
+		->and($result->exitCode)->toBe(7)
+		->and($result->succeeded())->toBeFalse()
+		->and($result->outputWithErrors())->toBe('standard outputstandard error');
+});
+
+test('local transport passes metacharacters as data without a shell', function () {
+	$payload   = 'value; printf injected | $(whoami)';
+	$transport = new LocalRrdTransport(PHP_BINARY);
+	$command   = new RrdCommand('-r', ['fwrite(STDOUT, $argv[1]);', $payload]);
+
+	$result = $transport->execute($command);
+
+	expect($result->succeeded())->toBeTrue()
+		->and($result->stdout)->toBe($payload)
+		->and($result->stderr)->toBe('');
+});
+
+test('rrd updates use the structured command path', function () {
+	$source = file_get_contents(dirname(__DIR__, 4) . '/lib/rrd.php');
+	$start  = strpos($source, 'function rrdtool_function_update(');
+	$end    = strpos($source, 'function rrdtool_function_tune(', $start);
+
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+
+	expect($function)->toContain("new \\Cacti\\Rrd\\RrdCommand('update', \$arguments)")
+		->not->toContain("rrdtool_execute('update '");
+});
+
+test('rrd fetches use the structured command path', function () {
+	$source = file_get_contents(dirname(__DIR__, 4) . '/lib/rrd.php');
+	$start  = strpos($source, 'function rrdtool_function_fetch(');
+	$end    = strpos($source, 'function rrd_function_process_graph_options(', $start);
+
+	expect($start)->not->toBeFalse()
+		->and($end)->not->toBeFalse();
+
+	$function = substr($source, $start, $end - $start);
+
+	expect($function)->toContain("new \\Cacti\\Rrd\\RrdCommand('fetch', \$arguments)")
+		->not->toContain("\$cmd_line = 'fetch '");
+});

--- a/tests/Unit/Core/Rrd/LocalRrdTransportTest.php
+++ b/tests/Unit/Core/Rrd/LocalRrdTransportTest.php
@@ -63,7 +63,7 @@ test('rrd updates use the structured command path', function () {
 
 	$function = substr($source, $start, $end - $start);
 
-	expect($function)->toContain("new \\Cacti\\Rrd\\RrdCommand('update', \$arguments)")
+	expect($function)->toContain('new \\Cacti\\Rrd\\DataSource\\UpdateCommandBuilder()')
 		->not->toContain("rrdtool_execute('update '");
 });
 
@@ -77,6 +77,13 @@ test('rrd fetches use the structured command path', function () {
 
 	$function = substr($source, $start, $end - $start);
 
-	expect($function)->toContain("new \\Cacti\\Rrd\\RrdCommand('fetch', \$arguments)")
+	expect($function)->toContain('new \\Cacti\\Rrd\\DataSource\\FetchCommandBuilder()')
 		->not->toContain("\$cmd_line = 'fetch '");
+});
+
+test('local transport wraps process startup errors', function () {
+	$transport = new LocalRrdTransport("rrdtool\n--daemon");
+
+	expect(fn () => $transport->execute(new RrdCommand('info', ['/tmp/test.rrd'])))
+		->toThrow(\Cacti\Rrd\RrdTransportException::class, 'Unable to execute RRDtool');
 });

--- a/tests/Unit/Core/Rrd/RrdCommandTest.php
+++ b/tests/Unit/Core/Rrd/RrdCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types = 1);
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Cacti: The Complete RRDtool-based Graphing Solution                     |
+ +-------------------------------------------------------------------------+
+*/
+
+use Cacti\Rrd\RrdCommand;
+use Cacti\Rrd\RrdCommandSerializer;
+
+require_once dirname(__DIR__, 4) . '/lib/Rrd/RrdCommand.php';
+require_once dirname(__DIR__, 4) . '/lib/Rrd/RrdCommandSerializer.php';
+
+test('a command preserves raw arguments for shellless execution', function () {
+	$command = new RrdCommand('update', [
+		'/var/lib/cacti/a file.rrd',
+		'--template',
+		'traffic_in:traffic_out',
+		'100:1; echo not-a-command',
+	]);
+
+	expect($command->toArgv('/usr/bin/rrdtool'))->toBe([
+		'/usr/bin/rrdtool',
+		'update',
+		'/var/lib/cacti/a file.rrd',
+		'--template',
+		'traffic_in:traffic_out',
+		'100:1; echo not-a-command',
+	]);
+});
+
+test('line protocol serialization escapes arguments but not the operation', function () {
+	$command    = new RrdCommand('fetch', ['/var/lib/cacti/a file.rrd', 'AVERAGE']);
+	$serializer = new RrdCommandSerializer();
+
+	expect($serializer->forLineProtocol($command, 'escapeshellarg'))
+		->toBe("fetch '/var/lib/cacti/a file.rrd' 'AVERAGE'");
+});
+
+test('the compatibility list constructor normalizes scalar arguments', function () {
+	$command = RrdCommand::fromList(['fetch', '/tmp/test.rrd', 'AVERAGE', -300, null]);
+
+	expect($command->operation)->toBe('fetch')
+		->and($command->arguments)->toBe(['/tmp/test.rrd', 'AVERAGE', '-300', '']);
+});
+
+test('commands reject line protocol control characters', function (string $token) {
+	expect(fn () => new RrdCommand('update', [$token]))
+		->toThrow(InvalidArgumentException::class);
+})->with([
+	'line feed'       => "value\nfetch other.rrd AVERAGE",
+	'carriage return' => "value\rquit",
+	'null byte'       => "value\0suffix",
+]);
+
+test('commands reject operations containing whitespace', function () {
+	expect(fn () => new RrdCommand('fetch another-command'))
+		->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Unit/Core/Rrd/RrdCommandTest.php
+++ b/tests/Unit/Core/Rrd/RrdCommandTest.php
@@ -65,3 +65,26 @@ test('commands reject operations containing whitespace', function () {
 	expect(fn () => new RrdCommand('fetch another-command'))
 		->toThrow(InvalidArgumentException::class);
 });
+
+test('commands reject an empty operation and a non-list argument array', function () {
+	expect(fn () => new RrdCommand(''))->toThrow(InvalidArgumentException::class)
+		->and(fn () => new RrdCommand('fetch', ['path' => '/tmp/test.rrd']))
+		->toThrow(InvalidArgumentException::class);
+});
+
+test('commands reject invalid binary paths', function (string $binary) {
+	expect(fn () => (new RrdCommand('fetch'))->toArgv($binary))
+		->toThrow(InvalidArgumentException::class);
+})->with(['', "rrdtool\n--daemon", 'two words']);
+
+test('an empty list cannot create a command', function () {
+	expect(fn () => RrdCommand::fromList([]))
+		->toThrow(InvalidArgumentException::class);
+});
+
+test('a command without arguments serializes to its operation', function () {
+	$serializer = new RrdCommandSerializer();
+
+	expect($serializer->forLineProtocol(new RrdCommand('flushcached'), 'escapeshellarg'))
+		->toBe('flushcached');
+});

--- a/tests/Unit/Security/Shell/RrdEscapeCommandRemovalTest.php
+++ b/tests/Unit/Security/Shell/RrdEscapeCommandRemovalTest.php
@@ -41,10 +41,10 @@ test('escape_command is not redefined elsewhere under lib', function () {
 	expect($found)->toBe([]);
 });
 
-test('__rrd_execute escapes array arguments one at a time', function () use ($rrdPath) {
+test('__rrd_execute serializes structured arguments one at a time', function () use ($rrdPath) {
 	$source = file_get_contents($rrdPath);
 
-	expect($source)->toContain("array_map('cacti_escapeshellarg', \$command)")
+	expect($source)->toContain("forLineProtocol(\$command, 'cacti_escapeshellarg')")
 		->toContain('$command_line = rrdtool_build_command($command_line);');
 });
 


### PR DESCRIPTION
## Summary

- add typed RRDtool command, result, serializer, and shell-free Symfony Process transport boundaries
- extract fetch, update, and tune command builders from `lib/rrd.php`
- validate graph options through Symfony OptionsResolver while retaining plugin extension values
- preserve the hardened persistent and proxy transports from current `develop`
- add PSR-4 autoloading and a dedicated 100% coverage gate for `lib/Rrd`

## Verification

- PHP 8.3 RRD/security suite: 109 passed
- PHPStan level 8 for `lib/rrd.php` and `lib/Rrd`: clean
- dedicated PHP 8.4/Xdebug component coverage: 100.0%
- Composer validation and locked install dry run: clean
- sink inventory and architectural hotspot guards: clean
- full Unit suite: 2,123 passed, 4 skipped, with one unrelated pre-existing HTMX integrity assertion failure
