### PR TITLE
ci: Remove platform as it causes conflicts during ci

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -252,8 +252,7 @@ jobs:
         sudo apt-get install \
         -o Acquire::http::Timeout="10" \
         -o Acquire::https::Timeout="10" \
-        -o Acquire::Retries="30" apache2 snmp snmpd rrdtool \
-          libapache2-mod-php${{ matrix.php }} php${{ matrix.php }}-mysql
+        -o Acquire::Retries="30" snmp snmpd rrdtool 
 
     - name: Start SNMPD Agent and Test Agent
       run: |

--- a/composer.json
+++ b/composer.json
@@ -66,9 +66,6 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
-        "platform": {
-            "php": "8.1.0"
-        },
         "platform-check": "php-only",
         "sort-packages": true,
         "vendor-dir": "./include/vendor"

--- a/composer.lock
+++ b/composer.lock
@@ -324,8 +324,5 @@
         "ext-xml": "*"
     },
     "platform-dev": {},
-    "platform-overrides": {
-        "php": "8.1.0"
-    },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
The platform attribute seems to conflict with the requirements section of the composer.json inside of workflows.